### PR TITLE
Minor 3.0 docs updates

### DIFF
--- a/sphinx/source/_static/custom.css
+++ b/sphinx/source/_static/custom.css
@@ -82,6 +82,7 @@ div.highlight pre {
 #search-input {
   border: 1px solid var(--pst-color-borders);
   border-radius: 1.5px;
+  color: var(--pst-color-text-base);
 }
 
 /* More compact autoclasstoc tables */

--- a/sphinx/source/_static/custom.css
+++ b/sphinx/source/_static/custom.css
@@ -10,12 +10,15 @@ html[data-theme=light] {
 }
 
 /* customize display of inline pre elements */
-.literal .pre {
+.literal .pre, span .pre {
   font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;
   color: var(--pst-color-text-base);
   padding: 2px 1px 0px 1px;
   font-size: 100%;
-  background-color:#eef0f1;
+}
+
+code {
+background-color:#eef0f1;
 }
 
 /* Match color of RST :ref: to that of other clickable links */


### PR DESCRIPTION
This PR partially fixes some small CSS issues mentioned in https://github.com/bokeh/bokeh/issues/12203

Specifically: 

- [x] all pre text (including in the ref guide) is now consistently using the same color (instead of occasionally being pink)
- [x] the text entered in the search box now appears in black