### PR TITLE
Toggle opacity not visibility of descriptions

### DIFF
--- a/bokehjs/src/less/widgets/inputs.less
+++ b/bokehjs/src/less/widgets/inputs.less
@@ -152,13 +152,13 @@ select[multiple], select[size], textarea {
   cursor: pointer;
 
   &> .bk-icon {
-    visibility: hidden;
+    opacity: 0.5;
     width: 18px;
     height: 18px;
     .icon-mask(var(--bokeh-icon-help2), gray);
   }
 }
 
-label:hover > .bk-description > .bk-icon {
-  visibility: visible;
+label:hover > .bk-description > .bk-icon, .bk-icon.bk-opaque {
+  opacity: 1.0;
 }

--- a/bokehjs/src/lib/models/widgets/input_widget.ts
+++ b/bokehjs/src/lib/models/widgets/input_widget.ts
@@ -78,7 +78,7 @@ export abstract class InputWidgetView extends ControlView {
             visible,
             closable: persistent,
           })
-          icon_el.style.visibility = visible && persistent ? "visible" : ""
+          icon_el.classList.toggle(inputs.opaque, visible && persistent)
         }
 
         this.on_change(description.model.properties.visible, () => {


### PR DESCRIPTION
A follow up after PR #12154. In this PR, instead of toggling visibility of description icon, opacity is changed instead. Here's the default look:

![image](https://user-images.githubusercontent.com/27475/174976529-07ffa61c-7f7d-4549-a16f-a9c1e29809ee.png)

The opacity changes to full when hovered or clicked.

This is technically configurable on CSS level. It could be made configurable through a property if needed so.