### PR TITLE
docs: Fix a few typos

### DIFF
--- a/bokeh/util/token.py
+++ b/bokeh/util/token.py
@@ -101,11 +101,11 @@ def generate_jwt_token(session_id: ID,
             The session id to add to the token
 
         secret_key (str, optional) :
-            Secret key (default: value of BOKEH_SECRET_KEY environment varariable)
+            Secret key (default: value of BOKEH_SECRET_KEY environment variable)
 
         signed (bool, optional) :
             Whether to sign the session ID (default: value of BOKEH_SIGN_SESSIONS
-            envronment varariable)
+            envronment variable)
 
         extra_payload (dict, optional) :
             Extra key/value pairs to include in the Bokeh session token

--- a/sphinx/docserver.py
+++ b/sphinx/docserver.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 # -----------------------------------------------------------------------------
-""" Basic webserver for developing Bokeh documention locally.
+""" Basic webserver for developing Bokeh documentation locally.
 
 Executing this script will automatically open a browser tab to the locally
 built documentation index page.


### PR DESCRIPTION
There are small typos in:
- bokeh/util/token.py
- sphinx/docserver.py

Fixes:
- Should read `variable` rather than `varariable`.
- Should read `documentation` rather than `documention`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md