### PR TITLE
Add context formatter for datetime axes

### DIFF
--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -97,6 +97,7 @@ __all__ = (
     'AutosizeMode',
     'ButtonType',
     'CalendarPosition',
+    'ContextWhich',
     'DashPattern',
     'DateFormat',
     'DatetimeUnits',
@@ -272,6 +273,9 @@ ButtonType = enumeration("default", "primary", "success", "warning", "danger", "
 
 #: Specify a position for the DatePicker calendar to display
 CalendarPosition = enumeration("auto", "above", "below")
+
+#: Specify which tick to add additional context to
+ContextWhich = enumeration("start", "center", "end", "all")
 
 #: Specify a named dashing patter for stroking lines
 DashPattern = enumeration("solid", "dashed", "dotted", "dotdash", "dashdot")

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -25,7 +25,13 @@ log = logging.getLogger(__name__)
 import warnings
 
 # Bokeh imports
-from ..core.enums import LatLon, NumeralLanguage, RoundingFunction
+from ..core.enums import (
+    ContextWhich,
+    LatLon,
+    LocationType,
+    NumeralLanguage,
+    RoundingFunction,
+)
 from ..core.has_props import abstract
 from ..core.properties import (
     AnyRef,
@@ -52,15 +58,16 @@ from .tickers import Ticker
 #-----------------------------------------------------------------------------
 
 __all__ = (
-    'TickFormatter',
-    'BasicTickFormatter',
-    'MercatorTickFormatter',
-    'NumeralTickFormatter',
-    'PrintfTickFormatter',
-    'LogTickFormatter',
-    'CategoricalTickFormatter',
-    'CustomJSTickFormatter',
-    'DatetimeTickFormatter',
+    "BASIC_DATETIME_CONTEXT",
+    "BasicTickFormatter",
+    "CategoricalTickFormatter",
+    "CustomJSTickFormatter",
+    "DatetimeTickFormatter",
+    "LogTickFormatter",
+    "MercatorTickFormatter",
+    "NumeralTickFormatter",
+    "PrintfTickFormatter",
+    "TickFormatter",
 )
 
 #-----------------------------------------------------------------------------
@@ -431,8 +438,8 @@ class DatetimeTickFormatter(TickFormatter):
         The day of the month as a decimal number (range 01 to 31).
 
     %D
-        Equivalent to %m/%d/%y.  (Americans should note that in many
-        other countries %d/%m/%y is rather common. This means that in
+        Equivalent to **%m/%d/%y**.  (Americans should note that in many
+        other countries **%d/%m/%y** is rather common. This means that in
         international context this format is ambiguous and should not
         be used.)
 
@@ -446,7 +453,7 @@ class DatetimeTickFormatter(TickFormatter):
         available to `timezone`_.
 
     %F
-        Equivalent to %Y-%m-%d (the ISO 8601 date format).
+        Equivalent to **%Y-%m-%d** (the ISO 8601 date format).
 
     %G
         The ISO 8601 week-based year with century as a decimal number.
@@ -456,10 +463,10 @@ class DatetimeTickFormatter(TickFormatter):
         is used instead.
 
     %g
-        Like %G, but without century, that is, with a 2-digit year (00-99).
+        Like **%G**, but without century, that is, with a 2-digit year (00-99).
 
     %h
-        Equivalent to %b.
+        Equivalent to **%b**.
 
     %H
         The hour as a decimal number using a 24-hour clock (range 00
@@ -474,11 +481,11 @@ class DatetimeTickFormatter(TickFormatter):
 
     %k
         The hour (24-hour clock) as a decimal number (range 0 to 23).
-        Single digits are preceded by a blank.  (See also %H.)
+        Single digits are preceded by a blank. See also **%H**.
 
     %l
         The hour (12-hour clock) as a decimal number (range 1 to 12).
-        Single digits are preceded by a blank.  (See also %I.)  (TZ)
+        Single digits are preceded by a blank. See also **%I**.
 
     %m
         The month as a decimal number (range 01 to 12).
@@ -508,11 +515,11 @@ class DatetimeTickFormatter(TickFormatter):
 
     %r
         The time in a.m. or p.m. notation.  In the POSIX locale this
-        is equivalent to %I:%M:%S %p.
+        is equivalent to **%I:%M:%S %p**.
 
     %R
-        The time in 24-hour notation (%H:%M). For a version including
-        the seconds, see %T below.
+        The time in 24-hour notation (**%H:%M**). For a version including
+        the seconds, see **%T** below.
 
     %s
         The number of seconds since the Epoch, 1970-01-01 00:00:00
@@ -527,7 +534,7 @@ class DatetimeTickFormatter(TickFormatter):
         characters.
 
     %T
-        The time in 24-hour notation (%H:%M:%S).
+        The time in 24-hour notation (**%H:%M:%S**).
 
     %u
         The day of the week as a decimal, range 1 to 7, Monday being 1.
@@ -536,7 +543,7 @@ class DatetimeTickFormatter(TickFormatter):
     %U
         The week number of the current year as a decimal number, range
         00 to 53, starting with the first Sunday as the first day of
-        week 01.  See also %V and %W.
+        week 01.  See also **%V** and **%W**.
 
     %V
         The ISO 8601 week number (see NOTES) of the current year as a
@@ -596,36 +603,63 @@ class DatetimeTickFormatter(TickFormatter):
         super().__init__(*args, **kwargs)
 
     microseconds = String(help=_DATETIME_TICK_FORMATTER_HELP("``microseconds``"),
-                        default="%fus").accepts(List(String), _deprecated_datetime_list_format)
+                          default="%fus").accepts(List(String), _deprecated_datetime_list_format)
 
     milliseconds = String(help=_DATETIME_TICK_FORMATTER_HELP("``milliseconds``"),
-                        default="%3Nms").accepts(List(String), _deprecated_datetime_list_format)
+                          default="%3Nms").accepts(List(String), _deprecated_datetime_list_format)
 
-    seconds      = String(help=_DATETIME_TICK_FORMATTER_HELP("``seconds``"),
-                        default="%Ss").accepts(List(String), _deprecated_datetime_list_format)
+    seconds = String(help=_DATETIME_TICK_FORMATTER_HELP("``seconds``"),
+                     default="%Ss").accepts(List(String), _deprecated_datetime_list_format)
 
-    minsec       = String(help=_DATETIME_TICK_FORMATTER_HELP("``minsec`` (for combined minutes and seconds)"),
-                        default=":%M:%S").accepts(List(String), _deprecated_datetime_list_format)
+    minsec = String(help=_DATETIME_TICK_FORMATTER_HELP("``minsec`` (for combined minutes and seconds)"),
+                    default=":%M:%S").accepts(List(String), _deprecated_datetime_list_format)
 
-    minutes      = String(help=_DATETIME_TICK_FORMATTER_HELP("``minutes``"),
-                        default=":%M").accepts(List(String), _deprecated_datetime_list_format)
+    minutes = String(help=_DATETIME_TICK_FORMATTER_HELP("``minutes``"),
+                     default=":%M").accepts(List(String), _deprecated_datetime_list_format)
 
-    hourmin      = String(help=_DATETIME_TICK_FORMATTER_HELP("``hourmin`` (for combined hours and minutes)"),
-                        default="%H:%M").accepts(List(String), _deprecated_datetime_list_format)
+    hourmin = String(help=_DATETIME_TICK_FORMATTER_HELP("``hourmin`` (for combined hours and minutes)"),
+                     default="%H:%M").accepts(List(String), _deprecated_datetime_list_format)
 
-    hours        = String(help=_DATETIME_TICK_FORMATTER_HELP("``hours``"),
-                        default="%Hh").accepts(List(String), _deprecated_datetime_list_format)
+    hours = String(help=_DATETIME_TICK_FORMATTER_HELP("``hours``"),
+                   default="%I %p").accepts(List(String), _deprecated_datetime_list_format)
 
-    days         = String(help=_DATETIME_TICK_FORMATTER_HELP("``days``"),
-                        default="%m/%d").accepts(List(String), _deprecated_datetime_list_format)
+    days = String(help=_DATETIME_TICK_FORMATTER_HELP("``days``"),
+                  default="%m/%d").accepts(List(String), _deprecated_datetime_list_format)
 
-    months       = String(help=_DATETIME_TICK_FORMATTER_HELP("``months``"),
-                        default="%m/%Y").accepts(List(String), _deprecated_datetime_list_format)
+    months = String(help=_DATETIME_TICK_FORMATTER_HELP("``months``"),
+                    default="%m/%Y").accepts(List(String), _deprecated_datetime_list_format)
 
-    years        = String(help=_DATETIME_TICK_FORMATTER_HELP("``years``"),
-                        default="%Y").accepts(List(String), _deprecated_datetime_list_format)
+    years = String(help=_DATETIME_TICK_FORMATTER_HELP("``years``"),
+                   default="%Y").accepts(List(String), _deprecated_datetime_list_format)
 
     strip_leading_zeros = Bool(default=True, help="Whether to strip any leading zeros in the formatted ticks")
+
+    context = Nullable(Either(String, Instance("bokeh.models.formatters.DatetimeTickFormatter")), default=None, help="""
+    A format for adding context to the tick or ticks specified by ``context_which``.
+    """)
+
+    context_which = Enum(ContextWhich, default="start", help="""
+    Which tick or ticks to add a formatted context string to.
+    """)
+
+    context_location = Enum(LocationType, default="below", help="""
+    Relative to the tick label text baseline, where the context should be
+    rendered.
+    """)
+
+def BASIC_DATETIME_CONTEXT() -> DatetimeTickFormatter:
+    return DatetimeTickFormatter(
+        microseconds = "%T",
+        milliseconds = "%T",
+        seconds = "%H:%M",
+        minsec = "%I %p",
+        minutes = "%I %p",
+        hourmin = "%F",
+        hours = "%F",
+        days = "%Y",
+        months = "",
+        years = "",
+    )
 
 #-----------------------------------------------------------------------------
 # Dev API
@@ -636,10 +670,10 @@ class DatetimeTickFormatter(TickFormatter):
 #-----------------------------------------------------------------------------
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
-_df = DatetimeTickFormatter()
-_df_fields = ['microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 'hourmin', 'hours', 'days', 'months', 'years']
-_df_defaults = _df.properties_with_values()
-_df_defaults_string = "\n\n        ".join("%s = %s" % (name, _df_defaults[name]) for name in _df_fields)
+_dttf = DatetimeTickFormatter()
+_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 'hourmin', 'hours', 'days', 'months', 'years')
+_dttf_defaults = _dttf.properties_with_values()
+_dttf_defaults_string = "\n\n        ".join(f"{name} = {_dttf_defaults[name]!r}" for name in _dttf_fields)
 
-DatetimeTickFormatter.__doc__ = format_docstring(DatetimeTickFormatter.__doc__, defaults=_df_defaults_string)
-del _df, _df_fields, _df_defaults, _df_defaults_string
+DatetimeTickFormatter.__doc__ = format_docstring(DatetimeTickFormatter.__doc__, defaults=_dttf_defaults_string)
+del _dttf, _dttf_fields, _dttf_defaults, _dttf_defaults_string

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -636,23 +636,23 @@ class DatetimeTickFormatter(TickFormatter):
 
     context = Nullable(Either(String, Instance("bokeh.models.formatters.DatetimeTickFormatter")), default=None, help="""
     A format for adding context to the tick or ticks specified by ``context_which``.
-    Valid vlues are:
+    Valid values are:
 
     * None, no context is added
-    * A standard ``DatetimeTickFormatter`` format string, the single format is
+    * A standard :class:`~bokeh.models.DatetimeTickFormatter` format string, the single format is
       used across all scales
-    * Another ``DatetimeTickFormetter`` instance, to have scale-dependent
+    * Another :class:`~bokeh.models.DatetimeTickFormatter` instance, to have scale-dependent
       context
     """)
 
     context_which = Enum(ContextWhich, default="start", help="""
     Which tick or ticks to add a formatted context string to. Valid values are:
-    "start", "end", "center", and  "all".
+    `"start"`, `"end"`, `"center"`, and  `"all"`.
     """)
 
     context_location = Enum(LocationType, default="below", help="""
     Relative to the tick label text baseline, where the context should be
-    rendered. Valid values are: "below", "above", "left", and "right".
+    rendered. Valid values are: `"below"`, `"above"`, `"left"`, and `"right"`.
     """)
 
 def RELATIVE_DATETIME_CONTEXT() -> DatetimeTickFormatter:

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -621,7 +621,7 @@ class DatetimeTickFormatter(TickFormatter):
                      default="%H:%M").accepts(List(String), _deprecated_datetime_list_format)
 
     hours = String(help=_DATETIME_TICK_FORMATTER_HELP("``hours``"),
-                   default="%I %p").accepts(List(String), _deprecated_datetime_list_format)
+                   default="%Hh").accepts(List(String), _deprecated_datetime_list_format)
 
     days = String(help=_DATETIME_TICK_FORMATTER_HELP("``days``"),
                   default="%m/%d").accepts(List(String), _deprecated_datetime_list_format)
@@ -652,8 +652,8 @@ def RELATIVE_DATETIME_CONTEXT() -> DatetimeTickFormatter:
         microseconds = "%T",
         milliseconds = "%T",
         seconds = "%H:%M",
-        minsec = "%I %p",
-        minutes = "%I %p",
+        minsec = "%Hh",
+        minutes = "%Hh",
         hourmin = "%F",
         hours = "%F",
         days = "%Y",

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -58,7 +58,7 @@ from .tickers import Ticker
 #-----------------------------------------------------------------------------
 
 __all__ = (
-    "BASIC_DATETIME_CONTEXT",
+    "RELATIVE_DATETIME_CONTEXT",
     "BasicTickFormatter",
     "CategoricalTickFormatter",
     "CustomJSTickFormatter",
@@ -647,7 +647,7 @@ class DatetimeTickFormatter(TickFormatter):
     rendered.
     """)
 
-def BASIC_DATETIME_CONTEXT() -> DatetimeTickFormatter:
+def RELATIVE_DATETIME_CONTEXT() -> DatetimeTickFormatter:
     return DatetimeTickFormatter(
         microseconds = "%T",
         milliseconds = "%T",

--- a/bokeh/models/formatters.py
+++ b/bokeh/models/formatters.py
@@ -636,15 +636,23 @@ class DatetimeTickFormatter(TickFormatter):
 
     context = Nullable(Either(String, Instance("bokeh.models.formatters.DatetimeTickFormatter")), default=None, help="""
     A format for adding context to the tick or ticks specified by ``context_which``.
+    Valid vlues are:
+
+    * None, no context is added
+    * A standard ``DatetimeTickFormatter`` format string, the single format is
+      used across all scales
+    * Another ``DatetimeTickFormetter`` instance, to have scale-dependent
+      context
     """)
 
     context_which = Enum(ContextWhich, default="start", help="""
-    Which tick or ticks to add a formatted context string to.
+    Which tick or ticks to add a formatted context string to. Valid values are:
+    "start", "end", "center", and  "all".
     """)
 
     context_location = Enum(LocationType, default="below", help="""
     Relative to the tick label text baseline, where the context should be
-    rendered.
+    rendered. Valid values are: "below", "above", "left", and "right".
     """)
 
 def RELATIVE_DATETIME_CONTEXT() -> DatetimeTickFormatter:

--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -29,6 +29,9 @@ export const ButtonType = Enum("default", "primary", "success", "warning", "dang
 export type CalendarPosition = "auto" | "above" | "below"
 export const CalendarPosition = Enum("auto", "above", "below")
 
+export type ContextWhich = "start" | "center" | "end" | "all"
+export const ContextWhich = Enum("start", "center", "end", "all")
+
 export type Dimension = "width" | "height"
 export const Dimension = Enum("width", "height")
 

--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -83,11 +83,11 @@ export const LegendLocation = Anchor
 export type LineCap = "butt" | "round" | "square"
 export const LineCap = Enum("butt", "round", "square")
 
-export type LineJoin = "miter" | "round" | "bevel"
-export const LineJoin = Enum("miter", "round", "bevel")
-
 export type LineDash = "solid" | "dashed" | "dotted" | "dotdash" | "dashdot"
 export const LineDash = Enum("solid", "dashed", "dotted", "dotdash", "dashdot")
+
+export type LineJoin = "miter" | "round" | "bevel"
+export const LineJoin = Enum("miter", "round", "bevel")
 
 export type LinePolicy = "prev" | "next" | "nearest" | "interp" | "none"
 export const LinePolicy = Enum("prev", "next", "nearest", "interp", "none")

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -131,7 +131,7 @@ export class DatetimeTickFormatter extends TickFormatter {
       minsec: [ String, ":%M:%S" ],
       minutes: [ String, ":%M" ],
       hourmin: [ String, "%H:%M" ],
-      hours: [ String, "%I %p" ],
+      hours: [ String, "%Hh" ],
       days: [ String, "%m/%d" ],
       months: [ String, "%m/%Y" ],
       years: [ String, "%Y" ],

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -1,5 +1,8 @@
+import {ContextWhich, Location} from "core/enums"
 import * as p from "core/properties"
+import {enumerate} from "core/util/iterator"
 import {sprintf} from "core/util/templating"
+import {isString, is_undefined} from "core/util/types"
 import {TickFormatter} from "models/formatters/tick_formatter"
 import {ONE_DAY, ONE_HOUR, ONE_MILLI, ONE_MINUTE, ONE_MONTH, ONE_SECOND, ONE_YEAR} from "models/tickers/util"
 import tz from "timezone"
@@ -25,59 +28,6 @@ tm_index_for_resolution.set("minsec", 4)
 tm_index_for_resolution.set("minutes", 4)
 tm_index_for_resolution.set("hourmin", 3)
 tm_index_for_resolution.set("hours", 3)
-
-export function _compute_label(t: number, resolution: ResolutionType,  model: DatetimeTickFormatter): string {
-  const s0 = _strftime(t, model[resolution])
-  const tm = _mktime(t)
-  const resolution_index = resolution_order.indexOf(resolution)
-
-  let s = s0
-  let hybrid_handled = false
-  let next_index = resolution_index
-  let next_resolution: ResolutionType
-
-  // As we format each tick, check to see if we are at a boundary of the
-  // next higher unit of time.  If so, replace the current format with one
-  // from that resolution.  This is not the best heuristic in the world,
-  // but it works!  There is some trickiness here due to having to deal
-  // with hybrid formats in a reasonable manner.
-  while (tm[tm_index_for_resolution.get(resolution_order[next_index])!] == 0) {
-    next_index += 1
-
-    if (next_index == resolution_order.length)
-      break
-
-    // The way to check that we are at the boundary of the next unit of
-    // time is by checking that we have 0 units of the resolution, i.e.
-    // we are at zero minutes, so display hours, or we are at zero seconds,
-    // so display minutes (and if that is zero as well, then display hours).
-    if ((resolution == "minsec" || resolution == "hourmin") && !hybrid_handled) {
-      if ((resolution == "minsec" && tm[4] == 0 && tm[5] != 0) || (resolution == "hourmin" && tm[3] == 0 && tm[4] != 0)) {
-        next_resolution = resolution_order[resolution_index-1]
-        s = _strftime(t, model[next_resolution])
-        break
-      } else {
-        hybrid_handled = true
-      }
-    }
-
-    next_resolution = resolution_order[next_index]
-    s = _strftime(t, model[next_resolution])
-  }
-
-  if (model.strip_leading_zeros) {
-    const ss = s.replace(/^0+/g, "")
-    if (ss != s && isNaN(parseInt(ss))) {
-      // If the string can now be parsed as starting with an integer, then
-      // leave all zeros stripped, otherwise start with a zero. Hence:
-      // A label such as '000ms' should leave one zero.
-      // A label such as '001ms' or '0-1ms' should not leave a leading zero.
-      return `0${ss}`
-    }
-    return ss
-  }
-  return s
-}
 
 export function _get_resolution(resolution_secs: number, span_secs: number): ResolutionType {
   // Our resolution boundaries should not be round numbers, because we want
@@ -158,6 +108,9 @@ export namespace DatetimeTickFormatter {
     months: p.Property<string>
     years: p.Property<string>
     strip_leading_zeros: p.Property<boolean>
+    context: p.Property<string | DatetimeTickFormatter | null>
+    context_which: p.Property<ContextWhich>
+    context_location: p.Property<Location>
   }
 }
 
@@ -171,34 +124,118 @@ export class DatetimeTickFormatter extends TickFormatter {
   }
 
   static {
-    this.define<DatetimeTickFormatter.Props>(({Boolean, String}) => ({
+    this.define<DatetimeTickFormatter.Props>(({Boolean, Nullable, Or, Ref, String}) => ({
       microseconds: [ String, "%fus" ],
       milliseconds: [ String, "%3Nms" ],
       seconds: [ String, "%Ss" ],
       minsec: [ String, ":%M:%S" ],
       minutes: [ String, ":%M" ],
       hourmin: [ String, "%H:%M" ],
-      hours: [ String, "%Hh" ],
+      hours: [ String, "%I %p" ],
       days: [ String, "%m/%d" ],
       months: [ String, "%m/%Y" ],
       years: [ String, "%Y" ],
       strip_leading_zeros: [ Boolean, true ],
+      context: [ Nullable(Or(String, Ref(DatetimeTickFormatter))), null ],
+      context_which: [ ContextWhich, "start" ],
+      context_location: [ Location, "below" ],
     }))
   }
 
-  doFormat(ticks: number[], _opts: {loc: number}): string[] {
+  doFormat(ticks: number[], _opts: {loc: number}, _resolution?: ResolutionType): string[] {
     if (ticks.length == 0)
       return []
 
     const span = Math.abs(ticks[ticks.length-1] - ticks[0])/1000.0
     const r = span / (ticks.length - 1)
-    const resolution = _get_resolution(r, span)
+    const resolution = is_undefined(_resolution) ? _get_resolution(r, span) : _resolution
 
     const labels: string[] = []
-    for (const t of ticks) {
-      labels.push(_compute_label(t, resolution, this))
+    for (const [tick, i] of enumerate(ticks)) {
+      const base_label = this._compute_label(tick, resolution)
+      const full_label = this._add_context(tick, base_label, i, ticks.length, resolution)
+      labels.push(full_label)
     }
     return labels
+  }
+
+  _compute_label(t: number, resolution: ResolutionType): string {
+    const s0 = _strftime(t, this[resolution])
+    const tm = _mktime(t)
+    const resolution_index = resolution_order.indexOf(resolution)
+
+    let s = s0
+    let hybrid_handled = false
+    let next_index = resolution_index
+    let next_resolution: ResolutionType
+
+    // As we format each tick, check to see if we are at a boundary of the
+    // next higher unit of time. If so, replace the current format with one
+    // from that resolution. This is not the best heuristic but it works.
+    while (tm[tm_index_for_resolution.get(resolution_order[next_index])!] == 0) {
+      next_index += 1
+
+      if (next_index == resolution_order.length)
+        break
+
+      // The way to check that we are at the boundary of the next unit of
+      // time is by checking that we have 0 units of the resolution, i.e.
+      // we are at zero minutes, so display hours, or we are at zero seconds,
+      // so display minutes (and if that is zero as well, then display hours).
+      if ((resolution == "minsec" || resolution == "hourmin") && !hybrid_handled) {
+        if ((resolution == "minsec" && tm[4] == 0 && tm[5] != 0) || (resolution == "hourmin" && tm[3] == 0 && tm[4] != 0)) {
+          next_resolution = resolution_order[resolution_index-1]
+          s = _strftime(t, this[next_resolution])
+          break
+        } else {
+          hybrid_handled = true
+        }
+      }
+
+      next_resolution = resolution_order[next_index]
+      s = _strftime(t, this[next_resolution])
+    }
+
+    if (this.strip_leading_zeros) {
+      const ss = s.replace(/^0+/g, "")
+      if (ss != s && isNaN(parseInt(ss))) {
+        // If the string can now be parsed as starting with an integer, then
+        // leave all zeros stripped, otherwise start with a zero.
+        return `0${ss}`
+      }
+      return ss
+    }
+    return s
+  }
+
+  _add_context(tick: number, label: string, i: number, N: number, resolution: ResolutionType): string {
+    const loc = this.context_location
+    const which = this.context_which
+
+    if (this.context == null)
+      return label
+
+    if ((which == "start" && i == 0) ||
+        (which == "end" && i == N-1) ||
+        (which == "center" && i == Math.floor(N/2)) ||
+        (which == "all")) {
+
+      const context = isString(this.context) ?
+        _strftime(tick, this.context) : this.context.doFormat([tick], {loc: 0}, resolution)
+
+      if (context == "")
+        return label
+
+      if (loc == "above")
+        return `${context}\n${label}`
+      if (loc == "below")
+        return `${label}\n${context}`
+      if (loc == "left")
+        return `${context} ${label}`
+      if (loc == "right")
+        return `${label} ${context}`
+    }
+    return label
   }
 
 }

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -221,7 +221,7 @@ export class DatetimeTickFormatter extends TickFormatter {
         (which == "all")) {
 
       const context = isString(this.context) ?
-        _strftime(tick, this.context) : this.context.doFormat([tick], {loc: 0}, resolution)
+        _strftime(tick, this.context) : this.context.doFormat([tick], {loc: 0}, resolution)[0]
 
       if (context == "")
         return label

--- a/bokehjs/test/unit/core/enums.ts
+++ b/bokehjs/test/unit/core/enums.ts
@@ -4,6 +4,18 @@ import * as enums from "@bokehjs/core/enums"
 
 describe("enums module", () => {
 
+  it("should have Align", () => {
+    expect([...enums.Align]).to.be.equal(["start", "center", "end"])
+  })
+
+  it("should have HAlign", () => {
+    expect([...enums.HAlign]).to.be.equal(["left", "center", "right"])
+  })
+
+  it("should have VAlign", () => {
+    expect([...enums.VAlign]).to.be.equal(["top", "center", "bottom"])
+  })
+
   it("should have Anchor", () => {
     expect([...enums.Anchor]).to.be.equal([
       "top_left",    "top_center",    "top_right",
@@ -23,6 +35,14 @@ describe("enums module", () => {
 
   it("should have ButtonType", () => {
     expect([...enums.ButtonType]).to.be.equal(["default", "primary", "success", "warning", "danger", "light"])
+  })
+
+  it("should have CalendarPosition", () => {
+    expect([...enums.CalendarPosition]).to.be.equal(["auto", "above", "below"])
+  })
+
+  it("should have ContextWhich", () => {
+    expect([...enums.ContextWhich]).to.be.equal(["start", "center", "end", "all"])
   })
 
   it("should have Dimension", () => {
@@ -66,6 +86,10 @@ describe("enums module", () => {
     expect([...enums.HoverMode]).to.be.equal(["mouse", "hline", "vline"])
   })
 
+  it("should have ImageOrigin", () => {
+    expect([...enums.ImageOrigin]).to.be.equal(["bottom_left", "top_left", "bottom_right", "top_right"])
+  })
+
   it("should have LatLon", () => {
     expect([...enums.LatLon]).to.be.equal(["lat", "lon"])
   })
@@ -85,6 +109,10 @@ describe("enums module", () => {
 
   it("should have LineCap", () => {
     expect([...enums.LineCap]).to.be.equal(["butt", "round", "square"])
+  })
+
+  it("should have LineDash", () => {
+    expect([...enums.LineDash]).to.be.equal(["solid", "dashed", "dotted", "dotdash", "dashdot"])
   })
 
   it("should have LineJoin", () => {
@@ -111,6 +139,10 @@ describe("enums module", () => {
       "square_pin", "square_x", "star", "star_dot", "triangle", "triangle_dot",
       "triangle_pin", "x", "y",
     ])
+  })
+
+  it("should have MutedPolicy", () => {
+    expect([...enums.MutedPolicy]).to.be.equal(["show", "ignore"])
   })
 
   it("should have Orientation", () => {
@@ -147,6 +179,10 @@ describe("enums module", () => {
 
   it("should have RoundingFunction", () => {
     expect([...enums.RoundingFunction]).to.be.equal(["round", "nearest", "floor", "rounddown", "ceil", "roundup"])
+  })
+
+  it("should have SelectionMode", () => {
+    expect([...enums.SelectionMode]).to.be.equal(["replace", "append", "intersect", "subtract"])
   })
 
   it("should have Side", () => {
@@ -203,5 +239,42 @@ describe("enums module", () => {
 
   it("should have VerticalAlign", () => {
     expect([...enums.VerticalAlign]).to.be.equal(["top", "middle", "bottom"])
+  })
+
+  it("should have ToolIcon", () => {
+    expect([...enums.ToolIcon]).to.be.equal([
+      "append_mode",
+      "box_edit",
+      "box_select",
+      "box_zoom",
+      "clear_selection",
+      "copy",
+      "crosshair",
+      "freehand_draw",
+      "help",
+      "hover",
+      "intersect_mode",
+      "lasso_select",
+      "line_edit",
+      "pan",
+      "point_draw",
+      "poly_draw",
+      "poly_edit",
+      "polygon_select",
+      "range",
+      "redo",
+      "replace_mode",
+      "reset",
+      "save",
+      "subtract_mode",
+      "tap_select",
+      "undo",
+      "wheel_pan",
+      "wheel_zoom",
+      "xpan",
+      "ypan",
+      "zoom_in",
+      "zoom_out",
+    ])
   })
 })

--- a/bokehjs/test/unit/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/datetime_tick_formatter.ts
@@ -134,6 +134,13 @@ describe("_us", () => {
   })
 })
 
+const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
+const MIN = 60 * 1000
+const HOUR = 3600 * 1000
+const DAY = 3600 * 24 * 1000
+const MONTH = 3600 * 24 * 30 * 1000
+const YEAR = 3600 * 24 * 365 * 1000
+
 describe("DatetimeTickFormatter", () => {
   describe("doFormat method", () => {
     it("should handle empty list", () => {
@@ -142,74 +149,136 @@ describe("DatetimeTickFormatter", () => {
       expect(labels).to.be.equal([])
     })
     it("should handle microseconds", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+0.001, t+0.002], {loc: 0})
       expect(labels).to.be.equal(["752000us", "752001us", "752002us"])
     })
     it("should handle milliseconds", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+1, t+2], {loc: 0})
       expect(labels).to.be.equal(["752ms", "753ms", "754ms"])
     })
     it("should handle seconds", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+1000, t+2000], {loc: 0})
       expect(labels).to.be.equal(["19s", "20s", "21s"])
     })
     it("should handle minsec", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+50000, t+100000], {loc: 0})
       expect(labels).to.be.equal([":55:19", ":56:09", ":56:59"])
     })
     it("should handle minutes", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
-      const MIN = 60 * 1000
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+MIN, t+MIN*2], {loc: 0})
       expect(labels).to.be.equal([":55", ":56", ":57"])
     })
     it("should handle hourmin", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
-      const MIN = 60 * 1000
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+MIN*30, t+MIN*60], {loc: 0})
       expect(labels).to.be.equal([":55", "1:25", "1:55"])
     })
     it("should handle hours", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
-      const HOUR = 3600 * 1000
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
       // happens to test near day boundary
-      expect(labels).to.be.equal(["6/23", "1h", "2h"])
+      expect(labels).to.be.equal(["6/23", "1 AM", "2 AM"])
     })
     it("should handle days", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
-      const DAY = 3600 * 24 * 1000
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+DAY, t+DAY*2], {loc: 0})
-      // happens to test near day boundary
       expect(labels).to.be.equal(["6/23", "6/24", "6/25"])
     })
     it("should handle months", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
-      const MONTH = 3600 * 24 * 30 * 1000
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+MONTH, t+MONTH*2], {loc: 0})
-      // happens to test near day boundary
       expect(labels).to.be.equal(["6/2022", "7/2022", "8/2022"])
     })
     it("should handle years", () => {
-      const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT
-      const YEAR = 3600 * 24 * 365 * 1000
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+YEAR, t+YEAR*2], {loc: 0})
-      // happens to test near day boundary
       expect(labels).to.be.equal(["2022", "2023", "2024"])
+    })
+  })
+
+  describe("context", () => {
+    it("should handle plain string", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "FOO"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["6/23\nFOO", "1 AM", "2 AM"])
+    })
+    it("should handle a format string", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["6/23\n2022", "1 AM", "2 AM"])
+    })
+    it("should handle a DatetimeTickFormatter", () => {
+      const context = new dttf.DatetimeTickFormatter({
+        microseconds: "microseconds",
+        milliseconds: "milliseconds",
+        seconds: "s",
+        minsec: "minsec",
+        minutes: "minutes",
+        hourmin: "hourmin",
+        hours: "hours",
+        days: "days",
+        months: "months",
+        years: "years"})
+      const formatter = new dttf.DatetimeTickFormatter({context})
+
+      // A tick formatter used for context will format according to the "parent" resolution
+      const us_labels = formatter.doFormat([t, t+0.001, t+0.002], {loc: 0})
+      expect(us_labels).to.be.equal(["752000us\nmicroseconds", "752001us", "752002us"])
+
+      const days_labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(days_labels).to.be.equal(["6/23\ndays", "1 AM", "2 AM"])
+
+      const years_labels = formatter.doFormat([t, t+YEAR, t+YEAR*2], {loc: 0})
+      expect(years_labels).to.be.equal(["2022\nyears", "2023", "2024"])
+    })
+  })
+  describe("context_which", () => {
+    it("should handle start", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_which: "start"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["6/23\n2022", "1 AM", "2 AM"])
+    })
+    it("should handle end", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_which: "end"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["6/23", "1 AM", "2 AM\n2022"])
+    })
+    it("should handle center", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_which: "center"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["6/23", "1 AM\n2022", "2 AM"])
+    })
+    it("should handle all", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_which: "all"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["6/23\n2022", "1 AM\n2022", "2 AM\n2022"])
+    })
+  })
+  describe("context_location", () => {
+    it("should handle left", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_location: "left"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["2022 6/23", "1 AM", "2 AM"])
+    })
+    it("should handle right", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_location: "right"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["6/23 2022", "1 AM", "2 AM"])
+    })
+    it("should handle above", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_location: "above"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["2022\n6/23", "1 AM", "2 AM"])
+    })
+    it("should handle below", () => {
+      const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_location: "below"})
+      const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
+      expect(labels).to.be.equal(["6/23\n2022", "1 AM", "2 AM"])
     })
   })
 })

--- a/bokehjs/test/unit/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/datetime_tick_formatter.ts
@@ -182,7 +182,7 @@ describe("DatetimeTickFormatter", () => {
       const formatter = new dttf.DatetimeTickFormatter()
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
       // happens to test near day boundary
-      expect(labels).to.be.equal(["6/23", "1 AM", "2 AM"])
+      expect(labels).to.be.equal(["6/23", "1h", "2h"])
     })
     it("should handle days", () => {
       const formatter = new dttf.DatetimeTickFormatter()
@@ -205,12 +205,12 @@ describe("DatetimeTickFormatter", () => {
     it("should handle plain string", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "FOO"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["6/23\nFOO", "1 AM", "2 AM"])
+      expect(labels).to.be.equal(["6/23\nFOO", "1h", "2h"])
     })
     it("should handle a format string", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["6/23\n2022", "1 AM", "2 AM"])
+      expect(labels).to.be.equal(["6/23\n2022", "1h", "2h"])
     })
     it("should handle a DatetimeTickFormatter", () => {
       const context = new dttf.DatetimeTickFormatter({
@@ -231,7 +231,7 @@ describe("DatetimeTickFormatter", () => {
       expect(us_labels).to.be.equal(["752000us\nmicroseconds", "752001us", "752002us"])
 
       const days_labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(days_labels).to.be.equal(["6/23\ndays", "1 AM", "2 AM"])
+      expect(days_labels).to.be.equal(["6/23\ndays", "1h", "2h"])
 
       const years_labels = formatter.doFormat([t, t+YEAR, t+YEAR*2], {loc: 0})
       expect(years_labels).to.be.equal(["2022\nyears", "2023", "2024"])
@@ -241,44 +241,44 @@ describe("DatetimeTickFormatter", () => {
     it("should handle start", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_which: "start"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["6/23\n2022", "1 AM", "2 AM"])
+      expect(labels).to.be.equal(["6/23\n2022", "1h", "2h"])
     })
     it("should handle end", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_which: "end"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["6/23", "1 AM", "2 AM\n2022"])
+      expect(labels).to.be.equal(["6/23", "1h", "2h\n2022"])
     })
     it("should handle center", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_which: "center"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["6/23", "1 AM\n2022", "2 AM"])
+      expect(labels).to.be.equal(["6/23", "1h\n2022", "2h"])
     })
     it("should handle all", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_which: "all"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["6/23\n2022", "1 AM\n2022", "2 AM\n2022"])
+      expect(labels).to.be.equal(["6/23\n2022", "1h\n2022", "2h\n2022"])
     })
   })
   describe("context_location", () => {
     it("should handle left", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_location: "left"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["2022 6/23", "1 AM", "2 AM"])
+      expect(labels).to.be.equal(["2022 6/23", "1h", "2h"])
     })
     it("should handle right", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_location: "right"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["6/23 2022", "1 AM", "2 AM"])
+      expect(labels).to.be.equal(["6/23 2022", "1h", "2h"])
     })
     it("should handle above", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_location: "above"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["2022\n6/23", "1 AM", "2 AM"])
+      expect(labels).to.be.equal(["2022\n6/23", "1h", "2h"])
     })
     it("should handle below", () => {
       const formatter = new dttf.DatetimeTickFormatter({context: "%Y", context_location: "below"})
       const labels = formatter.doFormat([t, t+HOUR, t+HOUR*2], {loc: 0})
-      expect(labels).to.be.equal(["6/23\n2022", "1 AM", "2 AM"])
+      expect(labels).to.be.equal(["6/23\n2022", "1h", "2h"])
     })
   })
 })

--- a/examples/plotting/file/hover_glyph.py
+++ b/examples/plotting/file/hover_glyph.py
@@ -1,4 +1,4 @@
-from bokeh.models import HoverTool
+from bokeh.models import BASIC_DATETIME_CONTEXT, HoverTool
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.glucose import data
 
@@ -7,7 +7,8 @@ y = data.loc['2010-10-06']['glucose']
 
 # Basic plot setup
 p = figure(width=800, height=400, x_axis_type="datetime",
-           tools="", toolbar_location=None, title='Hover over points')
+           tools="pan,wheel_zoom", title='Hover over points')
+p.xaxis.formatter.context = BASIC_DATETIME_CONTEXT()
 p.ygrid.grid_line_color = None
 p.background_fill_color = "#fafafa"
 

--- a/examples/plotting/file/hover_glyph.py
+++ b/examples/plotting/file/hover_glyph.py
@@ -1,4 +1,4 @@
-from bokeh.models import BASIC_DATETIME_CONTEXT, HoverTool
+from bokeh.models import RELATIVE_DATETIME_CONTEXT, HoverTool
 from bokeh.plotting import figure, output_file, show
 from bokeh.sampledata.glucose import data
 
@@ -8,7 +8,7 @@ y = data.loc['2010-10-06']['glucose']
 # Basic plot setup
 p = figure(width=800, height=400, x_axis_type="datetime",
            tools="pan,wheel_zoom", title='Hover over points')
-p.xaxis.formatter.context = BASIC_DATETIME_CONTEXT()
+p.xaxis.formatter.context = RELATIVE_DATETIME_CONTEXT()
 p.ygrid.grid_line_color = None
 p.background_fill_color = "#fafafa"
 

--- a/sphinx/source/docs/user_guide/examples/styling_datetime_tick_context.py
+++ b/sphinx/source/docs/user_guide/examples/styling_datetime_tick_context.py
@@ -1,0 +1,14 @@
+from bokeh.models import RELATIVE_DATETIME_CONTEXT
+from bokeh.plotting import figure, show
+from bokeh.sampledata.glucose import data
+
+x = data.loc['2010-10-06'].index.to_series()
+y = data.loc['2010-10-06']['glucose']
+
+p = figure(sizing_mode="stretch_width", x_axis_type="datetime",
+           tools="xwheel_zoom")
+p.xaxis.formatter.context = RELATIVE_DATETIME_CONTEXT()
+
+p.line(x, y, line_dash="4 4", line_width=3, color='gray')
+
+show(p)

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -787,25 +787,31 @@ Datetime tick context
 Datetime tick formatters have additional properties for adding more context to
 ticks on datetime axes. For instance, a context format might show the year,
 month, and day on the first tick, while the regular ticks show an hour and
-minute. The context options are:
+minute.
+
+This is especially useful in cases where an axis is zoomable. For example: when
+zooming in to a level of seconds, the tick formatter context can provide
+additional information about broader units of time, such as day or month.
+
+The context options are:
 
 ``context``
     A format for adding context to the tick or ticks specified by
     ``context_which``. Values are:
 
     * None, no context is added
-    * A standard ``DatetimeTickFormatter`` format string, the single
+    * A standard  :class:`~bokeh.models.DatetimeTickFormatter` format string, this single
       format is used across all scales
-    * Another ``DatetimeTickFormetter`` instance, to have scale-dependent
+    * Another :class:`~bokeh.models.DatetimeTickFormatter` instance, to add scale-dependent
       context
 
 ``context_which``
     Which tick or ticks to add a formatted context string to. Values are:
-    "start", "end", "center", and  "all".
+    `"start"`, `"end"`, `"center"`, and `"all"`.
 
 ``context_location``
     Relative to the tick label text baseline, where the context should be
-    rendered. Values are: "below", "above", "left", and "right"
+    rendered. Values are: `"below"`, `"above"`, `"left"`, and `"right"`.
 
 There is a pre-defined ``RELATIVE_DATETIME_CONTEXT`` that adds context that
 is more or less a single scale higher. The example below demonstrates these

--- a/sphinx/source/docs/user_guide/styling.rst
+++ b/sphinx/source/docs/user_guide/styling.rst
@@ -779,6 +779,49 @@ the snippet or function namespace at render time:
 .. bokeh-plot:: docs/user_guide/examples/styling_custom_js_tick_formatter.py
     :source-position: above
 
+.. _userguide_styling_axes_datetime_tick_context:
+
+Datetime tick context
+~~~~~~~~~~~~~~~~~~~~~
+
+Datetime tick formatters have additional properties for adding more context to
+ticks on datetime axes. For instance, a context format might show the year,
+month, and day on the first tick, while the regular ticks show an hour and
+minute. The context options are:
+
+``context``
+    A format for adding context to the tick or ticks specified by
+    ``context_which``. Values are:
+
+    * None, no context is added
+    * A standard ``DatetimeTickFormatter`` format string, the single
+      format is used across all scales
+    * Another ``DatetimeTickFormetter`` instance, to have scale-dependent
+      context
+
+``context_which``
+    Which tick or ticks to add a formatted context string to. Values are:
+    "start", "end", "center", and  "all".
+
+``context_location``
+    Relative to the tick label text baseline, where the context should be
+    rendered. Values are: "below", "above", "left", and "right"
+
+There is a pre-defined ``RELATIVE_DATETIME_CONTEXT`` that adds context that
+is more or less a single scale higher. The example below demonstrates these
+options:
+
+.. bokeh-plot:: docs/user_guide/examples/styling_datetime_tick_context.py
+    :source-position: above
+
+It is possible to "chain" multiple ``DatetimeTickFomatter`` instances together,
+for as many levels of context as desired. For example:
+
+.. code-block:: python
+
+    p.xaxis.formatter.context = DatetimeTickFormatter(...)
+    p.xaxis.formatter.context.context = DatetimeTickFormatter(...)
+
 .. _userguide_styling_axes_tick_label_orientation:
 
 Tick label orientation

--- a/tests/unit/bokeh/core/test_enums.py
+++ b/tests/unit/bokeh/core/test_enums.py
@@ -35,6 +35,7 @@ ALL  = (
     'AutosizeMode',
     'ButtonType',
     'CalendarPosition',
+    'ContextWhich',
     'DashPattern',
     'DateFormat',
     'DatetimeUnits',
@@ -157,6 +158,9 @@ class Test_bce:
 
     def test_CalendarPosition(self) -> None:
         assert tuple(bce.CalendarPosition) == ("auto", "above", "below")
+
+    def test_ContextWhich(self) -> None:
+        assert tuple(bce.ContextWhich) == ("start", "center", "end", "all")
 
     def test_DashPattern(self) -> None:
         assert tuple(bce.DashPattern) ==("solid", "dashed", "dotted", "dotdash", "dashdot")
@@ -327,6 +331,7 @@ def test_enums_contents() -> None:
         'AutosizeMode',
         'ButtonType',
         'CalendarPosition',
+        'ContextWhich',
         'DashPattern',
         'DateFormat',
         'DatetimeUnits',


### PR DESCRIPTION
- [x] issues: fixes #9935 
- [x] tests added 
- [x] release document entry (if new feature or API change)

cc @bokeh/dev @jbednar @RiccardoGiro @carve11

This PR adds three new properties to `DatetimeTIckFormatter` that can be used to add additional context:
```python
context = Nullable(Either(String, Instance("DatetimeTickFormatter")), default=None, help="""
A format for adding context to the tick or ticks specified by ``context_which``.
""")

context_which = Enum(ContextWhich, default="start", help="""
Which tick or ticks to add a formatted context string to.
""")

context_location = Enum(LocationType, default="below", help="""
Relative to the tick label text baseline, where the context should be
rendered.
""")
```

## `context`

This value controls what context is displayed. Values can  be:

* None, no context is added
* A standard `DatetimeTickFormatter` format string, the single format is used across all scales
* Another `DatetimeTickFormetter` instance, to have scale-dependent context. Also note that a context formatter can have its own`context` property set, to add additional rows of information. (see below) 


## `context_which`

The images below show the possible values: `start`, `end`, `center`, `all`

<img src="https://user-images.githubusercontent.com/1078448/175791300-12e6d449-bbf8-46b4-94c6-9641736d1cd3.png" width=400><img src="https://user-images.githubusercontent.com/1078448/175791305-951c7683-07a7-442c-af31-61233f5708c2.png" width=400>
<img src="https://user-images.githubusercontent.com/1078448/175791308-a737ab59-5b52-4377-92cc-66a2964e0831.png" width=400><img src="https://user-images.githubusercontent.com/1078448/175791312-3ab1d659-11de-4954-8b38-7c7b2dc4965c.png" width=400>


## `context_location`

The images below show the possible values: `below`, `above`, `left`, `right`. This controls where the context information is added, relative to the tick text baseline. Note that `above` is probably mostly useful on a vertical axis. 

<img src="https://user-images.githubusercontent.com/1078448/175791516-56c97d5f-b324-45b0-aaa1-bc808f5e4945.png" width=400><img src="https://user-images.githubusercontent.com/1078448/175791520-d969d2ef-f3e4-46eb-899c-c28e23d97ed5.png" width=400>

<img src="https://user-images.githubusercontent.com/1078448/175791522-784b099e-d464-48d1-afc8-678ef285946c.png" width=400><img src="https://user-images.githubusercontent.com/1078448/175791524-d0fc992a-5348-4f64-8362-5560f4c129d0.png" width=400>

The above examples all have `context_which="start"` but context location can be specified regardless of which ticks context is added to. 

## Formatter chaining

As mentioned above, it is possible to "chain" multiple `DatetimeTickFomatter` instances together, for as many levels of context as desired. For simplicity, the image below just demonstrates with the same formatter repeated twice:
```python
p.xaxis.formatter.context = BASIC_DATETIME_CONTEXT()
p.xaxis.formatter.context.context = BASIC_DATETIME_CONTEXT()
```

![Screen Shot 2022-06-25 at 14 32 49](https://user-images.githubusercontent.com/1078448/175791600-c28c40fe-cb19-462d-9de5-f4feaca72a71.png)

However the nested `context` value could be a different tick formatter, or a single format string.

## `BASIC_DATETIME_CONTEXT`

I also added a `BASIC_DATETIME_CONTEXT` that can be used out of the box to get meaningful context across scales:

![ScreenFlow](https://user-images.githubusercontent.com/1078448/175791622-8070451f-6559-4290-be88-dd4b5d472df3.gif)


# Notes

I will add narrative docs after the implementation is settled. I could use input on some questions:

* Where should `BASIC_DATETIME_CONTEXT` live? Currently in `bokeh.models` (transitively from `.formatters`)
* Are the formats in `BASIC_DATETIME_CONTEXT` the best ones possible? Suggestions welcome. 
* Is there a way to make `BASIC_DATETIME_CONTEXT` the default context? I actually don't think so, unless possibly setting the value after `DatetimeTickFormatter` class definition somehow. 
* I tweaked some of the default formats, e.g. to show "2 AM", "4 PM", instead of "2h", "16h". Are there any concerns with this? Are there other changes we can consider at this major release?
* Are there any API changes? Better names for properties? Or other quick but valuable features to consider adding?
