### PR TITLE
Adding metadata to examples/models/file/buttons.py #11765

### DIFF
--- a/examples/models/file/buttons.py
+++ b/examples/models/file/buttons.py
@@ -1,3 +1,18 @@
+''' A rendering of all button widgets.
+
+This example demonstrates the types of button widgets available
+along with radio buttons and checkboxes.
+
+The types include button with click event enabled and disabled,
+a toggle button with default active or inactive status, checkboxes,
+radio buttons, dropdown menu, checkbox and radio with groups.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.models.widgets.buttons.Button, bokeh.models.widgets.buttons.Dropdown, bokeh.models.widgets.buttons.Toggle, bokeh.models.widgets.groups.CheckBoxButtonGroup, bokeh.models.widgets.groups.CheckboxGroup, bokeh.models.widgets.groups.RadioButtonGroup, bokeh.models.widgets.groups.RadioGroup  # noqa: E501
+    :refs: :ref:`userguide_layout` > :ref:`userguide_layout_gridplot`, :ref:`userguide_tools` > :ref:`userguide_tools_hover_tool`
+    :keywords: buttons, radio button, checkboxes, toggle button, dropdown
+
+'''
 from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Button, CheckboxButtonGroup, CheckboxGroup, Column,


### PR DESCRIPTION
Adding metadata to examples/models/file/buttons.py. I need help for filling the refs attributes in the file. Even the API's, I got them from the document section and dot (.) operation to the classes. Let me know this is correct process or there is a specific place to checkout the API's as well. I am asking to contribute to more examples.

- [ ] issues: addresses #11765 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
