### PR TITLE
Rename `NonNullable` to `Required`

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -149,6 +149,7 @@ Special Properties
 .. autoclass:: Nullable
 .. autoclass:: NonNullable
 .. autoclass:: Override
+.. autoclass:: Required
 
 Validation-only Properties
 --------------------------
@@ -249,6 +250,7 @@ __all__ = (
     'Readonly',
     'Regex',
     'RelativeDelta',
+    'Required',
     'RestrictedDict',
     'Seq',
     'Size',
@@ -362,6 +364,8 @@ from .property.primitive import Null; Null
 from .property.primitive import String; String
 
 from .property.readonly import Readonly; Readonly
+
+from .property.required import Required; Required
 
 from .property.string import MathString; MathString
 from .property.string import Regex; Regex

--- a/bokeh/core/property/factors.py
+++ b/bokeh/core/property/factors.py
@@ -18,10 +18,16 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+import typing as tp
+
+# External imports
+from typing_extensions import TypeAlias
+
 # Bokeh imports
+from .bases import Init, SingleParameterizedProperty
 from .container import Seq, Tuple
 from .either import Either
-from .nullable import NonNullable
 from .primitive import String
 from .singletons import Intrinsic
 
@@ -42,17 +48,22 @@ L1Factor = String
 L2Factor = Tuple(String, String)
 L3Factor = Tuple(String, String, String)
 
-class Factor(NonNullable):
+FactorType: TypeAlias = tp.Union[str, tp.Tuple[str, str], tp.Tuple[str, str]]
+FactorSeqType: TypeAlias = tp.Union[tp.Sequence[str], tp.Sequence[tp.Tuple[str, str]], tp.Sequence[tp.Tuple[str, str]]]
+
+class Factor(SingleParameterizedProperty[FactorType]):
     """ Represents a single categorical factor. """
 
-    def __init__(self, default=Intrinsic, *, help=None, serialized=None, readonly=False) -> None:
+    def __init__(self, default: Init[FactorType] = Intrinsic, *,
+            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
         type_param = Either(L1Factor, L2Factor, L3Factor)
         super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
 
-class FactorSeq(NonNullable):
+class FactorSeq(SingleParameterizedProperty[FactorSeqType]):
     """ Represents a collection of categorical factors. """
 
-    def __init__(self, default=Intrinsic, *, help=None, serialized=None, readonly=False) -> None:
+    def __init__(self, default: Init[FactorSeqType] = Intrinsic, *,
+            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
         type_param = Either(Seq(L1Factor), Seq(L2Factor), Seq(L3Factor))
         super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
 

--- a/bokeh/core/property/nullable.py
+++ b/bokeh/core/property/nullable.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 from typing import Any, TypeVar, Union
 
 # Bokeh imports
+from ...util.deprecation import deprecated
 from ._sphinx import property_link, register_type_link, type_link
 from .bases import (
     Init,
@@ -30,6 +31,7 @@ from .bases import (
     TypeOrInst,
 )
 from .required import Required
+from .singletons import Undefined
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -81,6 +83,11 @@ class NonNullable(Required[T]):
 
         Use ``bokeh.core.property.required.Required`` instead.
     """
+
+    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Undefined,
+            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
+        deprecated((3, 0, 0), "NonNullable(Type)", "Required(Type)")
+        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/required.py
+++ b/bokeh/core/property/required.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Provide ``Nullable`` and ``NonNullable`` properties. """
+""" Provide ``Required`` property. """
 
 #-----------------------------------------------------------------------------
 # Boilerplate
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 
 # Bokeh imports
 from ._sphinx import property_link, register_type_link, type_link
@@ -29,15 +29,14 @@ from .bases import (
     SingleParameterizedProperty,
     TypeOrInst,
 )
-from .required import Required
+from .singletons import Undefined
 
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
 
 __all__ = (
-    "NonNullable",
-    "Nullable",
+    "Required",
 )
 
 T = TypeVar("T")
@@ -46,41 +45,12 @@ T = TypeVar("T")
 # General API
 #-----------------------------------------------------------------------------
 
-class Nullable(SingleParameterizedProperty[Union[T, None]]):
-    """ A property accepting ``None`` or a value of some other type. """
+class Required(SingleParameterizedProperty[T]):
+    """ A property accepting a value of some other type while having undefined default. """
 
-    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T | None] = None,
+    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Undefined,
             help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
         super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
-
-    def transform(self, value: Any) -> T | None:
-        return None if value is None else super().transform(value)
-
-    def wrap(self, value: Any):
-        return None if value is None else super().wrap(value)
-
-    def validate(self, value: Any, detail: bool = True) -> None:
-        if value is None:
-            return
-
-        try:
-            super().validate(value, detail=False)
-        except ValueError:
-            pass
-        else:
-            return
-
-        msg = "" if not detail else f"expected either None or a value of type {self.type_param}, got {value!r}"
-        raise ValueError(msg)
-
-class NonNullable(Required[T]):
-    """
-    A property accepting a value of some other type while having undefined default.
-
-    .. deprecated:: 3.0.0
-
-        Use ``bokeh.core.property.required.Required`` instead.
-    """
 
 #-----------------------------------------------------------------------------
 # Dev API
@@ -94,7 +64,6 @@ class NonNullable(Required[T]):
 # Code
 #-----------------------------------------------------------------------------
 
-@register_type_link(Nullable)
-@register_type_link(NonNullable)
+@register_type_link(Required)
 def _sphinx_type_link(obj: SingleParameterizedProperty[Any]):
     return f"{property_link(obj)}({type_link(obj.type_param)})"

--- a/bokeh/models/annotations/html/labels.py
+++ b/bokeh/models/annotations/html/labels.py
@@ -37,10 +37,10 @@ from ....core.properties import (
     Enum,
     Float,
     Include,
-    NonNullable,
     NullStringSpec,
     NumberSpec,
     Override,
+    Required,
     String,
     field,
 )
@@ -94,7 +94,7 @@ class HTMLLabel(HTMLAnnotation):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    x = NonNullable(Float, help="""
+    x = Required(Float, help="""
     The x-coordinate in screen coordinates to locate the text anchors.
 
     Datetime values are also accepted, but note that they are immediately
@@ -106,7 +106,7 @@ class HTMLLabel(HTMLAnnotation):
     default.
     """)
 
-    y = NonNullable(Float, help="""
+    y = Required(Float, help="""
     The y-coordinate in screen coordinates to locate the text anchors.
 
     Datetime values are also accepted, but note that they are immediately

--- a/bokeh/models/annotations/labels.py
+++ b/bokeh/models/annotations/labels.py
@@ -35,10 +35,10 @@ from ...core.properties import (
     Enum,
     Float,
     Include,
-    NonNullable,
     NullStringSpec,
     NumberSpec,
     Override,
+    Required,
     TextLike,
     field,
 )
@@ -122,7 +122,7 @@ class Label(TextAnnotation):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    x = NonNullable(Float, help="""
+    x = Required(Float, help="""
     The x-coordinate in screen coordinates to locate the text anchors.
 
     Datetime values are also accepted, but note that they are immediately
@@ -134,7 +134,7 @@ class Label(TextAnnotation):
     default.
     """)
 
-    y = NonNullable(Float, help="""
+    y = Required(Float, help="""
     The y-coordinate in screen coordinates to locate the text anchors.
 
     Datetime values are also accepted, but note that they are immediately

--- a/bokeh/models/callbacks.py
+++ b/bokeh/models/callbacks.py
@@ -31,7 +31,7 @@ from ..core.properties import (
     Bool,
     Dict,
     Instance,
-    NonNullable as Required,
+    Required,
     String,
 )
 from ..core.property.bases import Init

--- a/bokeh/models/dom.py
+++ b/bokeh/models/dom.py
@@ -28,8 +28,8 @@ from ..core.properties import (
     Either,
     Instance,
     List,
-    NonNullable as Required,
     Nullable,
+    Required,
     String,
 )
 from ..core.property.bases import Init

--- a/bokeh/models/expressions.py
+++ b/bokeh/models/expressions.py
@@ -51,9 +51,9 @@ from ..core.properties import (
     Enum,
     Float,
     Instance,
-    NonNullable,
     Nullable,
     NumberSpec,
+    Required,
     Seq,
     String,
     field,
@@ -144,7 +144,7 @@ class CumSum(Expression):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    field = NonNullable(String, help="""
+    field = Required(String, help="""
     The name of a ``ColumnDataSource`` column to cumulatively sum for new values.
     """)
 
@@ -209,7 +209,7 @@ class Minimum(ScalarExpression):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    field = NonNullable(String)
+    field = Required(String)
     initial = Nullable(Float, default=float("+inf"))
 
 
@@ -220,7 +220,7 @@ class Maximum(ScalarExpression):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    field = NonNullable(String)
+    field = Required(String)
     initial = Nullable(Float, default=float("-inf"))
 
 

--- a/bokeh/models/filters.py
+++ b/bokeh/models/filters.py
@@ -25,8 +25,8 @@ from ..core.properties import (
     Instance,
     Int,
     NonEmpty,
-    NonNullable,
     Nullable,
+    Required,
     RestrictedDict,
     Seq,
     String,
@@ -94,7 +94,7 @@ class InversionFilter(Filter):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    operand = NonNullable(Instance(Filter), help="""
+    operand = Required(Instance(Filter), help="""
     Indices produced by this filter will be inverted.
     """)
 
@@ -105,7 +105,7 @@ class IntersectionFilter(Filter):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    operands = NonNullable(NonEmpty(Seq(Instance(Filter))), help="""
+    operands = Required(NonEmpty(Seq(Instance(Filter))), help="""
     Indices produced by a collection of these filters will be intersected.
     """)
 
@@ -116,7 +116,7 @@ class UnionFilter(Filter):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    operands = NonNullable(NonEmpty(Seq(Instance(Filter))), help="""
+    operands = Required(NonEmpty(Seq(Instance(Filter))), help="""
     Indices produced by a collection of these filters will be unioned.
     """)
 
@@ -127,7 +127,7 @@ class DifferenceFilter(Filter):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    operands = NonNullable(NonEmpty(Seq(Instance(Filter))), help="""
+    operands = Required(NonEmpty(Seq(Instance(Filter))), help="""
     Indices produced by a collection of these filters will be subtracted.
     """)
 
@@ -138,7 +138,7 @@ class SymmetricDifferenceFilter(Filter):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    operands = NonNullable(NonEmpty(Seq(Instance(Filter))), help="""
+    operands = Required(NonEmpty(Seq(Instance(Filter))), help="""
     Indices produced by a collection of these filters will be xored.
     """)
 
@@ -176,11 +176,11 @@ class GroupFilter(Filter):
     column column_name match the group variable.
     '''
 
-    column_name = NonNullable(String, help="""
+    column_name = Required(String, help="""
     The name of the column to perform the group filtering operation on.
     """)
 
-    group = NonNullable(String, help="""
+    group = Required(String, help="""
     The value of the column indicating the rows of data to keep.
     """)
 

--- a/bokeh/models/map_plots.py
+++ b/bokeh/models/map_plots.py
@@ -32,9 +32,9 @@ from ..core.properties import (
     Instance,
     InstanceDefault,
     Int,
-    NonNullable,
     Nullable,
     Override,
+    Required,
     String,
 )
 from ..core.validation import error, warning
@@ -69,11 +69,11 @@ class MapOptions(Model):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    lat = NonNullable(Float, help="""
+    lat = Required(Float, help="""
     The latitude where the map should be centered.
     """)
 
-    lng = NonNullable(Float, help="""
+    lng = Required(Float, help="""
     The longitude where the map should be centered.
     """)
 
@@ -191,7 +191,7 @@ class GMapPlot(MapPlot):
 
     background_fill_alpha = Override(default=0.0)
 
-    api_key = NonNullable(Bytes, help="""
+    api_key = Required(Bytes, help="""
     Google Maps API requires an API key. See https://developers.google.com/maps/documentation/javascript/get-api-key
     for more information on how to obtain your own.
     """).accepts(String, lambda val: val.encode("utf-8"))

--- a/bokeh/models/selectors.py
+++ b/bokeh/models/selectors.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import NonNullable as Required, String
+from ..core.properties import Required, String
 from ..core.property.bases import Init
 from ..core.property.singletons import Intrinsic
 from ..model import Model

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -43,11 +43,11 @@ from ..core.properties import (
     Instance,
     InstanceDefault,
     Int,
-    NonNullable,
     Nullable,
     PandasDataFrame,
     PandasGroupBy,
     Readonly,
+    Required,
     Seq,
     String,
 )
@@ -786,7 +786,7 @@ class GeoJSONDataSource(ColumnarDataSource):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    geojson = NonNullable(JSON, help="""
+    geojson = Required(JSON, help="""
     GeoJSON that contains features for plotting. Currently
     ``GeoJSONDataSource`` can only process a ``FeatureCollection`` or
     ``GeometryCollection``.
@@ -828,7 +828,7 @@ class WebDataSource(ColumnDataSource):
     replace existing data entirely.
     """)
 
-    data_url = NonNullable(String, help="""
+    data_url = Required(String, help="""
     A URL to to fetch data from.
     """)
 

--- a/bokeh/models/text.py
+++ b/bokeh/models/text.py
@@ -26,7 +26,7 @@ from ..core.properties import (
     Dict,
     Either,
     Int,
-    NonNullable,
+    Required,
     String,
     Tuple,
 )
@@ -60,7 +60,7 @@ class BaseText(Model):
 
         super().__init__(**kwargs)
 
-    text = NonNullable(String, help="""
+    text = Required(String, help="""
     The text value to render.
     """)
 

--- a/bokeh/models/textures.py
+++ b/bokeh/models/textures.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from ..core.enums import TextureRepetition
 from ..core.has_props import abstract
-from ..core.properties import Enum, NonNullable, String
+from ..core.properties import Enum, Required, String
 from ..model import Model
 
 #-----------------------------------------------------------------------------
@@ -63,7 +63,7 @@ class CanvasTexture(Texture):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    code = NonNullable(String, help="""
+    code = Required(String, help="""
     A snippet of JavaScript code to execute in the browser.
 
     """)
@@ -77,7 +77,7 @@ class ImageURLTexture(Texture):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    url = NonNullable(String, help="""
+    url = Required(String, help="""
     A URL to a drawable resource like image, video, etc.
 
     """)

--- a/bokeh/models/tickers.py
+++ b/bokeh/models/tickers.py
@@ -31,9 +31,9 @@ from ..core.properties import (
     Float,
     Instance,
     Int,
-    NonNullable,
     Nullable,
     Override,
+    Required,
     Seq,
 )
 from ..core.validation import error
@@ -188,7 +188,7 @@ class SingleIntervalTicker(ContinuousTicker):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    interval = NonNullable(Float, help="""
+    interval = Required(Float, help="""
     The interval between adjacent ticks.
     """)
 

--- a/bokeh/models/tiles.py
+++ b/bokeh/models/tiles.py
@@ -27,9 +27,9 @@ from ..core.properties import (
     Dict,
     Float,
     Int,
-    NonNullable,
     Nullable,
     Override,
+    Required,
     String,
 )
 from ..model import Model
@@ -91,11 +91,11 @@ class TileSource(Model):
     Data provider attribution content. This can include HTML content.
     """)
 
-    x_origin_offset = NonNullable(Float, help="""
+    x_origin_offset = Required(Float, help="""
     An x-offset in plot coordinates
     """)
 
-    y_origin_offset = NonNullable(Float, help="""
+    y_origin_offset = Required(Float, help="""
     A y-offset in plot coordinates
     """)
 

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -73,12 +73,12 @@ from ..core.properties import (
     InstanceDefault,
     Int,
     List,
-    NonNullable,
     Null,
     Nullable,
     Override,
     Percent,
     Regex,
+    Required,
     Seq,
     String,
     Tuple,
@@ -1325,7 +1325,7 @@ class EditTool(GestureTool):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    empty_value = NonNullable(Either(Bool, Int, Float, Date, Datetime, Color, String), help="""
+    empty_value = Required(Either(Bool, Int, Float, Date, Datetime, Color, String), help="""
     Defines the value to insert on non-coordinate columns when a new
     glyph is inserted into the ``ColumnDataSource`` columns, e.g. when a
     circle glyph defines 'x', 'y' and 'color' columns, adding a new

--- a/bokeh/models/transforms.py
+++ b/bokeh/models/transforms.py
@@ -31,8 +31,8 @@ from ..core.properties import (
     Enum,
     Float,
     Instance,
-    NonNullable,
     Nullable,
+    Required,
     Seq,
     String,
 )
@@ -223,11 +223,11 @@ class Interpolator(Transform):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    x = NonNullable(Either(String, Seq(Float)), help="""
+    x = Required(Either(String, Seq(Float)), help="""
     Independent coordinate denoting the location of a point.
     """)
 
-    y = NonNullable(Either(String, Seq(Float)), help="""
+    y = Required(Either(String, Seq(Float)), help="""
     Dependant coordinate denoting the value of a point at a location.
     """)
 

--- a/bokeh/models/ui/dialogs.py
+++ b/bokeh/models/ui/dialogs.py
@@ -26,8 +26,8 @@ from ...core.properties import (
     Either,
     Instance,
     List,
-    NonNullable as Required,
     Nullable,
+    Required,
     String,
 )
 from ..dom import DOMNode

--- a/bokeh/models/ui/icons.py
+++ b/bokeh/models/ui/icons.py
@@ -29,7 +29,7 @@ from ...core.properties import (
     Enum,
     FontSize,
     Int,
-    NonNullable as Required,
+    Required,
     String,
 )
 from ...core.property.bases import Init

--- a/bokeh/models/ui/menus.py
+++ b/bokeh/models/ui/menus.py
@@ -28,8 +28,8 @@ from ...core.properties import (
     Enum,
     Instance,
     List,
-    NonNullable as Required,
     Nullable,
+    Required,
     String,
 )
 from .icons import Icon

--- a/bokeh/models/ui/tooltips.py
+++ b/bokeh/models/ui/tooltips.py
@@ -29,9 +29,9 @@ from ...core.properties import (
     Enum,
     Float,
     Instance,
-    NonNullable as Required,
     Nullable,
     Override,
+    Required,
     String,
     Tuple,
 )

--- a/bokeh/models/widgets/buttons.py
+++ b/bokeh/models/widgets/buttons.py
@@ -32,9 +32,9 @@ from ...core.properties import (
     Enum,
     Instance,
     List,
-    NonNullable as Required,
     Nullable,
     Override,
+    Required,
     String,
     Tuple,
 )

--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -36,10 +36,10 @@ from ...core.properties import (
     Float,
     Instance,
     Int,
-    NonNullable,
     Nullable,
     Override,
     Readonly,
+    Required,
     String,
     Tuple,
 )
@@ -120,19 +120,19 @@ class Slider(AbstractSlider):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    start = NonNullable(Float, help="""
+    start = Required(Float, help="""
     The minimum allowable value.
     """)
 
-    end = NonNullable(Float, help="""
+    end = Required(Float, help="""
     The maximum allowable value.
     """)
 
-    value = NonNullable(Float, help="""
+    value = Required(Float, help="""
     Initial or selected value.
     """)
 
-    value_throttled = Readonly(NonNullable(Float), help="""
+    value_throttled = Readonly(Required(Float), help="""
     Initial or selected value, throttled according to report only on mouseup.
     """)
 
@@ -149,19 +149,19 @@ class RangeSlider(AbstractSlider):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    value = NonNullable(Tuple(Float, Float), help="""
+    value = Required(Tuple(Float, Float), help="""
     Initial or selected range.
     """)
 
-    value_throttled = Readonly(NonNullable(Tuple(Float, Float)), help="""
+    value_throttled = Readonly(Required(Tuple(Float, Float)), help="""
     Initial or selected value, throttled according to report only on mouseup.
     """)
 
-    start = NonNullable(Float, help="""
+    start = Required(Float, help="""
     The minimum allowable value.
     """)
 
-    end = NonNullable(Float, help="""
+    end = Required(Float, help="""
     The maximum allowable value.
     """)
 
@@ -207,19 +207,19 @@ class DateSlider(AbstractSlider):
 
         return self.value
 
-    value = NonNullable(Datetime, help="""
+    value = Required(Datetime, help="""
     Initial or selected value.
     """)
 
-    value_throttled = Readonly(NonNullable(Datetime), help="""
+    value_throttled = Readonly(Required(Datetime), help="""
     Initial or selected value, throttled to report only on mouseup.
     """)
 
-    start = NonNullable(Datetime, help="""
+    start = Required(Datetime, help="""
     The minimum allowable value.
     """)
 
-    end = NonNullable(Datetime, help="""
+    end = Required(Datetime, help="""
     The maximum allowable value.
     """)
 
@@ -278,19 +278,19 @@ class DateRangeSlider(AbstractSlider):
             d2 = v2
         return d1, d2
 
-    value = NonNullable(Tuple(Datetime, Datetime), help="""
+    value = Required(Tuple(Datetime, Datetime), help="""
     Initial or selected range.
     """)
 
-    value_throttled = Readonly(NonNullable(Tuple(Datetime, Datetime)), help="""
+    value_throttled = Readonly(Required(Tuple(Datetime, Datetime)), help="""
     Initial or selected value, throttled to report only on mouseup.
     """)
 
-    start = NonNullable(Datetime, help="""
+    start = Required(Datetime, help="""
     The minimum allowable value.
     """)
 
-    end = NonNullable(Datetime, help="""
+    end = Required(Datetime, help="""
     The maximum allowable value.
     """)
 
@@ -325,19 +325,19 @@ class DatetimeRangeSlider(AbstractSlider):
             d2 = v2
         return d1, d2
 
-    value = NonNullable(Tuple(Datetime, Datetime), help="""
+    value = Required(Tuple(Datetime, Datetime), help="""
     Initial or selected range.
     """)
 
-    value_throttled = Readonly(NonNullable(Tuple(Datetime, Datetime)), help="""
+    value_throttled = Readonly(Required(Tuple(Datetime, Datetime)), help="""
     Initial or selected value, throttled to report only on mouseup.
     """)
 
-    start = NonNullable(Datetime, help="""
+    start = Required(Datetime, help="""
     The minimum allowable value.
     """)
 
-    end = NonNullable(Datetime, help="""
+    end = Required(Datetime, help="""
     The maximum allowable value.
     """)
 

--- a/bokeh/models/widgets/tables.py
+++ b/bokeh/models/widgets/tables.py
@@ -40,9 +40,9 @@ from ...core.properties import (
     InstanceDefault,
     Int,
     List,
-    NonNullable,
     Nullable,
     Override,
+    Required,
     String,
 )
 from ...model import Model
@@ -674,7 +674,7 @@ class TableColumn(Model):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    field = NonNullable(String, help="""
+    field = Required(String, help="""
     The name of the field mapping to a column in the data source.
     """)
 

--- a/examples/custom/font-awesome/fontawesome_icon.py
+++ b/examples/custom/font-awesome/fontawesome_icon.py
@@ -1,4 +1,4 @@
-from bokeh.core.properties import Bool, Enum, NonNullable as Required
+from bokeh.core.properties import Bool, Enum, Required
 from bokeh.models import Icon
 
 from named_icon import NamedIcon

--- a/tests/unit/bokeh/core/property/test_nullable.py
+++ b/tests/unit/bokeh/core/property/test_nullable.py
@@ -16,6 +16,9 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+import warnings
+
 # Bokeh imports
 from bokeh._testing.util.api import verify_all
 from bokeh.core.properties import (
@@ -26,6 +29,7 @@ from bokeh.core.properties import (
     String,
 )
 from bokeh.core.property.wrappers import PropertyValueDict, PropertyValueList
+from bokeh.util.warnings import BokehDeprecationWarning
 
 from _util_property import _TestHasProps, _TestModel
 
@@ -101,9 +105,15 @@ class Test_Nullable:
 
 class Test_NonNullable:
 
+    def _test_deprecation(self) -> None:
+        with pytest.warns(BokehDeprecationWarning):
+            bcpn.NonNullable(List(Int))
+
     def test_str(self) -> None:
-        prop = bcpn.NonNullable(List(Int))
-        assert str(prop) == "NonNullable(List(Int))"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=BokehDeprecationWarning)
+            prop = bcpn.NonNullable(List(Int))
+            assert str(prop) == "NonNullable(List(Int))"
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/core/property/test_nullable.py
+++ b/tests/unit/bokeh/core/property/test_nullable.py
@@ -100,35 +100,6 @@ class Test_Nullable:
         assert prop.wrap(wrapped) is wrapped
 
 class Test_NonNullable:
-    def test_init(self) -> None:
-        with pytest.raises(TypeError):
-            bcpn.NonNullable()
-
-    def test_valid(self) -> None:
-        prop = bcpn.NonNullable(List(Int))
-
-        assert prop.is_valid([])
-        assert prop.is_valid([1, 2, 3])
-
-    def test_invalid(self) -> None:
-        prop = bcpn.NonNullable(List(Int))
-
-        assert not prop.is_valid(None)
-
-        assert not prop.is_valid(-100)
-        assert not prop.is_valid("yyy")
-        assert not prop.is_valid([1, 2, ""])
-
-        assert not prop.is_valid(())
-        assert not prop.is_valid({})
-        assert not prop.is_valid(_TestHasProps())
-        assert not prop.is_valid(_TestModel())
-
-    def test_has_ref(self) -> None:
-        prop0 = bcpn.NonNullable(Int)
-        assert not prop0.has_ref
-        prop1 = bcpn.NonNullable(Instance(_TestModel))
-        assert prop1.has_ref
 
     def test_str(self) -> None:
         prop = bcpn.NonNullable(List(Int))

--- a/tests/unit/bokeh/core/property/test_required.py
+++ b/tests/unit/bokeh/core/property/test_required.py
@@ -4,64 +4,73 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Auxiliary graphical models for aiding glyphs, guide renderers, etc.
-
-"""
 
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
-import logging # isort:skip
-log = logging.getLogger(__name__)
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
 
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from ..core.has_props import abstract
-from ..core.properties import Enum, Instance, Required
-from ..model import Model
+from bokeh._testing.util.api import verify_all
+from bokeh.core.properties import Instance, Int, List
+
+from _util_property import _TestHasProps, _TestModel
+
+# Module under test
+import bokeh.core.property.required as bcpr # isort:skip
 
 #-----------------------------------------------------------------------------
-# Globals and constants
+# Setup
 #-----------------------------------------------------------------------------
 
-__all__ = (
-    "Decoration",
-    "Marking",
+ALL = (
+    "Required",
 )
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-@abstract
-class Marking(Model):
-    """ Base class for graphical markings, e.g. arrow heads.
+class Test_Required:
+    def test_init(self) -> None:
+        with pytest.raises(TypeError):
+            bcpr.Required()
 
-    """
+    def test_valid(self) -> None:
+        prop = bcpr.Required(List(Int))
 
-    # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        assert prop.is_valid([])
+        assert prop.is_valid([1, 2, 3])
 
-class Decoration(Model):
-    """ Indicates a positioned marker, e.g. at a node of a glyph.
+    def test_invalid(self) -> None:
+        prop = bcpr.Required(List(Int))
 
-    """
+        assert not prop.is_valid(None)
 
-    # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        assert not prop.is_valid(-100)
+        assert not prop.is_valid("yyy")
+        assert not prop.is_valid([1, 2, ""])
 
-    marking = Instance(Marking, help="""
-    The graphical marking associated with this decoration, e.g. an arrow head.
-    """)
+        assert not prop.is_valid(())
+        assert not prop.is_valid({})
+        assert not prop.is_valid(_TestHasProps())
+        assert not prop.is_valid(_TestModel())
 
-    node = Required(Enum("start", "middle", "end"), help="""
-    The placement of the marking on the parent graphical object.
-    """)
+    def test_has_ref(self) -> None:
+        prop0 = bcpr.Required(Int)
+        assert not prop0.has_ref
+        prop1 = bcpr.Required(Instance(_TestModel))
+        assert prop1.has_ref
+
+    def test_str(self) -> None:
+        prop = bcpr.Required(List(Int))
+        assert str(prop) == "Required(List(Int))"
 
 #-----------------------------------------------------------------------------
 # Dev API
@@ -74,3 +83,5 @@ class Decoration(Model):
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------
+
+Test___all__ = verify_all(bcpr, ALL)

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -106,6 +106,7 @@ ALL = (
     'Readonly',
     'Regex',
     'RelativeDelta',
+    'Required',
     'RestrictedDict',
     'Seq',
     'Size',


### PR DESCRIPTION
So that we can avoid `from bokeh.core.properties import NonNullable as Required`. This rename makes sense, because `null`/`None` has no significance in bokeh's type system anymore. In fact in the long term, it would be better to use more symbols/domain specific singletons. I kept `NonNullable` deprecated for backwards compatibility (it as added in 2.3).
