### PR TITLE
Simplify DatetimeTickFormatter scale format type

### DIFF
--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+import warnings
+
 # Bokeh imports
 from ..core.enums import LatLon, NumeralLanguage, RoundingFunction
 from ..core.has_props import abstract
@@ -40,6 +43,7 @@ from ..core.properties import (
 from ..core.validation import error
 from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model
+from ..util.deprecation import deprecated
 from ..util.string import format_docstring
 from .tickers import Ticker
 
@@ -374,6 +378,14 @@ class CustomJSTickFormatter(TickFormatter):
             '''
     """)
 
+def _deprecated_datetime_list_format(fmt: list[str]) -> str:
+    deprecated("Passing lists of formats for DatetimeTickFormatter scales was deprecated in Bokeh 3.0. Configure a single string format for each scale")
+    if len(fmt) == 0:
+        raise ValueError("Datetime format list must contain one element")
+    if len(fmt) > 1:
+        warnings.warn(f"DatetimeFormatter scales now only accept a single format. Using the first prodvided: {fmt[0]!r} ")
+    return fmt[0]
+
 class DatetimeTickFormatter(TickFormatter):
     ''' A ``TickFormatter`` for displaying datetime values nicely across a
     range of scales.
@@ -583,45 +595,37 @@ class DatetimeTickFormatter(TickFormatter):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    microseconds = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``microseconds``"),
-                        default=['%fus']).accepts(String, lambda fmt: [fmt])
+    microseconds = String(help=_DATETIME_TICK_FORMATTER_HELP("``microseconds``"),
+                        default="%fus").accepts(List(String), _deprecated_datetime_list_format)
 
-    milliseconds = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``milliseconds``"),
-                        default=['%3Nms', '%S.%3Ns']).accepts(String, lambda fmt: [fmt])
+    milliseconds = String(help=_DATETIME_TICK_FORMATTER_HELP("``milliseconds``"),
+                        default="%3Nms").accepts(List(String), _deprecated_datetime_list_format)
 
-    seconds      = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``seconds``"),
-                        default=['%Ss']).accepts(String, lambda fmt: [fmt])
+    seconds      = String(help=_DATETIME_TICK_FORMATTER_HELP("``seconds``"),
+                        default="%Ss").accepts(List(String), _deprecated_datetime_list_format)
 
-    minsec       = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``minsec`` (for combined minutes and seconds)"),
-                        default=[':%M:%S']).accepts(String, lambda fmt: [fmt])
+    minsec       = String(help=_DATETIME_TICK_FORMATTER_HELP("``minsec`` (for combined minutes and seconds)"),
+                        default=":%M:%S").accepts(List(String), _deprecated_datetime_list_format)
 
-    minutes      = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``minutes``"),
-                        default=[':%M', '%Mm']).accepts(String, lambda fmt: [fmt])
+    minutes      = String(help=_DATETIME_TICK_FORMATTER_HELP("``minutes``"),
+                        default=":%M").accepts(List(String), _deprecated_datetime_list_format)
 
-    hourmin      = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``hourmin`` (for combined hours and minutes)"),
-                        default=['%H:%M']).accepts(String, lambda fmt: [fmt])
+    hourmin      = String(help=_DATETIME_TICK_FORMATTER_HELP("``hourmin`` (for combined hours and minutes)"),
+                        default="%H:%M").accepts(List(String), _deprecated_datetime_list_format)
 
-    hours        = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``hours``"),
-                        default=['%Hh', '%H:%M']).accepts(String, lambda fmt: [fmt])
+    hours        = String(help=_DATETIME_TICK_FORMATTER_HELP("``hours``"),
+                        default="%Hh").accepts(List(String), _deprecated_datetime_list_format)
 
-    days         = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``days``"),
-                        default=['%m/%d', '%a%d']).accepts(String, lambda fmt: [fmt])
+    days         = String(help=_DATETIME_TICK_FORMATTER_HELP("``days``"),
+                        default="%m/%d").accepts(List(String), _deprecated_datetime_list_format)
 
