### PR TITLE
Add support for alt tags for gallery thumbnails

### DIFF
--- a/bokeh/sphinxext/_templates/gallery_page.rst
+++ b/bokeh/sphinxext/_templates/gallery_page.rst
@@ -6,4 +6,7 @@
 .. |{{ opt['name'] }}| image:: /_images/gallery/{{ opt['name'] }}.png
     :target: {{ opt['ref'] }}
     :class: gallery
+    {% if opt['alt'] -%}
+    :alt: {{ opt['alt'] }}
+    {%- endif %}
 {% endfor %}

--- a/bokeh/sphinxext/bokeh_gallery.py
+++ b/bokeh/sphinxext/bokeh_gallery.py
@@ -83,13 +83,18 @@ class BokehGalleryDirective(BokehDirective):
             raise SphinxError(f"gallery dir {gallery_dir!r} missing for gallery file {gallery_file!r}")
 
         spec = json.load(open(gallery_file))
-        names = [detail["path"] for detail in spec["details"]]
 
         opts = []
-        for example in names:
-            pp = PurePath(example).parts
-            name = pp[-1].replace('.py', '')
-            opts.append({"name": name, "ref": f'examples/{pp[1]}/{name}.html'})
+        for detail in spec["details"]:
+            name = detail["path"]
+            alt = detail.get("alt", None)
+            path = PurePath(name).parts
+            name = path[-1].replace('.py', '')
+            opts.append({
+                "name": name,
+                "ref": f"examples/{path[1]}/{name}.html",
+                "alt": alt,
+            })
 
         rst_text = GALLERY_PAGE.render(opts=opts)
 

