### PR TITLE
Bryanv/10183 token arguments

### DIFF
--- a/bokeh/server/contexts.py
+++ b/bokeh/server/contexts.py
@@ -227,7 +227,7 @@ class ApplicationContext:
                     ])
                 # using private attr so users only have access to a read-only property
                 session_context._request = _RequestProxy(request,
-                                                         arguments=payload.get('arguments', request.arguments),
+                                                         arguments=payload.get('arguments'),
                                                          cookies=payload.get('cookies'),
                                                          headers=payload.get('headers'))
             session_context._token = token
@@ -335,15 +335,20 @@ class _RequestProxy:
     def __init__(
         self,
         request: HTTPServerRequest,
-        arguments: Dict[str, str | List[str]] | None = None,
+        arguments: Dict[str, bytes | List[bytes]] | None = None,
         cookies: Dict[str, str] | None = None,
         headers: Dict[str, str | List[str]] | None = None,
     ) -> None:
         self._request = request
 
-        if 'bokeh-session-id' in arguments:
-            del arguments['bokeh-session-id']
-        self._arguments = arguments
+        if arguments is not None:
+            self._arguments = arguments
+        elif hasattr(request, 'arguments'):
+            self._arguments = dict(request.arguments)
+        else:
+            self._arguments = {}
+        if 'bokeh-session-id' in self._arguments:
+            del self._arguments['bokeh-session-id']
 
         if cookies is not None:
             self._cookies = cookies

--- a/bokeh/server/contexts.py
+++ b/bokeh/server/contexts.py
@@ -227,6 +227,7 @@ class ApplicationContext:
                     ])
                 # using private attr so users only have access to a read-only property
                 session_context._request = _RequestProxy(request,
+                                                         arguments=payload.get('arguments', request.arguments),
                                                          cookies=payload.get('cookies'),
                                                          headers=payload.get('headers'))
             session_context._token = token
@@ -331,14 +332,19 @@ class _RequestProxy:
     _cookies: Dict[str, str]
     _headers: Dict[str, str | List[str]]
 
-    def __init__(self, request: HTTPServerRequest, cookies: Dict[str, str] | None = None,
-            headers: Dict[str, str | List[str]] | None = None) -> None:
+    def __init__(
+        self,
+        request: HTTPServerRequest,
+        arguments: Dict[str, str | List[str]] | None = None,
+        cookies: Dict[str, str] | None = None,
+        headers: Dict[str, str | List[str]] | None = None,
+    ) -> None:
         self._request = request
 
-        arguments = dict(request.arguments)
         if 'bokeh-session-id' in arguments:
             del arguments['bokeh-session-id']
         self._arguments = arguments
+
         if cookies is not None:
             self._cookies = cookies
         elif hasattr(request, 'cookies'):

--- a/bokeh/server/views/session_handler.py
+++ b/bokeh/server/views/session_handler.py
@@ -127,7 +127,7 @@ class SessionHandler(AuthRequestHandler):
                 # Do not include Cookie header since cookies can be restored from cookies dict
                 del headers['Cookie']
 
