### PR TITLE
Fix full-circle wedge hit test

### DIFF
--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -112,7 +112,8 @@ export class AnnularWedgeView extends XYGlyphView {
     for (const i of candidates) {
       // NOTE: minus the angle because JS uses non-mathy convention for angles
       const angle = Math.atan2(sy - this.sy[i], sx - this.sx[i])
-      if (angle_between(-angle, -this.start_angle.get(i), -this.end_angle.get(i), anticlock)) {
+      const is_full_circle = Math.abs(this.start_angle.get(i) - this.end_angle.get(i)) >= 2*Math.PI
+      if (is_full_circle || angle_between(-angle, -this.start_angle.get(i), -this.end_angle.get(i), anticlock)) {
         indices.push(i)
       }
     }

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -92,7 +92,8 @@ export class WedgeView extends XYGlyphView {
     for (const i of candidates) {
       // NOTE: minus the angle because JS uses non-mathy convention for angles
       const angle = Math.atan2(sy - this.sy[i], sx - this.sx[i])
-      if (angle_between(-angle, -this.start_angle.get(i), -this.end_angle.get(i), anticlock)) {
+      const is_full_circle = Math.abs(this.start_angle.get(i) - this.end_angle.get(i)) >= 2*Math.PI
+      if (is_full_circle || angle_between(-angle, -this.start_angle.get(i), -this.end_angle.get(i), anticlock)) {
         indices.push(i)
       }
     }

--- a/bokehjs/test/unit/models/glyphs/annular_wedge.ts
+++ b/bokehjs/test/unit/models/glyphs/annular_wedge.ts
@@ -79,5 +79,69 @@ describe("Glyph (using AnnularWedge as a concrete Glyph)", () => {
         expect(result.indices).to.be.equal(expected_hits[i])
       }
     })
+
+    it("should hit test full circle annular wedges against an index", async () => {
+      const data = {
+        // Single annular wedge going all the way around
+        start_angle: [0],
+        end_angle: [2*Math.PI],
+      }
+      const glyph = new AnnularWedge({
+        x: {value: 50},
+        y: {value: 50},
+        inner_radius: {value: 25},
+        outer_radius: {value: 50},
+        start_angle: {field: "start_angle"},
+        end_angle: {field: "end_angle"},
+      })
+
+      const glyph_renderer = await create_glyph_renderer_view(glyph, data, {axis_type: "linear"})
+      const glyph_view = glyph_renderer.glyph
+
+      const geometries: Geometry[] = [
+        // Points just inside and outside the outer circle
+        {type: "point", sx: 100 +  90, sy: 100},        // Right, inside
+        {type: "point", sx: 100 + 110, sy: 100},        // Right, outside
+        {type: "point", sx: 100,       sy: 100 -  90},  // Top, inside
+        {type: "point", sx: 100,       sy: 100 - 110},  // Top, outside
+        {type: "point", sx: 100 -  90, sy: 100},        // Left, inside
+        {type: "point", sx: 100 - 110, sy: 100},        // Left, outside
+        {type: "point", sx: 100,       sy: 100 +  90},  // Bottom, inside
+        {type: "point", sx: 100,       sy: 100 + 110},  // Bottom, outside
+        // Points just inside and outside the inner circle
+        {type: "point", sx: 100 + 40, sy: 100},       // Right, inside
+        {type: "point", sx: 100 + 60, sy: 100},       // Right, outside
+        {type: "point", sx: 100,      sy: 100 - 40},  // Top, inside
+        {type: "point", sx: 100,      sy: 100 - 60},  // Top, outside
+        {type: "point", sx: 100 - 40, sy: 100},       // Left, inside
+        {type: "point", sx: 100 - 60, sy: 100},       // Left, outside
+        {type: "point", sx: 100,      sy: 100 + 40},  // Bottom, inside
+        {type: "point", sx: 100,      sy: 100 + 60},  // Bottom, outside
+      ]
+
+      const expected_hits = [
+        [0],
+        [],
+        [0],
+        [],
+        [0],
+        [],
+        [0],
+        [],
+        [],
+        [0],
+        [],
+        [0],
+        [],
+        [0],
+        [],
+        [0],
+      ]
+
+      for (let i = 0; i < geometries.length; i++) {
+        const result = glyph_view.hit_test(geometries[i])!
+        expect(result.indices).to.be.equal(expected_hits[i])
+      }
+    })
   })
 })

--- a/bokehjs/test/unit/models/glyphs/wedge.ts
+++ b/bokehjs/test/unit/models/glyphs/wedge.ts
@@ -61,5 +61,51 @@ describe("Glyph (using Wedge as a concrete Glyph)", () => {
         expect(result.indices).to.be.equal(expected_hits[i])
       }
     })
+
+    it("should hit test full circle wedges against an index", async () => {
+      const data = {
+        // Single wedge going all the way around
+        start_angle: [0],
+        end_angle: [2*Math.PI],
+      }
+      const glyph = new Wedge({
+        x: {value: 50},
+        y: {value: 50},
+        radius: {value: 50},
+        start_angle: {field: "start_angle"},
+        end_angle: {field: "end_angle"},
+      })
+
+      const glyph_renderer = await create_glyph_renderer_view(glyph, data, {axis_type: "linear"})
+      const glyph_view = glyph_renderer.glyph
+
+      const geometries: Geometry[] = [
+        // Points just inside and outside the circle
+        {type: "point", sx: 100 +  90, sy: 100},        // Right, inside
+        {type: "point", sx: 100 + 110, sy: 100},        // Right, outside
+        {type: "point", sx: 100,       sy: 100 -  90},  // Top, inside
+        {type: "point", sx: 100,       sy: 100 - 110},  // Top, outside
+        {type: "point", sx: 100 -  90, sy: 100},        // Left, inside
+        {type: "point", sx: 100 - 110, sy: 100},        // Left, outside
+        {type: "point", sx: 100,       sy: 100 +  90},  // Bottom, inside
+        {type: "point", sx: 100,       sy: 100 + 110},  // Bottom, outside
+      ]
+
+      const expected_hits = [
+        [0],
+        [],
+        [0],
+        [],
+        [0],
+        [],
+        [0],
+        [],
+      ]
+
+      for (let i = 0; i < geometries.length; i++) {
+        const result = glyph_view.hit_test(geometries[i])!
+        expect(result.indices).to.be.equal(expected_hits[i])
+      }
+    })
   })
 })


### PR DESCRIPTION
When Wedge and AnnularWedge glyphs go all the way around a full circle,
the hit test would always fail. This is because `angle_between()`
normalizes between 0 and 2*pi, then returns false if they are equal.
This adds an additional check in the glyph's hit testing such that if
the start and end angle are more than a full circle apart, it is
considered a hit because the wedge is going all the way around in a
circle.

I chose to add a check in each glyph's hit test rather than modify `angle_between()` because I'm not sure where else that function is used, and I'm not sure if that would be appropriate behavior for that function.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [X] issues: fixes #11205
- [X] tests added / passed
- [ ] release document entry (if new feature or API change)
