### PR TITLE
add SRI hash for vis.js

### DIFF
--- a/examples/app/surface3d/templates/index.html
+++ b/examples/app/surface3d/templates/index.html
@@ -2,7 +2,12 @@
 
 {% block preamble %}
   {# This line loads the vis.js library for custom model extension to use #}
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.16.1/vis.min.js"></script>
+  <script
+    type="text/javascript"
+    src="https://unpkg.com/vis-graph3d@6.0.2/dist/vis-graph3d.min.js"
+    integrity="sha384-/w3emp/TDpiU/NL7tl+GT9ZZC1zCikTdVYa0Kit58LbrtTqNpLrZ5MaoOi7pR0UA"
+    crossorigin="anonymous"
+  ></script>
 
   <style>
   h1 {


### PR DESCRIPTION
Small PR to update `surface3d` example to load latest `vis.js` package using SRI hashes and also using the CDN location that the official docs currently specify. Addresses:

* https://github.com/bokeh/bokeh/security/code-scanning/18