-    months       = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``months``"),
-                        default=['%m/%Y', '%b %Y']).accepts(String, lambda fmt: [fmt])
+    months       = String(help=_DATETIME_TICK_FORMATTER_HELP("``months``"),
+                        default="%m/%Y").accepts(List(String), _deprecated_datetime_list_format)
 
-    years        = List(String,
-                        help=_DATETIME_TICK_FORMATTER_HELP("``years``"),
-                        default=['%Y']).accepts(String, lambda fmt: [fmt])
+    years        = String(help=_DATETIME_TICK_FORMATTER_HELP("``years``"),
+                        default="%Y").accepts(List(String), _deprecated_datetime_list_format)
+
+    strip_leading_zeros = Bool(default=True, help="Whether to strip any leading zeros in the formatted ticks")
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -98,7 +98,7 @@ export class DatetimeTickFormatter extends TickFormatter {
       days: [ String, "%m/%d" ],
       months: [ String, "%m/%Y" ],
       years: [ String, "%Y" ],
-      strip_leading_zeros: [Boolean, true],
+      strip_leading_zeros: [ Boolean, true ],
     }))
   }
 

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -102,10 +102,6 @@ export class DatetimeTickFormatter extends TickFormatter {
     }))
   }
 
-  override initialize(): void {
-    super.initialize()
-  }
-
   protected _get_resolution_str(resolution_secs: number, span_secs: number): FormatType {
     // Our resolution boundaries should not be round numbers, because we want
     // them to fall between the possible tick intervals (which *are* round

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -37,10 +37,10 @@ function _strftime(t: number, format: string): string {
   return tz(t, format)
 }
 
-type formatType = "microseconds" | "milliseconds" | "seconds" | "minsec" | "minutes" | "hourmin" | "hours" | "days" | "months" | "years"
+type FormatType = "microseconds" | "milliseconds" | "seconds" | "minsec" | "minutes" | "hourmin" | "hours" | "days" | "months" | "years"
 
 // Labels of time units, from finest to coarsest.
-const format_order: formatType[] = [
+const format_order: FormatType[] = [
   "microseconds", "milliseconds", "seconds", "minsec", "minutes", "hourmin", "hours", "days", "months", "years",
 ]
 
@@ -106,7 +106,7 @@ export class DatetimeTickFormatter extends TickFormatter {
     super.initialize()
   }
 
-  protected _get_resolution_str(resolution_secs: number, span_secs: number): formatType {
+  protected _get_resolution_str(resolution_secs: number, span_secs: number): FormatType {
     // Our resolution boundaries should not be round numbers, because we want
     // them to fall between the possible tick intervals (which *are* round
     // numbers, as we've worked hard to ensure).  Consequently, we adjust the
@@ -165,7 +165,7 @@ export class DatetimeTickFormatter extends TickFormatter {
       // we are at zero minutes, so display hours, or we are at zero seconds,
       // so display minutes (and if that is zero as well, then display hours).
       while (tm[time_tuple_ndx_for_resol[format_order[next_ndx]]] == 0) {
-        let next_format: formatType
+        let next_format: FormatType
         next_ndx += 1
 
         if (next_ndx == format_order.length)

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -49,15 +49,15 @@ const format_order: FormatType[] = [
 // everything to index 0, which is year.  This is not ideal; it might cause
 // a problem with the tick at midnight, january 1st, 0 a.d. being incorrectly
 // promoted at certain tick resolutions.
-const time_tuple_ndx_for_resol: {[key: string]: number} = {}
+const time_tuple_ndx_for_resol: Map<FormatType, number> = new Map()
 for (const fmt of format_order) {
-  time_tuple_ndx_for_resol[fmt] = 0
+  time_tuple_ndx_for_resol.set(fmt, 0)
 }
-time_tuple_ndx_for_resol.seconds = 5
-time_tuple_ndx_for_resol.minsec = 4
-time_tuple_ndx_for_resol.minutes = 4
-time_tuple_ndx_for_resol.hourmin = 3
-time_tuple_ndx_for_resol.hours = 3
+time_tuple_ndx_for_resol.set("seconds", 5)
+time_tuple_ndx_for_resol.set("minsec", 4)
+time_tuple_ndx_for_resol.set("minutes", 4)
+time_tuple_ndx_for_resol.set("hourmin", 3)
+time_tuple_ndx_for_resol.set("hours", 3)
 
 export namespace DatetimeTickFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -164,7 +164,7 @@ export class DatetimeTickFormatter extends TickFormatter {
       // time is by checking that we have 0 units of the resolution, i.e.
       // we are at zero minutes, so display hours, or we are at zero seconds,
       // so display minutes (and if that is zero as well, then display hours).
-      while (tm[time_tuple_ndx_for_resol[format_order[next_ndx]]] == 0) {
+      while (tm[time_tuple_ndx_for_resol.get(format_order[next_ndx])!] == 0) {
         let next_format: FormatType
         next_ndx += 1
 

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -1,24 +1,122 @@
-import tz from "timezone"
-
-import {TickFormatter} from "./tick_formatter"
-import {logger} from "core/logging"
 import * as p from "core/properties"
 import {sprintf} from "core/util/templating"
+import {TickFormatter} from "models/formatters/tick_formatter"
+import {ONE_DAY, ONE_HOUR, ONE_MILLI, ONE_MINUTE, ONE_MONTH, ONE_SECOND, ONE_YEAR} from "models/tickers/util"
+import tz from "timezone"
 
-function _us(t: number): number {
-  // From double-precision unix (millisecond) timestamp get
-  // microsecond since last second. Precision seems to run
-  // out around the hundreds of nanoseconds scale, so rounding
-  // to the nearest microsecond should round to a nice
-  // microsecond / millisecond tick.
-  return Math.round(((t / 1000) % 1) * 1000000)
+export type ResolutionType = "microseconds" | "milliseconds" | "seconds" | "minsec" | "minutes" | "hourmin" | "hours" | "days" | "months" | "years"
+
+// Labels of time units, from finest to coarsest.
+export const resolution_order: ResolutionType[] = [
+  "microseconds", "milliseconds", "seconds", "minsec", "minutes", "hourmin", "hours", "days", "months", "years",
+]
+
+// This dictionary maps the name of a time resolution (in @resolution_order)
+// to its index in a time.localtime() timetuple.  The default is to map
+// everything to index 0, which is year.  This is not ideal; it might cause
+// a problem with the tick at midnight, january 1st, 0 a.d. being incorrectly
+// promoted at certain tick resolutions.
+export const tm_index_for_resolution: Map<ResolutionType, number> = new Map()
+for (const fmt of resolution_order) {
+  tm_index_for_resolution.set(fmt, 0)
+}
+tm_index_for_resolution.set("seconds", 5)
+tm_index_for_resolution.set("minsec", 4)
+tm_index_for_resolution.set("minutes", 4)
+tm_index_for_resolution.set("hourmin", 3)
+tm_index_for_resolution.set("hours", 3)
+
+export function _compute_label(t: number, resolution: ResolutionType,  model: DatetimeTickFormatter): string {
+  const s0 = _strftime(t, model[resolution])
+  const tm = _mktime(t)
+  const resolution_index = resolution_order.indexOf(resolution)
+
+  let s = s0
+  let hybrid_handled = false
+  let next_index = resolution_index
+  let next_resolution: ResolutionType
+
+  // As we format each tick, check to see if we are at a boundary of the
+  // next higher unit of time.  If so, replace the current format with one
+  // from that resolution.  This is not the best heuristic in the world,
+  // but it works!  There is some trickiness here due to having to deal
+  // with hybrid formats in a reasonable manner.
+  while (tm[tm_index_for_resolution.get(resolution_order[next_index])!] == 0) {
+    next_index += 1
+
+    if (next_index == resolution_order.length)
+      break
+
+    // The way to check that we are at the boundary of the next unit of
+    // time is by checking that we have 0 units of the resolution, i.e.
+    // we are at zero minutes, so display hours, or we are at zero seconds,
+    // so display minutes (and if that is zero as well, then display hours).
+    if ((resolution == "minsec" || resolution == "hourmin") && !hybrid_handled) {
+      if ((resolution == "minsec" && tm[4] == 0 && tm[5] != 0) || (resolution == "hourmin" && tm[3] == 0 && tm[4] != 0)) {
+        next_resolution = resolution_order[resolution_index-1]
+        s = _strftime(t, model[next_resolution])
+        break
+      } else {
+        hybrid_handled = true
+      }
+    }
+
+    next_resolution = resolution_order[next_index]
+    s = _strftime(t, model[next_resolution])
+  }
+
+  if (model.strip_leading_zeros) {
+    const ss = s.replace(/^0+/g, "")
+    if (ss != s && isNaN(parseInt(ss))) {
+      // If the string can now be parsed as starting with an integer, then
+      // leave all zeros stripped, otherwise start with a zero. Hence:
+      // A label such as '000ms' should leave one zero.
+      // A label such as '001ms' or '0-1ms' should not leave a leading zero.
+      return `0${ss}`
+    }
+    return ss
+  }
+  return s
 }
 
-function _array(t: number): number[] {
+export function _get_resolution(resolution_secs: number, span_secs: number): ResolutionType {
+  // Our resolution boundaries should not be round numbers, because we want
+  // them to fall between the possible tick intervals (which *are* round
+  // numbers, as we've worked hard to ensure).  Consequently, we adjust the
+  // resolution upwards a small amount (less than any possible step in
+  // scales) to make the effective boundaries slightly lower.
+  const adjusted_ms = resolution_secs * 1.1 * 1000
+  const span_ms = span_secs * 1000
+
+  if (adjusted_ms < ONE_MILLI)
+    return "microseconds"
+
+  if (adjusted_ms < ONE_SECOND)
+    return "milliseconds"
+
+  if (adjusted_ms < ONE_MINUTE)
+    return span_ms >= ONE_MINUTE ? "minsec"  : "seconds"
+
+  if (adjusted_ms < ONE_HOUR)
+    return span_ms >= ONE_HOUR ? "hourmin" : "minutes"
+
+  if (adjusted_ms < ONE_DAY)
+    return "hours"
+
+  if (adjusted_ms < ONE_MONTH)
+    return "days"
+
+  if (adjusted_ms < ONE_YEAR)
+    return "months"
+
+  return "years"
+}
+
+export function _mktime(t: number): number[] {
   return tz(t, "%Y %m %d %H %M %S").split(/\s+/).map(e => parseInt(e, 10))
 }
 
-function _strftime(t: number, format: string): string {
+export function _strftime(t: number, format: string): string {
   // Python's datetime library augments the microsecond directive %f, which is not
   // supported by the javascript library timezone: http://bigeasy.github.io/timezone/.
   // Use a regular expression to replace %f directive with microseconds.
@@ -26,38 +124,24 @@ function _strftime(t: number, format: string): string {
   const microsecond_replacement_string = sprintf("$1%06d", _us(t))
   format = format.replace(/((^|[^%])(%%)*)%f/, microsecond_replacement_string)
 
+  // timezone seems to ignore any strings without any formatting directives,
+  // and just return the time argument back instead of the string argument.
+  // But we want the string argument, in case a user supplies a format string
+  // which doesn't contain a formatting directive or is only using %f.
   if (format.indexOf("%") == -1) {
-    // timezone seems to ignore any strings without any formatting directives,
-    // and just return the time argument back instead of the string argument.
-    // But we want the string argument, in case a user supplies a format string
-    // which doesn't contain a formatting directive or is only using %f.
     return format
   }
 
   return tz(t, format)
 }
 
-type FormatType = "microseconds" | "milliseconds" | "seconds" | "minsec" | "minutes" | "hourmin" | "hours" | "days" | "months" | "years"
-
-// Labels of time units, from finest to coarsest.
-const format_order: FormatType[] = [
-  "microseconds", "milliseconds", "seconds", "minsec", "minutes", "hourmin", "hours", "days", "months", "years",
-]
-
-// This dictionary maps the name of a time resolution (in @format_order)
-// to its index in a time.localtime() timetuple.  The default is to map
-// everything to index 0, which is year.  This is not ideal; it might cause
-// a problem with the tick at midnight, january 1st, 0 a.d. being incorrectly
-// promoted at certain tick resolutions.
-const time_tuple_ndx_for_resol: Map<FormatType, number> = new Map()
-for (const fmt of format_order) {
-  time_tuple_ndx_for_resol.set(fmt, 0)
+export function _us(t: number): number {
+  // From double-precision unix (millisecond) timestamp, get microseconds since
+  // last second. Precision seems to run out around the hundreds of nanoseconds
+  // scale, so rounding to the nearest microsecond should round to a nice
+  // microsecond / millisecond tick.
+  return Math.round(((t / 1000) % 1) * 1000000)
 }
-time_tuple_ndx_for_resol.set("seconds", 5)
-time_tuple_ndx_for_resol.set("minsec", 4)
-time_tuple_ndx_for_resol.set("minutes", 4)
-time_tuple_ndx_for_resol.set("hourmin", 3)
-time_tuple_ndx_for_resol.set("hours", 3)
 
 export namespace DatetimeTickFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -102,103 +186,19 @@ export class DatetimeTickFormatter extends TickFormatter {
     }))
   }
 
-  protected _get_resolution_str(resolution_secs: number, span_secs: number): FormatType {
-    // Our resolution boundaries should not be round numbers, because we want
-    // them to fall between the possible tick intervals (which *are* round
-    // numbers, as we've worked hard to ensure).  Consequently, we adjust the
-    // resolution upwards a small amount (less than any possible step in
-    // scales) to make the effective boundaries slightly lower.
-    const adjusted_secs = resolution_secs * 1.1
-
-    switch (false) {
-      case !(adjusted_secs < 1e-3):          return "microseconds"
-      case !(adjusted_secs < 1.0):           return "milliseconds"
-      case !(adjusted_secs < 60):            return span_secs >= 60   ? "minsec"  : "seconds"
-      case !(adjusted_secs < 3600):          return span_secs >= 3600 ? "hourmin" : "minutes"
-      case !(adjusted_secs < (24*3600)):     return "hours"
-      case !(adjusted_secs < (31*24*3600)):  return "days"
-      case !(adjusted_secs < (365*24*3600)): return "months"
-      default:                               return "years"
-    }
-  }
-
   doFormat(ticks: number[], _opts: {loc: number}): string[] {
-    // In order to pick the right set of labels, we need to determine
-    // the resolution of the ticks.  We can do this using a ticker if
-    // it's provided, or by computing the resolution from the actual
-    // ticks we've been given.
     if (ticks.length == 0)
       return []
 
-    const labels: string[] = []
-
     const span = Math.abs(ticks[ticks.length-1] - ticks[0])/1000.0
     const r = span / (ticks.length - 1)
-    const resol = this._get_resolution_str(r, span)
-    const resol_ndx = format_order.indexOf(resol)
+    const resolution = _get_resolution(r, span)
 
-    // As we format each tick, check to see if we are at a boundary of the
-    // next higher unit of time.  If so, replace the current format with one
-    // from that resolution.  This is not the best heuristic in the world,
-    // but it works!  There is some trickiness here due to having to deal
-    // with hybrid formats in a reasonable manner.
+    const labels: string[] = []
     for (const t of ticks) {
-      let s, tm
-      try {
-        tm = _array(t)
-        s = _strftime(t, this[resol])
-      } catch (error) {
-        logger.warn(`unable to format tick for timestamp value ${t} - ${error}`)
-        labels.push("ERR")
-        continue
-      }
-
-      let hybrid_handled = false
-      let next_ndx = resol_ndx
-
-      // The way to check that we are at the boundary of the next unit of
-      // time is by checking that we have 0 units of the resolution, i.e.
-      // we are at zero minutes, so display hours, or we are at zero seconds,
-      // so display minutes (and if that is zero as well, then display hours).
-      while (tm[time_tuple_ndx_for_resol.get(format_order[next_ndx])!] == 0) {
-        let next_format: FormatType
-        next_ndx += 1
-
-        if (next_ndx == format_order.length)
-          break
-
-        if ((resol == "minsec" || resol == "hourmin") && !hybrid_handled) {
-          if ((resol == "minsec" && tm[4] == 0 && tm[5] != 0) || (resol == "hourmin" && tm[3] == 0 && tm[4] != 0)) {
-            next_format = format_order[resol_ndx-1]
-            s = _strftime(t, this[next_format])
-            break
-          } else {
-            hybrid_handled = true
-          }
-        }
-
-        next_format = format_order[next_ndx]
-        s = _strftime(t, this[next_format])
-      }
-
-      const final = (() => {
-        if (this.strip_leading_zeros) {
-          const ss = s.replace(/^0+/g, "")
-          if (ss != s && isNaN(parseInt(ss))) {
-            // If the string can now be parsed as starting with an integer, then
-            // leave all zeros stripped, otherwise start with a zero. Hence:
-            // A label such as '000ms' should leave one zero.
-            // A label such as '001ms' or '0-1ms' should not leave a leading zero.
-            return `0${ss}`
-          }
-          return ss
-        }
-        return s
-      })()
-
-      labels.push(final)
+      labels.push(_compute_label(t, resolution, this))
     }
-
     return labels
   }
+
 }

--- a/bokehjs/test/unit/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/datetime_tick_formatter.ts
@@ -1,0 +1,215 @@
+import {expect} from "assertions"
+
+import * as dttf from "@bokehjs/models/formatters/datetime_tick_formatter"
+
+describe("resolution_order", () => {
+  it("should list resolutions in ascending order", () => {
+    const expected: dttf.ResolutionType[] = [
+      "microseconds", "milliseconds", "seconds", "minsec", "minutes", "hourmin", "hours", "days", "months", "years",
+    ]
+    expect(dttf.resolution_order).to.be.equal(expected)
+  })
+})
+
+describe("tm_index_for_resolution", () => {
+  for (const resolution of ["microseconds", "milliseconds", "days", "months", "years"]) {
+    it(`should map ${resolution}`, () => {
+      expect(dttf.tm_index_for_resolution.get("milliseconds")).to.be.equal(0)
+    })
+  }
+  it("should map seconds", () => {
+    expect(dttf.tm_index_for_resolution.get("seconds")).to.be.equal(5)
+  })
+  it("should map minsec", () => {
+    expect(dttf.tm_index_for_resolution.get("minsec")).to.be.equal(4)
+  })
+  it("should map minutes", () => {
+    expect(dttf.tm_index_for_resolution.get("minutes")).to.be.equal(4)
+  })
+  it("should map hourmin", () => {
+    expect(dttf.tm_index_for_resolution.get("hourmin")).to.be.equal(3)
+  })
+  it("should map hours", () => {
+    expect(dttf.tm_index_for_resolution.get("hours")).to.be.equal(3)
+  })
+})
+
+describe("_get_resolution", () => {
+  it("should handle microseconds", () => {
+    const low = 0
+    const high = 0.001 / 1.11
+    expect(dttf._get_resolution(low, 1)).to.be.equal("microseconds")
+    expect(dttf._get_resolution(high, 1)).to.be.equal("microseconds")
+  })
+  it("should handle milliseconds", () => {
+    const low  = 0.001 / 1.09
+    const high  = 1 / 1.11
+    expect(dttf._get_resolution(low, 1)).to.be.equal("milliseconds")
+    expect(dttf._get_resolution(high, 1)).to.be.equal("milliseconds")
+  })
+  it("should handle seconds", () => {
+    const low = 1 / 1.09
+    const high = 60 / 1.11
+    expect(dttf._get_resolution(low, 0)).to.be.equal("seconds")
+    expect(dttf._get_resolution(low, 59)).to.be.equal("seconds")
+    expect(dttf._get_resolution(high, 0)).to.be.equal("seconds")
+    expect(dttf._get_resolution(high, 59)).to.be.equal("seconds")
+  })
+  it("should handle minsec", () => {
+    const low = 1 / 1.09
+    const high = 60 / 1.11
+    expect(dttf._get_resolution(low, 60)).to.be.equal("minsec")
+    expect(dttf._get_resolution(high, 60)).to.be.equal("minsec")
+  })
+  it("should handle minutes", () => {
+    const low = 60 / 1.09
+    const high = 60 * 60 / 1.11
+    expect(dttf._get_resolution(low, 0)).to.be.equal("minutes")
+    expect(dttf._get_resolution(low, 3599)).to.be.equal("minutes")
+    expect(dttf._get_resolution(high, 0)).to.be.equal("minutes")
+    expect(dttf._get_resolution(high, 3599)).to.be.equal("minutes")
+  })
+  it("should handle hourmin", () => {
+    const low = 60 / 1.09
+    const high = 60 * 60 / 1.11
+    expect(dttf._get_resolution(low, 3600)).to.be.equal("hourmin")
+    expect(dttf._get_resolution(high, 3600)).to.be.equal("hourmin")
+  })
+  it("should handle hours", () => {
+    const low = 60 * 60 / 1.09
+    const high = 60 * 60 * 24 / 1.11
+    expect(dttf._get_resolution(low, 1)).to.be.equal("hours")
+    expect(dttf._get_resolution(high, 1)).to.be.equal("hours")
+  })
+  it("should handle days", () => {
+    const low = 60 * 60 * 24 / 1.09
+    const high = 60 * 60 * 24  * 30 / 1.11
+    expect(dttf._get_resolution(low, 1)).to.be.equal("days")
+    expect(dttf._get_resolution(high, 1)).to.be.equal("days")
+  })
+  it("should handle months", () => {
+    const low = 60 * 60 * 24 * 30 / 1.09
+    const high = 60 * 60 * 24 * 365 / 1.11
+    expect(dttf._get_resolution(low, 1)).to.be.equal("months")
+    expect(dttf._get_resolution(high, 1)).to.be.equal("months")
+  })
+  it("should handle years", () => {
+    const low = 60 * 60 * 24 * 365 / 1.09
+    expect(dttf._get_resolution(low, 1)).to.be.equal("years")
+  })
+})
+
+describe("_mktime", () => {
+  it("should return tm struct", () => {
+    const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+    const tm = dttf._mktime(t)
+    expect(tm.length).to.be.equal(6)
+    expect(tm[0]).to.be.equal(2022)
+    expect(tm[1]).to.be.equal(6)
+    expect(tm[2]).to.be.equal(23)
+    expect(tm[3]).to.be.equal(0)
+    expect(tm[4]).to.be.equal(55)
+    expect(tm[5]).to.be.equal(19)
+  })
+})
+
+describe("_strftime", () => {
+  it("should handle no format", () => {
+    const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+    expect(dttf._strftime(t, "foo")).to.be.equal("foo")
+  })
+  it("should handle no microseconds", () => {
+    const t = 123456789.1234
+    expect(dttf._strftime(t, "%f")).to.be.equal("789123")
+  })
+  it("should delegate to tz otherwise", () => {
+    const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+    expect(dttf._strftime(t, "%Y %m %d %H %M %S")).to.be.equal("2022 06 23 00 55 19")
+  })
+})
+
+describe("_us", () => {
+  it("should round microseconds", () => {
+    expect(dttf._us(123456789.1234)).to.be.equal(789123)
+  })
+})
+
+describe("DatetimeTickFormatter", () => {
+  describe("doFormat method", () => {
+    it("should handle empty list", () => {
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([], {loc: 0})
+      expect(labels).to.be.equal([])
+    })
+    it("should handle microseconds", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+0.001, t+0.002], {loc: 0})
+      expect(labels).to.be.equal(["752000us", "752001us", "752002us"])
+    })
+    it("should handle milliseconds", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+1, t+2], {loc: 0})
+      expect(labels).to.be.equal(["752ms", "753ms", "754ms"])
+    })
+    it("should handle seconds", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+1000, t+2000], {loc: 0})
+      expect(labels).to.be.equal(["19s", "20s", "21s"])
+    })
+    it("should handle minsec", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+50000, t+100000], {loc: 0})
+      expect(labels).to.be.equal([":55:19", ":56:09", ":56:59"])
+    })
+    it("should handle minutes", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const MIN = 60 * 1000
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+MIN, t+MIN*2], {loc: 0})
+      expect(labels).to.be.equal([":55", ":56", ":57"])
+    })
+    it("should handle hourmin", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const MIN = 60 * 1000
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+MIN*30, t+MIN*60], {loc: 0})
+      expect(labels).to.be.equal([":55", "1:25", "1:55"])
+    })
+    it("should handle hours", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const HOUR = 3600 * 1000
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      // happens to test near day boundary
+      expect(labels).to.be.equal(["6/23", "1h", "2h"])
+    })
+    it("should handle days", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const DAY = 3600 * 24 * 1000
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+DAY, t+DAY*2], {loc: 0})
+      // happens to test near day boundary
+      expect(labels).to.be.equal(["6/23", "6/24", "6/25"])
+    })
+    it("should handle months", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const MONTH = 3600 * 24 * 30 * 1000
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+MONTH, t+MONTH*2], {loc: 0})
+      // happens to test near day boundary
+      expect(labels).to.be.equal(["6/2022", "7/2022", "8/2022"])
+    })
+    it("should handle years", () => {
+      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+      const YEAR = 3600 * 24 * 365 * 1000
+      const formatter = new dttf.DatetimeTickFormatter()
+      const labels = formatter.doFormat([t, t+YEAR, t+YEAR*2], {loc: 0})
+      // happens to test near day boundary
+      expect(labels).to.be.equal(["2022", "2023", "2024"])
+    })
+  })
+})

