### PR TITLE
Convert DateRangeSlider/DateSlider step to days

### DIFF
--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -295,7 +295,7 @@ class DateRangeSlider(AbstractSlider):
     """)
 
     step = Int(default=1, help="""
-    The step between consecutive values.
+    The step between consecutive values, in units of days.
     """)
 
     format = Override(default="%d %b %Y")

--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -224,7 +224,7 @@ class DateSlider(AbstractSlider):
     """)
 
     step = Int(default=1, help="""
-    The step between consecutive values.
+    The step between consecutive values, in units of days.
     """)
 
     format = Override(default="%d %b %Y")

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -33,9 +33,13 @@ abstract class AbstractBaseSliderView extends OrientedControlView {
 
   private _noUiSlider: API
 
+  get _steps(): API['steps'] {
+    return this._noUiSlider.steps
+  }
+
   override connect_signals(): void {
     super.connect_signals()
-
+    
     const {direction, orientation, tooltips} = this.model.properties
     this.on_change([direction, orientation, tooltips], () => this.render())
 

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -33,13 +33,13 @@ abstract class AbstractBaseSliderView extends OrientedControlView {
 
   private _noUiSlider: API
 
-  get _steps(): API['steps'] {
+  get _steps(): API["steps"] {
     return this._noUiSlider.steps
   }
 
   override connect_signals(): void {
     super.connect_signals()
-    
+
     const {direction, orientation, tooltips} = this.model.properties
     this.on_change([direction, orientation, tooltips], () => this.render())
 

--- a/bokehjs/src/lib/models/widgets/date_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_range_slider.ts
@@ -9,11 +9,12 @@ export class DateRangeSliderView extends AbstractRangeSliderView {
   override model: DateRangeSlider
 
   protected override _calc_to(): SliderSpec {
+    const {start, end, value, step} = this.model
     return {
-      start: this.model.start,
-      end: this.model.end,
-      value: this.model.value,
-      step: this.model.step * 86_400_000,
+      start,
+      end,
+      value,
+      step: step * 86_400_000,
     }
   }
 

--- a/bokehjs/src/lib/models/widgets/date_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_range_slider.ts
@@ -1,12 +1,22 @@
 import tz from "timezone"
 
-import {AbstractSlider, AbstractRangeSliderView} from "./abstract_slider"
+import {AbstractSlider, AbstractRangeSliderView, SliderSpec} from "./abstract_slider"
 import {TickFormatter} from "../formatters/tick_formatter"
 import * as p from "core/properties"
 import {isString} from "core/util/types"
 
 export class DateRangeSliderView extends AbstractRangeSliderView {
   override model: DateRangeSlider
+
+  protected override _calc_to(): SliderSpec {
+    return {
+      start: this.model.start,
+      end: this.model.end,
+      value: this.model.value,
+      step: this.model.step * 86_400_000,
+    }
+  }
+
 }
 
 export namespace DateRangeSlider {

--- a/bokehjs/src/lib/models/widgets/date_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_slider.ts
@@ -1,12 +1,22 @@
 import tz from "timezone"
 
-import {AbstractSlider, AbstractSliderView} from "./abstract_slider"
+import {AbstractSlider, AbstractSliderView, SliderSpec} from "./abstract_slider"
 import {TickFormatter} from "../formatters/tick_formatter"
 import * as p from "core/properties"
 import {isString} from "core/util/types"
 
 export class DateSliderView extends AbstractSliderView {
   override model: DateSlider
+
+  protected override _calc_to(): SliderSpec {
+    const {start, end, value, step} = this.model
+    return {
+      start,
+      end,
+      value: [value],
+      step: step * 86_400_000,
+    }
+  }
 }
 
 export namespace DateSlider {

--- a/bokehjs/test/unit/models/widgets/slider.ts
+++ b/bokehjs/test/unit/models/widgets/slider.ts
@@ -43,6 +43,20 @@ describe("RangeSlider", () => {
   })
 })
 
+describe("DateSliderView", () => {
+  it("should convert steps from 1 day in the model to 86_400_000 milliseconds in the slider element", async () => {
+    const start = 1451606400000 // 01 Jan 2016
+    const end = 1451952000000 // 05 Jan 2016
+    const value = 1451779200000 // 03 Jan 2016
+    const slider = new DateSlider({start, end, value, step: 1})
+    const view = (await build_view(slider)).build()
+
+    const [next_step] = view._steps()
+
+    expect(next_step).to.be.equal([86_400_000, 86_400_000])
+  })
+})
+
 describe("DateSlider", () => {
   it("should support string format", () => {
     const slider = new DateSlider({format: "%Y"})

--- a/bokehjs/test/unit/models/widgets/slider.ts
+++ b/bokehjs/test/unit/models/widgets/slider.ts
@@ -56,6 +56,20 @@ describe("DateSlider", () => {
   })
 })
 
+describe("DateRangeSliderView", () => {
+  it("should convert steps from 1 day in the model to 86_400_000 milliseconds in the slider element", async () => {
+    const start = 1451606400000 // 01 Jan 2016
+    const end = 1451952000000 // 05 Jan 2016
+    const slider = new DateRangeSlider({start, end, value: [start, end], step: 1})
+    const view = (await build_view(slider)).build()
+
+    const [next_left_step, next_right_step] = view._steps()
+
+    expect(next_left_step).to.be.equal([null, 86_400_000])
+    expect(next_right_step).to.be.equal([86_400_000, null])
+  })
+})
+
 describe("DateRangeSlider", () => {
   it("should support string format", () => {
     const slider = new DateRangeSlider({format: "%Y"})

--- a/sphinx/source/docs/user_guide/interaction/widgets.rst
+++ b/sphinx/source/docs/user_guide/interaction/widgets.rst
@@ -143,7 +143,7 @@ DateRangeSlider
 ~~~~~~~~~~~~~~~
 
 The Bokeh date range-slider can be configured with ``start`` and ``end`` date
-values, a ``step`` size, an initial ``value``, and a ``title``:
+values, a ``step`` size in units of days, an initial ``value``, and a ``title``:
 
 .. bokeh-plot:: docs/user_guide/examples/interaction_daterangeslider.py
     :source-position: below

--- a/tests/integration/widgets/test_dateslider.py
+++ b/tests/integration/widgets/test_dateslider.py
@@ -124,7 +124,7 @@ class Test_DateSlider:
 
     @flaky(max_runs=10)
     def test_server_on_change_round_trip(self, bokeh_server_page: BokehServerPage) -> None:
-        slider = DateSlider(start=start, end=end, value=value, width=300, step=24*3600*1000)
+        slider = DateSlider(start=start, end=end, value=value, width=300, step=1)
 
         def modify_doc(doc):
             source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))


### PR DESCRIPTION
- [x] issues: fixes #12033
- [x] TODO: apply same treatment to `DateSlider` as requested by @bryevdv 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

### Notes
- Updated `_calc_to()` in `DateRangeSliderView` as suggested by @ianthomas23
- In  `AbstractBaseSliderView` I exposed `steps` from the noUiSlider API so we could unit test down to the slider level
- I don't have selenium on my machine at the moment, so I'll wait and see if integration tests break in CI. May be useful to add a new integration test to demonstrate fewer change events as the slider is dragged?