### PR TITLE
use correct zoom scale factors

### DIFF
--- a/bokehjs/src/lib/core/util/zoom.ts
+++ b/bokehjs/src/lib/core/util/zoom.ts
@@ -1,5 +1,4 @@
 import {Interval} from "../types"
-import {clamp} from "./math"
 
 import {CartesianFrame} from "models/canvas/cartesian_frame"
 import {Scale} from "models/scales/scale"
@@ -48,9 +47,6 @@ export function scale_range(frame: CartesianFrame, factor: number,
    * Returns:
    *   ScaleRange
    */
-
-  // clamp the  magnitude of factor, if it is > 1 bad things happen
-  factor = clamp(factor, -0.9, 0.9)
 
   const hfactor = h_axis ? factor : 0
   const [sx0, sx1] = scale_highlow(frame.bbox.h_range, hfactor, center != null ? center.x : undefined)

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -14,7 +14,9 @@ export abstract class ZoomBaseToolView extends ActionToolView {
     const h_axis = dims == "width"  || dims == "both"
     const v_axis = dims == "height" || dims == "both"
 
-    const zoom_info = scale_range(frame, this.model.sign*this.model.factor, h_axis, v_axis)
+    const factor = this.model.get_factor()
+
+    const zoom_info = scale_range(frame, factor, h_axis, v_axis)
 
     this.plot_view.state.push("zoom_out", {range: zoom_info})
     this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus: this.model.maintain_focus})
@@ -51,11 +53,11 @@ export abstract class ZoomBaseTool extends ActionTool {
     }))
   }
 
-  readonly sign: -1 | 1
-
   override get tooltip(): string {
     return this._get_dim_tooltip(this.dimensions)
   }
 
   abstract readonly maintain_focus: boolean
+
+  abstract get_factor(): number
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -25,7 +25,10 @@ export class ZoomInTool extends ZoomBaseTool {
     this.register_alias("yzoom_in", () => new ZoomInTool({dimensions: "height"}))
   }
 
-  override sign = 1 as 1
+  get_factor(): number {
+    return this.factor
+  }
+
   override tool_name = "Zoom In"
   override tool_icon = tool_icon_zoom_in
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -38,7 +38,10 @@ export class ZoomOutTool extends ZoomBaseTool {
     this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: "height"}))
   }
 
-  override sign = -1 as -1
+  get_factor(): number {
+    return -this.factor / (1 - this.factor)
+  }
+
   override tool_name = "Zoom Out"
   override tool_icon = tool_icon_zoom_out
 }

--- a/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
@@ -34,6 +34,7 @@ describe("ZoomInTool", () => {
   })
 
   describe("View", () => {
+    // range values chosen to complement zoom_out test as inverse
     async function mkplot(tool: Tool): Promise<PlotView> {
       const plot = new Plot({
         x_range: new Range1d({start: -1, end: 1}),
@@ -55,10 +56,10 @@ describe("ZoomInTool", () => {
       zoom_in_tool_view.doit()
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.equal([-0.9, 0.9])
+      expect([hr.start, hr.end]).to.be.similar([-0.9, 0.9])
 
       const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.equal([-0.9, 0.9])
+      expect([vr.start, vr.end]).to.be.similar([-0.9, 0.9])
     })
 
     it("should zoom the x-axis only", async () => {
@@ -71,10 +72,10 @@ describe("ZoomInTool", () => {
       zoom_in_tool_view.doit()
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.equal([-0.9, 0.9])
+      expect([hr.start, hr.end]).to.be.similar([-0.9, 0.9])
 
       const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.equal([-1.0, 1.0])
+      expect([vr.start, vr.end]).to.be.similar([-1.0, 1.0])
     })
 
     it("should zoom the y-axis only", async () => {
@@ -87,10 +88,10 @@ describe("ZoomInTool", () => {
       zoom_in_tool_view.doit()
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.equal([-1.0, 1.0])
+      expect([hr.start, hr.end]).to.be.similar([-1.0, 1.0])
 
       const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.equal([-0.9, 0.9])
+      expect([vr.start, vr.end]).to.be.similar([-0.9, 0.9])
     })
   })
 })

--- a/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
@@ -34,10 +34,11 @@ describe("ZoomOutTool", () => {
   })
 
   describe("View", () => {
+    // range values chosen to complement zoom_in test as inverse
     async function mkplot(tool: Tool): Promise<PlotView> {
       const plot = new Plot({
-        x_range: new Range1d({start: -1, end: 1}),
-        y_range: new Range1d({start: -1, end: 1}),
+        x_range: new Range1d({start: -0.9, end: 0.9}),
+        y_range: new Range1d({start: -0.9, end: 0.9}),
       })
       plot.add_tools(tool)
       const document = new Document()
@@ -55,10 +56,10 @@ describe("ZoomOutTool", () => {
       zoom_out_tool_view.doit()
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.equal([-1.1, 1.1])
+      expect([hr.start, hr.end]).to.be.similar([-1, 1])
 
       const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.equal([-1.1, 1.1])
+      expect([vr.start, vr.end]).to.be.similar([-1, 1])
     })
 
     it("should zoom the x-axis only", async () => {
@@ -71,10 +72,10 @@ describe("ZoomOutTool", () => {
       zoom_out_tool_view.doit()
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.equal([-1.1, 1.1])
+      expect([hr.start, hr.end]).to.be.similar([-1.0, 1.0])
 
       const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.equal([-1.0, 1.0])
+      expect([vr.start, vr.end]).to.be.similar([-0.9, 0.9])
     })
 
     it("should zoom the y-axis only", async () => {
@@ -87,10 +88,10 @@ describe("ZoomOutTool", () => {
       zoom_out_tool_view.doit()
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.equal([-1.0, 1.0])
+      expect([hr.start, hr.end]).to.be.similar([-0.9, 0.9])
 
       const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.equal([-1.1, 1.1])
+      expect([vr.start, vr.end]).to.be.similar([-1.0, 1.0])
     })
   })
 })


### PR DESCRIPTION
- [x] issues: fixes #11838
- [x] tests added / passed

Proper inverse factors for the way we compute things (about a center):

```python
# zoom in, factor = 0.1
# low = 0 - (0 - 10) * 0.1 = 1
# hi = 20 - (20 - 10) * 0.1 = 19

# zoom out, factor = 0.1
# low = 1 - (1 - 10) * -0.1/(1-0.1) = 0
# hi = 19 - (19 - 10) * -0.1/(1-0.1) = 20
```

I have updated the zoom-in and zoom-out tests to mirror each other as inverses.
