### PR TITLE
`build_js` as a subcommand

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ include _setup_support.py
 
 # Package files and data
 include bokeh/LICENSE.txt
+graft bokehjs
 graft bokeh/core/_templates
 graft bokeh/sampledata/_data
 graft bokeh/sphinxext/_templates

--- a/_setup_support.py
+++ b/_setup_support.py
@@ -13,9 +13,10 @@ import re
 import shutil
 import sys
 import time
-from distutils.cmd import Command
 from pathlib import Path
 from subprocess import PIPE, CompletedProcess, run
+
+from setuptools import Command
 
 # -----------------------------------------------------------------------------
 # Module global variables

--- a/_setup_support.py
+++ b/_setup_support.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from subprocess import PIPE, CompletedProcess, run
 
 from setuptools import Command
+from setuptools.command.develop import develop
 
 # -----------------------------------------------------------------------------
 # Module global variables
@@ -152,6 +153,12 @@ class BuildJSCmd(Command):
     def summarize(self) -> None:
         kind = "NEWLY BUILT" if self.action == "build" else "PREVIOUSLY BUILT"
         print(SUMMARY_MSG.format(kind=kind))
+
+class DevelopWithJs(develop):
+    def run(self):
+        super().run()
+        if not self.uninstall:
+            self.run_command("build_js")
 
 # -----------------------------------------------------------------------------
 # Status and error message strings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [tool.mypy]
 python_version = "3.8"
 mypy_path = "typings/"

--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,13 @@ option, e.g:
 from setuptools import find_namespace_packages, setup
 
 import sys
-import versioneer
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
 sys.path.append(str(ROOT))  # avoid depending on `build_meta:__legacy__`
 
-from _setup_support import INSTALL_REQUIRES, BuildJSCmd, check_python
+import versioneer
+from _setup_support import INSTALL_REQUIRES, BuildJSCmd, DevelopWithJs, check_python
 
 try:
     from setuptools.command.build import build  # future-proof
@@ -63,6 +63,9 @@ except ImportError:
 build.sub_commands.insert(0, ('build_js', None))
 
 check_python() # bail on unsupported Python versions
+
+
+commands = {"build_js": BuildJSCmd, "develop": DevelopWithJs}
 
 setup(
     # basic package metadata
@@ -84,5 +87,5 @@ setup(
     include_package_data=True,
     entry_points={'console_scripts': ['bokeh = bokeh.__main__:main']},
     zip_safe=False,
-    cmdclass=versioneer.get_cmdclass({"build_js": BuildJSCmd}),
+    cmdclass=versioneer.get_cmdclass(commands),
 )


### PR DESCRIPTION
Hi @bryevdv, this PR is a suggestion of changes to be added on top of your existing PR: https://github.com/bokeh/bokeh/pull/12164.

Here I am proposing an alternative approach (instead of replacing `build_ext`, to add a new subcommand).
I think this should be a bit safer. The downside is that you also have to overwrite `develop` to use the editable mode.

Since, I am not very familiar with bokeh's testing procedure, I have not fully tested the changes proposed here, but the idea is more of giving a few hints of what can be changed in your original PR, so please feel free to simple close this PR and just absorb the parts you feel work for you.

The way I tested the changes here was by running [`python -m build`](https://pypa-build.readthedocs.io/en/stable/) and inspecting the contents of the generated `wheel` file. It is very likely that some adjusts of what should be included or not in the distribution need to be made via `MANIFEST.in` and/or `exclude_package_data`, but since I don't know exactly what files should be present, I have not touched it.
