### PR TITLE
Pin Selenium 4.2

### DIFF
--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -45,7 +45,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - requests >=1.2.3
-  - selenium >=3.8
+  - selenium 4.2
   - scipy
   - pre-commit
 

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -45,7 +45,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - requests >=1.2.3
-  - selenium >=3.8
+  - selenium 4.2
   - scipy
   - pre-commit
 

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -45,7 +45,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - requests >=1.2.3
-  - selenium >=3.8
+  - selenium 4.2
   - scipy
   - pre-commit
 

--- a/ci/environment-test-minimal-deps.yml
+++ b/ci/environment-test-minimal-deps.yml
@@ -42,7 +42,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - requests >=1.2.3
-  - selenium >=3.8
+  - selenium 4.2
   - pre-commit
 
   # examples

--- a/environment.yml
+++ b/environment.yml
@@ -52,7 +52,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - requests >=1.2.3
-  - selenium >=3.8
+  - selenium 4.2
   - scipy
   - pre-commit
 

--- a/sphinx/.gitignore
+++ b/sphinx/.gitignore
@@ -1,2 +1,3 @@
 /build
 /source/docs/gallery/*
+/source/docs/examples/*


### PR DESCRIPTION
Selenium 4.3 was just released, which breaks a large number of our integration tests. Nothing in the [`CHANGELOG`](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES) really stands out, and the failures are assertion failures, not exceptions or errors. Until the root problem can be identified, pin to version 4.2