-            payload = {'headers': headers, 'cookies': cookies}
+            payload = {'headers': headers, 'cookies': cookies, 'arguments': self.request.arguments}
             payload.update(self.application_context.application.process_request(self.request))
             token = generate_jwt_token(session_id,
                                        secret_key=app.secret_key,

--- a/bokeh/server/views/session_handler.py
+++ b/bokeh/server/views/session_handler.py
@@ -127,7 +127,8 @@ class SessionHandler(AuthRequestHandler):
                 # Do not include Cookie header since cookies can be restored from cookies dict
                 del headers['Cookie']
 
-            payload = {'headers': headers, 'cookies': cookies, 'arguments': self.request.arguments}
+            arguments = {} if self.request.arguments is None else self.request.arguments
+            payload = {'headers': headers, 'cookies': cookies, 'arguments': arguments}
             payload.update(self.application_context.application.process_request(self.request))
             token = generate_jwt_token(session_id,
                                        secret_key=app.secret_key,

--- a/bokeh/util/token.py
+++ b/bokeh/util/token.py
@@ -235,9 +235,9 @@ class _BytesEncoder(json.JSONEncoder):
 
 class _BytesDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
-        super().__init__(object_hook=self.object_hook, *args, **kwargs)
+        super().__init__(object_hook=self.bytes_object_hook, *args, **kwargs)
 
-    def object_hook(self, obj):
+    def bytes_object_hook(self, obj):
         if set(obj.keys()) == {"bytes"}:
             return _base64_decode(obj["bytes"])
         return obj

--- a/bokeh/util/token.py
+++ b/bokeh/util/token.py
@@ -34,12 +34,7 @@ import hmac
 import json
 import time
 import zlib
-from typing import (
-    Any,
-    Dict,
-    Tuple,
-    Union,
-)
+from typing import Any, Dict
 
 # Bokeh imports
 from ..core.types import ID
@@ -94,7 +89,7 @@ def generate_jwt_token(session_id: ID,
                        signed: bool = settings.sign_sessions(),
                        extra_payload: TokenPayload | None = None,
                        expiration: int = 300) -> str:
-    """Generates a JWT token given a session_id and additional payload.
+    """ Generates a JWT token given a session_id and additional payload.
 
     Args:
         session_id (str):
@@ -247,7 +242,7 @@ class _BytesDecoder(json.JSONDecoder):
             return _base64_decode(obj["bytes"])
         return obj
 
-def _get_sysrandom() -> Tuple[Any, bool]:
+def _get_sysrandom() -> tuple[Any, bool]:
     # Use the system PRNG for session id generation (if possible)
     # NOTE: secure random string generation implementation is adapted
     #       from the Django project. Reference:
@@ -268,7 +263,7 @@ def _get_sysrandom() -> Tuple[Any, bool]:
         using_sysrandom = False
         return random, using_sysrandom
 
-def _ensure_bytes(secret_key: Union[str, bytes, None]) -> bytes | None:
+def _ensure_bytes(secret_key: str | bytes | None) -> bytes | None:
     if secret_key is None:
         return None
     elif isinstance(secret_key, bytes):
@@ -290,7 +285,7 @@ def _reseed_if_needed(using_sysrandom: bool, secret_key: bytes | None) -> None:
         random.seed(hashlib.sha256(data).digest())
 
 
-def _base64_encode(decoded: Union[bytes, str]) -> str:
+def _base64_encode(decoded: bytes | str) -> str:
     # base64 encode both takes and returns bytes, we want to work with strings.
     # If 'decoded' isn't bytes already, assume it's utf-8
     decoded_as_bytes = _ensure_bytes(decoded)
@@ -301,7 +296,7 @@ def _base64_encode(decoded: Union[bytes, str]) -> str:
     return str(encoded.rstrip('='))
 
 
-def _base64_decode(encoded: Union[bytes, str]) -> bytes:
+def _base64_decode(encoded: bytes | str) -> bytes:
     # base64 lib both takes and returns bytes, we want to work with strings
     encoded_as_bytes = codecs.encode(encoded, 'ascii') if isinstance(encoded, str) else encoded
     # put the padding back
@@ -322,11 +317,12 @@ def _get_random_string(
         length: int = 44,
         allowed_chars: str = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
         secret_key: bytes | None = settings.secret_key_bytes()) -> str:
-    """
-    Return a securely generated random string.
+    """ Return a securely generated random string.
+
     With the a-z, A-Z, 0-9 character set:
     Length 12 is a 71-bit value. log_2((26+26+10)^12) =~ 71
     Length 44 is a 261-bit value. log_2((26+26+10)^44) = 261
+
     """
     secret_key = _ensure_bytes(secret_key)
     _reseed_if_needed(using_sysrandom, secret_key)

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -294,6 +294,16 @@ async def test_server_applications_callable_arg(ManagedServerLoop: MSL) -> None:
         session = server.get_sessions('/foo')[0]
         assert session.document.title == "Hello, world!"
 
+async def test__token_arguments(ManagedServerLoop: MSL) -> None:
+    application = Application()
+    with ManagedServerLoop(application) as server:
+        response = await http_get(server.io_loop, url(server) + "?foo=10")
+        html = response.body
+        token = extract_token_from_json(html)
+        payload = get_token_payload(token)
+        assert 'arguments' in payload
+        assert payload['arguments'] == {'foo': [b'10']}
+
 async def test__include_headers(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application, include_headers=['Custom']) as server:


### PR DESCRIPTION
This PR changes HTTP argument handling. Currently the arguments are pulled off the Tornado `HTTPServerRequest` in every process, but can vary when `--num-procs` is greater than one, resulting in incorrect values. Instead, the arguments from the original session handler request are encoded into the token so that they will be consistently accessible on any subsequent process.

- [x] issues: fixes #10183
- [x] tests added / passed

@philippjfr if there is something you want to do with reducing redundant cookie payloads, please feel free to push commits with tests to this branch (I'm not going to have more bandwidth for this PR).