### PR TITLE
Improvements to image selection and highlighting

### DIFF
--- a/bokeh/core/property_mixins.py
+++ b/bokeh/core/property_mixins.py
@@ -16,6 +16,8 @@ of properties, use the mix-in classes in this module:
 
 * |HatchProps| --- properties for hatching pattern, color, alpha, etc.
 
+* |ImageProps| --- properties for global alpha on images
+
 * |LineProps| --- properties for line color, dashing, width, etc.
 
 * |TextProps| --- properties for text color, font, etc.
@@ -40,6 +42,7 @@ specific to each property.
 
 .. |FillProps| replace:: :class:`~bokeh.core.property_mixins.FillProps`
 .. |HatchProps| replace:: :class:`~bokeh.core.property_mixins.HatchProps`
+.. |ImageProps| replace:: :class:`~bokeh.core.property_mixins.ImageProps`
 .. |LineProps| replace:: :class:`~bokeh.core.property_mixins.LineProps`
 .. |TextProps| replace:: :class:`~bokeh.core.property_mixins.TextProps`
 
@@ -117,10 +120,12 @@ from .properties import (
 __all__ = (
     'FillProps',
     'HatchProps',
+    'ImageProps',
     'LineProps',
     'TextProps',
     'ScalarFillProps',
     'ScalarHatchProps',
+    'ScalarImageProps',
     'ScalarLineProps',
     'ScalarTextProps',
 )
@@ -253,7 +258,7 @@ class ScalarFillProps(HasProps):
     '''
 
     fill_color = Nullable(Color, default="gray", help=_color_help  % "fill paths")
-    fill_alpha = Alpha(help=_alpha_help)
+    fill_alpha = Alpha(help=_alpha_help % "fill paths")
 
 class HatchProps(HasProps):
     ''' Properties relevant to rendering fill regions.
@@ -282,6 +287,25 @@ class ScalarHatchProps(HasProps):
     hatch_pattern = Nullable(String, help=_hatch_pattern_help)  # String to accommodate user custom values
     hatch_weight = Size(default=1.0, help=_hatch_weight_help)
     hatch_extra = Dict(String, Instance("bokeh.models.textures.Texture"))
+
+class ImageProps(HasProps):
+    ''' Properties relevant to rendering images.
+
+    Mirrors the BokehJS ``properties.ImageVector`` class.
+
+    '''
+
+    global_alpha = AlphaSpec(help=_alpha_help % "images")
+
+class ScalarImageProps(HasProps):
+    ''' Properties relevant to rendering images.
+
+    Mirrors the BokehJS ``properties.Image`` class.
+
+    '''
+
+    global_alpha = Alpha(help=_alpha_help % "images")
+
 
 class LineProps(HasProps):
     ''' Properties relevant to rendering path operations.

--- a/bokeh/models/glyphs.py
+++ b/bokeh/models/glyphs.py
@@ -75,6 +75,7 @@ from ..core.properties import (
 from ..core.property_mixins import (
     FillProps,
     HatchProps,
+    ImageProps,
     LineProps,
     ScalarFillProps,
     ScalarHatchProps,
@@ -678,9 +679,8 @@ class ImageBase(XYGlyph):
         That number is fixed by the image itself.
     """)
 
-    global_alpha = NumberSpec(1.0, help="""
-    An overall opacity that each image is rendered with (in addition
-    to any inherent alpha values in the image itself).
+    image_props = Include(ImageProps, help="""
+    The {prop} values for the images.
     """)
 
     dilate = Bool(False, help="""

--- a/bokeh/models/selections.py
+++ b/bokeh/models/selections.py
@@ -22,8 +22,10 @@ from ..core.has_props import abstract
 from ..core.properties import (
     Dict,
     Int,
+    List,
     Seq,
     String,
+    Struct,
 )
 from ..model import Model
 
@@ -87,7 +89,9 @@ class Selection(Model):
     keys of this dictionary (converted to ints).
     """)
 
-    # TODO (bev) image_indicies
+    image_indices = List(Struct(index=Int, i=Int, j=Int, flat_index=Int), help="""
+
+    """)
 
 @abstract
 class SelectionPolicy(Model):

--- a/bokehjs/src/lib/core/property_mixins.ts
+++ b/bokehjs/src/lib/core/property_mixins.ts
@@ -26,6 +26,10 @@ export type Fill = {
   fill_alpha: p.Property<number>
 }
 
+export type Image = {
+  global_alpha: p.Property<number>
+}
+
 export type Hatch = {
   hatch_color: p.Property<Color | null>
   hatch_alpha: p.Property<number>
@@ -59,6 +63,10 @@ export const Line: p.DefineOf<Line> = {
 export const Fill: p.DefineOf<Fill> = {
   fill_color:       [ k.Nullable(k.Color), "gray" ],
   fill_alpha:       [ k.Alpha, 1.0 ],
+}
+
+export const Image: p.DefineOf<Image> = {
+  global_alpha:     [ k.Alpha, 1.0 ],
 }
 
 export const Hatch: p.DefineOf<Hatch> = {
@@ -98,6 +106,10 @@ export type FillScalar = {
   fill_alpha: p.ScalarSpec<number>
 }
 
+export type ImageScalar = {
+  global_alpha: p.ScalarSpec<number>
+}
+
 export type HatchScalar = {
   hatch_color: p.ScalarSpec<Color | null>
   hatch_alpha: p.ScalarSpec<number>
@@ -131,6 +143,10 @@ export const LineScalar: p.DefineOf<LineScalar> = {
 export const FillScalar: p.DefineOf<FillScalar> = {
   fill_color:       [ p.ColorScalar,        "gray"      ],
   fill_alpha:       [ p.NumberScalar,       1.0         ],
+}
+
+export const ImageScalar: p.DefineOf<ImageScalar> = {
+  global_alpha:       [ p.NumberScalar,       1.0         ],
 }
 
 export const HatchScalar: p.DefineOf<HatchScalar> = {
@@ -170,6 +186,10 @@ export type FillVector = {
   fill_alpha: p.VectorSpec<number>
 }
 
+export type ImageVector = {
+  global_alpha: p.VectorSpec<number>
+}
+
 export type HatchVector = {
   hatch_color: p.ColorSpec
   hatch_alpha: p.VectorSpec<number>
@@ -203,6 +223,10 @@ export const LineVector: p.DefineOf<LineVector> = {
 export const FillVector: p.DefineOf<FillVector> = {
   fill_color:       [ p.ColorSpec,      "gray"      ],
   fill_alpha:       [ p.NumberSpec,     1.0         ],
+}
+
+export const ImageVector: p.DefineOf<ImageVector> = {
+  global_alpha:       [ p.NumberSpec,     1.0         ],
 }
 
 export const HatchVector: p.DefineOf<HatchVector> = {
@@ -248,7 +272,7 @@ export type SeparatorLine = Prefixed<"separator", Line>
 export type SubGroupText = Prefixed<"subgroup", Text>
 export type TitleText = Prefixed<"title", Text>
 
-type Mixins = Text | Line | Fill | Hatch
+type Mixins = Text | Line | Fill | Hatch | Image
 
 export function attrs_of<P extends string, T extends Mixins>(
     model: HasProps, prefix: P, mixin: p.DefineOf<T>, prefixed: boolean = false): {[key: string]: unknown} {

--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -76,7 +76,7 @@ function  _get_special_value(name: string, special_vars: Vars) {
     throw new Error(`Unknown special variable '\$${name}'`)
 }
 
-export function _get_column_value(name: string, data_source: ColumnarDataSource, i: Index | null): unknown | null {
+export function _get_column_value(name: string, data_source: ColumnarDataSource, ind: Index | null): unknown | null {
   const column = data_source.get_column(name)
 
   // missing column
@@ -84,22 +84,22 @@ export function _get_column_value(name: string, data_source: ColumnarDataSource,
     return null
 
   // null index (e.g for patch)
-  if (i == null)
+  if (ind == null)
     return null
 
   // typical (non-image) index
-  if (isNumber(i))
-    return column[i]
+  if (isNumber(ind))
+    return column[ind]
 
   // image index
-  const data = column[i.index]
+  const data = column[ind.index]
   if (isTypedArray(data) || isArray(data)) {
     // inspect array of arrays
     if (isArray(data[0])) {
-      const row: any = data[i.dim2]
-      return row[i.dim1]
+      const row: any = data[ind.j]
+      return row[ind.i]
     } else
-      return data[i.flat_index] // inspect flat array
+      return data[ind.flat_index] // inspect flat array
   } else
     return data // inspect per-image scalar data
 }

--- a/bokehjs/src/lib/core/visuals/image.ts
+++ b/bokehjs/src/lib/core/visuals/image.ts
@@ -1,0 +1,101 @@
+import {VisualProperties, VisualUniforms, ValuesOf} from "./visual"
+import * as p from "../properties"
+import * as mixins from "../property_mixins"
+import {Context2d} from "../util/canvas"
+
+export interface Image extends Readonly<mixins.Image> {}
+export class Image extends VisualProperties {
+  get doit(): boolean {
+    const alpha = this.global_alpha.get_value()
+    return !(alpha == 0)
+  }
+
+  apply(ctx: Context2d): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_value(ctx)
+    }
+    return doit
+  }
+
+  Values: ValuesOf<mixins.Image>
+  values(): this["Values"] {
+    return {
+      global_alpha: this.global_alpha.get_value(),
+    }
+  }
+
+  set_value(ctx: Context2d): void {
+    const alpha = this.global_alpha.get_value()
+    ctx.globalAlpha = alpha
+  }
+}
+
+export class ImageScalar extends VisualUniforms {
+  readonly global_alpha: p.UniformScalar<number>
+
+  get doit(): boolean {
+    const alpha = this.global_alpha.value
+    return !(alpha == 0)
+  }
+
+  apply(ctx: Context2d): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_value(ctx)
+    }
+    return doit
+  }
+
+  Values: ValuesOf<mixins.Image>
+  values(): this["Values"] {
+    return {
+      global_alpha: this.global_alpha.value,
+    }
+  }
+
+  set_value(ctx: Context2d): void {
+    const alpha = this.global_alpha.value
+    ctx.globalAlpha = alpha
+  }
+}
+
+export class ImageVector extends VisualUniforms {
+  readonly global_alpha: p.Uniform<number>
+
+  get doit(): boolean {
+    const {global_alpha} = this
+    if (global_alpha.is_Scalar() && global_alpha.value == 0)
+      return false
+    return true
+  }
+
+  apply(ctx: Context2d, i: number): boolean {
+    const {doit} = this
+    if (doit) {
+      this.set_vectorize(ctx, i)
+    }
+    return doit
+  }
+
+  Values: ValuesOf<mixins.Image>
+  values(i: number): this["Values"] {
+    return {
+      alpha: this.global_alpha.get(i),
+    }
+  }
+
+  set_vectorize(ctx: Context2d, i: number): void {
+    const alpha = this.global_alpha.get(i)
+    ctx.globalAlpha = alpha
+  }
+}
+
+Image.prototype.type = "image"
+Image.prototype.attrs = Object.keys(mixins.Image)
+
+ImageScalar.prototype.type = "image"
+ImageScalar.prototype.attrs = Object.keys(mixins.ImageScalar)
+
+ImageVector.prototype.type = "image"
+ImageVector.prototype.attrs = Object.keys(mixins.ImageVector)

--- a/bokehjs/src/lib/core/visuals/index.ts
+++ b/bokehjs/src/lib/core/visuals/index.ts
@@ -2,11 +2,13 @@ import {Line, LineScalar, LineVector} from "./line"
 import {Fill, FillScalar, FillVector} from "./fill"
 import {Text, TextScalar, TextVector} from "./text"
 import {Hatch, HatchScalar, HatchVector} from "./hatch"
+import {Image, ImageScalar, ImageVector} from "./image"
 
 export {Line, LineScalar, LineVector}
 export {Fill, FillScalar, FillVector}
 export {Text, TextScalar, TextVector}
 export {Hatch, HatchScalar, HatchVector}
+export {Image, ImageScalar, ImageVector}
 
 import {View} from "../view"
 import * as mixins from "../property_mixins"
@@ -37,6 +39,9 @@ export class Visuals {
           case mixins.Hatch:       return new Hatch(view, prefix)
           case mixins.HatchScalar: return new HatchScalar(view, prefix)
           case mixins.HatchVector: return new HatchVector(view, prefix)
+          case mixins.Image:       return new Image(view, prefix)
+          case mixins.ImageScalar: return new ImageScalar(view, prefix)
+          case mixins.ImageVector: return new ImageVector(view, prefix)
           default:
             throw new Error("unknown visual")
         }

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -251,13 +251,13 @@ export abstract class ImageBaseView extends XYGlyphView {
     const height = this._height[index]
     const dx = (r - l) / width
     const dy = (t - b) / height
-    let dim1 = Math.floor((x - l) / dx)
-    let dim2 = Math.floor((y - b) / dy)
+    let i = Math.floor((x - l) / dx)
+    let j = Math.floor((y - b) / dy)
     if (this.renderer.xscale.source_range.is_reversed)
-      dim1 = width-dim1-1
+      i = width-i-1
     if (this.renderer.yscale.source_range.is_reversed)
-      dim2 = height-dim2-1
-    return {index, dim1, dim2, flat_index: dim2*width + dim1}
+      j = height-j-1
+    return {index, i, j, flat_index: j*width + i}
   }
 
   override _hit_point(geometry: PointGeometry): Selection {
@@ -268,11 +268,14 @@ export abstract class ImageBaseView extends XYGlyphView {
     const candidates = this.index.indices({x0: x, x1: x, y0: y, y1: y})
     const result = new Selection()
 
+    const indices = []
     for (const index of candidates) {
       if (sx != Infinity && sy != Infinity) {
+        indices.push(index)
         result.image_indices.push(this._image_index(index, x, y))
       }
     }
+    result.indices = indices
 
     return result
   }

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -2,6 +2,8 @@ import {XYGlyph, XYGlyphView, XYGlyphData} from "./xy_glyph"
 import {Arrayable, ScreenArray, to_screen} from "core/types"
 import {Anchor, Align, HAlign, VAlign, ImageOrigin} from "core/enums"
 import * as p from "core/properties"
+import * as visuals from "core/visuals"
+import * as mixins from "core/property_mixins"
 import {Context2d} from "core/util/canvas"
 import {Selection, ImageIndex} from "../selections/selection"
 import {PointGeometry} from "core/geometry"
@@ -16,7 +18,6 @@ export type ImageDataBase = XYGlyphData & {
   readonly image: p.Uniform<NDArray>
   readonly dw: p.Uniform<number>
   readonly dh: p.Uniform<number>
-  readonly global_alpha: p.Uniform<number>
 
   sw: ScreenArray
   sh: ScreenArray
@@ -113,42 +114,37 @@ export abstract class ImageBaseView extends XYGlyphView {
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: ImageDataBase): void {
-    const {image_data, sx, sy, sw, sh, global_alpha} = data ?? this
+    const {image_data, sx, sy, sw, sh} = data ?? this
 
     const old_smoothing = ctx.getImageSmoothingEnabled()
     ctx.setImageSmoothingEnabled(false)
-
-    const scalar_alpha = global_alpha.is_Scalar()
-    if (scalar_alpha)
-      ctx.globalAlpha = global_alpha.value
 
     const [x_sign, y_sign] = this.xy_sign
     const [x_scale, y_scale] = this.xy_scale
     const [x_offset, y_offset] = this.xy_offset
     const [x_anchor, y_anchor] = this.xy_anchor
 
-    for (const i of indices) {
-      const image_data_i = image_data[i]
-      const sx_i = sx[i]
-      const sy_i = sy[i]
-      const sw_i = sw[i]
-      const sh_i = sh[i]
-      const alpha_i = this.global_alpha.get(i)
+    if (this.visuals.image.doit) {
+      for (const i of indices) {
+        const image_data_i = image_data[i]
+        const sx_i = sx[i]
+        const sy_i = sy[i]
+        const sw_i = sw[i]
+        const sh_i = sh[i]
 
-      if (image_data_i == null || !isFinite(sx_i + sy_i + sw_i + sh_i + alpha_i))
-        continue
+        if (image_data_i == null || !isFinite(sx_i + sy_i + sw_i + sh_i))
+          continue
 
-      if (!scalar_alpha)
-        ctx.globalAlpha = alpha_i
+        const tx_i = x_sign*x_anchor*sw_i
+        const ty_i = y_sign*y_anchor*sh_i
 
-      const tx_i = x_sign*x_anchor*sw_i
-      const ty_i = y_sign*y_anchor*sh_i
-
-      ctx.save()
-      ctx.translate(sx_i - tx_i, sy_i - ty_i)
-      ctx.scale(x_sign*x_scale, y_sign*y_scale)
-      ctx.drawImage(image_data_i, -x_offset*sw_i, -y_offset*sh_i, sw_i, sh_i)
-      ctx.restore()
+        ctx.save()
+        ctx.translate(sx_i - tx_i, sy_i - ty_i)
+        ctx.scale(x_sign*x_scale, y_sign*y_scale)
+        this.visuals.image.set_vectorize(ctx, i)
+        ctx.drawImage(image_data_i, -x_offset*sw_i, -y_offset*sh_i, sw_i, sh_i)
+        ctx.restore()
+      }
     }
 
     ctx.setImageSmoothingEnabled(old_smoothing)
@@ -288,13 +284,14 @@ export namespace ImageBase {
     image: p.NDArraySpec
     dw: p.DistanceSpec
     dh: p.DistanceSpec
-    global_alpha: p.NumberSpec
     dilate: p.Property<boolean>
     origin: p.Property<ImageOrigin>
     anchor: p.Property<Anchor | [Align | HAlign | number, Align | VAlign | number]>
-  }
+  } & Mixins
 
-  export type Visuals = XYGlyph.Visuals
+  export type Mixins = mixins.ImageVector
+
+  export type Visuals = XYGlyph.Visuals & {image: visuals.ImageVector}
 }
 
 export interface ImageBase extends ImageBase.Attrs {}
@@ -308,11 +305,11 @@ export abstract class ImageBase extends XYGlyph {
   }
 
   static {
+    this.mixins<ImageBase.Mixins>(mixins.ImageVector)
     this.define<ImageBase.Props>(({Boolean, Number, Or, Tuple}) => ({
       image:        [ p.NDArraySpec, {field: "image"} ],
       dw:           [ p.DistanceSpec, {field: "dw"} ],
       dh:           [ p.DistanceSpec, {field: "dh"} ],
-      global_alpha: [ p.NumberSpec, {value: 1.0} ],
       dilate:       [ Boolean, false ],
       origin:       [ ImageOrigin, "bottom_left" ],
       anchor:       [ Or(Anchor, Tuple(Or(Align, HAlign, Number), Or(Align, VAlign, Number))), "bottom_left" ],

--- a/bokehjs/src/lib/models/selections/selection.ts
+++ b/bokehjs/src/lib/models/selections/selection.ts
@@ -11,8 +11,8 @@ export type MultiIndices = {[key: string]: OpaqueIndices}
 
 export type ImageIndex = {
   index: number
-  dim1: number
-  dim2: number
+  i: number
+  j: number
   flat_index: number
 }
 
@@ -43,17 +43,16 @@ export class Selection extends Model {
   }
 
   static {
-    this.define<Selection.Props>(({Int, Array, Dict}) => ({
+    this.define<Selection.Props>(({Int, Array, Dict, Struct}) => ({
       indices:           [ Array(Int), [] ],
       line_indices:      [ Array(Int), [] ],
       multiline_indices: [ Dict(Array(Int)), {} ],
+      image_indices:     [ Array(Struct({index: Int, i: Int, j: Int, flat_index: Int})), [] ],
     }))
 
-    this.internal<Selection.Props>(({Int, Array, AnyRef, Struct, Nullable}) => ({
+    this.internal<Selection.Props>(({Array, AnyRef, Nullable}) => ({
       selected_glyphs:   [ Array(AnyRef()), [] ],
       view:              [ Nullable(AnyRef()), null ],
-      // Used internally to support hover tool for now. Python API TBD
-      image_indices:     [ Array(Struct({index: Int, dim1: Int, dim2: Int, flat_index: Int})), [] ],
     }))
   }
 

--- a/bokehjs/test/unit/core/util/templating.ts
+++ b/bokehjs/test/unit/core/util/templating.ts
@@ -104,8 +104,8 @@ describe("templating module", () => {
         labels: ["test label"],
       },
     })
-    const imindex1 = {index: 0, dim1: 2, dim2: 1, flat_index: 5}
-    const imindex2 = {index: 0, dim1: 1, dim2: 0, flat_index: 1}
+    const imindex1 = {index: 0, i: 2, j: 1, flat_index: 5}
+    const imindex2 = {index: 0, i: 1, j: 0, flat_index: 1}
 
     it("should return $ values from special_vars", () => {
       const v = tmpl.get_value("$x", source, 0, {x: 99999})


### PR DESCRIPTION
- [x] issues: fixes #12207
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

This PR does two things: 

* Fixes image selection/nonselection highlighting (at least for point hit testing) by converting the awkward `global_alpha` property to be a proper "visual". Now if you specify `nonselection_alpha` on an image glyph it does what is expected:

  <img width="634" alt="Screen Shot 2022-07-01 at 18 14 05" src="https://user-images.githubusercontent.com/1078448/176981847-e8a7ee3e-68ec-4dbc-a02f-f66733811af9.png">


* Exposes `Selection.image_indices` publicly, so that users may inspect detailed image selections. Additionally, `Selection.indices` is set with the top-level index (i.e. which image). 

I will look in to adding tests, but the implementation is complete and ready for review. 



