### PR TITLE
Remove id attribute of bk-root after plotting

### DIFF
--- a/bokehjs/src/lib/embed/notebook.ts
+++ b/bokehjs/src/lib/embed/notebook.ts
@@ -88,6 +88,6 @@ export function embed_items_notebook(docs_json: DocsJson, render_items: RenderIt
     const roots = _resolve_root_elements(item)
 
     add_document_standalone(document, element, roots)
-    roots[0].removeAttribute('id')
+    roots[0].removeAttribute("id")
   }
 }

--- a/bokehjs/src/lib/embed/notebook.ts
+++ b/bokehjs/src/lib/embed/notebook.ts
@@ -88,5 +88,6 @@ export function embed_items_notebook(docs_json: DocsJson, render_items: RenderIt
     const roots = _resolve_root_elements(item)
 
     add_document_standalone(document, element, roots)
+    roots[0].removeAttribute('id')
   }
 }


### PR DESCRIPTION
A workaround that addresses a bug "Problem copying a plot from one jupyter cell to another" from this discussion:
https://github.com/bokeh/bokeh/discussions/12195