--- a/sphinx/source/docs/gallery.json
+++ b/sphinx/source/docs/gallery.json
@@ -1,58 +1,274 @@
 {
-    "details": [
-        { "path": "examples/plotting/file/marker_map.py",                      "name": "marker_map"                     },
-        { "path": "examples/plotting/file/latex_blackbody_radiation.py",       "name": "latex_blackbody_radiation"      },
-        { "path": "examples/plotting/file/latex_normal_distribution.py",       "name": "latex_normal_distribution"      },
-        { "path": "examples/plotting/file/network_graph.py",                   "name": "network_graph"                  },
-        { "path": "examples/plotting/file/hexbin.py",                          "name": "hexbin"                         },
-        { "path": "examples/plotting/file/sprint.py",                          "name": "sprint"                         },
-        { "path": "examples/plotting/file/ridgeplot.py",                       "name": "ridgeplot"                      },
-        { "path": "examples/plotting/file/hex_tile.py",                        "name": "hex_tile"                       },
-        { "path": "examples/plotting/file/bar_colormapped.py",                 "name": "bar_colormapped"                },
-        { "path": "examples/plotting/file/bar_intervals.py",                   "name": "bar_intervals"                  },
-        { "path": "examples/plotting/file/range_tool.py",                      "name": "range_tool"                     },
-        { "path": "examples/plotting/file/pie.py",                             "name": "pie_chart"                      },
-        { "path": "examples/plotting/file/bar_mixed.py",                       "name": "bar_mixed"                      },
-        { "path": "examples/plotting/file/bar_nested_colormapped.py",          "name": "bar_nested_colormapped"         },
-        { "path": "examples/plotting/file/categorical_heatmap.py",             "name": "categorical_heatmap"            },
-        { "path": "examples/plotting/file/schrodinger.py",                     "name": "schrodinger"                    },
-        { "path": "examples/plotting/file/bar_pandas_groupby_colormapped.py",  "name": "bar_pandas_groupby_colormapped" },
-        { "path": "examples/plotting/file/bar_pandas_groupby_nested.py",       "name": "bar_pandas_groupby_nested"      },
-        { "path": "examples/plotting/file/bar_stacked.py",                     "name": "bar_stacked"                    },
-        { "path": "examples/plotting/file/bar_stacked_split.py",               "name": "bar_stacked_split"              },
-        { "path": "examples/plotting/file/categorical_scatter_jitter.py",      "name": "categorical_scatter_jitter"     },
-        { "path": "examples/plotting/file/bar_nested.py",                      "name": "bar_nested"                     },
-        { "path": "examples/plotting/file/candlestick.py",                     "name": "candlestick"                    },
-        { "path": "examples/plotting/file/legend.py",                          "name": "legend"                         },
-        { "path": "examples/plotting/file/bar_colors.py",                      "name": "bar_colors"                     },
-        { "path": "examples/plotting/file/box_annotation.py",                  "name": "box_annotation"                 },
-        { "path": "examples/plotting/file/les_mis.py",                         "name": "les_mis"                        },
-        { "path": "examples/plotting/file/bar_dodged.py",                      "name": "bar_dodged"                     },
-        { "path": "examples/plotting/file/unemployment.py",                    "name": "unemployment"                   },
-        { "path": "examples/plotting/file/stocks.py",                          "name": "stocks"                         },
-        { "path": "examples/plotting/file/hatch_grid_band.py",                 "name": "hatch_grid_band"                },
-        { "path": "examples/plotting/file/image_rgba.py",                      "name": "image_rgba"                     },
-        { "path": "examples/plotting/file/dotplot.py",                         "name": "dotplot"                        },
-        { "path": "examples/plotting/file/periodic.py",                        "name": "periodic"                       },
-        { "path": "examples/plotting/file/histogram.py",                       "name": "histogram"                      },
-        { "path": "examples/plotting/file/image.py",                           "name": "image"                          },
-        { "path": "examples/plotting/file/slider.py",                          "name": "slider"                         },
-        { "path": "examples/plotting/file/jitter.py",                          "name": "jitter"                         },
-        { "path": "examples/plotting/file/lorenz.py",                          "name": "lorenz"                         },
-        { "path": "examples/plotting/file/color_scatter.py",                   "name": "color_scatter"                  },
-        { "path": "examples/plotting/file/color_sliders.py",                   "name": "color_sliders"                  },
-        { "path": "examples/models/file/iris_splom.py",                        "name": "iris_splom"                     },
-        { "path": "examples/models/file/anscombe.py",                          "name": "anscombe"                       },
-        { "path": "examples/plotting/file/texas.py",                           "name": "texas"                          },
-        { "path": "examples/plotting/file/markers.py",                         "name": "markers"                        },
-        { "path": "examples/plotting/file/burtin.py",                          "name": "burtin"                         },
-        { "path": "examples/plotting/file/bar_basic.py",                       "name": "bar_basic"                      },
-        { "path": "examples/plotting/file/stacked_area.py",                    "name": "stacked_area"                   },
-        { "path": "examples/plotting/file/elements.py",                        "name": "elements"                       },
-        { "path": "examples/plotting/file/boxplot.py",                         "name": "boxplot"                        },
-        { "path": "examples/plotting/file/logplot.py",                         "name": "logplot"                        },
-        { "path": "examples/plotting/file/eclipse.py",                         "name": "eclipse"                        },
-        { "path": "examples/plotting/file/iris.py",                            "name": "iris"                           },
-        { "path": "examples/plotting/file/bessel.py",                          "name": "bessel"                         }
-    ]
+  "details": [
+    {
+      "path": "examples/plotting/file/marker_map.py",
+      "name": "marker_map",
+      "alt": "Thumbnail link to the examples/file/marker_map.py example"
+    },
+    {
+      "path": "examples/plotting/file/latex_blackbody_radiation.py",
+      "name": "latex_blackbody_radiation",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/latex_normal_distribution.py",
+      "name": "latex_normal_distribution",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/network_graph.py",
+      "name": "network_graph",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/hexbin.py",
+      "name": "hexbin",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/sprint.py",
+      "name": "sprint",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/ridgeplot.py",
+      "name": "ridgeplot",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/hex_tile.py",
+      "name": "hex_tile",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_colormapped.py",
+      "name": "bar_colormapped",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_intervals.py",
+      "name": "bar_intervals",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/range_tool.py",
+      "name": "range_tool",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/pie.py",
+      "name": "pie_chart",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_mixed.py",
+      "name": "bar_mixed",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_nested_colormapped.py",
+      "name": "bar_nested_colormapped",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/categorical_heatmap.py",
+      "name": "categorical_heatmap",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/schrodinger.py",
+      "name": "schrodinger",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_pandas_groupby_colormapped.py",
+      "name": "bar_pandas_groupby_colormapped",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_pandas_groupby_nested.py",
+      "name": "bar_pandas_groupby_nested",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_stacked.py",
+      "name": "bar_stacked",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_stacked_split.py",
+      "name": "bar_stacked_split",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/categorical_scatter_jitter.py",
+      "name": "categorical_scatter_jitter",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_nested.py",
+      "name": "bar_nested",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/candlestick.py",
+      "name": "candlestick",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/legend.py",
+      "name": "legend",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_colors.py",
+      "name": "bar_colors",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/box_annotation.py",
+      "name": "box_annotation",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/les_mis.py",
+      "name": "les_mis",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_dodged.py",
+      "name": "bar_dodged",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/unemployment.py",
+      "name": "unemployment",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/stocks.py",
+      "name": "stocks",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/hatch_grid_band.py",
+      "name": "hatch_grid_band",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/image_rgba.py",
+      "name": "image_rgba",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/dotplot.py",
+      "name": "dotplot",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/periodic.py",
+      "name": "periodic",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/histogram.py",
+      "name": "histogram",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/image.py",
+      "name": "image",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/slider.py",
+      "name": "slider",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/jitter.py",
+      "name": "jitter",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/lorenz.py",
+      "name": "lorenz",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/color_scatter.py",
+      "name": "color_scatter",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/color_sliders.py",
+      "name": "color_sliders",
+      "alt": ""
+    },
+    {
+      "path": "examples/models/file/iris_splom.py",
+      "name": "iris_splom",
+      "alt": ""
+    },
+    {
+      "path": "examples/models/file/anscombe.py",
+      "name": "anscombe",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/texas.py",
+      "name": "texas",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/markers.py",
+      "name": "markers",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/burtin.py",
+      "name": "burtin",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bar_basic.py",
+      "name": "bar_basic",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/stacked_area.py",
+      "name": "stacked_area",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/elements.py",
+      "name": "elements",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/boxplot.py",
+      "name": "boxplot",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/logplot.py",
+      "name": "logplot",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/eclipse.py",
+      "name": "eclipse",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/iris.py",
+      "name": "iris",
+      "alt": ""
+    },
+    {
+      "path": "examples/plotting/file/bessel.py",
+      "name": "bessel",
+      "alt": ""
+     }
+  ]
 }


### PR DESCRIPTION
This PR adds support for an "alt" field in the `gallery.json` details. This optional field is rendered as an HTML alt tag in the corresponding gallery thumbnail images:

<img width="727" alt="Screen Shot 2022-07-02 at 21 06 08" src="https://user-images.githubusercontent.com/1078448/177024210-d0f82a48-ddbe-4e86-959a-359b55929113.png">

@pavithraes once this is merged, there is a "place" to make placeholder edits for the alt-text PR for gallery examples (other `image` directives will need to have placeholders added manually)

cc @tcmetzger 