--- a/examples/models/file/daylight.py
+++ b/examples/models/file/daylight.py
@@ -90,7 +90,7 @@ xaxis = DatetimeAxis(formatter=xformatter, ticker=xticker)
 plot.add_layout(xaxis, 'below')
 
 yaxis = DatetimeAxis()
-yaxis.formatter.hours = ['%H:%M']
+yaxis.formatter.hours = '%H:%M'
 plot.add_layout(yaxis, 'left')
 
 legend = Legend(items=[

--- a/sphinx/source/docs/user_guide/examples/categorical_scatter_jitter.py
+++ b/sphinx/source/docs/user_guide/examples/categorical_scatter_jitter.py
@@ -16,7 +16,7 @@ p = figure(height=300, y_range=DAYS, x_axis_type='datetime',
 
 p.circle(x='time', y=jitter('day', width=0.6, range=p.y_range),  source=source, alpha=0.3)
 
-p.xaxis[0].formatter.days = ['%Hh']
+p.xaxis[0].formatter.days = '%Hh'
 p.x_range.range_padding = 0
 p.ygrid.grid_line_color = None
 


### PR DESCRIPTION
- [x] issues: fixes #11347
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

Incredibly, no tests were disturbed the these changes 😲 

This PR also exposes `strip_leading_zeros` as a public property.

I do intend one more commit to add tests, at least for the new deprecation codepath, but hopefully some long overdue unit tests of the implementation itself. 

CC @bokeh/dev it would probably be reasonable to review the default formats at this time. FWIW, looking over the old code, when there was a list of formats, the one that resulted in the shortest formatted tick was always chosen. 