### PR TITLE
Normalize built-in types and remove `Unknown`

### DIFF
--- a/bokeh/_testing/plugins/project.py
+++ b/bokeh/_testing/plugins/project.py
@@ -29,9 +29,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Protocol,
-    Tuple,
 )
 
 # External imports
@@ -106,7 +104,7 @@ def output_file_url(request: pytest.FixtureRequest, file_server: SimpleWebServer
     return file_server.where_is(url)
 
 @pytest.fixture
-def test_file_path_and_url(request: pytest.FixtureRequest, file_server: SimpleWebServer) -> Tuple[str, str]:
+def test_file_path_and_url(request: pytest.FixtureRequest, file_server: SimpleWebServer) -> tuple[str, str]:
     filename = request.function.__name__ + '.html'
     file_obj = request.fspath.dirpath().join(filename)
     file_path = file_obj.strpath
@@ -133,7 +131,7 @@ def find_free_port() -> int:
         return s.getsockname()[1]
 
 class BokehAppInfo(Protocol):
-    def __call__(self, modify_doc: ModifyDoc) -> Tuple[str, ws.MessageTestPort]: ...
+    def __call__(self, modify_doc: ModifyDoc) -> tuple[str, ws.MessageTestPort]: ...
 
 class HasNoConsoleErrors(Protocol):
     def __call__(self, webdriver: WebDriver) -> bool: ...
@@ -148,7 +146,7 @@ def bokeh_app_info(request: pytest.FixtureRequest, driver: WebDriver) -> BokehAp
 
     '''
 
-    def func(modify_doc: ModifyDoc) -> Tuple[str, ws.MessageTestPort]:
+    def func(modify_doc: ModifyDoc) -> tuple[str, ws.MessageTestPort]:
         ws._message_test_port = ws.MessageTestPort(sent=[], received=[])
         port = find_free_port()
         def worker() -> None:
@@ -240,7 +238,7 @@ class _BokehPageMixin(_ElementMixin):
     _has_no_console_errors: HasNoConsoleErrors
 
     @property
-    def results(self) -> Dict[str, Any]:
+    def results(self) -> dict[str, Any]:
         WebDriverWait(self._driver, 10).until(EC.staleness_of(self.test_div))
         self.test_div = find_matching_element(self._driver, ".bokeh-test-div")
         return self._driver.execute_script(RESULTS)

--- a/bokeh/_testing/plugins/selenium.py
+++ b/bokeh/_testing/plugins/selenium.py
@@ -25,7 +25,6 @@ from typing import (
     TYPE_CHECKING,
     Callable,
     Iterator,
-    List,
     NoReturn,
     Sequence,
 )
@@ -53,7 +52,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def pytest_report_collectionfinish(config: config.Config, startdir: py.path.local, items: Sequence[nodes.Item]) -> List[str]:
+def pytest_report_collectionfinish(config: config.Config, startdir: py.path.local, items: Sequence[nodes.Item]) -> list[str]:
     '''
 
     '''

--- a/bokeh/_testing/util/compare.py
+++ b/bokeh/_testing/util/compare.py
@@ -31,6 +31,7 @@ from typing import (
 # External imports
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import TypeAlias
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -44,8 +45,8 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-Num = Union[int, float]
-Data = Dict[str,
+Num: TypeAlias = Union[int, float]
+Data: TypeAlias = Dict[str,
     Union[
         Sequence[Num],
         Sequence[Sequence[Num]],

--- a/bokeh/_testing/util/examples.py
+++ b/bokeh/_testing/util/examples.py
@@ -34,10 +34,11 @@ from os.path import (
     relpath,
     splitext,
 )
-from typing import List, Literal, Union
+from typing import Literal, Union
 
 # External imports
 import yaml
+from typing_extensions import TypeAlias
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -52,7 +53,7 @@ __all__ = (
 
 JOB_ID = os.environ.get("GITHUB_ACTION", "local")
 
-PathLike = Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
+PathLike: TypeAlias = Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
 
 #-----------------------------------------------------------------------------
 # General API
@@ -69,7 +70,7 @@ class Flags:
 
 
 class Example:
-    def __init__(self, path: str, flags: int, examples_dir: str, extensions: List[str] = []) -> None:
+    def __init__(self, path: str, flags: int, examples_dir: str, extensions: list[str] = []) -> None:
         self.path = normpath(path)
         self.flags = flags
         self.examples_dir = examples_dir
@@ -146,9 +147,9 @@ class Example:
 
 All = Literal["all"]
 
-def add_examples(list_of_examples: List[Example], path: str, examples_dir: str, example_type: int | None = None,
-        slow: List[str] | All | None = None, skip: List[str] | All | None = None,
-        xfail: List[str] | All | None = None, no_js: List[str] | All | None = None) -> None:
+def add_examples(list_of_examples: list[Example], path: str, examples_dir: str, example_type: int | None = None,
+        slow: list[str] | All | None = None, skip: list[str] | All | None = None,
+        xfail: list[str] | All | None = None, no_js: list[str] | All | None = None) -> None:
     if path.endswith("*"):
         star_path = join(examples_dir, path[:-1])
 
@@ -162,7 +163,7 @@ def add_examples(list_of_examples: List[Example], path: str, examples_dir: str, 
 
     for name in sorted(os.listdir(example_path)):
         flags = 0
-        extensions: List[str] = []
+        extensions: list[str] = []
         orig_name = name
 
         if name.startswith(('_', '.')):
@@ -207,9 +208,9 @@ def add_examples(list_of_examples: List[Example], path: str, examples_dir: str, 
         list_of_examples.append(Example(join(example_path, name), flags, examples_dir, extensions))
 
 
-def collect_examples(config_path: str) -> List[Example]:
+def collect_examples(config_path: str) -> list[Example]:
     examples_dir = join(dirname(config_path), pardir)
-    list_of_examples: List[Example] = []
+    list_of_examples: list[Example] = []
 
     with open(config_path, "r") as f:
         examples = yaml.safe_load(f.read())

--- a/bokeh/_testing/util/filesystem.py
+++ b/bokeh/_testing/util/filesystem.py
@@ -32,7 +32,6 @@ from typing import (
     Awaitable,
     Callable,
     ContextManager,
-    Dict,
     Iterator,
     Type,
 )
@@ -78,7 +77,7 @@ class TmpDir(ContextManager[str]):
     def __enter__(self) -> str:
         return self._dir
 
-def with_directory_contents(contents: Dict[PathLike, str | None], func: Callable[[str], None]) -> None:
+def with_directory_contents(contents: dict[PathLike, str | None], func: Callable[[str], None]) -> None:
     '''
 
     '''

--- a/bokeh/_testing/util/project.py
+++ b/bokeh/_testing/util/project.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from pathlib import Path
 from subprocess import run
-from typing import List, Sequence
+from typing import Sequence
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -42,12 +42,12 @@ TOP_PATH = Path(__file__).resolve().parent.parent.parent.parent
 # General API
 #-----------------------------------------------------------------------------
 
-def ls_files(*patterns: str) -> List[str]:
+def ls_files(*patterns: str) -> list[str]:
     proc = run(["git", "ls-files", "--", *patterns], capture_output=True)
     return proc.stdout.decode("utf-8").split("\n")
 
-def ls_modules(*, dir: str = "bokeh", skip_prefixes: Sequence[str] = [], skip_main: bool = True) -> List[str]:
-    modules: List[str] = []
+def ls_modules(*, dir: str = "bokeh", skip_prefixes: Sequence[str] = [], skip_main: bool = True) -> list[str]:
+    modules: list[str] = []
 
     files = ls_files(f"{dir}/**.py")
 
@@ -67,7 +67,7 @@ def ls_modules(*, dir: str = "bokeh", skip_prefixes: Sequence[str] = [], skip_ma
 
     return modules
 
-def verify_clean_imports(target: str, modules: List[str]) -> str:
+def verify_clean_imports(target: str, modules: list[str]) -> str:
     imports =  ";".join(f"import {m}" for m in modules)
     return f"import sys; {imports}; sys.exit(1 if any({target!r} in x for x in sys.modules.keys()) else 0)"
 

--- a/bokeh/_testing/util/screenshot.py
+++ b/bokeh/_testing/util/screenshot.py
@@ -29,7 +29,7 @@ from os.path import (
     pardir,
     split,
 )
-from typing import List, TypedDict
+from typing import TypedDict
 
 # Bokeh imports
 from bokeh.util.terminal import fail, trace
@@ -66,8 +66,8 @@ class JSResult(TypedDict):
     success: bool
     timeout: float | None
     image: JSImage
-    errors: List[JSError]
-    messages: List[JSMessage]
+    errors: list[JSError]
+    messages: list[JSMessage]
 
 def run_in_chrome(url: str, local_wait: int | None = None, global_wait: int | None = None) -> JSResult:
     return _run_in_browser(_get_chrome(), url, local_wait, global_wait)
@@ -80,10 +80,10 @@ def run_in_chrome(url: str, local_wait: int | None = None, global_wait: int | No
 # Private API
 #-----------------------------------------------------------------------------
 
-def _get_chrome() -> List[str]:
+def _get_chrome() -> list[str]:
     return ["node", join(dirname(__file__), "chrome_screenshot.js")]
 
-def _run_in_browser(engine: List[str], url: str, local_wait: int | None = None, global_wait: int | None = None) -> JSResult:
+def _run_in_browser(engine: list[str], url: str, local_wait: int | None = None, global_wait: int | None = None) -> JSResult:
     """
     wait is in milliseconds
     """

--- a/bokeh/_testing/util/selenium.py
+++ b/bokeh/_testing/util/selenium.py
@@ -21,13 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    List,
-    Sequence,
-    Set,
-)
+from typing import TYPE_CHECKING, Any, Sequence
 
 # External imports
 from selenium.webdriver.common.action_chains import ActionChains
@@ -109,7 +103,7 @@ MATCHES_SCRIPT = """
     return [...descend(root, selector)]
 """
 
-def find_matching_elements(driver: WebDriver, selector: str, *, root: WebElement | None = None) -> List[WebElement]:
+def find_matching_elements(driver: WebDriver, selector: str, *, root: WebElement | None = None) -> list[WebElement]:
     return driver.execute_script(MATCHES_SCRIPT, selector, root)
 
 def find_matching_element(driver: WebDriver, selector: str, *, root: WebElement | None = None) -> WebElement:
@@ -209,7 +203,7 @@ FIND_SCRIPT = """
     }
 """
 
-def find_elements_for(driver: WebDriver, model: Model, selector: str | None = None) -> List[WebElement]:
+def find_elements_for(driver: WebDriver, model: Model, selector: str | None = None) -> list[WebElement]:
     script = FIND_SCRIPT + """
     for (const els of find(Object.values(Bokeh.index))) {
         return els
@@ -402,7 +396,7 @@ def paste_values(driver: WebDriver, el: WebElement | None = None) -> None:
     # actions.send_keys(Keys.CONTROL, 'v')
     actions.perform()
 
-def get_table_column_cells(driver: WebDriver, table: DataTable, col: int) -> List[str]:
+def get_table_column_cells(driver: WebDriver, table: DataTable, col: int) -> list[str]:
     result = []
     rows = find_elements_for(driver, table, ".slick-row")
     for row in rows:
@@ -413,7 +407,7 @@ def get_table_column_cells(driver: WebDriver, table: DataTable, col: int) -> Lis
 def get_table_row(driver: WebDriver, table: DataTable, row: int) -> WebElement:
     return find_element_for(driver, table, f".slick-row:nth-child({row})")
 
-def get_table_selected_rows(driver: WebDriver, table: DataTable) -> Set[int]:
+def get_table_selected_rows(driver: WebDriver, table: DataTable) -> set[int]:
     result = set()
     rows = find_elements_for(driver, table, ".slick-row")
     for i, row in enumerate(rows):

--- a/bokeh/application/application.py
+++ b/bokeh/application/application.py
@@ -36,10 +36,10 @@ from typing import (
     Awaitable,
     Callable,
     ClassVar,
-    Dict,
-    List,
-    Tuple,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..core.types import ID
@@ -70,7 +70,7 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-Callback = Callable[[], None]
+Callback: TypeAlias = Callable[[], None]
 
 class Application:
     ''' An Application is a factory for Document instances.
@@ -86,10 +86,10 @@ class Application:
     _is_a_bokeh_application_class: ClassVar[bool] = True
 
     _static_path: str | None
-    _handlers: List[Handler]
-    _metadata: Dict[str, Any] | None
+    _handlers: list[Handler]
+    _metadata: dict[str, Any] | None
 
-    def __init__(self, *handlers: Handler, metadata: Dict[str, Any] | None = None) -> None:
+    def __init__(self, *handlers: Handler, metadata: dict[str, Any] | None = None) -> None:
         ''' Application factory.
 
         Args:
@@ -126,14 +126,14 @@ class Application:
     # Properties --------------------------------------------------------------
 
     @property
-    def handlers(self) -> Tuple[Handler, ...]:
+    def handlers(self) -> tuple[Handler, ...]:
         ''' The ordered list of handlers this Application is configured with.
 
         '''
         return tuple(self._handlers)
 
     @property
-    def metadata(self) -> Dict[str, Any] | None:
+    def metadata(self) -> dict[str, Any] | None:
         ''' Arbitrary user-supplied metadata to associate with this application.
 
         '''
@@ -250,7 +250,7 @@ class Application:
             await h.on_session_destroyed(session_context)
         return None
 
-    def process_request(self, request: HTTPServerRequest) -> Dict[str, Any]:
+    def process_request(self, request: HTTPServerRequest) -> dict[str, Any]:
         ''' Processes incoming HTTP request returning a dictionary of
         additional data to add to the session_context.
 
@@ -261,7 +261,7 @@ class Application:
             A dictionary of JSON serializable data to be included on
             the session context.
         '''
-        request_data: Dict[str, Any] = {}
+        request_data: dict[str, Any] = {}
         for h in self._handlers:
             request_data.update(h.process_request(request))
         return request_data
@@ -279,7 +279,7 @@ class ServerContext(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def sessions(self) -> List[ServerSession]:
+    def sessions(self) -> list[ServerSession]:
         ''' ``SessionContext`` instances belonging to this application.
 
         *Subclasses must implement this method.*

--- a/bokeh/application/handlers/code.py
+++ b/bokeh/application/handlers/code.py
@@ -39,13 +39,7 @@ log = logging.getLogger(__name__)
 from contextlib import contextmanager
 from os.path import basename, splitext
 from types import ModuleType
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    List,
-)
+from typing import Any, Callable, ClassVar
 
 # Bokeh imports
 from ...core.types import PathLike
@@ -81,13 +75,13 @@ class CodeHandler(Handler):
     # to be no-ops, with a warning.
     _io_functions = ['output_notebook', 'output_file', 'show', 'save', 'reset_output']
 
-    _loggers: Dict[str, Callable[..., None]]
+    _loggers: dict[str, Callable[..., None]]
 
     _logger_text: ClassVar[str]
 
     _origin: ClassVar[str]
 
-    def __init__(self, *, source: str, filename: PathLike, argv: List[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, source: str, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
         '''
 
         Args:
@@ -199,9 +193,9 @@ class CodeHandler(Handler):
 # code should be calling these functions, and we're only making a best effort to
 # warn people so no big deal if we fail.
 @contextmanager
-def _monkeypatch_io(loggers: Dict[str, Callable[..., None]]) -> Dict[str, Any]:
+def _monkeypatch_io(loggers: dict[str, Callable[..., None]]) -> dict[str, Any]:
     import bokeh.io as io
-    old: Dict[str, Any] = {}
+    old: dict[str, Any] = {}
     for f in CodeHandler._io_functions:
         old[f] = getattr(io, f)
         setattr(io, f, loggers[f])

--- a/bokeh/application/handlers/code_runner.py
+++ b/bokeh/application/handlers/code_runner.py
@@ -27,7 +27,7 @@ import sys
 import traceback
 from os.path import basename
 from types import CodeType, ModuleType
-from typing import Callable, List
+from typing import Callable
 
 # Bokeh imports
 from ...core.types import PathLike
@@ -63,7 +63,7 @@ class CodeRunner:
     _permanent_error_detail: str | None
     _path: PathLike
     _source: str
-    _argv: List[str]
+    _argv: list[str]
     _package: ModuleType | None
     ran: bool
 
@@ -71,7 +71,7 @@ class CodeRunner:
     _error: str | None
     _error_detail: str | None
 
-    def __init__(self, source: str, path: PathLike, argv: List[str], package: ModuleType | None = None) -> None:
+    def __init__(self, source: str, path: PathLike, argv: list[str], package: ModuleType | None = None) -> None:
         '''
 
         Args:

--- a/bokeh/application/handlers/directory.py
+++ b/bokeh/application/handlers/directory.py
@@ -56,13 +56,7 @@ from os.path import (
     join,
 )
 from types import ModuleType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Coroutine,
-    Dict,
-    List,
-)
+from typing import TYPE_CHECKING, Any, Coroutine
 
 # External imports
 from jinja2 import Environment, FileSystemLoader, Template
@@ -116,7 +110,7 @@ class DirectoryHandler(Handler):
     _static: str | None
     _template: Template | None
 
-    def __init__(self, *, filename: PathLike, argv: List[str] = []) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] = []) -> None:
         '''
         Keywords:
             filename (str) : a path to an application directory with either "main.py" or "main.ipynb"
@@ -297,7 +291,7 @@ class DirectoryHandler(Handler):
         '''
         return self._lifecycle_handler.on_session_destroyed(session_context)
 
-    def process_request(self, request: HTTPServerRequest) -> Dict[str, Any]:
+    def process_request(self, request: HTTPServerRequest) -> dict[str, Any]:
         ''' Processes incoming HTTP request returning a dictionary of
         additional data to add to the session_context.
 

--- a/bokeh/application/handlers/handler.py
+++ b/bokeh/application/handlers/handler.py
@@ -46,7 +46,7 @@ log = logging.getLogger(__name__)
 import os
 import sys
 import traceback
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from ...document import Document
@@ -197,7 +197,7 @@ class Handler:
         '''
         pass
 
-    def process_request(self, request: HTTPServerRequest) -> Dict[str, Any]:
+    def process_request(self, request: HTTPServerRequest) -> dict[str, Any]:
         ''' Processes incoming HTTP request returning a dictionary of
         additional data to add to the session_context.
 

--- a/bokeh/application/handlers/notebook.py
+++ b/bokeh/application/handlers/notebook.py
@@ -31,7 +31,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import re
 from types import ModuleType
-from typing import List
 
 # Bokeh imports
 from ...core.types import PathLike
@@ -66,7 +65,7 @@ class NotebookHandler(CodeHandler):
 
     _origin = "Notebook"
 
-    def __init__(self, *, filename: PathLike, argv: List[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
         '''
 
         Keywords:
@@ -88,7 +87,7 @@ class NotebookHandler(CodeHandler):
                 """
                 Given the source of a cell, filter out all cell and line magics.
                 """
-                filtered: List[str] = []
+                filtered: list[str] = []
                 for line in source.splitlines():
                     match = self._magic_pattern.match(line)
                     if match is None:

--- a/bokeh/application/handlers/request_handler.py
+++ b/bokeh/application/handlers/request_handler.py
@@ -22,12 +22,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-)
+from typing import TYPE_CHECKING, Any, Callable
 
 # Bokeh imports
 from .handler import Handler
@@ -58,7 +53,7 @@ class RequestHandler(Handler):
 
     '''
 
-    _process_request: Callable[[HTTPServerRequest], Dict[str, Any]]
+    _process_request: Callable[[HTTPServerRequest], dict[str, Any]]
 
     def __init__(self) -> None:
         super().__init__()
@@ -66,7 +61,7 @@ class RequestHandler(Handler):
 
     # Public methods ----------------------------------------------------------
 
-    def process_request(self, request: HTTPServerRequest) -> Dict[str, Any]:
+    def process_request(self, request: HTTPServerRequest) -> dict[str, Any]:
         ''' Processes incoming HTTP request returning a dictionary of
         additional data to add to the session_context.
 
@@ -87,7 +82,7 @@ class RequestHandler(Handler):
 # Private API
 #-----------------------------------------------------------------------------
 
-def _return_empty(request: HTTPServerRequest) -> Dict[str, Any]:
+def _return_empty(request: HTTPServerRequest) -> dict[str, Any]:
     return {}
 
 #-----------------------------------------------------------------------------

--- a/bokeh/application/handlers/script.py
+++ b/bokeh/application/handlers/script.py
@@ -47,7 +47,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from types import ModuleType
-from typing import List
 
 # Bokeh imports
 from ...core.types import PathLike
@@ -80,7 +79,7 @@ class ScriptHandler(CodeHandler):
 
     _origin = "Script"
 
-    def __init__(self, *, filename: PathLike, argv: List[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
         '''
 
         Keywords:

--- a/bokeh/application/handlers/server_lifecycle.py
+++ b/bokeh/application/handlers/server_lifecycle.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import os
 from types import ModuleType
-from typing import List
 
 # Bokeh imports
 from ...core.types import PathLike
@@ -55,7 +54,7 @@ class ServerLifecycleHandler(LifecycleHandler):
 
     '''
 
-    def __init__(self, *, filename: PathLike, argv: List[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
         '''
 
         Keyword Args:

--- a/bokeh/application/handlers/server_request_handler.py
+++ b/bokeh/application/handlers/server_request_handler.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import os
 from types import ModuleType
-from typing import List
 
 # Bokeh imports
 from ...core.types import PathLike
@@ -57,7 +56,7 @@ class ServerRequestHandler(RequestHandler):
 
     _module: ModuleType
 
-    def __init__(self, *, filename: PathLike, argv: List[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
         '''
 
         Keyword Args:

--- a/bokeh/client/connection.py
+++ b/bokeh/client/connection.py
@@ -25,13 +25,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-)
+from typing import TYPE_CHECKING, Any, Callable
 
 # External imports
 from tornado.httpclient import HTTPClientError, HTTPRequest
@@ -91,7 +85,7 @@ class ClientConnection:
     _until_predicate: Callable[[], bool] | None
 
     def __init__(self, session: ClientSession, websocket_url: str, io_loop: IOLoop | None = None,
-            arguments: Dict[str, str] | None = None, max_message_size: int = 20*1024*1024) -> None:
+            arguments: dict[str, str] | None = None, max_message_size: int = 20*1024*1024) -> None:
         ''' Opens a websocket connection to the server.
 
         '''
@@ -370,8 +364,8 @@ class ClientConnection:
         waiter = WAITING_FOR_REPLY(message.header['msgid'])
         self._state = waiter
 
-        send_result: List[None] = []
-        async def handle_message(message: Message[Any], send_result: List[None]) -> None:
+        send_result: list[None] = []
+        async def handle_message(message: Message[Any], send_result: list[None]) -> None:
             result = await self.send_message(message)
             send_result.append(result)
         self._loop.add_callback(handle_message, message, send_result)

--- a/bokeh/client/session.py
+++ b/bokeh/client/session.py
@@ -34,12 +34,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Literal,
-)
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote_plus
 
 ## External imports
@@ -83,7 +78,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 def pull_session(session_id: ID | None = None, url: str = "default", io_loop: IOLoop | None = None,
-        arguments: Dict[str, str] | None = None, max_message_size: int = 20*1024*1024) -> ClientSession:
+        arguments: dict[str, str] | None = None, max_message_size: int = 20*1024*1024) -> ClientSession:
     ''' Create a session by loading the current server-side document.
 
     ``session.document`` will be a fresh document loaded from
@@ -278,7 +273,7 @@ class ClientSession:
     _callbacks: DocumentCallbackGroup
 
     def __init__(self, session_id: ID | None = None, websocket_url: str = DEFAULT_SERVER_WEBSOCKET_URL,
-            io_loop: IOLoop | None = None, arguments: Dict[str, str] | None = None, max_message_size: int = 20*1024*1024):
+            io_loop: IOLoop | None = None, arguments: dict[str, str] | None = None, max_message_size: int = 20*1024*1024):
         ''' A connection which attaches to a particular named session on the
         server.
 

--- a/bokeh/colors/util.py
+++ b/bokeh/colors/util.py
@@ -21,12 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    ClassVar,
-    Iterator,
-    List,
-    Tuple,
-)
+from typing import ClassVar, Iterator
 
 # Bokeh imports
 from .color import RGB
@@ -53,7 +48,7 @@ class _ColorGroupMeta(type):
     enumerations.
 
     '''
-    _colors: Tuple[str, ...]
+    _colors: tuple[str, ...]
 
     def __len__(self) -> int:
         return len(self._colors)
@@ -97,8 +92,8 @@ class NamedColor(RGB):
 
     '''
 
-    __all__: ClassVar[List[str]] = []
-    colors: ClassVar[List[NamedColor]] = []
+    __all__: ClassVar[list[str]] = []
+    colors: ClassVar[list[NamedColor]] = []
 
     def __init__(self, name: str, r: int, g: int, b: int) -> None:
         '''

--- a/bokeh/command/subcommand.py
+++ b/bokeh/command/subcommand.py
@@ -34,6 +34,9 @@ from typing import (
     Union,
 )
 
+# External imports
+from typing_extensions import TypeAlias
+
 # Bokeh imports
 from ..util.dataclasses import (
     NotRequired,
@@ -61,7 +64,7 @@ __all__ = (
 @dataclass
 class Argument:
     action: NotRequired[Literal["store", "store_const", "store_true", "append", "append_const", "count", "help", "version", "extend"]] = Unspecified
-    nargs: NotRequired[Union[int, Literal["?", "*", "+", "..."]]] = Unspecified
+    nargs: NotRequired[int | Literal["?", "*", "+", "..."]] = Unspecified
     const: NotRequired[Any] = Unspecified
     default: NotRequired[Any] = Unspecified
     type: NotRequired[Type[Any]] = Unspecified
@@ -70,8 +73,8 @@ class Argument:
     help: NotRequired[str] = Unspecified
     metavar: NotRequired[str] = Unspecified
 
-Arg = Tuple[Union[str, Tuple[str, ...]], Argument]
-Args = Tuple[Arg, ...]
+Arg: TypeAlias = Tuple[Union[str, Tuple[str, ...]], Argument]
+Args: TypeAlias = Tuple[Arg, ...]
 
 class Subcommand(metaclass=ABCMeta):
     ''' Abstract base class for subcommands

--- a/bokeh/command/subcommands/__init__.py
+++ b/bokeh/command/subcommands/__init__.py
@@ -46,7 +46,7 @@ __all__ = (
 # Private API
 #-----------------------------------------------------------------------------
 
-def _collect() -> List[Type[Subcommand]]:
+def _collect() -> list[Type[Subcommand]]:
     from importlib import import_module
     from os import listdir
     from os.path import dirname

--- a/bokeh/command/subcommands/file_output.py
+++ b/bokeh/command/subcommands/file_output.py
@@ -25,7 +25,6 @@ import argparse
 import sys
 from abc import abstractmethod
 from os.path import splitext
-from typing import List, Union
 
 # Bokeh imports
 from ...document import Document
@@ -147,7 +146,7 @@ class FileOutputSubcommand(Subcommand):
         applications = build_single_handler_applications(args.files, argvs)
 
         if args.output is None:
-            outputs: List[str] = []
+            outputs: list[str] = []
         else:
             outputs = list(args.output)  # copy so we can pop from it
 
@@ -214,7 +213,7 @@ class FileOutputSubcommand(Subcommand):
         pass
 
     @abstractmethod
-    def file_contents(self, args: argparse.Namespace, doc: Document) -> Union[str, bytes, List[str], List[bytes]]:
+    def file_contents(self, args: argparse.Namespace, doc: Document) -> str | bytes | list[str] | list[bytes]:
         ''' Subclasses must override this method to return the contents of the output file for the given doc.
         subclassed methods return different types:
         str: html, json

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -425,7 +425,7 @@ import argparse
 import os
 from fnmatch import fnmatch
 from glob import glob
-from typing import Any, Dict, List
+from typing import Any
 
 # External imports
 from tornado.autoreload import watch
@@ -770,14 +770,14 @@ class Serve(Subcommand):
         )),
     )
 
-    def customize_applications(self, args: argparse.Namespace, applications: Dict[str, Any]) -> Dict[str, Any]:
+    def customize_applications(self, args: argparse.Namespace, applications: dict[str, Any]) -> dict[str, Any]:
         '''Allows subclasses to customize ``applications``.
 
         Should modify and return a copy of the ``applications`` dictionary.
         '''
         return dict(applications)
 
-    def customize_kwargs(self, args: argparse.Namespace, server_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def customize_kwargs(self, args: argparse.Namespace, server_kwargs: dict[str, Any]) -> dict[str, Any]:
         '''Allows subclasses to customize ``server_kwargs``.
 
         Should modify and return a copy of the ``server_kwargs`` dictionary.
@@ -806,7 +806,7 @@ class Serve(Subcommand):
         # even if Tornado is not installed
         from bokeh.server.server import Server
 
-        files: List[str] = []
+        files: list[str] = []
         for f in args.files:
             if args.glob:
                 files.extend(glob(f))
@@ -918,7 +918,7 @@ class Serve(Subcommand):
                         log.info("Watching: " + os.path.join(path, name))
                         watch(os.path.join(path, name))
 
-        def add_optional_autoreload_files(file_list: List[str]) -> None:
+        def add_optional_autoreload_files(file_list: list[str]) -> None:
             for filen in file_list:
                 if os.path.isdir(filen):
                     log.warning("Cannot watch directory " + filen)

--- a/bokeh/command/subcommands/static.py
+++ b/bokeh/command/subcommands/static.py
@@ -19,7 +19,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from argparse import Namespace
-from typing import Dict
 
 # Bokeh imports
 from bokeh.settings import settings
@@ -75,7 +74,7 @@ class Static(Subcommand):
         # even if Tornado is not installed
         from bokeh.server.server import Server
 
-        applications: Dict[str, Application] = {}
+        applications: dict[str, Application] = {}
 
         _allowed_keys = ['port', 'address']
         server_kwargs = { key: getattr(args, key) for key in _allowed_keys if getattr(args, key, None) is not None }

--- a/bokeh/command/util.py
+++ b/bokeh/command/util.py
@@ -25,7 +25,7 @@ import errno
 import os
 import sys
 import warnings
-from typing import Dict, Iterator, List
+from typing import Iterator
 
 # Bokeh imports
 from bokeh.application import Application
@@ -76,7 +76,7 @@ call "bokeh serve" on the directory instead. For example:
 If this is not the case, renaming main.py will suppress this warning.
 """
 
-def build_single_handler_application(path: str, argv: List[str] | None = None) -> Application:
+def build_single_handler_application(path: str, argv: list[str] | None = None) -> Application:
     ''' Return a Bokeh application built using a single handler for a script,
     notebook, or directory.
 
@@ -141,7 +141,7 @@ def build_single_handler_application(path: str, argv: List[str] | None = None) -
 
     return application
 
-def build_single_handler_applications(paths: List[str], argvs: Dict[str, List[str]] | None = None) -> Dict[str, Application]:
+def build_single_handler_applications(paths: list[str], argvs: dict[str, list[str]] | None = None) -> dict[str, Application]:
     ''' Return a dictionary mapping routes to Bokeh applications built using
     single handlers, for specified files or directories.
 
@@ -163,7 +163,7 @@ def build_single_handler_applications(paths: List[str], argvs: Dict[str, List[st
         RuntimeError
 
     '''
-    applications: Dict[str, Application] = {}
+    applications: dict[str, Application] = {}
     argvs = argvs or {}
 
     for path in paths:

--- a/bokeh/core/enums.py
+++ b/bokeh/core/enums.py
@@ -75,9 +75,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from typing import (
     Any,
-    Dict,
     Iterator,
-    List,
     Literal,
     get_args,
 )
@@ -171,7 +169,7 @@ class Enumeration:
     '''
     __slots__ = ()
 
-    _values: List[str]
+    _values: list[str]
     _default: str
     _case_sensitive: bool
     _quote: bool
@@ -235,7 +233,7 @@ def enumeration(*values: Any, case_sensitive: bool = True, quote: bool = False) 
     if len(values) != len(set(values)):
         raise ValueError(f"enumeration items must be unique, got {nice_join(values)}")
 
-    attrs: Dict[str, Any] = {value: value for value in values}
+    attrs: dict[str, Any] = {value: value for value in values}
     attrs.update({
         "_values": list(values),
         "_default": values[0],

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -67,7 +67,7 @@ from .serialization import (
     Serializable,
     Serializer,
 )
-from .types import ID, Unknown
+from .types import ID
 
 if TYPE_CHECKING:
     from ..client.session import ClientSession
@@ -113,8 +113,8 @@ def is_DataModel(cls: Type[HasProps]) -> bool:
     from ..model import DataModel
     return issubclass(cls, HasProps) and getattr(cls, "__data_model__", False) and cls != DataModel
 
-def _overridden_defaults(class_dict: dict[str, Any]) -> dict[str, Unknown]:
-    overridden_defaults: dict[str, Unknown] = {}
+def _overridden_defaults(class_dict: dict[str, Any]) -> dict[str, Any]:
+    overridden_defaults: dict[str, Any] = {}
     for name, prop in tuple(class_dict.items()):
         if isinstance(prop, Override):
             del class_dict[name]
@@ -142,8 +142,8 @@ class MetaHasProps(type):
     '''
 
     __properties__: dict[str, Property[Any]]
-    __overridden_defaults__: dict[str, Unknown]
-    __themed_values__: dict[str, Unknown]
+    __overridden_defaults__: dict[str, Any]
+    __themed_values__: dict[str, Any]
 
     def __new__(cls, class_name: str, bases: tuple[type, ...], class_dict: dict[str, Any]):
         '''
@@ -207,9 +207,9 @@ class HasProps(Serializable, metaclass=MetaHasProps):
     '''
     _initialized: bool = False
 
-    _property_values: dict[str, Unknown]
-    _unstable_default_values: dict[str, Unknown]
-    _unstable_themed_values: dict[str, Unknown]
+    _property_values: dict[str, Any]
+    _unstable_default_values: dict[str, Any]
+    _unstable_themed_values: dict[str, Any]
 
     __view_model__: ClassVar[str]
     __view_module__: ClassVar[str]
@@ -275,7 +275,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
         self._initialized = True
 
-    def __setattr__(self, name: str, value: Unknown) -> None:
+    def __setattr__(self, name: str, value: Any) -> None:
         ''' Intercept attribute setting on HasProps in order to special case
         a few situations:
 
@@ -533,7 +533,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         from .property.dataspec import DataSpec  # avoid circular import
         return {k: v for k, v in cls.properties(_with_props=True).items() if isinstance(v, DataSpec)}
 
-    def properties_with_values(self, *, include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Unknown]:
+    def properties_with_values(self, *, include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Any]:
         ''' Collect a dict mapping property names to their values.
 
         This method *always* traverses the class hierarchy and includes
@@ -558,20 +558,20 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             include_defaults=include_defaults, include_undefined=include_undefined)
 
     @classmethod
-    def _overridden_defaults(cls) -> dict[str, Unknown]:
+    def _overridden_defaults(cls) -> dict[str, Any]:
         ''' Returns a dictionary of defaults that have been overridden.
 
         .. note::
             This is an implementation detail of ``Property``.
 
         '''
-        defaults: dict[str, Unknown] = {}
+        defaults: dict[str, Any] = {}
         for c in reversed(cls.__mro__):
             defaults.update(getattr(c, "__overridden_defaults__", {}))
         return defaults
 
     def query_properties_with_values(self, query: Callable[[PropertyDescriptor[Any]], bool], *,
-            include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Unknown]:
+            include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Any]:
         ''' Query the properties values of |HasProps| instances with a
         predicate.
 
@@ -589,7 +589,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
         '''
         themed_keys: set[str] = set()
-        result: dict[str, Unknown] = {}
+        result: dict[str, Any] = {}
 
         if include_defaults:
             keys = self.properties(_with_props=True)
@@ -625,7 +625,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
         return result
 
-    def themed_values(self) -> dict[str, Unknown] | None:
+    def themed_values(self) -> dict[str, Any] | None:
         ''' Get any theme-provided overrides.
 
         Results are returned as a dict from property name to value, or
@@ -637,7 +637,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         '''
         return getattr(self, '__themed_values__', None)
 
-    def apply_theme(self, property_values: dict[str, Unknown]) -> None:
+    def apply_theme(self, property_values: dict[str, Any]) -> None:
         ''' Apply a set of theme values which will be used rather than
         defaults, but will not override application-set values.
 
@@ -664,7 +664,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         if old_dict is not None:
             removed.update(set(old_dict.keys()))
         added = set(property_values.keys())
-        old_values: dict[str, Unknown] = {}
+        old_values: dict[str, Any] = {}
         for k in added.union(removed):
             old_values[k] = getattr(self, k)
 
@@ -709,11 +709,11 @@ class _PropertyDef(TypedDict):
     name: str
     kind: KindRef
 class PropertyDef(_PropertyDef, total=False):
-    default: Unknown
+    default: Any
 
 class OverrideDef(TypedDict):
     name: str
-    default: Unknown
+    default: Any
 
 class _ModelDef(TypedDict):
     type: Literal["model"]

--- a/bokeh/core/has_props.py
+++ b/bokeh/core/has_props.py
@@ -34,13 +34,9 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
     Iterable,
-    List,
     Literal,
     NoReturn,
-    Set,
-    Tuple,
     Type,
     TypedDict,
     TypeVar,
@@ -54,6 +50,9 @@ if TYPE_CHECKING:
     def lru_cache(arg: int | None) -> Callable[[F], F]: ...
 else:
     from functools import lru_cache
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..util.string import append_docstring, nice_join
@@ -97,7 +96,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 if TYPE_CHECKING:
-    Setter = Union[ClientSession, ServerSession]
+    Setter: TypeAlias = Union[ClientSession, ServerSession]
 
 C = TypeVar("C", bound=Type["HasProps"])
 
@@ -114,8 +113,8 @@ def is_DataModel(cls: Type[HasProps]) -> bool:
     from ..model import DataModel
     return issubclass(cls, HasProps) and getattr(cls, "__data_model__", False) and cls != DataModel
 
-def _overridden_defaults(class_dict: Dict[str, Any]) -> Dict[str, Unknown]:
-    overridden_defaults: Dict[str, Unknown] = {}
+def _overridden_defaults(class_dict: dict[str, Any]) -> dict[str, Unknown]:
+    overridden_defaults: dict[str, Unknown] = {}
     for name, prop in tuple(class_dict.items()):
         if isinstance(prop, Override):
             del class_dict[name]
@@ -123,8 +122,8 @@ def _overridden_defaults(class_dict: Dict[str, Any]) -> Dict[str, Unknown]:
                 overridden_defaults[name] = prop.default
     return overridden_defaults
 
-def _generators(class_dict: Dict[str, Any]):
-    generators: Dict[str, PropertyDescriptorFactory[Any]] = {}
+def _generators(class_dict: dict[str, Any]):
+    generators: dict[str, PropertyDescriptorFactory[Any]] = {}
     for name, generator in tuple(class_dict.items()):
         if isinstance(generator, PropertyDescriptorFactory):
             del class_dict[name]
@@ -142,11 +141,11 @@ class MetaHasProps(type):
 
     '''
 
-    __properties__: Dict[str, Property[Any]]
-    __overridden_defaults__: Dict[str, Unknown]
-    __themed_values__: Dict[str, Unknown]
+    __properties__: dict[str, Property[Any]]
+    __overridden_defaults__: dict[str, Unknown]
+    __themed_values__: dict[str, Unknown]
 
-    def __new__(cls, class_name: str, bases: Tuple[type, ...], class_dict: Dict[str, Any]):
+    def __new__(cls, class_name: str, bases: tuple[type, ...], class_dict: dict[str, Any]):
         '''
 
         '''
@@ -169,13 +168,13 @@ class MetaHasProps(type):
 
         return super().__new__(cls, class_name, bases, class_dict)
 
-    def __init__(cls, class_name: str, bases: Tuple[type, ...], _) -> None:
+    def __init__(cls, class_name: str, bases: tuple[type, ...], _) -> None:
         # HasProps itself may not have any properties defined
         if class_name == "HasProps":
             return
 
         # Check for improperly redeclared a Property attribute.
-        base_properties: Dict[str, Any] = {}
+        base_properties: dict[str, Any] = {}
         for base in (x for x in bases if issubclass(x, HasProps)):
             base_properties.update(base.properties(_with_props=True))
         own_properties = {k: v for k, v in cls.__dict__.items() if isinstance(v, PropertyDescriptor)}
@@ -208,9 +207,9 @@ class HasProps(Serializable, metaclass=MetaHasProps):
     '''
     _initialized: bool = False
 
-    _property_values: Dict[str, Unknown]
-    _unstable_default_values: Dict[str, Unknown]
-    _unstable_themed_values: Dict[str, Unknown]
+    _property_values: dict[str, Unknown]
+    _unstable_default_values: dict[str, Unknown]
+    _unstable_themed_values: dict[str, Unknown]
 
     __view_model__: ClassVar[str]
     __view_module__: ClassVar[str]
@@ -218,7 +217,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
     __implementation__: ClassVar[Any] # TODO: specific type
     __data_model__: ClassVar[bool]
 
-    model_class_reverse_map: ClassVar[Dict[str, Type[HasProps]]] = {}
+    model_class_reverse_map: ClassVar[dict[str, Type[HasProps]]] = {}
 
     @classmethod
     def __init_subclass__(cls):
@@ -474,16 +473,16 @@ class HasProps(Serializable, metaclass=MetaHasProps):
     @overload
     @classmethod
     @lru_cache(None)
-    def properties(cls, *, _with_props: Literal[False] = False) -> Set[str]: ...
+    def properties(cls, *, _with_props: Literal[False] = False) -> set[str]: ...
 
     @overload
     @classmethod
     @lru_cache(None)
-    def properties(cls, *, _with_props: Literal[True] = True) -> Dict[str, Property[Any]]: ...
+    def properties(cls, *, _with_props: Literal[True] = True) -> dict[str, Property[Any]]: ...
 
     @classmethod
     @lru_cache(None)
-    def properties(cls, *, _with_props: bool = False) -> Set[str] | Dict[str, Property[Any]]:
+    def properties(cls, *, _with_props: bool = False) -> set[str] | dict[str, Property[Any]]:
         ''' Collect the names of properties on this class.
 
         .. warning::
@@ -495,7 +494,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             property names
 
         '''
-        props: Dict[str, Property[Any]] = {}
+        props: dict[str, Property[Any]] = {}
         for c in reversed(cls.__mro__):
             props.update(getattr(c, "__properties__", {}))
 
@@ -506,7 +505,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
     @classmethod
     @lru_cache(None)
-    def properties_with_refs(cls) -> Dict[str, Property[Any]]:
+    def properties_with_refs(cls) -> dict[str, Property[Any]]:
         ''' Collect the names of all properties on this class that also have
         references.
 
@@ -521,7 +520,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
     @classmethod
     @lru_cache(None)
-    def dataspecs(cls) -> Dict[str, DataSpec]:
+    def dataspecs(cls) -> dict[str, DataSpec]:
         ''' Collect the names of all ``DataSpec`` properties on this class.
 
         This method *always* traverses the class hierarchy and includes
@@ -534,7 +533,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         from .property.dataspec import DataSpec  # avoid circular import
         return {k: v for k, v in cls.properties(_with_props=True).items() if isinstance(v, DataSpec)}
 
-    def properties_with_values(self, *, include_defaults: bool = True, include_undefined: bool = False) -> Dict[str, Unknown]:
+    def properties_with_values(self, *, include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Unknown]:
         ''' Collect a dict mapping property names to their values.
 
         This method *always* traverses the class hierarchy and includes
@@ -559,20 +558,20 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             include_defaults=include_defaults, include_undefined=include_undefined)
 
     @classmethod
-    def _overridden_defaults(cls) -> Dict[str, Unknown]:
+    def _overridden_defaults(cls) -> dict[str, Unknown]:
         ''' Returns a dictionary of defaults that have been overridden.
 
         .. note::
             This is an implementation detail of ``Property``.
 
         '''
-        defaults: Dict[str, Unknown] = {}
+        defaults: dict[str, Unknown] = {}
         for c in reversed(cls.__mro__):
             defaults.update(getattr(c, "__overridden_defaults__", {}))
         return defaults
 
     def query_properties_with_values(self, query: Callable[[PropertyDescriptor[Any]], bool], *,
-            include_defaults: bool = True, include_undefined: bool = False) -> Dict[str, Unknown]:
+            include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Unknown]:
         ''' Query the properties values of |HasProps| instances with a
         predicate.
 
@@ -589,8 +588,8 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             dict : mapping of property names and values for matching properties
 
         '''
-        themed_keys: Set[str] = set()
-        result: Dict[str, Unknown] = {}
+        themed_keys: set[str] = set()
+        result: dict[str, Unknown] = {}
 
         if include_defaults:
             keys = self.properties(_with_props=True)
@@ -626,7 +625,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
         return result
 
-    def themed_values(self) -> Dict[str, Unknown] | None:
+    def themed_values(self) -> dict[str, Unknown] | None:
         ''' Get any theme-provided overrides.
 
         Results are returned as a dict from property name to value, or
@@ -638,7 +637,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         '''
         return getattr(self, '__themed_values__', None)
 
-    def apply_theme(self, property_values: Dict[str, Unknown]) -> None:
+    def apply_theme(self, property_values: dict[str, Unknown]) -> None:
         ''' Apply a set of theme values which will be used rather than
         defaults, but will not override application-set values.
 
@@ -659,13 +658,13 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         if old_dict is property_values:  # lgtm [py/comparison-using-is]
             return
 
-        removed: Set[str] = set()
+        removed: set[str] = set()
         # we're doing a little song-and-dance to avoid storing __themed_values__ or
         # an empty dict, if there's no theme that applies to this HasProps instance.
         if old_dict is not None:
             removed.update(set(old_dict.keys()))
         added = set(property_values.keys())
-        old_values: Dict[str, Unknown] = {}
+        old_values: dict[str, Unknown] = {}
         for k in added.union(removed):
             old_values[k] = getattr(self, k)
 
@@ -721,8 +720,8 @@ class _ModelDef(TypedDict):
     name: str
 class ModelDef(_ModelDef, total=False):
     extends: Ref | None
-    properties: List[PropertyDef]
-    overrides: List[OverrideDef]
+    properties: list[PropertyDef]
+    overrides: list[OverrideDef]
 
 def _HasProps_to_serializable(cls: Type[HasProps], serializer: Serializer) -> Ref | ModelDef:
     from ..model import DataModel, Model
@@ -734,7 +733,7 @@ def _HasProps_to_serializable(cls: Type[HasProps], serializer: Serializer) -> Re
         return ref
 
     # TODO: consider supporting mixin models
-    bases: List[Type[HasProps]] = [ base for base in cls.__bases__ if issubclass(base, Model) and base != DataModel ]
+    bases: list[Type[HasProps]] = [ base for base in cls.__bases__ if issubclass(base, Model) and base != DataModel ]
     if len(bases) == 0:
         extends = None
     elif len(bases) == 1:
@@ -743,8 +742,8 @@ def _HasProps_to_serializable(cls: Type[HasProps], serializer: Serializer) -> Re
     else:
         serializer.error("multiple bases are not supported")
 
-    properties: List[PropertyDef] = []
-    overrides: List[OverrideDef] = []
+    properties: list[PropertyDef] = []
+    overrides: list[OverrideDef] = []
 
     # TODO: don't use unordered sets
     for prop_name in cls.__properties__:

--- a/bokeh/core/json_encoder.py
+++ b/bokeh/core/json_encoder.py
@@ -50,7 +50,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from json import JSONEncoder
-from typing import Any, List, Tuple
+from typing import Any
 
 # Bokeh imports
 from ..settings import settings
@@ -138,7 +138,7 @@ def serialize_json(obj: Any | Serialized[Any], *, pretty: bool | None = None, in
         indent = 2
 
     content: Any
-    buffers: List[Buffer]
+    buffers: list[Buffer]
     if isinstance(obj, Serialized):
         content = obj.content
         buffers = obj.buffers or []
@@ -154,8 +154,8 @@ def serialize_json(obj: Any | Serialized[Any], *, pretty: bool | None = None, in
 #-----------------------------------------------------------------------------
 
 class PayloadEncoder(JSONEncoder):
-    def __init__(self, *, buffers: List[Buffer] = [], threshold: int = 100,
-            indent: int | None = None, separators: Tuple[str, str] | None = None):
+    def __init__(self, *, buffers: list[Buffer] = [], threshold: int = 100,
+            indent: int | None = None, separators: tuple[str, str] | None = None):
         super().__init__(sort_keys=False, allow_nan=False, indent=indent, separators=separators)
         self._buffers = {buf.id: buf for buf in buffers}
         self._threshold = threshold

--- a/bokeh/core/property/_sphinx.py
+++ b/bokeh/core/property/_sphinx.py
@@ -21,12 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Type,
-)
+from typing import Any, Callable, Type
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -39,7 +34,7 @@ __all__ = (
     'type_link',
 )
 
-_type_links: Dict[Type[Any], Callable[[Any], str]] = {}
+_type_links: dict[Type[Any], Callable[[Any], str]] = {}
 
 #-----------------------------------------------------------------------------
 # General API

--- a/bokeh/core/property/bases.py
+++ b/bokeh/core/property/bases.py
@@ -33,9 +33,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
-    List,
-    Tuple,
     Type,
     TypeVar,
     Union,
@@ -43,6 +40,7 @@ from typing import (
 
 # External imports
 import numpy as np
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ...util.dependencies import import_optional
@@ -82,9 +80,9 @@ __all__ = (
 
 T = TypeVar("T")
 
-TypeOrInst = Union[Type[T], T]
+TypeOrInst: TypeAlias = Union[Type[T], T]
 
-Init = Union[T, UndefinedType, IntrinsicType]
+Init: TypeAlias = Union[T, UndefinedType, IntrinsicType]
 
 class Property(PropertyDescriptorFactory[T]):
     """ Base class for Bokeh property instances, which can be added to Bokeh
@@ -114,8 +112,8 @@ class Property(PropertyDescriptorFactory[T]):
 
     _readonly: bool
 
-    alternatives: List[Tuple[Property[Any], Callable[[Property[Any]], T]]]
-    assertions: List[Tuple[Callable[[HasProps, T], bool], str | Callable[[HasProps, str, T], None]]]
+    alternatives: list[tuple[Property[Any], Callable[[Property[Any]], T]]]
+    assertions: list[tuple[Callable[[HasProps, T], bool], str | Callable[[HasProps, str, T], None]]]
 
     def __init__(self, default: Init[T] = Intrinsic, help: str | None = None,
             serialized: bool | None = None, readonly: bool = False):
@@ -137,7 +135,7 @@ class Property(PropertyDescriptorFactory[T]):
     def __str__(self) -> str:
         return self.__class__.__name__
 
-    def make_descriptors(self, name: str) -> List[PropertyDescriptor[T]]:
+    def make_descriptors(self, name: str) -> list[PropertyDescriptor[T]]:
         """ Return a list of ``PropertyDescriptor`` instances to install
         on a class, in order to delegate attribute access to this property.
 
@@ -183,7 +181,7 @@ class Property(PropertyDescriptorFactory[T]):
         """
         return self._copy_default(self._default, no_eval=no_eval)
 
-    def themed_default(self, cls: Type[HasProps], name: str, theme_overrides: Dict[str, Any] | None, *, no_eval: bool = False) -> T:
+    def themed_default(self, cls: Type[HasProps], name: str, theme_overrides: dict[str, Any] | None, *, no_eval: bool = False) -> T:
         """ The default, transformed by prepare_value() and the theme overrides.
 
         """
@@ -442,7 +440,7 @@ class ParameterizedProperty(Property[TItem]):
         raise ValueError(f"expected a Property as type parameter, got {type_param}")
 
     @property
-    def type_params(self) -> List[Property[Any]]:
+    def type_params(self) -> list[Property[Any]]:
         raise NotImplementedError("abstract method")
 
     @property
@@ -466,7 +464,7 @@ class SingleParameterizedProperty(ParameterizedProperty[T]):
         super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
 
     @property
-    def type_params(self) -> List[Property[Any]]:
+    def type_params(self) -> list[Property[Any]]:
         return [self.type_param]
 
     def __str__(self) -> str:
@@ -502,7 +500,7 @@ class PrimitiveProperty(Property[T]):
 
     """
 
-    _underlying_type: ClassVar[Tuple[Type[Any], ...]]
+    _underlying_type: ClassVar[tuple[Type[Any], ...]]
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)

--- a/bokeh/core/property/descriptor_factory.py
+++ b/bokeh/core/property/descriptor_factory.py
@@ -57,12 +57,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Generic,
-    List,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from .descriptors import PropertyDescriptor
@@ -119,7 +114,7 @@ class PropertyDescriptorFactory(Generic[T]):
 
     """
 
-    def make_descriptors(self, name: str) -> List[PropertyDescriptor[T]]:
+    def make_descriptors(self, name: str) -> list[PropertyDescriptor[T]]:
         """ Return a list of ``PropertyDescriptor`` instances to install on a
         class, in order to delegate attribute access to this property.
 

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -110,7 +110,6 @@ from .wrappers import PropertyValueColumnData, PropertyValueContainer
 if TYPE_CHECKING:
     from ...document.events import DocumentPatchedEvent
     from ..has_props import HasProps, Setter
-    from ..types import Unknown
     from .bases import Property
 
 #-----------------------------------------------------------------------------
@@ -385,7 +384,7 @@ class PropertyDescriptor(Generic[T]):
         old = self._get(obj)
         self._set(obj, old, value, setter=setter)
 
-    def trigger_if_changed(self, obj: HasProps, old: Unknown) -> None:
+    def trigger_if_changed(self, obj: HasProps, old: Any) -> None:
         """ Send a change event notification if the property is set to a
         value is not equal to ``old``.
 
@@ -502,7 +501,7 @@ class PropertyDescriptor(Generic[T]):
 
         return default
 
-    def _set_value(self, obj: HasProps, value: Unknown) -> None:
+    def _set_value(self, obj: HasProps, value: Any) -> None:
         """ Actual descriptor value assignment. """
         if isinstance(value, PropertyValueContainer):
             value._register_owner(obj, self)
@@ -515,7 +514,7 @@ class PropertyDescriptor(Generic[T]):
 
         obj._property_values[self.name] = value
 
-    def _set(self, obj: HasProps, old: Unknown, value: Unknown, *,
+    def _set(self, obj: HasProps, old: Any, value: Any, *,
             hint: DocumentPatchedEvent | None = None, setter: Setter | None = None) -> None:
         """ Internal implementation helper to set property values.
 
@@ -578,7 +577,7 @@ class PropertyDescriptor(Generic[T]):
 
     # called when a container is mutated "behind our back" and
     # we detect it with our collection wrappers.
-    def _notify_mutated(self, obj: HasProps, old: Unknown, hint: DocumentPatchedEvent | None = None) -> None:
+    def _notify_mutated(self, obj: HasProps, old: Any, hint: DocumentPatchedEvent | None = None) -> None:
         """ A method to call when a container is mutated "behind our back"
         and we detect it with our |PropertyContainer| wrappers.
 
@@ -613,7 +612,7 @@ class PropertyDescriptor(Generic[T]):
 
         self._set(obj, old, value, hint=hint)
 
-    def _trigger(self, obj: HasProps, old: Unknown, value: Unknown, *,
+    def _trigger(self, obj: HasProps, old: Any, value: Any, *,
             hint: DocumentPatchedEvent | None = None, setter: Setter | None = None) -> None:
         """ Unconditionally send a change event notification for the property.
 

--- a/bokeh/core/property/struct.py
+++ b/bokeh/core/property/struct.py
@@ -22,12 +22,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    Any,
-    Generic,
-    Set,
-    TypeVar,
-)
+from typing import Any, Generic, TypeVar
 
 # Bokeh imports
 from .bases import ParameterizedProperty, Property
@@ -57,7 +52,7 @@ class Struct(ParameterizedProperty):
 
     """
 
-    _optional: Set[str]
+    _optional: set[str]
 
     def __init__(self, **fields) -> None:
         default = fields.pop("default", None)

--- a/bokeh/core/property/vectorization.py
+++ b/bokeh/core/property/vectorization.py
@@ -21,12 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Union
 
 # External imports
 from typing_extensions import TypeAlias
@@ -75,7 +70,7 @@ class Value(Serializable):
         return serializer.encode_struct(type="value", value=self.value, transform=self.transform, units=self.units)
 
     @classmethod
-    def from_serializable(cls, rep: Dict[str, AnyRep], deserializer: Deserializer) -> Value:
+    def from_serializable(cls, rep: dict[str, AnyRep], deserializer: Deserializer) -> Value:
         if "value" not in rep:
             deserializer.error("expected 'value' field")
         value = deserializer.decode(rep["value"])
@@ -103,7 +98,7 @@ class Field(Serializable):
         return serializer.encode_struct(type="field", field=self.field, transform=self.transform, units=self.units)
 
     @classmethod
-    def from_serializable(cls, rep: Dict[str, AnyRep], deserializer: Deserializer) -> Field:
+    def from_serializable(cls, rep: dict[str, AnyRep], deserializer: Deserializer) -> Field:
         if "field" not in rep:
             deserializer.error("expected 'field' field")
         field = deserializer.decode(rep["field"])
@@ -131,7 +126,7 @@ class Expr(Serializable):
         return serializer.encode_struct(type="expr", expr=self.expr, transform=self.transform, units=self.units)
 
     @classmethod
-    def from_serializable(cls, rep: Dict[str, AnyRep], deserializer: Deserializer) -> Expr:
+    def from_serializable(cls, rep: dict[str, AnyRep], deserializer: Deserializer) -> Expr:
         if "expr" not in rep:
             deserializer.error("expected 'expr' field")
         expr = deserializer.decode(rep["expr"])

--- a/bokeh/core/property/wrappers.py
+++ b/bokeh/core/property/wrappers.py
@@ -75,7 +75,6 @@ if TYPE_CHECKING:
     from ...document.events import DocumentPatchedEvent
     from ...models.sources import ColumnarDataSource
     from ..has_props import HasProps, Setter
-    from ..types import Unknown
     from .descriptors import PropertyDescriptor
 
 #-----------------------------------------------------------------------------
@@ -153,7 +152,7 @@ class PropertyValueContainer:
     def _unregister_owner(self, owner: HasProps, descriptor: PropertyDescriptor[Any]) -> None:
         self._owners.discard((owner, descriptor))
 
-    def _notify_owners(self, old: Unknown, hint: DocumentPatchedEvent | None = None) -> None:
+    def _notify_owners(self, old: Any, hint: DocumentPatchedEvent | None = None) -> None:
         for (owner, descriptor) in self._owners:
             descriptor._notify_mutated(owner, old, hint=hint)
 

--- a/bokeh/core/property/wrappers.py
+++ b/bokeh/core/property/wrappers.py
@@ -65,13 +65,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import copy
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Set,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Any
 
 # External imports
 import numpy as np
@@ -147,7 +141,7 @@ class PropertyValueContainer:
     those owners when mutating changes occur.
 
     """
-    _owners: Set[Tuple[HasProps, PropertyDescriptor[Any]]]
+    _owners: set[tuple[HasProps, PropertyDescriptor[Any]]]
 
     def __init__(self, *args, **kwargs) -> None:
         self._owners = set()
@@ -394,7 +388,7 @@ class PropertyValueColumnData(PropertyValueDict):
         return result
 
     # don't wrap with notify_owner --- notifies owners explicitly
-    def _stream(self, doc: Document, source: ColumnarDataSource, new_data: Dict[str, Any],
+    def _stream(self, doc: Document, source: ColumnarDataSource, new_data: dict[str, Any],
             rollover: int | None = None, setter: Setter | None = None) -> None:
         """ Internal implementation to handle special-casing stream events
         on ``ColumnDataSource`` columns.

--- a/bokeh/core/query.py
+++ b/bokeh/core/query.py
@@ -31,6 +31,9 @@ from typing import (
     Union,
 )
 
+# External imports
+from typing_extensions import TypeAlias
+
 # Bokeh imports
 from ..model import Model
 
@@ -53,7 +56,7 @@ __all__ = (
     'is_single_string_selector',
 )
 
-SelectorType = Dict[Union[str, Type["_Operator"]], Any]
+SelectorType: TypeAlias = Dict[Union[str, Type["_Operator"]], Any]
 
 #-----------------------------------------------------------------------------
 # General API
@@ -347,7 +350,7 @@ class NEQ(_Operator):
 #-----------------------------------------------------------------------------
 
 # realizations of the abstract predicate operators
-_operators: Dict[Type["_Operator"], Callable[[Any, Any], Any]] = {
+_operators: dict[Type["_Operator"], Callable[[Any, Any], Any]] = {
    IN:  lambda x, y: x in y,
    GT:  lambda x, y: x > y,
    LT:  lambda x, y: x < y,

--- a/bokeh/core/templates.py
+++ b/bokeh/core/templates.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 import sys
 from functools import lru_cache
 from os.path import dirname, join
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 # External imports
 from jinja2 import Environment, FileSystemLoader, Template
@@ -110,7 +110,7 @@ AUTOLOAD_NB_JS: Template
 AUTOLOAD_TAG: Template
 AUTOLOAD_REQUEST_TAG: Template
 
-_templates: Dict[str, Callable[[], Template]] = dict(
+_templates: dict[str, Callable[[], Template]] = dict(
     JS_RESOURCES=lambda: get_env().get_template("js_resources.html"),
     CSS_RESOURCES=lambda: get_env().get_template("css_resources.html"),
     SCRIPT_TAG=lambda: get_env().get_template("script_tag.html"),

--- a/bokeh/core/types.py
+++ b/bokeh/core/types.py
@@ -31,6 +31,9 @@ from typing import (
     Union,
 )
 
+# External imports
+from typing_extensions import TypeAlias
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -51,9 +54,9 @@ __all__ = (
 
 ID = NewType("ID", str)
 
-PathLike = Union[str, "os.PathLike[str]"]
+PathLike: TypeAlias = Union[str, "os.PathLike[str]"]
 
-Unknown = Any
+Unknown: TypeAlias = Any
 
 # TODO: move this to types/geometry.py
 class PointGeometry(TypedDict):
@@ -79,7 +82,7 @@ class PolyGeometry(TypedDict):
     sx: Sequence[float]
     sy: Sequence[float]
 
-Geometry = Union[PointGeometry, SpanGeometry, RectGeometry, PolyGeometry]
+Geometry: TypeAlias = Union[PointGeometry, SpanGeometry, RectGeometry, PolyGeometry]
 
 class PointGeometryData(PointGeometry):
     x: float
@@ -99,7 +102,7 @@ class PolyGeometryData(PolyGeometry):
     x: Sequence[float]
     y: Sequence[float]
 
-GeometryData = Union[PointGeometryData, SpanGeometryData, RectGeometryData, PolyGeometryData]
+GeometryData: TypeAlias = Union[PointGeometryData, SpanGeometryData, RectGeometryData, PolyGeometryData]
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/core/types.py
+++ b/bokeh/core/types.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import os  # lgtm [py/unused-import]
 from typing import (
-    Any,
     Literal,
     NewType,
     Sequence,
@@ -41,7 +40,6 @@ from typing_extensions import TypeAlias
 __all__ = (
     "ID",
     "PathLike",
-    "Unknown",
 )
 
 #-----------------------------------------------------------------------------
@@ -55,8 +53,6 @@ __all__ = (
 ID = NewType("ID", str)
 
 PathLike: TypeAlias = Union[str, "os.PathLike[str]"]
-
-Unknown: TypeAlias = Any
 
 # TODO: move this to types/geometry.py
 class PointGeometry(TypedDict):

--- a/bokeh/core/validation/check.py
+++ b/bokeh/core/validation/check.py
@@ -25,10 +25,8 @@ import contextlib
 from typing import (
     Iterable,
     Iterator,
-    List,
     Literal,
     Protocol,
-    Set,
 )
 
 # Bokeh imports
@@ -41,7 +39,7 @@ from .issue import Warning
 # Globals and constants
 #-----------------------------------------------------------------------------
 
-__silencers__: Set[Warning] = set()
+__silencers__: set[Warning] = set()
 
 __all__ = (
     'check_integrity',
@@ -62,16 +60,16 @@ class ValidationIssue:
 
 @dataclass
 class ValidationIssues:
-    error: List[ValidationIssue]
-    warning: List[ValidationIssue]
+    error: list[ValidationIssue]
+    warning: list[ValidationIssue]
 
 ValidatorType = Literal["error", "warning"]
 
 class Validator(Protocol):
-    def __call__(self) -> List[ValidationIssue]: ...
+    def __call__(self) -> list[ValidationIssue]: ...
     validator_type: ValidatorType
 
-def silence(warning: Warning, silence: bool = True) -> Set[Warning]:
+def silence(warning: Warning, silence: bool = True) -> set[Warning]:
     ''' Silence a particular warning on all Bokeh models.
 
     Args:
@@ -162,7 +160,7 @@ def check_integrity(models: Iterable[Model]) -> ValidationIssues:
     issues = ValidationIssues(error=[], warning=[])
 
     for model in models:
-        validators: List[Validator] = []
+        validators: list[Validator] = []
         for name in dir(model):
             if not name.startswith("_check"):
                 continue
@@ -199,13 +197,13 @@ def process_validation_issues(issues: ValidationIssues) -> None:
     errors = issues.error
     warnings = [issue for issue in issues.warning if not is_silenced(Warning.get_by_code(issue.code))]
 
-    warning_messages: List[str] = []
+    warning_messages: list[str] = []
     for warning in sorted(warnings, key=lambda warning: warning.code):
         msg = f"W-{warning.code} ({warning.name}): {warning.text}: {warning.extra}"
         warning_messages.append(msg)
         log.warning(msg)
 
-    error_messages: List[str] = []
+    error_messages: list[str] = []
     for error in sorted(errors, key=lambda error: error.code):
         msg = f"E-{error.code} ({error.name}): {error.text}: {error.extra}"
         error_messages.append(msg)

--- a/bokeh/core/validation/decorators.py
+++ b/bokeh/core/validation/decorators.py
@@ -24,11 +24,13 @@ log = logging.getLogger(__name__)
 from typing import (
     Any,
     Callable,
-    List,
     Type,
     Union,
     cast,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from .check import ValidationIssue, Validator, ValidatorType
@@ -47,10 +49,10 @@ __all__ = (
 # Private API
 #-----------------------------------------------------------------------------
 
-ValidationFunction = Callable[..., Union[str, None]]
-ValidationDecorator = Callable[[ValidationFunction], Validator]
+ValidationFunction: TypeAlias = Callable[..., Union[str, None]]
+ValidationDecorator: TypeAlias = Callable[[ValidationFunction], Validator]
 
-def _validator(code_or_name: Union[int, str, Issue], validator_type: ValidatorType) -> ValidationDecorator:
+def _validator(code_or_name: int | str | Issue, validator_type: ValidatorType) -> ValidationDecorator:
     """ Internal shared implementation to handle both error and warning
     validation checks.
 
@@ -66,7 +68,7 @@ def _validator(code_or_name: Union[int, str, Issue], validator_type: ValidatorTy
         Error if validator_type == "error" else Warning
 
     def decorator(func: ValidationFunction) -> Validator:
-        def _wrapper(*args: Any, **kwargs: Any) -> List[ValidationIssue]:
+        def _wrapper(*args: Any, **kwargs: Any) -> list[ValidationIssue]:
             extra = func(*args, **kwargs)
             if extra is None:
                 return []
@@ -102,7 +104,7 @@ def _validator(code_or_name: Union[int, str, Issue], validator_type: ValidatorTy
 # Dev API
 #-----------------------------------------------------------------------------
 
-def error(code_or_name: Union[int, str, Issue]) -> ValidationDecorator:
+def error(code_or_name: int | str | Issue) -> ValidationDecorator:
     """ Decorator to mark a validator method for a Bokeh error condition
 
     Args:
@@ -142,7 +144,7 @@ def error(code_or_name: Union[int, str, Issue]) -> ValidationDecorator:
     """
     return _validator(code_or_name, "error")
 
-def warning(code_or_name: Union[int, str, Issue]) -> ValidationDecorator:
+def warning(code_or_name: int | str | Issue) -> ValidationDecorator:
     """ Decorator to mark a validator method for a Bokeh error condition
 
     Args:

--- a/bokeh/core/validation/issue.py
+++ b/bokeh/core/validation/issue.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import ClassVar, Dict, List
+from typing import ClassVar
 
 # Bokeh imports
 from ...util.dataclasses import dataclass
@@ -47,8 +47,8 @@ class Issue:
 
 @dataclass(frozen=True)
 class Warning(Issue):
-    _code_map: ClassVar[Dict[int, Warning]] = {}
-    _name_map: ClassVar[Dict[str, Warning]] = {}
+    _code_map: ClassVar[dict[int, Warning]] = {}
+    _name_map: ClassVar[dict[str, Warning]] = {}
 
     def __post_init__(self) -> None:
         Warning._code_map[self.code] = self
@@ -63,13 +63,13 @@ class Warning(Issue):
         return cls._name_map[name]
 
     @classmethod
-    def all(cls) -> List[Warning]:
+    def all(cls) -> list[Warning]:
         return list(cls._code_map.values())
 
 @dataclass(frozen=True)
 class Error(Issue):
-    _code_map: ClassVar[Dict[int, Error]] = {}
-    _name_map: ClassVar[Dict[str, Error]] = {}
+    _code_map: ClassVar[dict[int, Error]] = {}
+    _name_map: ClassVar[dict[str, Error]] = {}
 
     def __post_init__(self) -> None:
         Error._code_map[self.code] = self
@@ -84,7 +84,7 @@ class Error(Issue):
         return cls._name_map[name]
 
     @classmethod
-    def all(cls) -> List[Error]:
+    def all(cls) -> list[Error]:
         return list(cls._code_map.values())
 
 #-----------------------------------------------------------------------------

--- a/bokeh/document/callbacks.py
+++ b/bokeh/document/callbacks.py
@@ -29,9 +29,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
-    Set,
     Type,
 )
 
@@ -92,16 +89,16 @@ class DocumentCallbackManager:
 
     _document : weakref.ReferenceType[Document]
 
-    _change_callbacks: Dict[Any, DocumentChangeCallback]
-    _event_callbacks: Dict[str, List[EventCallback]]
-    _message_callbacks: Dict[str, List[MessageCallback]]
-    _session_destroyed_callbacks: Set[SessionDestroyedCallback]
-    _session_callbacks: Set[SessionCallback]
+    _change_callbacks: dict[Any, DocumentChangeCallback]
+    _event_callbacks: dict[str, list[EventCallback]]
+    _message_callbacks: dict[str, list[MessageCallback]]
+    _session_destroyed_callbacks: set[SessionDestroyedCallback]
+    _session_callbacks: set[SessionCallback]
 
-    _subscribed_models: Dict[str, Set[weakref.ReferenceType[Model]]]
+    _subscribed_models: dict[str, set[weakref.ReferenceType[Model]]]
 
     _hold: HoldPolicyType | None = None
-    _held_events: List[DocumentChangedEvent]
+    _held_events: list[DocumentChangedEvent]
 
     def __init__(self, document: Document):
         '''
@@ -127,21 +124,21 @@ class DocumentCallbackManager:
         self.on_message("bokeh_event", self.trigger_event)
 
     @property
-    def session_callbacks(self) -> List[SessionCallback]:
+    def session_callbacks(self) -> list[SessionCallback]:
         ''' A list of all the session callbacks for this document.
 
         '''
         return list(self._session_callbacks)
 
     @property
-    def session_destroyed_callbacks(self) -> Set[SessionDestroyedCallback]:
+    def session_destroyed_callbacks(self) -> set[SessionDestroyedCallback]:
         ''' A list of all the on_session_destroyed callbacks for this document.
 
         '''
         return self._session_destroyed_callbacks
 
     @session_destroyed_callbacks.setter
-    def session_destroyed_callbacks(self, callbacks: Set[SessionDestroyedCallback]) -> None:
+    def session_destroyed_callbacks(self, callbacks: set[SessionDestroyedCallback]) -> None:
         self._session_destroyed_callbacks = callbacks
 
     def add_session_callback(self, callback_obj: SessionCallback, callback: Callback, one_shot: bool) -> SessionCallback:
@@ -413,7 +410,7 @@ def invoke_with_curdoc(doc: Document, f: Callable[[], None]) -> None:
 # Private API
 #-----------------------------------------------------------------------------
 
-def _combine_document_events(new_event: DocumentChangedEvent, old_events: List[DocumentChangedEvent]) -> None:
+def _combine_document_events(new_event: DocumentChangedEvent, old_events: list[DocumentChangedEvent]) -> None:
     ''' Attempt to combine a new event with a list of previous events.
 
     The ``old_event`` will be scanned in reverse, and ``.combine(new_event)``

--- a/bokeh/document/callbacks.py
+++ b/bokeh/document/callbacks.py
@@ -34,7 +34,6 @@ from typing import (
 
 # Bokeh imports
 from ..core.enums import HoldPolicy, HoldPolicyType
-from ..core.types import Unknown
 from ..events import (
     _CONCRETE_EVENT_CLASSES,
     DocumentEvent,
@@ -71,7 +70,7 @@ __all__ = (
 Callback = Callable[[], None]
 Originator = Callable[..., Any]
 
-MessageCallback = Callable[[Unknown], None]
+MessageCallback = Callable[[Any], None]
 EventCallback = Callable[[Event], None]
 
 #-----------------------------------------------------------------------------
@@ -210,7 +209,7 @@ class DocumentCallbackManager:
     def hold_value(self) -> HoldPolicyType | None:
         return self._hold
 
-    def notify_change(self, model: Model, attr: str, old: Unknown, new: Unknown,
+    def notify_change(self, model: Model, attr: str, old: Any, new: Any,
             hint: DocumentPatchedEvent | None = None, setter: Setter | None = None, callback_invoker: Invoker | None = None) -> None:
         ''' Called by Model when it changes
 

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -40,10 +40,7 @@ from json import loads
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Iterable,
-    List,
-    Set,
     Type,
 )
 
@@ -128,12 +125,12 @@ class Document:
     models: DocumentModelManager
     modules: DocumentModuleManager
 
-    _roots: List[Model]
+    _roots: list[Model]
     _theme: Theme
     _title: str
     _template: Template
     _session_context: weakref.ReferenceType[SessionContext] | None
-    _template_variables: Dict[str, Unknown]
+    _template_variables: dict[str, Unknown]
 
     def __init__(self, *, theme: Theme = default_theme, title: str = DEFAULT_TITLE) -> None:
         self.callbacks = DocumentCallbackManager(self)
@@ -151,28 +148,28 @@ class Document:
     # Properties --------------------------------------------------------------
 
     @property
-    def roots(self) -> List[Model]:
+    def roots(self) -> list[Model]:
         ''' A list of all the root models in this Document.
 
         '''
         return list(self._roots)
 
     @property
-    def session_callbacks(self) -> List[SessionCallback]:
+    def session_callbacks(self) -> list[SessionCallback]:
         ''' A list of all the session callbacks for this document.
 
         '''
         return self.callbacks.session_callbacks
 
     @property
-    def session_destroyed_callbacks(self) -> Set[SessionDestroyedCallback]:
+    def session_destroyed_callbacks(self) -> set[SessionDestroyedCallback]:
         ''' A list of all the on_session_destroyed callbacks for this document.
 
         '''
         return self.callbacks.session_destroyed_callbacks
 
     @session_destroyed_callbacks.setter
-    def session_destroyed_callbacks(self, callbacks: Set[SessionDestroyedCallback]) -> None:
+    def session_destroyed_callbacks(self, callbacks: set[SessionDestroyedCallback]) -> None:
         self.callbacks.session_destroyed_callbacks = callbacks
 
     @property
@@ -196,7 +193,7 @@ class Document:
         self._template = template
 
     @property
-    def template_variables(self) -> Dict[str, Unknown]:
+    def template_variables(self) -> dict[str, Unknown]:
         ''' A dictionary of template variables to pass when rendering
         ``self.template``.
 
@@ -376,7 +373,7 @@ class Document:
         patch: PatchJson = deserializer.deserialize(patch_json)
 
         events = patch["events"]
-        assert isinstance(events, list) # List[DocumentPatched]
+        assert isinstance(events, list) # list[DocumentPatched]
 
         for event in events:
             # TODO: assert isinstance(event, DocumentPatchedEvent)
@@ -693,7 +690,7 @@ class Document:
             return None
         return result[0]
 
-    def set_select(self, selector: SelectorType | Type[Model], updates: Dict[str, Unknown]) -> None:
+    def set_select(self, selector: SelectorType | Type[Model], updates: dict[str, Unknown]) -> None:
         ''' Update objects that match a given selector with the specified
         attribute/value updates.
 
@@ -788,7 +785,7 @@ class Document:
         # we have to remove ALL roots before adding any
         # to the new doc or else models referenced from multiple
         # roots could be in both docs at once, which isn't allowed.
-        roots: List[Model] = []
+        roots: list[Model] = []
 
         with self.models.freeze():
             while self.roots:

--- a/bokeh/document/document.py
+++ b/bokeh/document/document.py
@@ -53,7 +53,7 @@ from ..core.has_props import is_DataModel
 from ..core.query import find, is_single_string_selector
 from ..core.serialization import Deserializer, Serialized, Serializer
 from ..core.templates import FILE
-from ..core.types import ID, Unknown
+from ..core.types import ID
 from ..core.validation import check_integrity, process_validation_issues
 from ..events import Event
 from ..model import Model
@@ -130,7 +130,7 @@ class Document:
     _title: str
     _template: Template
     _session_context: weakref.ReferenceType[SessionContext] | None
-    _template_variables: dict[str, Unknown]
+    _template_variables: dict[str, Any]
 
     def __init__(self, *, theme: Theme = default_theme, title: str = DEFAULT_TITLE) -> None:
         self.callbacks = DocumentCallbackManager(self)
@@ -193,7 +193,7 @@ class Document:
         self._template = template
 
     @property
-    def template_variables(self) -> dict[str, Unknown]:
+    def template_variables(self) -> dict[str, Any]:
         ''' A dictionary of template variables to pass when rendering
         ``self.template``.
 
@@ -690,7 +690,7 @@ class Document:
             return None
         return result[0]
 
-    def set_select(self, selector: SelectorType | Type[Model], updates: dict[str, Unknown]) -> None:
+    def set_select(self, selector: SelectorType | Type[Model], updates: dict[str, Any]) -> None:
         ''' Update objects that match a given selector with the specified
         attribute/value updates.
 

--- a/bokeh/document/events.py
+++ b/bokeh/document/events.py
@@ -90,7 +90,6 @@ from .json import (
 
 if TYPE_CHECKING:
     from ..core.has_props import Setter
-    from ..core.types import Unknown
     from ..model import Model
     from ..models.sources import DataDict
     from ..protocol.message import BufferRef
@@ -294,7 +293,7 @@ class ModelChangedEvent(DocumentPatchedEvent):
 
     kind = "ModelChanged"
 
-    def __init__(self, document: Document, model: Model, attr: str, new: Unknown,
+    def __init__(self, document: Document, model: Model, attr: str, new: Any,
             setter: Setter | None = None, callback_invoker: Invoker | None = None):
         '''
 

--- a/bokeh/document/events.py
+++ b/bokeh/document/events.py
@@ -61,14 +61,15 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
     List,
     Type,
     Union,
     cast,
 )
 
-## External imports
+# External imports
+from typing_extensions import TypeAlias
+
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -125,9 +126,9 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 if TYPE_CHECKING:
-    Buffers = Union[List[BufferRef], None]
+    Buffers: TypeAlias = Union[List[BufferRef], None]
 
-    Invoker = Callable[..., Any] # TODO
+    Invoker: TypeAlias = Callable[..., Any] # TODO
 
 class DocumentChangedMixin:
     def _document_changed(self, event: DocumentChangedEvent) -> None: ...
@@ -209,7 +210,7 @@ class DocumentPatchedEvent(DocumentChangedEvent, Serializable):
 
     kind: ClassVar[str]
 
-    _handlers: ClassVar[Dict[str, Type[DocumentPatchedEvent]]] = {}
+    _handlers: ClassVar[dict[str, Type[DocumentPatchedEvent]]] = {}
 
     def __init_subclass__(cls):
         cls._handlers[cls.kind] = cls
@@ -261,7 +262,7 @@ class MessageSentEvent(DocumentPatchedEvent):
 
     kind = "MessageSent"
 
-    def __init__(self, document: Document, msg_type: str, msg_data: Union[Any, bytes],
+    def __init__(self, document: Document, msg_type: str, msg_data: Any | bytes,
             setter: Setter | None = None, callback_invoker: Invoker | None = None):
         super().__init__(document, setter, callback_invoker)
         self.msg_type = msg_type
@@ -391,7 +392,7 @@ class ColumnDataChangedEvent(DocumentPatchedEvent):
     kind = "ColumnDataChanged"
 
     def __init__(self, document: Document, model: Model, attr: str, data: DataDict | None = None,
-            cols: List[str] | None = None, setter: Setter | None = None, callback_invoker: Invoker | None = None):
+            cols: list[str] | None = None, setter: Setter | None = None, callback_invoker: Invoker | None = None):
         '''
 
         Args:

--- a/bokeh/document/json.py
+++ b/bokeh/document/json.py
@@ -31,6 +31,9 @@ from typing import (
     Union,
 )
 
+# External imports
+from typing_extensions import TypeAlias
+
 ## Bokeh imports
 if TYPE_CHECKING:
     from ..core.has_props import ModelDef
@@ -52,9 +55,9 @@ __all__ = ()
 # Dev API
 #-----------------------------------------------------------------------------
 
-Patch = Any # TODO
+Patch: TypeAlias = Any # TODO
 
-Patches = Dict[str, List[Patch]]
+Patches: TypeAlias = Dict[str, List[Patch]]
 
 class ModelChanged(TypedDict):
     kind: Literal["ModelChanged"]
@@ -84,7 +87,7 @@ class ColumnDataChanged(TypedDict):
     model: Ref
     attr: str
     data: DataDict
-    cols: List[str] | None
+    cols: list[str] | None
 
 class ColumnsStreamed(TypedDict):
     kind: Literal["ColumnsStreamed"]
@@ -99,7 +102,7 @@ class ColumnsPatched(TypedDict):
     attr: str
     patches: Patches
 
-DocumentPatched = Union[
+DocumentPatched: TypeAlias = Union[
     MessageSent,
     ModelChanged,
     ColumnDataChanged,
@@ -115,11 +118,11 @@ DocumentChanged = DocumentPatched
 class DocJson(TypedDict):
     version: str | None
     title: str | None
-    defs: List[ModelDef] | None
-    roots: List[ModelRep]
+    defs: list[ModelDef] | None
+    roots: list[ModelRep]
 
 class PatchJson(TypedDict):
-    events: List[DocumentChanged]
+    events: list[DocumentChanged]
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/bokeh/document/json.py
+++ b/bokeh/document/json.py
@@ -38,7 +38,6 @@ from typing_extensions import TypeAlias
 if TYPE_CHECKING:
     from ..core.has_props import ModelDef
     from ..core.serialization import ModelRep, Ref
-    from ..core.types import Unknown
     from ..models.sources import DataDict
 
 #-----------------------------------------------------------------------------
@@ -63,12 +62,12 @@ class ModelChanged(TypedDict):
     kind: Literal["ModelChanged"]
     model: Ref
     attr: str
-    new: Unknown
+    new: Any
 
 class MessageSent(TypedDict):
     kind: Literal["MessageSent"]
     msg_type: str
-    msg_data: Unknown | None
+    msg_data: Any | None
 
 class TitleChanged(TypedDict):
     kind: Literal["TitleChanged"]

--- a/bokeh/document/models.py
+++ b/bokeh/document/models.py
@@ -24,14 +24,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import contextlib
 import weakref
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    Generator,
-    Iterator,
-    List,
-    Set,
-)
+from typing import TYPE_CHECKING, Generator, Iterator
 
 # Bokeh imports
 from ..core.types import ID
@@ -64,10 +57,10 @@ class DocumentModelManager:
 
     _document : weakref.ReferenceType[Document]
     _freeze_count: int
-    _models: Dict[ID, Model]
-    _new_models: Set[Model]
+    _models: dict[ID, Model]
+    _new_models: set[Model]
     _models_by_name: MultiValuedDict[str, Model]
-    _seen_model_ids: Set[ID] = set()
+    _seen_model_ids: set[ID] = set()
 
     def __init__(self, document: Document):
         '''
@@ -136,7 +129,7 @@ class DocumentModelManager:
         yield
         self._pop_freeze()
 
-    def get_all_by_name(self, name: str) -> List[Model]:
+    def get_all_by_name(self, name: str) -> list[Model]:
         ''' Find all the models for this Document with a given name.
 
         Args:
@@ -176,7 +169,7 @@ class DocumentModelManager:
         return self._models_by_name.get_one(name, f"Found more than one model named '{name}'")
 
     @property
-    def synced_references(self) -> Set[Model]:
+    def synced_references(self) -> set[Model]:
         return set(model for model in self._models.values() if model not in self._new_models)
 
     def flush(self) -> None:
@@ -209,7 +202,7 @@ class DocumentModelManager:
         if document is None:
             return
 
-        new_models: Set[Model] = set()
+        new_models: set[Model] = set()
         for mr in document.roots:
             new_models |= mr.references()
 
@@ -218,7 +211,7 @@ class DocumentModelManager:
         to_detach = old_models - new_models
         to_attach = new_models - old_models
 
-        recomputed: Dict[ID, Model] = {}
+        recomputed: dict[ID, Model] = {}
         recomputed_by_name: MultiValuedDict[str, Model] = MultiValuedDict()
 
         for mn in new_models:

--- a/bokeh/document/modules.py
+++ b/bokeh/document/modules.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 import sys
 import weakref
 from types import ModuleType
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .document import Document
@@ -48,8 +48,8 @@ class DocumentModuleManager:
 
     '''
 
-    _document : weakref.ReferenceType[Document]
-    _modules: List[ModuleType]
+    _document: weakref.ReferenceType[Document]
+    _modules: list[ModuleType]
 
     def __init__(self, document: Document):
         '''

--- a/bokeh/embed/bundle.py
+++ b/bokeh/embed/bundle.py
@@ -35,12 +35,8 @@ from os.path import (
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
     Iterator,
-    List,
     Sequence,
-    Set,
-    Tuple,
     Type,
     TypedDict,
 )
@@ -102,14 +98,14 @@ class Style(Artifact):
 
 class Bundle:
 
-    js_files: List[str]
-    js_raw: List[str]
-    css_files: List[str]
-    css_raw: List[str]
+    js_files: list[str]
+    js_raw: list[str]
+    css_files: list[str]
+    css_raw: list[str]
     hashes: Hashes
 
-    def __init__(self, js_files: List[str] = [], js_raw: List[str] = [],
-            css_files: List[str] = [], css_raw: List[str] = [], hashes: Hashes = {}):
+    def __init__(self, js_files: list[str] = [], js_raw: list[str] = [],
+            css_files: list[str] = [], css_raw: list[str] = [], hashes: Hashes = {}):
         self.js_files = js_files[:]
         self.js_raw = js_raw[:]
         self.css_files = css_files[:]
@@ -133,11 +129,11 @@ class Bundle:
             return "\n".join(self.js_raw)
 
     @property
-    def js_urls(self) -> List[str]:
+    def js_urls(self) -> list[str]:
         return self.js_files
 
     @property
-    def css_urls(self) -> List[str]:
+    def css_urls(self) -> list[str]:
         return self.css_files
 
     def add(self, artifact: Artifact) -> None:
@@ -151,7 +147,7 @@ class Bundle:
             self.css_raw.append(artifact.content)
 
 def bundle_for_objs_and_resources(objs: Sequence[Model | Document] | None,
-        resources: BaseResources | Tuple[BaseResources | None, BaseResources | None] | None) -> Bundle:
+        resources: BaseResources | tuple[BaseResources | None, BaseResources | None] | None) -> Bundle:
     ''' Generate rendered CSS and JS resources suitable for the given
     collection of Bokeh objects
 
@@ -190,10 +186,10 @@ def bundle_for_objs_and_resources(objs: Sequence[Model | Document] | None,
     use_gl      = _use_gl(objs)      if objs else True
     use_mathjax = _use_mathjax(objs) if objs else True
 
-    js_files: List[str] = []
-    js_raw: List[str] = []
-    css_files: List[str] = []
-    css_raw: List[str] = []
+    js_files: list[str] = []
+    js_raw: list[str] = []
+    css_files: list[str] = []
+    css_raw: list[str] = []
 
     if js_resources:
         js_resources = deepcopy(js_resources)
@@ -242,7 +238,7 @@ def bundle_for_objs_and_resources(objs: Sequence[Model | Document] | None,
 #-----------------------------------------------------------------------------
 
 def _query_extensions(objs: Sequence[Model | Document], query: Callable[[Type[Model]], bool]) -> bool:
-    names: Set[str] = set()
+    names: set[str] = set()
 
     for obj in _all_objs(objs):
         if hasattr(obj, "__implementation__"):
@@ -275,11 +271,11 @@ class Pkg(TypedDict, total=False):
     module: str
     main: str
 
-extension_dirs: Dict[str, str] = {} # name -> path
+extension_dirs: dict[str, str] = {} # name -> path
 
-def _bundle_extensions(objs: Sequence[Model | Document], resources: Resources) -> List[ExtensionEmbed]:
-    names: Set[str] = set()
-    bundles: List[ExtensionEmbed] = []
+def _bundle_extensions(objs: Sequence[Model | Document], resources: Resources) -> list[ExtensionEmbed]:
+    names: set[str] = set()
+    bundles: list[ExtensionEmbed] = []
 
     extensions = [".min.js", ".js"] if resources.minified else [".js"]
 
@@ -352,8 +348,8 @@ def _bundle_extensions(objs: Sequence[Model | Document], resources: Resources) -
 
     return bundles
 
-def _all_objs(objs: Sequence[Model | Document]) -> Set[Model]:
-    all_objs: Set[Model] = set()
+def _all_objs(objs: Sequence[Model | Document]) -> set[Model]:
+    all_objs: set[Model] = set()
 
     for obj in objs:
         if isinstance(obj, Document):

--- a/bokeh/embed/elements.py
+++ b/bokeh/embed/elements.py
@@ -22,13 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from html import escape
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Any
 
 ## External imports
 if TYPE_CHECKING:
@@ -85,9 +79,9 @@ def div_for_render_item(item: RenderItem) -> str:
     '''
     return PLOT_DIV.render(doc=item, macros=MACROS)
 
-def html_page_for_render_items(bundle: Bundle | Tuple[str, str], docs_json: Dict[ID, DocJson],
-        render_items: List[RenderItem], title: str, template: Template | str | None = None,
-        template_variables: Dict[str, Any] = {}) -> str:
+def html_page_for_render_items(bundle: Bundle | tuple[str, str], docs_json: dict[ID, DocJson],
+        render_items: list[RenderItem], title: str, template: Template | str | None = None,
+        template_variables: dict[str, Any] = {}) -> str:
     ''' Render an HTML page from a template and Bokeh render items.
 
     Args:
@@ -151,7 +145,7 @@ def html_page_for_render_items(bundle: Bundle | Tuple[str, str], docs_json: Dict
     html = template.render(context)
     return html
 
-def script_for_render_items(docs_json_or_id: ID | Dict[ID, DocJson], render_items: List[RenderItem],
+def script_for_render_items(docs_json_or_id: ID | dict[ID, DocJson], render_items: list[RenderItem],
                             app_path: str | None = None, absolute_url: str | None = None) -> str:
     ''' Render an script for Bokeh render items.
     Args:

--- a/bokeh/embed/notebook.py
+++ b/bokeh/embed/notebook.py
@@ -21,7 +21,10 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Tuple, Union
+from typing import Union
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..core.json_encoder import serialize_json
@@ -48,9 +51,9 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-ThemeSource = Union[Theme, FromCurdoc, None]
+ThemeSource: TypeAlias = Union[Theme, FromCurdoc, None]
 
-def notebook_content(model: Model, notebook_comms_target: str | None = None, theme: ThemeSource = FromCurdoc) -> Tuple[str, str, Document]:
+def notebook_content(model: Model, notebook_comms_target: str | None = None, theme: ThemeSource = FromCurdoc) -> tuple[str, str, Document]:
     ''' Return script and div that will display a Bokeh plot in a Jupyter
     Notebook.
 

--- a/bokeh/embed/server.py
+++ b/bokeh/embed/server.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Dict, Literal
+from typing import TYPE_CHECKING, Literal
 from urllib.parse import quote_plus, urlparse
 
 ## External imports
@@ -58,7 +58,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 def server_document(url: str = "default", relative_urls: bool = False, resources: Literal["default"] | None = "default",
-        arguments: Dict[str, str] | None = None, headers: Dict[str, str] | None = None) -> str:
+        arguments: dict[str, str] | None = None, headers: dict[str, str] | None = None) -> str:
     ''' Return a script tag that embeds content from a Bokeh server.
 
     Bokeh apps embedded using these methods will NOT set the browser window title.
@@ -127,7 +127,7 @@ def server_document(url: str = "default", relative_urls: bool = False, resources
     return tag
 
 def server_session(model: Model | None = None, session_id: ID | None = None, url: str = "default",
-        relative_urls: bool = False, resources: Literal["default"] | None = "default", headers: Dict[str, str] = {}) -> str:
+        relative_urls: bool = False, resources: Literal["default"] | None = "default", headers: dict[str, str] = {}) -> str:
     ''' Return a script tag that embeds content from a specific existing session on
     a Bokeh server.
 
@@ -223,7 +223,7 @@ def server_session(model: Model | None = None, session_id: ID | None = None, url
 #-----------------------------------------------------------------------------
 
 def server_html_page_for_session(session: ServerSession, resources: Resources, title: str,
-        template: Template = FILE, template_variables: Dict[str, Unknown] | None = None):
+        template: Template = FILE, template_variables: dict[str, Unknown] | None = None):
     '''
 
     Args:
@@ -294,7 +294,7 @@ def _get_app_path(url: str) -> str:
         app_path = "/" + app_path
     return app_path
 
-def _process_arguments(arguments: Dict[str, str] | None) -> str:
+def _process_arguments(arguments: dict[str, str] | None) -> str:
     ''' Return user-supplied HTML arguments to add to a Bokeh server URL.
 
     Args:

--- a/bokeh/embed/server.py
+++ b/bokeh/embed/server.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote_plus, urlparse
 
 ## External imports
@@ -38,7 +38,7 @@ from .elements import html_page_for_render_items
 from .util import RenderItem
 
 if TYPE_CHECKING:
-    from ..core.types import ID, Unknown
+    from ..core.types import ID
     from ..model import Model
     from ..resources import Resources
     from ..server.session import ServerSession
@@ -223,7 +223,7 @@ def server_session(model: Model | None = None, session_id: ID | None = None, url
 #-----------------------------------------------------------------------------
 
 def server_html_page_for_session(session: ServerSession, resources: Resources, title: str,
-        template: Template = FILE, template_variables: dict[str, Unknown] | None = None):
+        template: Template = FILE, template_variables: dict[str, Any] | None = None):
     '''
 
     Args:

--- a/bokeh/embed/standalone.py
+++ b/bokeh/embed/standalone.py
@@ -25,10 +25,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    List,
     Literal,
     Sequence,
-    Tuple,
     Type,
     TypedDict,
     Union,
@@ -38,6 +36,7 @@ from typing import (
 
 # External imports
 from jinja2 import Template
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from .. import __version__
@@ -78,16 +77,16 @@ __all__ = (
     'json_item',
 )
 
-ModelLike = Union[Model, Document]
-ModelLikeCollection = Union[Sequence[ModelLike], Dict[str, ModelLike]]
+ModelLike: TypeAlias = Union[Model, Document]
+ModelLikeCollection: TypeAlias = Union[Sequence[ModelLike], Dict[str, ModelLike]]
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-ThemeLike = Union[None, Theme, Type[FromCurdoc]]
+ThemeLike: TypeAlias = Union[None, Theme, Type[FromCurdoc]]
 
-def autoload_static(model: Union[Model, Document], resources: Resources, script_path: str) -> Tuple[str, str]:
+def autoload_static(model: Model | Document, resources: Resources, script_path: str) -> tuple[str, str]:
     ''' Return JavaScript code and a script tag that can be used to embed
     Bokeh Plots.
 
@@ -139,27 +138,27 @@ def autoload_static(model: Union[Model, Document], resources: Resources, script_
 
 @overload
 def components(models: Model, wrap_script: bool = ..., # type: ignore[misc] # XXX: mypy bug
-    wrap_plot_info: Literal[True] = ..., theme: ThemeLike = ...) -> Tuple[str, str]: ...
+    wrap_plot_info: Literal[True] = ..., theme: ThemeLike = ...) -> tuple[str, str]: ...
 @overload
 def components(models: Model, wrap_script: bool = ..., wrap_plot_info: Literal[False] = ...,
-    theme: ThemeLike = ...) -> Tuple[str, RenderRoot]: ...
+    theme: ThemeLike = ...) -> tuple[str, RenderRoot]: ...
 
 @overload
 def components(models: Sequence[Model], wrap_script: bool = ..., # type: ignore[misc] # XXX: mypy bug
-    wrap_plot_info: Literal[True] = ..., theme: ThemeLike = ...) -> Tuple[str, Sequence[str]]: ...
+    wrap_plot_info: Literal[True] = ..., theme: ThemeLike = ...) -> tuple[str, Sequence[str]]: ...
 @overload
 def components(models: Sequence[Model], wrap_script: bool = ..., wrap_plot_info: Literal[False] = ...,
-    theme: ThemeLike = ...) -> Tuple[str, Sequence[RenderRoot]]: ...
+    theme: ThemeLike = ...) -> tuple[str, Sequence[RenderRoot]]: ...
 
 @overload
-def components(models: Dict[str, Model], wrap_script: bool = ..., # type: ignore[misc] # XXX: mypy bug
-    wrap_plot_info: Literal[True] = ..., theme: ThemeLike = ...) -> Tuple[str, Dict[str, str]]: ...
+def components(models: dict[str, Model], wrap_script: bool = ..., # type: ignore[misc] # XXX: mypy bug
+    wrap_plot_info: Literal[True] = ..., theme: ThemeLike = ...) -> tuple[str, dict[str, str]]: ...
 @overload
-def components(models: Dict[str, Model], wrap_script: bool = ..., wrap_plot_info: Literal[False] = ...,
-    theme: ThemeLike = ...) -> Tuple[str, Dict[str, RenderRoot]]: ...
+def components(models: dict[str, Model], wrap_script: bool = ..., wrap_plot_info: Literal[False] = ...,
+    theme: ThemeLike = ...) -> tuple[str, dict[str, RenderRoot]]: ...
 
-def components(models: Model | Sequence[Model] | Dict[str, Model], wrap_script: bool = True,
-               wrap_plot_info: bool = True, theme: ThemeLike = None) -> Tuple[str, Any]:
+def components(models: Model | Sequence[Model] | dict[str, Model], wrap_script: bool = True,
+               wrap_plot_info: bool = True, theme: ThemeLike = None) -> tuple[str, Any]:
     ''' Return HTML components to embed a Bokeh plot. The data for the plot is
     stored directly in the returned HTML.
 
@@ -248,7 +247,7 @@ def components(models: Model | Sequence[Model] | Dict[str, Model], wrap_script: 
 
     # now convert dict to list, saving keys in the same order
     model_keys = None
-    dict_type: Type[Dict[Any, Any]] = dict
+    dict_type: Type[dict[Any, Any]] = dict
     if isinstance(models, dict):
         dict_type = models.__class__
         model_keys = models.keys()
@@ -266,7 +265,7 @@ def components(models: Model | Sequence[Model] | Dict[str, Model], wrap_script: 
     def div_for_root(root: RenderRoot) -> str:
         return ROOT_DIV.render(root=root, macros=MACROS)
 
-    results: List[str] | List[RenderRoot]
+    results: list[str] | list[RenderRoot]
     if wrap_plot_info:
         results = [div_for_root(root) for root in render_item.roots]
     else:
@@ -284,10 +283,10 @@ def components(models: Model | Sequence[Model] | Dict[str, Model], wrap_script: 
     return script, result
 
 def file_html(models: Model | Document | Sequence[Model],
-              resources: Resources | Tuple[JSResources | None, CSSResources | None] | None,
+              resources: Resources | tuple[JSResources | None, CSSResources | None] | None,
               title: str | None = None,
               template: Template | str = FILE,
-              template_variables: Dict[str, Any] = {},
+              template_variables: dict[str, Any] = {},
               theme: ThemeLike = None,
               suppress_callback_warning: bool = False,
               _always_new: bool = False) -> str:
@@ -436,7 +435,7 @@ def json_item(model: Model, target: ID | None = None, theme: ThemeLike = None) -
 # Private API
 #-----------------------------------------------------------------------------
 
-def _check_models_or_docs(models: Union[ModelLike, ModelLikeCollection]) -> ModelLikeCollection:
+def _check_models_or_docs(models: ModelLike | ModelLikeCollection) -> ModelLikeCollection:
     '''
 
     '''
@@ -462,7 +461,7 @@ def _check_models_or_docs(models: Union[ModelLike, ModelLikeCollection]) -> Mode
 
     return models
 
-def _title_from_models(models: Sequence[Union[Model, Document]], title: str | None) -> str:
+def _title_from_models(models: Sequence[Model | Document], title: str | None) -> str:
     # use override title
     if title is not None:
         return title

--- a/bokeh/embed/util.py
+++ b/bokeh/embed/util.py
@@ -26,11 +26,8 @@ from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Iterator,
-    List,
     Sequence,
-    Tuple,
     Type,
 )
 from weakref import WeakKeyDictionary
@@ -184,7 +181,7 @@ def OutputDocumentFor(objs: Sequence[Model], apply_theme: Theme | Type[FromCurdo
 
 class RenderItem:
     def __init__(self, docid: ID | None = None, token: str | None = None, elementid: ID | None = None,
-            roots: List[Model] | Dict[Model, ID] | None = None, use_for_title: bool | None = None):
+            roots: list[Model] | dict[Model, ID] | None = None, use_for_title: bool | None = None):
 
         if (docid is None and token is None) or (docid is not None and token is not None):
             raise ValueError("either docid or sessionid must be provided")
@@ -200,8 +197,8 @@ class RenderItem:
         self.roots = RenderRoots(roots)
         self.use_for_title = use_for_title
 
-    def to_json(self) -> Dict[str, Any]:
-        json: Dict[str, Any] = {}
+    def to_json(self) -> dict[str, Any]:
+        json: dict[str, Any] = {}
 
         if self.docid is not None:
             json["docid"] = self.docid
@@ -246,7 +243,7 @@ class RenderRoot:
     name: str | None = field(default="", compare=False)
 
     #: A list of any user-supplied tag values for this root
-    tags: List[Any] = field(default_factory=list, compare=False)
+    tags: list[Any] = field(default_factory=list, compare=False)
 
     def __post_init__(self):
         # Model.name is nullable, and field() won't enforce the default when name=None
@@ -254,7 +251,7 @@ class RenderRoot:
 
 
 class RenderRoots:
-    def __init__(self, roots: Dict[Model, ID]) -> None:
+    def __init__(self, roots: dict[Model, ID]) -> None:
         self._roots = roots
 
     def __iter__(self) -> Iterator[RenderRoot]:
@@ -279,13 +276,13 @@ class RenderRoots:
     def __getattr__(self, key: str) -> RenderRoot:
         return self.__getitem__(key)
 
-    def to_json(self) -> Dict[ID, ID]:
+    def to_json(self) -> dict[ID, ID]:
         return {root.id: elementid for root, elementid in self._roots.items()}
 
     def __repr__(self) -> str:
         return repr(self._roots)
 
-def standalone_docs_json(models: Sequence[Model | Document]) -> Dict[ID, DocJson]:
+def standalone_docs_json(models: Sequence[Model | Document]) -> dict[ID, DocJson]:
     '''
 
     '''
@@ -293,7 +290,7 @@ def standalone_docs_json(models: Sequence[Model | Document]) -> Dict[ID, DocJson
     return docs_json
 
 def standalone_docs_json_and_render_items(models: Model | Document | Sequence[Model | Document],
-        suppress_callback_warning: bool = False) -> Tuple[Dict[ID, DocJson], List[RenderItem]]:
+        suppress_callback_warning: bool = False) -> tuple[dict[ID, DocJson], list[RenderItem]]:
     '''
 
     '''
@@ -306,7 +303,7 @@ def standalone_docs_json_and_render_items(models: Model | Document | Sequence[Mo
     if submodel_has_python_callbacks(models) and not suppress_callback_warning:
         log.warning(_CALLBACKS_WARNING)
 
-    docs: Dict[Document, Tuple[ID, Dict[Model, ID]]] = {}
+    docs: dict[Document, tuple[ID, dict[Model, ID]]] = {}
     for model_or_doc in models:
         if isinstance(model_or_doc, Document):
             model = None
@@ -329,11 +326,11 @@ def standalone_docs_json_and_render_items(models: Model | Document | Sequence[Mo
             for model in doc.roots:
                 roots[model] = make_globally_unique_id()
 
-    docs_json: Dict[ID, DocJson] = {}
+    docs_json: dict[ID, DocJson] = {}
     for doc, (docid, _) in docs.items():
         docs_json[docid] = doc.to_json()
 
-    render_items: List[RenderItem] = []
+    render_items: list[RenderItem] = []
     for _, (docid, roots) in docs.items():
         render_items.append(RenderItem(docid, roots=roots))
 

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -69,7 +69,6 @@ log = logging.getLogger(__name__)
 from typing import (
     TYPE_CHECKING,
     ClassVar,
-    Dict,
     Literal,
     Type,
     TypedDict,
@@ -125,7 +124,7 @@ __all__ = (
 # Private API
 #-----------------------------------------------------------------------------
 
-_CONCRETE_EVENT_CLASSES: Dict[str, Type[Event]] = {}
+_CONCRETE_EVENT_CLASSES: dict[str, Type[Event]] = {}
 
 #-----------------------------------------------------------------------------
 # General API
@@ -134,7 +133,7 @@ _CONCRETE_EVENT_CLASSES: Dict[str, Type[Event]] = {}
 class EventRep(TypedDict):
     type: Literal["event"]
     name: str
-    values: Dict[str, Unknown]
+    values: dict[str, Unknown]
 
 class Event:
     ''' Base class for all Bokeh events.

--- a/bokeh/events.py
+++ b/bokeh/events.py
@@ -68,6 +68,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from typing import (
     TYPE_CHECKING,
+    Any,
     ClassVar,
     Literal,
     Type,
@@ -78,7 +79,7 @@ from typing import (
 from .core.serialization import Deserializer
 
 if TYPE_CHECKING:
-    from .core.types import GeometryData, Unknown
+    from .core.types import GeometryData
     from .model import Model
     from .models.plots import Plot
     from .models.widgets.buttons import AbstractButton
@@ -133,7 +134,7 @@ _CONCRETE_EVENT_CLASSES: dict[str, Type[Event]] = {}
 class EventRep(TypedDict):
     type: Literal["event"]
     name: str
-    values: dict[str, Unknown]
+    values: dict[str, Any]
 
 class Event:
     ''' Base class for all Bokeh events.

--- a/bokeh/ext.py
+++ b/bokeh/ext.py
@@ -21,7 +21,6 @@ log = logging.getLogger(__name__)
 import os
 from os.path import join
 from subprocess import Popen
-from typing import List
 
 # Bokeh imports
 from . import __version__
@@ -57,7 +56,7 @@ def init(base_dir: PathLike, *, interactive: bool = False,
         bool
 
     """
-    args: List[str] = []
+    args: list[str] = []
     if interactive:
         args.append("--interactive")
     if bokehjs_version:
@@ -81,7 +80,7 @@ def build(base_dir: PathLike, *, rebuild: bool = False, debug: bool = False) -> 
         bool
 
     """
-    args: List[str] = []
+    args: list[str] = []
     if rebuild:
         args.append("--rebuild")
     proc = _run_command("build", base_dir, args, debug)
@@ -95,7 +94,7 @@ def build(base_dir: PathLike, *, rebuild: bool = False, debug: bool = False) -> 
 # Private API
 #-----------------------------------------------------------------------------
 
-def _run_command(command: str, base_dir: PathLike, args: List[str], debug: bool = False) -> Popen[bytes]:
+def _run_command(command: str, base_dir: PathLike, args: list[str], debug: bool = False) -> Popen[bytes]:
     bokehjs_dir = settings.bokehjsdir()
 
     if debug:

--- a/bokeh/io/doc.py
+++ b/bokeh/io/doc.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import weakref
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator, List
+from typing import TYPE_CHECKING, Iterator
 
 # Bokeh imports
 from .state import curstate
@@ -101,7 +101,7 @@ def set_curdoc(doc: Document) -> None:
 # Private API
 #-----------------------------------------------------------------------------
 
-_PATCHED_CURDOCS: List[weakref.ReferenceType[Document | UnlockedDocumentProxy]] = []
+_PATCHED_CURDOCS: list[weakref.ReferenceType[Document | UnlockedDocumentProxy]] = []
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/io/export.py
+++ b/bokeh/io/export.py
@@ -32,7 +32,6 @@ from typing import (
     Any,
     Iterator,
     List,
-    Tuple,
     cast,
 )
 
@@ -122,7 +121,7 @@ def export_png(obj: LayoutDOM | Document, *, filename: PathLike | None = None, w
     return abspath(expanduser(filename))
 
 def export_svg(obj: LayoutDOM | Document, *, filename: PathLike | None = None, width: int | None = None,
-        height: int | None = None, webdriver: WebDriver | None = None, timeout: int = 5) -> List[str]:
+        height: int | None = None, webdriver: WebDriver | None = None, timeout: int = 5) -> list[str]:
     ''' Export a layout as SVG file or a document as a set of SVG files.
 
     If the filename is not given, it is derived from the script name
@@ -158,7 +157,7 @@ def export_svg(obj: LayoutDOM | Document, *, filename: PathLike | None = None, w
     return _write_collection(svgs, filename, "svg")
 
 def export_svgs(obj: LayoutDOM | Document, *, filename: str | None = None, width: int | None = None,
-        height: int | None = None, webdriver: WebDriver | None = None, timeout: int = 5) -> List[str]:
+        height: int | None = None, webdriver: WebDriver | None = None, timeout: int = 5) -> list[str]:
     ''' Export the SVG-enabled plots within a layout. Each plot will result
     in a distinct SVG file.
 
@@ -246,7 +245,7 @@ def get_screenshot_as_png(obj: LayoutDOM | Document, *, driver: WebDriver | None
                  .resize((width, height)))
 
 def get_svg(obj: LayoutDOM | Document, *, driver: WebDriver | None = None, timeout: int = 5,
-        resources: Resources = INLINE, width: int | None = None, height: int | None = None) -> List[str]:
+        resources: Resources = INLINE, width: int | None = None, height: int | None = None) -> list[str]:
     from .webdriver import webdriver_control
 
     with _tmp_html() as tmp:
@@ -262,7 +261,7 @@ def get_svg(obj: LayoutDOM | Document, *, driver: WebDriver | None = None, timeo
     return svgs
 
 def get_svgs(obj: LayoutDOM | Document, *, driver: WebDriver | None = None, timeout: int = 5,
-        resources: Resources = INLINE, width: int | None = None, height: int | None = None) -> List[str]:
+        resources: Resources = INLINE, width: int | None = None, height: int | None = None) -> list[str]:
     from .webdriver import webdriver_control
 
     with _tmp_html() as tmp:
@@ -363,12 +362,12 @@ def _resized(obj: Plot, width: int | None, height: int | None) -> Iterator[None]
     obj.width = old_width
     obj.height = old_height
 
-def _write_collection(items: List[str], filename: PathLike | None, ext: str) -> List[str]:
+def _write_collection(items: list[str], filename: PathLike | None, ext: str) -> list[str]:
     if filename is None:
         filename = default_filename(ext)
     filename = os.fspath(filename)
 
-    filenames: List[str] = []
+    filenames: list[str] = []
 
     def _indexed(name: str, i: int) -> str:
         basename, ext = splitext(name)
@@ -396,13 +395,13 @@ def _log_console(driver: WebDriver) -> None:
         for message in messages:
             log.warning(message)
 
-def _maximize_viewport(web_driver: WebDriver) -> Tuple[int, int, int]:
+def _maximize_viewport(web_driver: WebDriver) -> tuple[int, int, int]:
     calculate_viewport_size = """\
         const root_view = Object.values(Bokeh.index)[0]
         const {width, height} = root_view.el.getBoundingClientRect()
         return [width, height, window.devicePixelRatio]
     """
-    viewport_size: Tuple[int, int, int] = web_driver.execute_script(calculate_viewport_size)
+    viewport_size: tuple[int, int, int] = web_driver.execute_script(calculate_viewport_size)
     calculate_window_size = """\
         const [width, height, dpr] = arguments
         return [

--- a/bokeh/io/notebook.py
+++ b/bokeh/io/notebook.py
@@ -26,7 +26,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     List,
     Literal,
     Protocol,
@@ -450,8 +449,8 @@ def load_notebook(resources: Resources | None = None, verbose: bool = False,
 
     if not hide_banner:
         if resources.mode == 'inline':
-            js_info: str | List[str] = 'inline'
-            css_info: str | List[str] = 'inline'
+            js_info: str | list[str] = 'inline'
+            css_info: str | list[str] = 'inline'
         else:
             js_info = resources.js_files[0] if len(resources.js_files) == 1 else resources.js_files
             css_info = resources.css_files[0] if len(resources.css_files) == 1 else resources.css_files
@@ -488,8 +487,8 @@ def load_notebook(resources: Resources | None = None, verbose: bool = False,
         LOAD_MIME_TYPE : jl_js,
     })
 
-def publish_display_data(data: Dict[str, Any], metadata: Dict[Any, Any] | None = None,
-        source: str | None = None, *, transient: Dict[str, Any] | None = None, **kwargs: Any) -> None:
+def publish_display_data(data: dict[str, Any], metadata: dict[Any, Any] | None = None,
+        source: str | None = None, *, transient: dict[str, Any] | None = None, **kwargs: Any) -> None:
     '''
 
     '''
@@ -602,7 +601,7 @@ def show_doc(obj: Model, state: State, notebook_handle: CommsHandle | None = Non
 # Private API
 #-----------------------------------------------------------------------------
 
-_HOOKS: Dict[str, Hooks] = {}
+_HOOKS: dict[str, Hooks] = {}
 
 _NOTEBOOK_LOADED: Resources | None = None
 

--- a/bokeh/io/saving.py
+++ b/bokeh/io/saving.py
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from os.path import abspath, expanduser
-from typing import Tuple
 from warnings import warn
 
 # External imports
@@ -107,7 +106,7 @@ def save(obj: LayoutDOM, filename: PathLike | None = None, resources: ResourcesL
 #-----------------------------------------------------------------------------
 
 def _get_save_args(state: State, filename: PathLike | None, resources: ResourcesLike | None,
-        title: str | None) -> Tuple[PathLike, Resources, str]:
+        title: str | None) -> tuple[PathLike, Resources, str]:
     '''
 
     '''
@@ -119,7 +118,7 @@ def _get_save_args(state: State, filename: PathLike | None, resources: Resources
 
     return filename, resources, title
 
-def _get_save_filename(state: State, filename: PathLike | None) -> Tuple[PathLike, bool]:
+def _get_save_filename(state: State, filename: PathLike | None) -> tuple[PathLike, bool]:
     if filename is not None:
         return filename, False
 

--- a/bokeh/io/state.py
+++ b/bokeh/io/state.py
@@ -46,7 +46,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, cast
+from typing import TYPE_CHECKING, cast
 
 # Bokeh imports
 from ..core.types import PathLike
@@ -83,7 +83,7 @@ class State:
     _notebook: bool
     _notebook_type: NotebookType | None
     last_comms_handle: CommsHandle | None
-    uuid_to_server: Dict[ID, Server]
+    uuid_to_server: dict[ID, Server]
 
     def __init__(self) -> None:
         self.last_comms_handle = None

--- a/bokeh/io/webdriver.py
+++ b/bokeh/io/webdriver.py
@@ -35,7 +35,7 @@ from os.path import (
     join,
 )
 from shutil import which
-from typing import List, Literal, Set
+from typing import Literal
 
 # External imports
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -94,7 +94,7 @@ def create_firefox_webdriver() -> WebDriver:
         service_log_path=devnull,
     )
 
-def create_chromium_webdriver(extra_options: List[str] | None = None) -> WebDriver:
+def create_chromium_webdriver(extra_options: list[str] | None = None) -> WebDriver:
     from selenium.webdriver.chrome.options import Options
     options = Options()
     options.add_argument("--headless")
@@ -133,7 +133,7 @@ class _WebdriverState:
     kind: DriverKind | None
 
     current: WebDriver | None
-    _drivers: Set[WebDriver]
+    _drivers: set[WebDriver]
 
     def __init__(self, *, kind: DriverKind | None = None, reuse: bool = True) -> None:
         self.kind = kind

--- a/bokeh/layouts.py
+++ b/bokeh/layouts.py
@@ -28,9 +28,7 @@ from typing import (
     Any,
     Iterable,
     Iterator,
-    List,
     Sequence,
-    Tuple,
     Type,
     TypeVar,
     overload,
@@ -73,11 +71,11 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 @overload
-def row(children: List[LayoutDOM], *, sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Row: ...
+def row(children: list[LayoutDOM], *, sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Row: ...
 @overload
 def row(*children: LayoutDOM, sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Row: ...
 
-def row(*children: LayoutDOM | List[LayoutDOM], sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Row:
+def row(*children: LayoutDOM | list[LayoutDOM], sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Row:
     """ Create a row of Bokeh Layout objects. Forces all objects to
     have the same sizing_mode, which is required for complex layouts to work.
 
@@ -109,11 +107,11 @@ def row(*children: LayoutDOM | List[LayoutDOM], sizing_mode: SizingModeType | No
     return Row(children=_children, sizing_mode=sizing_mode, **kwargs)
 
 @overload
-def column(children: List[LayoutDOM], *, sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Column: ...
+def column(children: list[LayoutDOM], *, sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Column: ...
 @overload
 def column(*children: LayoutDOM, sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Column: ...
 
-def column(*children: LayoutDOM | List[LayoutDOM], sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Column:
+def column(*children: LayoutDOM | list[LayoutDOM], sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Column:
     """ Create a column of Bokeh Layout objects. Forces all objects to
     have the same sizing_mode, which is required for complex layouts to work.
 
@@ -145,7 +143,7 @@ def column(*children: LayoutDOM | List[LayoutDOM], sizing_mode: SizingModeType |
     return Column(children=_children, sizing_mode=sizing_mode, **kwargs)
 
 
-def layout(*args: LayoutDOM, children: List[LayoutDOM] | None = None, sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Column:
+def layout(*args: LayoutDOM, children: list[LayoutDOM] | None = None, sizing_mode: SizingModeType | None = None, **kwargs: Any) -> Column:
     """ Create a grid-based arrangement of Bokeh Layout objects.
 
     Args:
@@ -183,7 +181,7 @@ def layout(*args: LayoutDOM, children: List[LayoutDOM] | None = None, sizing_mod
     return _create_grid(_children, sizing_mode, **kwargs)
 
 def gridplot(
-        children: List[List[LayoutDOM | None]], *,
+        children: list[list[LayoutDOM | None]], *,
         sizing_mode: SizingModeType | None = None,
         toolbar_location: LocationType | None = "above",
         ncols: int | None = None,
@@ -262,8 +260,8 @@ def gridplot(
         children = []
 
     # Make the grid
-    tools: List[Tool | ToolProxy] = []
-    items: List[Tuple[LayoutDOM, int, int]] = []
+    tools: list[Tool | ToolProxy] = []
+    items: list[tuple[LayoutDOM, int, int]] = []
 
     for y, row in enumerate(children):
         for x, item in enumerate(row):
@@ -292,15 +290,15 @@ def gridplot(
 
 # XXX https://github.com/python/mypy/issues/731
 @overload
-def grid(children: List[LayoutDOM | List[LayoutDOM | List[Any]]], *, sizing_mode: SizingModeType | None = ...) -> GridBox: ...
+def grid(children: list[LayoutDOM | list[LayoutDOM | list[Any]]], *, sizing_mode: SizingModeType | None = ...) -> GridBox: ...
 @overload
 def grid(children: Row | Column, *, sizing_mode: SizingModeType | None = ...) -> GridBox: ...
 @overload
-def grid(children: List[LayoutDOM | None], *, sizing_mode: SizingModeType | None = ..., nrows: int) -> GridBox: ...
+def grid(children: list[LayoutDOM | None], *, sizing_mode: SizingModeType | None = ..., nrows: int) -> GridBox: ...
 @overload
-def grid(children: List[LayoutDOM | None], *, sizing_mode: SizingModeType | None = ..., ncols: int) -> GridBox: ...
+def grid(children: list[LayoutDOM | None], *, sizing_mode: SizingModeType | None = ..., ncols: int) -> GridBox: ...
 @overload
-def grid(children: List[LayoutDOM | None], *, sizing_mode: SizingModeType | None = ..., nrows: int, ncols: int) -> GridBox: ...
+def grid(children: list[LayoutDOM | None], *, sizing_mode: SizingModeType | None = ..., nrows: int, ncols: int) -> GridBox: ...
 @overload
 def grid(children: str, *, sizing_mode: SizingModeType | None = ...) -> GridBox: ...
 
@@ -355,10 +353,10 @@ def grid(children: Any = [], sizing_mode: SizingModeType | None = None, nrows: i
     """
     @dataclass
     class row:
-        children: List[row | col]
+        children: list[row | col]
     @dataclass
     class col:
-        children: List[row | col]
+        children: list[row | col]
 
     @dataclass
     class Item:
@@ -372,7 +370,7 @@ def grid(children: Any = [], sizing_mode: SizingModeType | None = None, nrows: i
     class Grid:
         nrows: int
         ncols: int
-        items: List[Item]
+        items: list[Item]
 
     def flatten(layout) -> GridBox:
         def gcd(a: int, b: int) -> int:
@@ -398,7 +396,7 @@ def grid(children: Any = [], sizing_mode: SizingModeType | None = None, nrows: i
                 nrows = lcm(*[ child.nrows for child in children ])
                 ncols = sum(child.ncols for child in children)
 
-                items: List[Item] = []
+                items: list[Item] = []
                 offset = 0
                 for child in children:
                     factor = nrows//child.nrows
@@ -448,7 +446,7 @@ def grid(children: Any = [], sizing_mode: SizingModeType | None = None, nrows: i
                 ncols = math.ceil(N/nrows)
             layout = col([ row(children[i:i+ncols]) for i in range(0, N, ncols) ])
         else:
-            def traverse(children: List[LayoutDOM], level: int = 0):
+            def traverse(children: list[LayoutDOM], level: int = 0):
                 if isinstance(children, list):
                     container = col if level % 2 == 0 else row
                     return container([ traverse(child, level+1) for child in children ])
@@ -489,15 +487,15 @@ def grid(children: Any = [], sizing_mode: SizingModeType | None = None, nrows: i
 # Dev API
 #-----------------------------------------------------------------------------
 
-def group_tools(tools: List[Tool | ToolProxy]) -> List[Tool | ToolProxy]:
+def group_tools(tools: list[Tool | ToolProxy]) -> list[Tool | ToolProxy]:
     """ Group common tools into tool proxies. """
     @dataclass
     class ToolEntry:
         tool: Tool
         props: Any
 
-    by_type: defaultdict[Type[Tool], List[ToolEntry]] = defaultdict(list)
-    computed: List[Tool | ToolProxy] = []
+    by_type: defaultdict[Type[Tool], list[ToolEntry]] = defaultdict(list)
+    computed: list[Tool | ToolProxy] = []
 
     for tool in tools:
         if isinstance(tool, ToolProxy):
@@ -511,7 +509,7 @@ def group_tools(tools: List[Tool | ToolProxy]) -> List[Tool | ToolProxy]:
     for tools_ in by_type.values():
         while tools_:
             head, *tail = tools_
-            group: List[Tool] = [head.tool]
+            group: list[Tool] = [head.tool]
             for item in list(tail):
                 if item.props == head.props:
                     group.append(item.tool)
@@ -533,7 +531,7 @@ def _has_auto_sizing(item: LayoutDOM) -> bool:
     return item.sizing_mode is None and item.width_policy == "auto" and item.height_policy == "auto"
 
 L = TypeVar("L", bound=LayoutDOM)
-def _parse_children_arg(*args: L | List[L], children: List[L] | None = None) -> List[L]:
+def _parse_children_arg(*args: L | list[L], children: list[L] | None = None) -> list[L]:
     # Set-up Children from args or kwargs
     if len(args) > 0 and children is not None:
         raise ValueError("'children' keyword cannot be used with positional arguments")
@@ -548,7 +546,7 @@ def _parse_children_arg(*args: L | List[L], children: List[L] | None = None) -> 
 
     return children
 
-def _handle_child_sizing(children: List[LayoutDOM], sizing_mode: SizingModeType | None, *, widget: str) -> None:
+def _handle_child_sizing(children: list[LayoutDOM], sizing_mode: SizingModeType | None, *, widget: str) -> None:
     for item in children:
         if not isinstance(item, LayoutDOM):
             raise ValueError(f"Only LayoutDOM items can be inserted into a {widget}. Tried to insert: {item} of type {type(item)}")
@@ -556,9 +554,9 @@ def _handle_child_sizing(children: List[LayoutDOM], sizing_mode: SizingModeType 
             item.sizing_mode = sizing_mode
 
 
-def _create_grid(iterable: Iterable[LayoutDOM | List[LayoutDOM]], sizing_mode: SizingModeType | None, layer: int = 0, **kwargs) -> Row | Column:
+def _create_grid(iterable: Iterable[LayoutDOM | list[LayoutDOM]], sizing_mode: SizingModeType | None, layer: int = 0, **kwargs) -> Row | Column:
     """Recursively create grid from input lists."""
-    return_list: List[LayoutDOM] = []
+    return_list: list[LayoutDOM] = []
     for item in iterable:
         if isinstance(item, list):
             return_list.append(_create_grid(item, sizing_mode, layer + 1))

--- a/bokeh/model/model.py
+++ b/bokeh/model/model.py
@@ -25,10 +25,7 @@ from inspect import Parameter, Signature, isclass
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Iterable,
-    List,
-    Set,
     Type,
 )
 
@@ -147,7 +144,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     """)
 
-    tags: List[Any] = p.List(p.AnyRef, help="""
+    tags: list[Any] = p.List(p.AnyRef, help="""
     An optional list of arbitrary, user-supplied values to attach to this
     model.
 
@@ -227,7 +224,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     @classmethod
     @without_property_validation
-    def parameters(cls: Type[Model]) -> List[Parameter]:
+    def parameters(cls: Type[Model]) -> list[Parameter]:
         ''' Generate Python ``Parameter`` values suitable for functions that are
         derived from the glyph.
 
@@ -463,7 +460,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
         descriptor = self.lookup(attr)
         super().on_change(descriptor.name, *callbacks)
 
-    def references(self) -> Set[Model]:
+    def references(self) -> set[Model]:
         ''' Returns all ``Models`` that this object has references to.
 
         '''
@@ -500,7 +497,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
             return None
         return result[0]
 
-    def set_select(self, selector: Type[Model] | SelectorType, updates: Dict[str, Unknown]) -> None:
+    def set_select(self, selector: Type[Model] | SelectorType, updates: dict[str, Unknown]) -> None:
         ''' Update objects that match a given selector with the specified
         attribute/value updates.
 

--- a/bokeh/model/model.py
+++ b/bokeh/model/model.py
@@ -35,7 +35,7 @@ from ..core.has_props import HasProps, abstract
 from ..core.property._sphinx import type_link
 from ..core.property.validation import without_property_validation
 from ..core.serialization import ObjectRefRep, Ref, Serializer
-from ..core.types import ID, Unknown
+from ..core.types import ID
 from ..events import Event
 from ..themes import default as default_theme
 from ..util.callback_manager import EventCallbackManager, PropertyCallbackManager
@@ -497,7 +497,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
             return None
         return result[0]
 
-    def set_select(self, selector: Type[Model] | SelectorType, updates: dict[str, Unknown]) -> None:
+    def set_select(self, selector: Type[Model] | SelectorType, updates: dict[str, Any]) -> None:
         ''' Update objects that match a given selector with the specified
         attribute/value updates.
 
@@ -531,7 +531,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
         return rep
 
-    def trigger(self, attr: str, old: Unknown, new: Unknown,
+    def trigger(self, attr: str, old: Any, new: Any,
             hint: DocumentPatchedEvent | None = None, setter: Setter | None = None) -> None:
         '''
 

--- a/bokeh/model/util.py
+++ b/bokeh/model/util.py
@@ -21,13 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    List,
-    Set,
-    Type,
-)
+from typing import TYPE_CHECKING, Callable, Type
 
 # Bokeh imports
 from ..core.has_props import HasProps, Qualified
@@ -82,7 +76,7 @@ class HasDocumentRef:
     def document(self, doc: Document) -> None:
         self._document = doc
 
-def collect_filtered_models(discard: Callable[[Model], bool] | None, *input_values: Unknown) -> List[Model]:
+def collect_filtered_models(discard: Callable[[Model], bool] | None, *input_values: Unknown) -> list[Model]:
     ''' Collect a duplicate-free list of all other Bokeh models referred to by
     this model, or by any of its references, etc, unless filtered-out by the
     provided callable.
@@ -105,9 +99,9 @@ def collect_filtered_models(discard: Callable[[Model], bool] | None, *input_valu
 
     '''
 
-    ids: Set[ID] = set()
-    collected: List[Model] = []
-    queued: List[Model] = []
+    ids: set[ID] = set()
+    collected: list[Model] = []
+    queued: list[Model] = []
 
     def queue_one(obj: Model) -> None:
         if obj.id not in ids and not (callable(discard) and discard(obj)):
@@ -125,7 +119,7 @@ def collect_filtered_models(discard: Callable[[Model], bool] | None, *input_valu
 
     return collected
 
-def collect_models(*input_values: Unknown) -> List[Model]:
+def collect_models(*input_values: Unknown) -> list[Model]:
     ''' Collect a duplicate-free list of all other Bokeh models referred to by
     this model, or by any of its references, etc.
 

--- a/bokeh/model/util.py
+++ b/bokeh/model/util.py
@@ -21,13 +21,18 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Callable, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Type,
+)
 
 # Bokeh imports
 from ..core.has_props import HasProps, Qualified
 
 if TYPE_CHECKING:
-    from ..core.types import ID, Unknown
+    from ..core.types import ID
     from ..document import Document
     from .model import Model
 
@@ -76,7 +81,7 @@ class HasDocumentRef:
     def document(self, doc: Document) -> None:
         self._document = doc
 
-def collect_filtered_models(discard: Callable[[Model], bool] | None, *input_values: Unknown) -> list[Model]:
+def collect_filtered_models(discard: Callable[[Model], bool] | None, *input_values: Any) -> list[Model]:
     ''' Collect a duplicate-free list of all other Bokeh models referred to by
     this model, or by any of its references, etc, unless filtered-out by the
     provided callable.
@@ -119,7 +124,7 @@ def collect_filtered_models(discard: Callable[[Model], bool] | None, *input_valu
 
     return collected
 
-def collect_models(*input_values: Unknown) -> list[Model]:
+def collect_models(*input_values: Any) -> list[Model]:
     ''' Collect a duplicate-free list of all other Bokeh models referred to by
     this model, or by any of its references, etc.
 
@@ -173,7 +178,7 @@ def get_class(view_model_name: str) -> Type[Model]:
     else:
         raise KeyError(f"View model name '{view_model_name}' not found")
 
-def visit_immediate_value_references(value: Unknown, visitor: Callable[[Model], None]) -> None:
+def visit_immediate_value_references(value: Any, visitor: Callable[[Model], None]) -> None:
     ''' Visit all references to another Model without recursing into any
     of the child Model; may visit the same Model more than once if
     it's referenced more than once. Does not visit the passed-in value.
@@ -187,7 +192,7 @@ def visit_immediate_value_references(value: Unknown, visitor: Callable[[Model], 
         visit_value_and_its_immediate_references(value, visitor)
 
 
-def visit_value_and_its_immediate_references(obj: Unknown, visitor: Callable[[Model], None]) -> None:
+def visit_value_and_its_immediate_references(obj: Any, visitor: Callable[[Model], None]) -> None:
     ''' Visit Models, HasProps, and Python containers.
 
     Recurses down HasProps references and Python containers (does not recurse

--- a/bokeh/models/dom.py
+++ b/bokeh/models/dom.py
@@ -111,10 +111,10 @@ class TableRow(DOMElement):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-def vbox(children: List[DOMNode]) -> Div:
+def vbox(children: list[DOMNode]) -> Div:
     return Div(style=Styles(display="flex", flex_direction="column"), children=children)
 
-def hbox(children: List[DOMNode]) -> Div:
+def hbox(children: list[DOMNode]) -> Div:
     return Div(style=Styles(display="flex", flex_direction="row"), children=children)
 
 @abstract

--- a/bokeh/models/plots.py
+++ b/bokeh/models/plots.py
@@ -22,12 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import warnings
-from typing import (
-    Any,
-    List as TList,
-    Literal,
-    overload,
-)
+from typing import Any, Literal, overload
 
 # External imports
 import xyzservices
@@ -275,11 +270,11 @@ class Plot(LayoutDOM):
         return _list_attr_splat(self.xgrid + self.ygrid)
 
     @property
-    def tools(self) -> TList[Tool]:
+    def tools(self) -> list[Tool]:
         return self.toolbar.tools
 
     @tools.setter
-    def tools(self, tools: TList[Tool]):
+    def tools(self, tools: list[Tool]):
         self.toolbar.tools = tools
 
     def add_layout(self, obj: Renderer, place: PlaceType = "center") -> None:
@@ -425,7 +420,7 @@ class Plot(LayoutDOM):
 
     @error(REQUIRED_RANGE)
     def _check_required_range(self) -> str | None:
-        missing: TList[str] = []
+        missing: list[str] = []
         if not self.x_range: missing.append('x_range')
         if not self.y_range: missing.append('y_range')
         if missing:
@@ -433,7 +428,7 @@ class Plot(LayoutDOM):
 
     @error(REQUIRED_SCALE)
     def _check_required_scale(self) -> str | None:
-        missing: TList[str] = []
+        missing: list[str] = []
         if not self.x_scale: missing.append('x_scale')
         if not self.y_scale: missing.append('y_scale')
         if missing:
@@ -441,7 +436,7 @@ class Plot(LayoutDOM):
 
     @error(INCOMPATIBLE_SCALE_AND_RANGE)
     def _check_compatible_scale_and_ranges(self) -> str | None:
-        incompatible: TList[str] = []
+        incompatible: list[str] = []
         x_ranges = list(self.extra_x_ranges.values())
         if self.x_range: x_ranges.append(self.x_range)
         y_ranges = list(self.extra_y_ranges.values())

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -64,7 +64,6 @@ from .selections import Selection, SelectionPolicy, UnionRenderers
 
 if TYPE_CHECKING:
     from ..core.has_props import Setter
-    from ..core.types import Unknown
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -93,7 +92,7 @@ if TYPE_CHECKING:
 
     Index: TypeAlias = Union[int, slice, Tuple[Union[int, slice], ...]]
 
-    Patches: TypeAlias = TDict[str, TList[Tuple[Index, Unknown]]]
+    Patches: TypeAlias = TDict[str, TList[Tuple[Index, Any]]]
 
 @abstract
 class DataSource(Model):
@@ -380,7 +379,7 @@ class ColumnDataSource(ColumnarDataSource):
             raise RuntimeError('Pandas must be installed to convert to a Pandas Dataframe')
         return pd.DataFrame(self.data)
 
-    def add(self, data: Sequence[Unknown], name: str | None = None) -> str:
+    def add(self, data: Sequence[Any], name: str | None = None) -> str:
         ''' Appends a new column of data to the data source.
 
         Args:

--- a/bokeh/models/sources.py
+++ b/bokeh/models/sources.py
@@ -25,11 +25,13 @@ from typing import (
     Dict as TDict,
     List as TList,
     Sequence,
-    Set,
     Tuple,
     Union,
     overload,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..core.has_props import abstract
@@ -87,11 +89,11 @@ if TYPE_CHECKING:
     import numpy.typing as npt
     import pandas as pd
 
-    DataDict = TDict[str, Union[Sequence[TAny], npt.NDArray[TAny], pd.Series, pd.Index]]
+    DataDict: TypeAlias = TDict[str, Union[Sequence[TAny], npt.NDArray[TAny], pd.Series, pd.Index]]
 
-    Index = Union[int, slice, Tuple[Union[int, slice], ...]]
+    Index: TypeAlias = Union[int, slice, Tuple[Union[int, slice], ...]]
 
-    Patches = TDict[str, TList[Tuple[Index, Unknown]]]
+    Patches: TypeAlias = TDict[str, TList[Tuple[Index, Unknown]]]
 
 @abstract
 class DataSource(Model):
@@ -239,7 +241,7 @@ class ColumnDataSource(ColumnarDataSource):
         self.data.update(raw_data)
 
     @property
-    def column_names(self) -> TList[str]:
+    def column_names(self) -> list[str]:
         ''' A list of the column names in this data source.
 
         '''
@@ -543,7 +545,7 @@ class ColumnDataSource(ColumnarDataSource):
 
         import numpy as np
         if needs_length_check:
-            lengths: Set[int] = set()
+            lengths: set[int] = set()
             arr_types = (np.ndarray, pd.Series) if pd else np.ndarray
             for _, x in new_data.items():
                 if isinstance(x, arr_types):
@@ -757,7 +759,7 @@ class CDSView(Model):
     """)
 
     @property
-    def filters(self) -> TList[Filter]:
+    def filters(self) -> list[Filter]:
         deprecated("CDSView.filters was deprecated in bokeh 3.0. Use CDSView.filter instead.")
         filter = self.filter
         if isinstance(filter, IntersectionFilter):
@@ -768,7 +770,7 @@ class CDSView(Model):
             return [filter]
 
     @filters.setter
-    def filters(self, filters: TList[Filter]) -> None:
+    def filters(self, filters: list[Filter]) -> None:
         deprecated("CDSView.filters was deprecated in bokeh 3.0. Use CDSView.filter instead.")
         if len(filters) == 0:
             self.filter = AllIndices()

--- a/bokeh/models/tools.py
+++ b/bokeh/models/tools.py
@@ -184,7 +184,7 @@ class Tool(Model):
     user interface as a tooltip.
     """)
 
-    _known_aliases: tp.ClassVar[tp.Dict[str, tp.Callable[[], Tool]]] = {}
+    _known_aliases: tp.ClassVar[dict[str, tp.Callable[[], Tool]]] = {}
 
     @classmethod
     def from_string(cls, name: str) -> Tool:
@@ -323,25 +323,25 @@ class Toolbar(Model):
     A list of tools to add to the plot.
     """)
 
-    active_drag: tp.Union[Literal["auto"], Drag, None] = Either(Null, Auto, Instance(Drag), default="auto", help="""
+    active_drag: Literal["auto"] | Drag | None = Either(Null, Auto, Instance(Drag), default="auto", help="""
     Specify a drag tool to be active when the plot is displayed.
     """)
 
-    active_inspect: tp.Union[Literal["auto"], InspectTool, tp.Sequence[InspectTool], None] = \
+    active_inspect: Literal["auto"] | InspectTool | tp.Sequence[InspectTool] | None = \
         Either(Null, Auto, Instance(InspectTool), Seq(Instance(InspectTool)), default="auto", help="""
     Specify an inspection tool or sequence of inspection tools to be active when
     the plot is displayed.
     """)
 
-    active_scroll: tp.Union[Literal["auto"], Scroll, None] = Either(Null, Auto, Instance(Scroll), default="auto", help="""
+    active_scroll: Literal["auto"] | Scroll | None = Either(Null, Auto, Instance(Scroll), default="auto", help="""
     Specify a scroll/pinch tool to be active when the plot is displayed.
     """)
 
-    active_tap: tp.Union[Literal["auto"], Tap, None] = Either(Null, Auto, Instance(Tap), default="auto", help="""
+    active_tap: Literal["auto"] | Tap | None = Either(Null, Auto, Instance(Tap), default="auto", help="""
     Specify a tap/click tool to be active when the plot is displayed.
     """)
 
-    active_multi: tp.Union[Literal["auto"], GestureTool, None] = Either(Null, Auto, Instance(GestureTool), default="auto", help="""
+    active_multi: Literal["auto"] | GestureTool | None = Either(Null, Auto, Instance(GestureTool), default="auto", help="""
     Specify an active multi-gesture tool, for instance an edit tool or a range
     tool.
 

--- a/bokeh/models/util/structure.py
+++ b/bokeh/models/util/structure.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from itertools import permutations
-from typing import TYPE_CHECKING, Dict, Set
+from typing import TYPE_CHECKING
 
 ## External dependencies
 if TYPE_CHECKING:
@@ -185,7 +185,7 @@ class _BokehStructureGraph:
             return answer1 | answer2 | answer3
 
         K = nx.DiGraph()
-        T: Dict[ID, Set[ID]] = {}
+        T: dict[ID, set[ID]] = {}
         for m in M.references():
             T[m.id] = {y.id for y in m.references()}
 

--- a/bokeh/models/widgets/sliders.py
+++ b/bokeh/models/widgets/sliders.py
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import numbers
-import typing as tp
 from datetime import date, datetime
 
 # Bokeh imports
@@ -237,7 +236,7 @@ class DateRangeSlider(AbstractSlider):
         super().__init__(*args, **kwargs)
 
     @property
-    def value_as_datetime(self) -> tp.Tuple[datetime, datetime] | None:
+    def value_as_datetime(self) -> tuple[datetime, datetime] | None:
         ''' Convenience property to retrieve the value tuple as a tuple of
         datetime objects.
 
@@ -257,7 +256,7 @@ class DateRangeSlider(AbstractSlider):
         return d1, d2
 
     @property
-    def value_as_date(self) -> tp.Tuple[date, date] | None:
+    def value_as_date(self) -> tuple[date, date] | None:
         ''' Convenience property to retrieve the value tuple as a tuple of
         date objects.
 
@@ -308,7 +307,7 @@ class DatetimeRangeSlider(AbstractSlider):
         super().__init__(*args, **kwargs)
 
     @property
-    def value_as_datetime(self) -> tp.Tuple[datetime, datetime] | None:
+    def value_as_datetime(self) -> tuple[datetime, datetime] | None:
         ''' Convenience property to retrieve the value tuple as a tuple of
         datetime objects.
         '''

--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -418,10 +418,11 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import math
 from copy import deepcopy
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 # External imports
 import numpy as np
+from typing_extensions import TypeAlias
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -433,9 +434,9 @@ import numpy as np
 # General API
 #-----------------------------------------------------------------------------
 
-Palette = Tuple[str, ...]
-PaletteCollection = Dict[int, Palette]
-PaletteMap = Dict[str, PaletteCollection]
+Palette: TypeAlias = Tuple[str, ...]
+PaletteCollection: TypeAlias = Dict[int, Palette]
+PaletteMap: TypeAlias = Dict[str, PaletteCollection]
 
 YlGn3 = ("#31a354", "#addd8e", "#f7fcb9")
 YlGn4 = ("#238443", "#78c679", "#c2e699", "#ffffcc")
@@ -1382,7 +1383,7 @@ Category20c = { 3:  Category20c_3,  4:  Category20c_4,  5:  Category20c_5,  6:  
                 18: Category20c_18, 19: Category20c_19, 20: Category20c_20 }
 Colorblind  = { 3: Colorblind3, 4: Colorblind4, 5: Colorblind5, 6: Colorblind6, 7: Colorblind7, 8: Colorblind8 }
 Bright = { 3: Bright3, 4: Bright4, 5: Bright5, 6: Bright6, 7: Bright7 }
-HighContrast: Dict[int, Tuple[str, ...]] = { 3: HighContrast3 }
+HighContrast: dict[int, tuple[str, ...]] = { 3: HighContrast3 }
 Vibrant = { 3: Vibrant3, 4: Vibrant4, 5: Vibrant5, 6: Vibrant6, 7: Vibrant7 }
 Muted = { 3: Muted3, 4: Muted4, 5: Muted5, 6: Muted6, 7: Muted7, 8: Muted8, 9: Muted9 }
 MediumContrast = { 3: MediumContrast3, 4: MediumContrast4, 5: MediumContrast5, 6: MediumContrast6 }
@@ -1816,7 +1817,7 @@ def gray(n: int) -> Palette:
 # Code
 #-----------------------------------------------------------------------------
 
-__palettes__: List[str] = []
+__palettes__: list[str] = []
 for name, palettes in sorted(all_palettes.items(), key=lambda arg: arg[0]):
     name = name + "_" if name[-1].isdigit() else name
     __palettes__ += [ name + str(index) for index in sorted(palettes.keys()) ]

--- a/bokeh/plotting/_renderer.py
+++ b/bokeh/plotting/_renderer.py
@@ -284,7 +284,7 @@ def _process_sequence_literals(glyphclass, kwargs, source, is_user_source):
                 elif val.dtype == "uint8" and val.ndim == 1:  # greys
                     pass
                 elif val.dtype.kind == "U" and val.ndim == 1: # CSS strings
-                    pass # TODO: currently this gets converted to List[str] in the serializer
+                    pass # TODO: currently this gets converted to list[str] in the serializer
                 elif (val.dtype == "uint8" or val.dtype.kind == "f") and val.ndim == 2 and val.shape[1] in (3, 4): # RGB/RGBA
                     pass
                 else:

--- a/bokeh/plotting/_tools.py
+++ b/bokeh/plotting/_tools.py
@@ -25,15 +25,16 @@ from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterator,
     List,
     Literal,
     Sequence,
-    Tuple,
     Union,
     cast,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..models import (
@@ -68,14 +69,14 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 # TODO: str should be literal union of e.g. pan | xpan | ypan
-Auto = Literal["auto"]
-ActiveDrag = Union[Drag, Auto, str, None]
-ActiveInspect = Union[List[InspectTool], InspectTool, Auto, str, None]
-ActiveScroll = Union[Scroll, Auto, str, None]
-ActiveTap = Union[Tap, Auto, str, None]
-ActiveMulti = Union[GestureTool, Auto, str, None]
+Auto: TypeAlias = Literal["auto"]
+ActiveDrag: TypeAlias = Union[Drag, Auto, str, None]
+ActiveInspect: TypeAlias = Union[List[InspectTool], InspectTool, Auto, str, None]
+ActiveScroll: TypeAlias = Union[Scroll, Auto, str, None]
+ActiveTap: TypeAlias = Union[Tap, Auto, str, None]
+ActiveMulti: TypeAlias = Union[GestureTool, Auto, str, None]
 
-def process_active_tools(toolbar: Toolbar, tool_map: Dict[str, Tool],
+def process_active_tools(toolbar: Toolbar, tool_map: dict[str, Tool],
         active_drag: ActiveDrag, active_inspect: ActiveInspect, active_scroll: ActiveScroll,
         active_tap: ActiveTap, active_multi: ActiveMulti) -> None:
     """ Adds tools to the plot object
@@ -132,7 +133,7 @@ def process_active_tools(toolbar: Toolbar, tool_map: Dict[str, Tool],
         raise ValueError(f"Got unknown {active_multi!r} for 'active_multi', which was not a string supplied in 'tools' argument")
 
 def process_tools_arg(plot: Plot, tools: str | Sequence[Tool | str],
-        tooltips: str | Tuple[str, str] | None = None) -> Tuple[List[Tool], Dict[str, Tool]]:
+        tooltips: str | tuple[str, str] | None = None) -> tuple[list[Tool], dict[str, Tool]]:
     """ Adds tools to the plot object
 
     Args:
@@ -167,9 +168,9 @@ def process_tools_arg(plot: Plot, tools: str | Sequence[Tool | str],
 # Private API
 #-----------------------------------------------------------------------------
 
-def _resolve_tools(tools: str | Sequence[Tool | str]) -> Tuple[List[Tool], Dict[str, Tool]]:
-    tool_objs: List[Tool] = []
-    tool_map: Dict[str, Tool] = {}
+def _resolve_tools(tools: str | Sequence[Tool | str]) -> tuple[list[Tool], dict[str, Tool]]:
+    tool_objs: list[Tool] = []
+    tool_map: dict[str, Tool] = {}
 
     if not isinstance(tools, str):
         temp_tool_str = ""
@@ -193,11 +194,11 @@ def _resolve_tools(tools: str | Sequence[Tool | str]) -> Tuple[List[Tool], Dict[
 
     return tool_objs, tool_map
 
-def _collect_repeated_tools(tool_objs: List[Tool]) -> Iterator[Tool]:
+def _collect_repeated_tools(tool_objs: list[Tool]) -> Iterator[Tool]:
     @dataclass(frozen=True)
     class Item:
         obj: Tool
-        properties: Dict[str, Any]
+        properties: dict[str, Any]
 
     key: Callable[[Tool], str] = lambda obj: obj.__class__.__name__
 

--- a/bokeh/plotting/contour.py
+++ b/bokeh/plotting/contour.py
@@ -18,17 +18,12 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    List,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Sequence, Union
 
 # External imports
 import numpy as np
 from numpy.typing import ArrayLike
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..core.property_mixins import FillProps, HatchProps, LineProps
@@ -44,8 +39,8 @@ if TYPE_CHECKING:
     from ..palettes import Palette, PaletteCollection
     from ..transform import ColorLike
 
-    ContourColor: Union[ColorLike, Sequence[ColorLike]]
-    ContourColorOrPalette: Union[ContourColor, Palette, PaletteCollection, ContourColor]
+    ContourColor: TypeAlias = Union[ColorLike, Sequence[ColorLike]]
+    ContourColorOrPalette: TypeAlias = Union[ContourColor, Palette, PaletteCollection, ContourColor]
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -64,15 +59,15 @@ __all__ = (
 class FillCoords:
     ''' Coordinates for all filled polygons over a whole sequence of contour levels.
     '''
-    xs: List[List[List[np.ndarray]]]
-    ys: List[List[List[np.ndarray]]]
+    xs: list[list[list[np.ndarray]]]
+    ys: list[list[list[np.ndarray]]]
 
 @dataclass(frozen=True)
 class LineCoords:
     ''' Coordinates for all contour lines over a whole sequence of contour levels.
     '''
-    xs: List[np.ndarray]
-    ys: List[np.ndarray]
+    xs: list[np.ndarray]
+    ys: list[np.ndarray]
 
 @dataclass(frozen=True)
 class ContourCoords:
@@ -233,8 +228,8 @@ class SingleFillCoords:
     a separate NumPy array for each boundary of that polygon; the first array
     is always the outer boundary, subsequent arrays are holes.
     '''
-    xs: List[List[np.ndarray]]
-    ys: List[List[np.ndarray]]
+    xs: list[list[np.ndarray]]
+    ys: list[list[np.ndarray]]
 
 @dataclass(frozen=True)
 class SingleLineCoords:
@@ -248,7 +243,7 @@ class SingleLineCoords:
 
 def _color(color: ContourColorOrPalette, n: int) -> ContourColor:
     # Dict to sequence of colors such as palettes.cividis
-    if isinstance(color, Dict):
+    if isinstance(color, dict):
         color = color.get(n, None)
         if not color or len(color) != n:
             raise ValueError(f"Dict of colors does not contain a key of {n}")

--- a/bokeh/protocol/__init__.py
+++ b/bokeh/protocol/__init__.py
@@ -72,7 +72,7 @@ MessageType = Literal[
     "SERVER-INFO-REQ",
 ]
 
-SPEC: Dict[MessageType, Type[Message[Any]]] = {
+SPEC: dict[MessageType, Type[Message[Any]]] = {
     "ACK": ack,
     "ERROR": error,
     "OK": ok,
@@ -96,7 +96,7 @@ class Protocol:
     ''' Provide a message factory for the Bokeh Server message protocol.
 
     '''
-    _messages: Dict[MessageType, Type[Message[Any]]]
+    _messages: dict[MessageType, Type[Message[Any]]]
 
     def __init__(self) -> None:
         self._messages = SPEC
@@ -111,7 +111,7 @@ class Protocol:
     @overload
     def create(self, msgtype: Literal["OK"], request_id: ID, **metadata: Any) -> ok: ...
     @overload
-    def create(self, msgtype: Literal["PATCH-DOC"], events: List[DocumentPatchedEvent], **metadata: Any) -> patch_doc: ...
+    def create(self, msgtype: Literal["PATCH-DOC"], events: list[DocumentPatchedEvent], **metadata: Any) -> patch_doc: ...
     @overload
     def create(self, msgtype: Literal["PULL-DOC-REPLY"], request_id: ID, document: Document, **metadata: Any) -> pull_doc_reply: ...
     @overload

--- a/bokeh/protocol/message.py
+++ b/bokeh/protocol/message.py
@@ -64,11 +64,13 @@ from typing import (
     ClassVar,
     Dict,
     Generic,
-    List,
     Tuple,
     TypedDict,
     TypeVar,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 import bokeh.util.serialization as bkserial
@@ -111,9 +113,9 @@ class BufferHeader(TypedDict):
 
 Content = TypeVar("Content")
 
-Metadata = Dict[str, Any]
+Metadata: TypeAlias = Dict[str, Any]
 
-BufferRef = Tuple[BufferHeader, bytes]
+BufferRef: TypeAlias = Tuple[BufferHeader, bytes]
 
 class Empty(TypedDict):
     pass
@@ -136,7 +138,7 @@ class Message(Generic[Content]):
     _metadata: Metadata
     _metadata_json: str | None
 
-    _buffers: List[Buffer]
+    _buffers: list[Buffer]
 
     def __init__(self, header: Header, metadata: Metadata, content: Content) -> None:
         ''' Initialize a new message from header, metadata, and content
@@ -400,7 +402,7 @@ class Message(Generic[Content]):
     # buffer properties
 
     @property
-    def buffers(self) -> List[Buffer]:
+    def buffers(self) -> list[Buffer]:
         return list(self._buffers)
 
 #-----------------------------------------------------------------------------

--- a/bokeh/protocol/messages/patch_doc.py
+++ b/bokeh/protocol/messages/patch_doc.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from ...core.serialization import Serializer
@@ -65,7 +65,7 @@ class patch_doc(Message[PatchJson]):
     msgtype = 'PATCH-DOC'
 
     @classmethod
-    def create(cls, events: List[DocumentPatchedEvent], **metadata: Any) -> patch_doc:
+    def create(cls, events: list[DocumentPatchedEvent], **metadata: Any) -> patch_doc:
         ''' Create a ``PATCH-DOC`` message
 
         Args:

--- a/bokeh/protocol/receiver.py
+++ b/bokeh/protocol/receiver.py
@@ -27,10 +27,12 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    List,
     Union,
     cast,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from .exceptions import ValidationError
@@ -55,7 +57,7 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-Fragment = Union[str, bytes]
+Fragment: TypeAlias = Union[str, bytes]
 
 class Receiver:
     ''' Receive wire message fragments and assemble complete Bokeh server
@@ -103,7 +105,7 @@ class Receiver:
     '''
 
     _current_consumer: Callable[[Receiver, Fragment], None]
-    _fragments: List[Fragment]
+    _fragments: list[Fragment]
     _message: Message[Any] | None
     _buf_header: BufferHeader | None
     _partial: Message[Any] | None

--- a/bokeh/resources.py
+++ b/bokeh/resources.py
@@ -42,14 +42,15 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
-    List,
     Literal,
     Protocol,
-    Tuple,
     Union,
     cast,
     get_args,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from . import __version__
@@ -70,10 +71,10 @@ DEFAULT_SERVER_HOST = "localhost"
 DEFAULT_SERVER_PORT = 5006
 DEFAULT_SERVER_HTTP_URL = f"http://{DEFAULT_SERVER_HOST}:{DEFAULT_SERVER_PORT}/"
 
-BaseMode = Literal["inline", "cdn", "server", "relative", "absolute"]
-DevMode = Literal["server-dev", "relative-dev", "absolute-dev"]
+BaseMode: TypeAlias = Literal["inline", "cdn", "server", "relative", "absolute"]
+DevMode: TypeAlias = Literal["server-dev", "relative-dev", "absolute-dev"]
 
-ResourcesMode = Union[BaseMode, DevMode]
+ResourcesMode: TypeAlias = Union[BaseMode, DevMode]
 
 # __all__ defined at the bottom on the class module
 
@@ -85,11 +86,11 @@ ResourcesMode = Union[BaseMode, DevMode]
 # Dev API
 # -----------------------------------------------------------------------------
 
-Hashes = Dict[str, str]
+Hashes: TypeAlias = Dict[str, str]
 
-_SRI_HASHES: Dict[str, Hashes] | None = None
+_SRI_HASHES: dict[str, Hashes] | None = None
 
-def get_all_sri_hashes() -> Dict[str, Hashes]:
+def get_all_sri_hashes() -> dict[str, Hashes]:
     """ Report SRI script hashes for all versions of BokehJS.
 
     Bokeh provides `Subresource Integrity`_ hashes for all JavaScript files that
@@ -211,7 +212,7 @@ def verify_sri_hashes() -> None:
     if len(hashes) > len(paths):
         raise RuntimeError("There are 'bokeh*.js' files missing in the package")
 
-    bad: List[str] = []
+    bad: list[str] = []
     for path in paths:
         name, suffix = basename(path).split(".", 1)
         filename = f"{name}-{__version__}.{suffix}"
@@ -234,16 +235,16 @@ class RuntimeMessage:
 # XXX: https://github.com/python/mypy/issues/5485
 class UrlsFn(Protocol):
     @staticmethod
-    def __call__(components: List[str], kind: Kind) -> List[str]: ...
+    def __call__(components: list[str], kind: Kind) -> list[str]: ...
 
 class HashesFn(Protocol):
     @staticmethod
-    def __call__(components: List[str], kind: Kind) -> Hashes: ...
+    def __call__(components: list[str], kind: Kind) -> Hashes: ...
 
 @dataclass
 class Urls:
     urls: UrlsFn
-    messages: List[RuntimeMessage] = field(default_factory=list)
+    messages: list[RuntimeMessage] = field(default_factory=list)
     hashes: HashesFn | None = None
 
 ResourceAttr = Literal["__css__", "__javascript__"]
@@ -253,12 +254,12 @@ class BaseResources:
     _default_root_url = DEFAULT_SERVER_HTTP_URL
 
     mode: BaseMode
-    messages: List[RuntimeMessage]
+    messages: list[RuntimeMessage]
 
     _log_level: LogLevel
 
-    _js_components: ClassVar[List[str]]
-    _css_components: ClassVar[List[str]]
+    _js_components: ClassVar[list[str]]
+    _css_components: ClassVar[list[str]]
 
     def __init__(
         self,
@@ -269,7 +270,7 @@ class BaseResources:
         log_level: LogLevel | None = None,
         root_url: str | None = None,
         path_versioner: PathVersioner | None = None,
-        components: List[str] | None = None,
+        components: list[str] | None = None,
         base_dir: str | None = None, # TODO: PathLike
     ):
         self._components = components
@@ -348,25 +349,25 @@ class BaseResources:
 
     # Public methods ----------------------------------------------------------
 
-    def components(self, kind: Kind) -> List[str]:
+    def components(self, kind: Kind) -> list[str]:
         components = self.js_components if kind == "js" else self.css_components
         if self._components is not None:
             components = [c for c in components if c in self._components]
         return components
 
-    def _file_paths(self, kind: Kind) -> List[str]:
+    def _file_paths(self, kind: Kind) -> list[str]:
         minified = ".min" if not self.dev and self.minified else ""
 
         files = [f"{component}{minified}.{kind}" for component in self.components(kind)]
         paths = [join(self.base_dir, kind, file) for file in files]
         return paths
 
-    def _collect_external_resources(self, resource_attr: ResourceAttr) -> List[str]:
+    def _collect_external_resources(self, resource_attr: ResourceAttr) -> list[str]:
         """ Collect external resources set on resource_attr attribute of all models."""
-        external_resources: List[str] = []
+        external_resources: list[str] = []
 
         for _, cls in sorted(Model.model_class_reverse_map.items(), key=lambda arg: arg[0]):
-            external: List[str] | str | None = getattr(cls, resource_attr, None)
+            external: list[str] | str | None = getattr(cls, resource_attr, None)
 
             if isinstance(external, str):
                 if external not in external_resources:
@@ -384,7 +385,7 @@ class BaseResources:
     def _server_urls(self) -> Urls:
         return _get_server_urls(self.root_url, False if self.dev else self.minified, self.path_versioner)
 
-    def _resolve(self, kind: Kind) -> Tuple[List[str], List[str], Hashes]:
+    def _resolve(self, kind: Kind) -> tuple[list[str], list[str], Hashes]:
         paths = self._file_paths(kind)
         files, raw = [], []
         hashes = {}
@@ -473,13 +474,13 @@ class JSResources(BaseResources):
     # Properties --------------------------------------------------------------
 
     @property
-    def js_files(self) -> List[str]:
+    def js_files(self) -> list[str]:
         files, _, _ = self._resolve("js")
         external_resources = self._collect_external_resources("__javascript__")
         return external_resources + files
 
     @property
-    def js_raw(self) -> List[str]:
+    def js_raw(self) -> list[str]:
         _, raw, _ = self._resolve("js")
 
         if self.log_level is not None:
@@ -550,18 +551,18 @@ class CSSResources(BaseResources):
     # Properties --------------------------------------------------------------
 
     @property
-    def css_files(self) -> List[str]:
+    def css_files(self) -> list[str]:
         files, _, _ = self._resolve("css")
         external_resources = self._collect_external_resources("__css__")
         return external_resources + files
 
     @property
-    def css_raw(self) -> List[str]:
+    def css_raw(self) -> list[str]:
         _, raw, _ = self._resolve("css")
         return raw
 
     @property
-    def css_raw_str(self) -> List[str]:
+    def css_raw_str(self) -> list[str]:
         return [json.dumps(css) for css in self.css_raw]
 
     # Public methods ----------------------------------------------------------
@@ -750,7 +751,7 @@ def _compute_single_hash(path: str) -> str:
 # Code
 # -----------------------------------------------------------------------------
 
-ResourcesLike = Union[Resources, ResourcesMode]
+ResourcesLike: TypeAlias = Union[Resources, ResourcesMode]
 
 CDN = Resources(mode="cdn")
 

--- a/bokeh/sampledata/us_states.py
+++ b/bokeh/sampledata/us_states.py
@@ -42,7 +42,7 @@ import codecs
 import csv
 import gzip
 import xml.etree.ElementTree as et
-from typing import Dict, TypedDict
+from typing import TypedDict
 
 # External imports
 from typing_extensions import TypeAlias
@@ -80,11 +80,11 @@ class StateData(TypedDict):
 
 nan = float('NaN')
 
-def _read_data() -> Dict[State, StateData]:
+def _read_data() -> dict[State, StateData]:
     '''
 
     '''
-    data: Dict[State, StateData] = {}
+    data: dict[State, StateData] = {}
 
     with gzip.open(package_path('US_Regions_State_Boundaries.csv.gz')) as f:
         decoded = codecs.iterdecode(f, "utf-8")

--- a/bokeh/server/auth_provider.py
+++ b/bokeh/server/auth_provider.py
@@ -22,9 +22,7 @@ from typing import (
     TYPE_CHECKING,
     Awaitable,
     Callable,
-    List,
     NewType,
-    Tuple,
     Type,
 )
 
@@ -75,11 +73,11 @@ class AuthProvider:
         self._validate()
 
     @property
-    def endpoints(self) -> List[Tuple[str, Type[RequestHandler]]]:
+    def endpoints(self) -> list[tuple[str, Type[RequestHandler]]]:
         ''' URL patterns for login/logout endpoints.
 
         '''
-        endpoints: List[Tuple[str, Type[RequestHandler]]] = []
+        endpoints: list[tuple[str, Type[RequestHandler]]] = []
         if self.login_handler:
             assert self.login_url is not None
             endpoints.append((self.login_url, self.login_handler))

--- a/bokeh/server/contexts.py
+++ b/bokeh/server/contexts.py
@@ -27,9 +27,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Dict,
     Iterable,
-    List,
 )
 
 # External imports
@@ -82,8 +80,8 @@ class BokehServerContext(ServerContext):
         return self._application_context()
 
     @property
-    def sessions(self) -> List[ServerSession]:
-        result: List[ServerSession] = []
+    def sessions(self) -> list[ServerSession]:
+        result: list[ServerSession] = []
         context = self.application_context
         if context:
             for session in context.sessions:
@@ -152,9 +150,9 @@ class ApplicationContext:
 
     '''
 
-    _sessions: Dict[ID, ServerSession]
-    _pending_sessions: Dict[ID, gen.Future[ServerSession]]
-    _session_contexts: Dict[ID, SessionContext]
+    _sessions: dict[ID, ServerSession]
+    _pending_sessions: dict[ID, gen.Future[ServerSession]]
+    _session_contexts: dict[ID, SessionContext]
     _server_context: BokehServerContext
 
     def __init__(self, application: Application, io_loop: IOLoop | None = None,
@@ -308,7 +306,7 @@ class ApplicationContext:
                 (session.milliseconds_since_last_unsubscribe > unused_session_linger_milliseconds or \
                  session.expiration_requested)
         # build a temp list to avoid trouble from self._sessions changes
-        to_discard: List[ServerSession] = []
+        to_discard: list[ServerSession] = []
         for session in self._sessions.values():
             if should_discard_ignoring_block(session) and not session.expiration_blocked:
                 to_discard.append(session)
@@ -328,16 +326,16 @@ class ApplicationContext:
 
 class _RequestProxy:
 
-    _arguments: Dict[str, List[bytes]]
-    _cookies: Dict[str, str]
-    _headers: Dict[str, str | List[str]]
+    _arguments: dict[str, list[bytes]]
+    _cookies: dict[str, str]
+    _headers: dict[str, str | list[str]]
 
     def __init__(
         self,
         request: HTTPServerRequest,
-        arguments: Dict[str, bytes | List[bytes]] | None = None,
-        cookies: Dict[str, str] | None = None,
-        headers: Dict[str, str | List[str]] | None = None,
+        arguments: dict[str, bytes | list[bytes]] | None = None,
+        cookies: dict[str, str] | None = None,
+        headers: dict[str, str | list[str]] | None = None,
     ) -> None:
         self._request = request
 
@@ -366,15 +364,15 @@ class _RequestProxy:
             self._headers = {}
 
     @property
-    def arguments(self) -> Dict[str, List[bytes]]:
+    def arguments(self) -> dict[str, list[bytes]]:
         return self._arguments
 
     @property
-    def cookies(self) -> Dict[str, str]:
+    def cookies(self) -> dict[str, str]:
         return self._cookies
 
     @property
-    def headers(self) -> Dict[str, str | List[str]]:
+    def headers(self) -> dict[str, str | list[str]]:
         return self._headers
 
     def __getattr__(self, name: str) -> Any:

--- a/bokeh/server/django/apps.py
+++ b/bokeh/server/django/apps.py
@@ -19,7 +19,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from importlib import import_module
-from typing import List
 
 # External imports
 from django.apps import AppConfig
@@ -47,7 +46,7 @@ class DjangoBokehConfig(AppConfig):
     _routes: RoutingConfiguration | None = None
 
     @property
-    def bokeh_apps(self) -> List[Routing]:
+    def bokeh_apps(self) -> list[Routing]:
         module = settings.ROOT_URLCONF
         url_conf = import_module(module) if isinstance(module, str) else module
         return url_conf.bokeh_apps

--- a/bokeh/server/django/consumers.py
+++ b/bokeh/server/django/consumers.py
@@ -22,7 +22,7 @@ import asyncio
 import calendar
 import datetime as dt
 import json
-from typing import Any, Dict, Set
+from typing import Any
 from urllib.parse import parse_qs, urljoin, urlparse
 
 # External imports
@@ -81,7 +81,7 @@ class ConsumerHelper(AsyncConsumer):
         return request
 
     @property
-    def arguments(self) -> Dict[str, str]:
+    def arguments(self) -> dict[str, str]:
         parsed_url = urlparse("/?" + self.scope["query_string"].decode())
         return {name: value for name, [value] in parse_qs(parsed_url.query).items()}
 
@@ -99,7 +99,7 @@ class SessionConsumer(AsyncHttpConsumer, ConsumerHelper):
 
     application_context: ApplicationContext
 
-    def __init__(self, scope: Dict[str, Any]) -> None:
+    def __init__(self, scope: dict[str, Any]) -> None:
         super().__init__(scope)
 
         kwargs = self.scope["url_route"]["kwargs"]
@@ -170,11 +170,11 @@ class DocConsumer(SessionConsumer):
 
 class WSConsumer(AsyncWebsocketConsumer, ConsumerHelper):
 
-    _clients: Set[ServerConnection]
+    _clients: set[ServerConnection]
 
     application_context: ApplicationContext
 
-    def __init__(self, scope: Dict[str, Any]) -> None:
+    def __init__(self, scope: dict[str, Any]) -> None:
         super().__init__(scope)
 
         kwargs = self.scope['url_route']["kwargs"]

--- a/bokeh/server/django/routing.py
+++ b/bokeh/server/django/routing.py
@@ -20,12 +20,13 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import re
 from pathlib import Path
-from typing import Callable, List, Union
+from typing import Callable, Union
 
 # External imports
 from channels.http import AsgiHandler
 from django.conf.urls import url
 from django.urls.resolvers import URLPattern
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from bokeh.application import Application
@@ -45,7 +46,7 @@ __all__ = (
     'RoutingConfiguration',
 )
 
-ApplicationLike = Union[Application, Callable, Path]
+ApplicationLike: TypeAlias = Union[Application, Callable, Path]
 
 #-----------------------------------------------------------------------------
 # General API
@@ -84,8 +85,8 @@ def document(url: str, app: ApplicationLike) -> Routing:
 def autoload(url: str, app: ApplicationLike) -> Routing:
     return Routing(url, app, autoload=True)
 
-def directory(*apps_paths: Path) -> List[Routing]:
-    paths: List[Path] = []
+def directory(*apps_paths: Path) -> list[Routing]:
+    paths: list[Path] = []
 
     for apps_path in apps_paths:
         if apps_path.exists():
@@ -97,17 +98,17 @@ def directory(*apps_paths: Path) -> List[Routing]:
 
 
 class RoutingConfiguration:
-    _http_urlpatterns: List[str] = []
-    _websocket_urlpatterns: List[str] = []
+    _http_urlpatterns: list[str] = []
+    _websocket_urlpatterns: list[str] = []
 
-    def __init__(self, routings: List[Routing]) -> None:
+    def __init__(self, routings: list[Routing]) -> None:
         for routing in routings:
             self._add_new_routing(routing)
 
-    def get_http_urlpatterns(self) -> List[URLPattern]:
+    def get_http_urlpatterns(self) -> list[URLPattern]:
         return self._http_urlpatterns + [url(r"", AsgiHandler)]
 
-    def get_websocket_urlpatterns(self) -> List[URLPattern]:
+    def get_websocket_urlpatterns(self) -> list[URLPattern]:
         return self._websocket_urlpatterns
 
     def _add_new_routing(self, routing: Routing) -> None:

--- a/bokeh/server/protocol_handler.py
+++ b/bokeh/server/protocol_handler.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 # Bokeh imports
 from ..protocol.exceptions import ProtocolError
@@ -60,7 +60,7 @@ class ProtocolHandler:
 
     '''
 
-    _handlers: Dict[str, Callable[..., Any]]
+    _handlers: dict[str, Callable[..., Any]]
 
     def __init__(self) -> None:
         self._handlers = {}

--- a/bokeh/server/server.py
+++ b/bokeh/server/server.py
@@ -38,13 +38,7 @@ import signal
 import socket
 import sys
 from types import FrameType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Mapping,
-)
+from typing import TYPE_CHECKING, Any, Mapping
 
 # External imports
 from tornado import netutil, version as tornado_version
@@ -228,7 +222,7 @@ class BaseServer:
         '''
         return self._tornado.get_session(app_path, session_id)
 
-    def get_sessions(self, app_path: str | None = None) -> List[ServerSession]:
+    def get_sessions(self, app_path: str | None = None) -> list[ServerSession]:
         ''' Gets all currently active sessions for applications.
 
         Args:
@@ -243,7 +237,7 @@ class BaseServer:
         '''
         if app_path is not None:
             return self._tornado.get_sessions(app_path)
-        all_sessions: List[ServerSession] = []
+        all_sessions: list[ServerSession] = []
         for path in self._tornado.app_paths:
             all_sessions += self._tornado.get_sessions(path)
         return all_sessions
@@ -357,7 +351,7 @@ class Server(BaseServer):
     '''
 
     def __init__(self, applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
-            io_loop: IOLoop | None = None, http_server_kwargs: Dict[str, Any] | None = None, **kwargs: Any) -> None:
+            io_loop: IOLoop | None = None, http_server_kwargs: dict[str, Any] | None = None, **kwargs: Any) -> None:
         ''' Create a ``Server`` instance.
 
         Args:
@@ -530,7 +524,7 @@ class _ServerOpts(Options):
     A path to a Jinja2 template to use for the index "/"
     """)  # type: ignore[assignment]
 
-    allow_websocket_origin: List[str] | None = Nullable(p.List(String), help="""
+    allow_websocket_origin: list[str] | None = Nullable(p.List(String), help="""
     A list of hosts that can connect to the websocket.
 
     This is typically required when embedding a Bokeh server app in an external

--- a/bokeh/server/session.py
+++ b/bokeh/server/session.py
@@ -30,8 +30,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    List,
-    Set,
     TypeVar,
 )
 
@@ -127,9 +125,9 @@ class ServerSession:
 
     '''
 
-    _subscribed_connections: Set[ServerConnection]
+    _subscribed_connections: set[ServerConnection]
     _current_patch_connection: ServerConnection | None
-    _pending_writes: List[Awaitable[None]] | None
+    _pending_writes: list[Awaitable[None]] | None
 
     def __init__(self, session_id: ID, document: Document, io_loop: IOLoop | None = None, token: str | None = None) -> None:
         if session_id is None:

--- a/bokeh/server/tornado.py
+++ b/bokeh/server/tornado.py
@@ -28,12 +28,8 @@ from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    List,
     Mapping,
     Sequence,
-    Set,
-    Tuple,
     Type,
 )
 from urllib.parse import urljoin
@@ -248,10 +244,10 @@ class BokehTornado(TornadoApplication):
     _loop: IOLoop
     _applications: Mapping[str, ApplicationContext]
     _prefix: str
-    _websocket_origins: Set[str]
+    _websocket_origins: set[str]
     auth_provider: AuthProvider
 
-    _clients: Set[ServerConnection]
+    _clients: set[ServerConnection]
 
     _mem_job: PeriodicCallback | None
     _ping_job: PeriodicCallback | None
@@ -278,10 +274,10 @@ class BokehTornado(TornadoApplication):
                  index: str | None = None,
                  auth_provider: AuthProvider = NullAuth(),
                  xsrf_cookies: bool = False,
-                 include_headers: List[str] | None = None,
-                 include_cookies: List[str] | None = None,
-                 exclude_headers: List[str] | None = None,
-                 exclude_cookies: List[str] | None = None,
+                 include_headers: list[str] | None = None,
+                 include_cookies: list[str] | None = None,
+                 exclude_headers: list[str] | None = None,
+                 exclude_cookies: list[str] | None = None,
                  session_token_expiration: int = DEFAULT_SESSION_TOKEN_EXPIRATION,
                  **kwargs: Any):
 
@@ -498,7 +494,7 @@ class BokehTornado(TornadoApplication):
         return self._applications
 
     @property
-    def app_paths(self) -> Set[str]:
+    def app_paths(self) -> set[str]:
         ''' A list of all application paths for all Bokeh applications
         configured on this Bokeh server instance.
 
@@ -536,7 +532,7 @@ class BokehTornado(TornadoApplication):
         return self._prefix
 
     @property
-    def websocket_origins(self) -> Set[str]:
+    def websocket_origins(self) -> set[str]:
         ''' A list of websocket origins permitted to connect to this server.
 
         '''
@@ -551,7 +547,7 @@ class BokehTornado(TornadoApplication):
         return self._secret_key
 
     @property
-    def include_cookies(self) -> List[str] | None:
+    def include_cookies(self) -> list[str] | None:
         ''' A list of request cookies to make available in the session
         context.
 
@@ -559,7 +555,7 @@ class BokehTornado(TornadoApplication):
         return self._include_cookies
 
     @property
-    def include_headers(self) -> List[str] | None:
+    def include_headers(self) -> list[str] | None:
         ''' A list of request headers to make available in the session
         context.
 
@@ -567,14 +563,14 @@ class BokehTornado(TornadoApplication):
         return self._include_headers
 
     @property
-    def exclude_cookies(self) -> List[str] | None:
+    def exclude_cookies(self) -> list[str] | None:
         ''' A list of request cookies to exclude in the session context.
 
         '''
         return self._exclude_cookies
 
     @property
-    def exclude_headers(self) -> List[str] | None:
+    def exclude_headers(self) -> list[str] | None:
         ''' A list of request headers to exclude in the session context.
 
         '''
@@ -694,7 +690,7 @@ class BokehTornado(TornadoApplication):
             raise ValueError("Application %s does not exist on this server" % app_path)
         return self._applications[app_path].get_session(session_id)
 
-    def get_sessions(self, app_path: str) -> List[ServerSession]:
+    def get_sessions(self, app_path: str) -> list[ServerSession]:
         ''' Gets all currently active sessions for an application.
 
         Args:
@@ -785,7 +781,7 @@ class BokehTornado(TornadoApplication):
 # Dev API
 #-----------------------------------------------------------------------------
 
-def create_static_handler(prefix: str, key: str, app: Application) -> Tuple[str, Type[StaticFileHandler | StaticHandler], Dict[str, Any]]:
+def create_static_handler(prefix: str, key: str, app: Application) -> tuple[str, Type[StaticFileHandler | StaticHandler], dict[str, Any]]:
     route = prefix
     route += "/static/(.*)" if key == "/" else key + "/static/(.*)"
     if app.static_path is not None:

--- a/bokeh/server/urls.py
+++ b/bokeh/server/urls.py
@@ -66,6 +66,7 @@ from typing import (
 
 # External imports
 from tornado.web import RequestHandler
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..embed.bundle import extension_dirs
@@ -94,9 +95,9 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-RouteContext = Dict[str, Any]
+RouteContext: TypeAlias = Dict[str, Any]
 
-URLRoutes = List[
+URLRoutes: TypeAlias = List[
     Union[
         Tuple[str, Type[RequestHandler]],
         Tuple[str, Type[RequestHandler], RouteContext],

--- a/bokeh/server/util.py
+++ b/bokeh/server/util.py
@@ -22,12 +22,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    List,
-    Sequence,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
     from socket import socket
@@ -50,7 +45,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def bind_sockets(address: str | None, port: int) -> Tuple[List[socket], int]:
+def bind_sockets(address: str | None, port: int) -> tuple[list[socket], int]:
     ''' Bind a socket to a port on an address.
 
     Args:
@@ -105,7 +100,7 @@ def check_allowlist(host: str, allowlist: Sequence[str]) -> bool:
 
     return any(match_host(host, pattern) for pattern in allowlist)
 
-def create_hosts_allowlist(host_list: Sequence[str] | None, port: int | None) -> List[str]:
+def create_hosts_allowlist(host_list: Sequence[str] | None, port: int | None) -> list[str]:
     '''
 
     This allowlist can be used to restrict websocket or other connections to
@@ -139,7 +134,7 @@ def create_hosts_allowlist(host_list: Sequence[str] | None, port: int | None) ->
     if not host_list:
         return ['localhost:' + str(port)]
 
-    hosts: List[str] = []
+    hosts: list[str] = []
     for host in host_list:
         if '*' in host:
             log.warning(

--- a/bokeh/server/views/multi_root_static_handler.py
+++ b/bokeh/server/views/multi_root_static_handler.py
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import os
-from typing import Dict
 
 # External imports
 from tornado.web import HTTPError, StaticFileHandler
@@ -45,12 +44,12 @@ __all__ = (
 
 class MultiRootStaticHandler(StaticFileHandler):
 
-    def initialize(self, root: Dict[str, str]) -> None:
+    def initialize(self, root: dict[str, str]) -> None:
         self.root = root
         self.default_filename = None
 
     @classmethod
-    def get_absolute_path(cls, root: Dict[str, str], path: str) -> str:
+    def get_absolute_path(cls, root: dict[str, str], path: str) -> str:
         try:
             name, artifact_path = path.split(os.sep, 1)
         except ValueError:

--- a/bokeh/server/views/ws.py
+++ b/bokeh/server/views/ws.py
@@ -23,13 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import calendar
 import datetime as dt
-from typing import (
-    Any,
-    Dict,
-    List,
-    Union,
-    cast,
-)
+from typing import Any, cast
 from urllib.parse import urlparse
 
 # External imports
@@ -162,7 +156,7 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
             # immediately, most likely.
             log.debug("Failed to fully open connection %r", e)
 
-    def select_subprotocol(self, subprotocols: List[str]) -> str | None:
+    def select_subprotocol(self, subprotocols: list[str]) -> str | None:
         log.debug('Subprotocol header received')
         log.trace('Supplied subprotocol headers: %r', subprotocols)
         if not len(subprotocols) == 2:
@@ -170,7 +164,7 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
         self._token = subprotocols[1]
         return subprotocols[0]
 
-    def get_compression_options(self) -> Dict[str, Any] | None:
+    def get_compression_options(self) -> dict[str, Any] | None:
         if self._compression_level is None:
             return None
         options = {'compression_level': self._compression_level}
@@ -287,7 +281,7 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
             log.warning("Failed sending message as connection was closed")
         return None
 
-    async def write_message(self, message: Union[bytes, str, Dict[str, Any]],
+    async def write_message(self, message: bytes | str | dict[str, Any],
             binary: bool = False, locked: bool = True) -> None:
         ''' Override parent write_message with a version that acquires a
         write lock before writing.
@@ -350,8 +344,8 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
 # should not be used for any other purpose.
 @dataclass
 class MessageTestPort:
-    sent: List[Message[Any]]
-    received: List[Message[Any]]
+    sent: list[Message[Any]]
+    received: list[Message[Any]]
 
 _message_test_port: MessageTestPort | None = None
 

--- a/bokeh/settings.py
+++ b/bokeh/settings.py
@@ -123,9 +123,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Generic,
-    List,
     Literal,
     Sequence,
     Type,
@@ -136,6 +134,7 @@ from typing import (
 
 # External imports
 import yaml
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from .util.paths import bokehjsdir, serverdir
@@ -165,7 +164,7 @@ def convert_str(value: str) -> str:
     '''
     return value
 
-def convert_bool(value: Union[bool, str]) -> bool:
+def convert_bool(value: bool | str) -> bool:
     ''' Convert a string to True or False.
 
     If a boolean is passed in, it is returned as-is. Otherwise the function
@@ -196,7 +195,7 @@ def convert_bool(value: Union[bool, str]) -> bool:
 
     raise ValueError(f"Cannot convert {value} to boolean value")
 
-def convert_str_seq(value: Union[List[str], str]) -> List[str]:
+def convert_str_seq(value: list[str] | str) -> list[str]:
     ''' Convert a string to a list of strings.
 
     If a list or tuple is passed in, it is returned as-is.
@@ -218,9 +217,9 @@ def convert_str_seq(value: Union[List[str], str]) -> List[str]:
         raise ValueError(f"Cannot convert {value} to list value")
 
 
-LogLevel = Literal["trace", "debug", "info", "warn", "error", "fatal"]
+LogLevel: TypeAlias = Literal["trace", "debug", "info", "warn", "error", "fatal"]
 
-PyLogLevel = Union[int, None]
+PyLogLevel: TypeAlias = Union[int, None]
 
 _log_levels = {
     "CRITICAL" : logging.CRITICAL,
@@ -232,7 +231,7 @@ _log_levels = {
     "NONE"     : None,
 }
 
-def convert_logging(value: Union[str, int]) -> PyLogLevel:
+def convert_logging(value: str | int) -> PyLogLevel:
     '''Convert a string to a Python logging level
 
     If a log level is passed in, it is returned as-is. Otherwise the function
@@ -269,7 +268,7 @@ def convert_logging(value: Union[str, int]) -> PyLogLevel:
 
 ValidationLevel = Literal["none", "errors", "all"]
 
-def convert_validation(value: Union[str, ValidationLevel]) -> ValidationLevel:
+def convert_validation(value: str | ValidationLevel) -> ValidationLevel:
     '''Convert a string to a validation level
 
     If a validation level is passed in, it is returned as-is.
@@ -328,7 +327,7 @@ class _Unset: pass
 
 T = TypeVar("T")
 
-Unset = Union[T, Type[_Unset]]
+Unset: TypeAlias = Union[T, Type[_Unset]]
 
 def is_dev() -> bool:
     return convert_bool(os.environ.get("BOKEH_DEV", False))
@@ -363,10 +362,10 @@ class PrioritizedSetting(Generic[T]):
     '''
 
     _parent: Settings | None
-    _user_value: Unset[Union[str, T]]
+    _user_value: Unset[str | T]
 
     def __init__(self, name: str, env_var: str | None = None, default: Unset[T] = _Unset,
-            dev_default: Unset[T] = _Unset, convert: Callable[[Union[T, str]], T] | None = None, help: str = "") -> None:
+            dev_default: Unset[T] = _Unset, convert: Callable[[T | str], T] | None = None, help: str = "") -> None:
         self._convert = convert if convert else convert_str
         self._default = default
         self._dev_default = dev_default
@@ -376,7 +375,7 @@ class PrioritizedSetting(Generic[T]):
         self._parent = None
         self._user_value = _Unset
 
-    def __call__(self, value: Union[T, str] | None = None, default: Unset[T] = _Unset) -> T:
+    def __call__(self, value: T | str | None = None, default: Unset[T] = _Unset) -> T:
         '''Return the setting value according to the standard precedence.
 
         Args:
@@ -436,10 +435,10 @@ class PrioritizedSetting(Generic[T]):
     def __get__(self, instance: Any, owner: Type[Any]) -> PrioritizedSetting[T]:
         return self
 
-    def __set__(self, instance: Any, value: Union[str, T]) -> None:
+    def __set__(self, instance: Any, value: str | T) -> None:
         self.set_value(value)
 
-    def set_value(self, value: Union[str, T]) -> None:
+    def set_value(self, value: str | T) -> None:
         ''' Specify a value for this setting programmatically.
 
         A value set this way takes precedence over all other methods except
@@ -509,9 +508,9 @@ class Settings:
 
     '''
 
-    _config_override: Dict[str, Any]
-    _config_user: Dict[str, Any]
-    _config_system: Dict[str, Any]
+    _config_override: dict[str, Any]
+    _config_user: dict[str, Any]
+    _config_system: dict[str, Any]
 
     def __init__(self) -> None:
         self._config_override = {}
@@ -523,22 +522,22 @@ class Settings:
                 x._parent = self
 
     @property
-    def config_system(self) -> Dict[str, Any]:
+    def config_system(self) -> dict[str, Any]:
         return dict(self._config_system)
 
     @property
-    def config_user(self) -> Dict[str, Any]:
+    def config_user(self) -> dict[str, Any]:
         return dict(self._config_user)
 
     @property
-    def config_override(self) -> Dict[str, Any]:
+    def config_override(self) -> dict[str, Any]:
         return dict(self._config_override)
 
     @property
     def dev(self) -> bool:
         return is_dev()
 
-    allowed_ws_origin: PrioritizedSetting[List[str]] = PrioritizedSetting("allowed_ws_origin", "BOKEH_ALLOW_WS_ORIGIN", default=[], convert=convert_str_seq, help="""
+    allowed_ws_origin: PrioritizedSetting[list[str]] = PrioritizedSetting("allowed_ws_origin", "BOKEH_ALLOW_WS_ORIGIN", default=[], convert=convert_str_seq, help="""
     A comma-separated list of allowed websocket origins for Bokeh server applications.
     """)
 
@@ -740,22 +739,22 @@ class Settings:
         '''
         return bokehjsdir(self.dev)
 
-    def css_files(self) -> List[str]:
+    def css_files(self) -> list[str]:
         ''' The CSS files in the BokehJS directory.
 
         '''
-        css_files: List[str] = []
+        css_files: list[str] = []
         for root, _, files in os.walk(self.bokehjsdir()):
             for fname in files:
                 if fname.endswith(".css"):
                     css_files.append(join(root, fname))
         return css_files
 
-    def js_files(self) -> List[str]:
+    def js_files(self) -> list[str]:
         ''' The JS files in the BokehJS directory.
 
         '''
-        js_files: List[str] = []
+        js_files: list[str] = []
         for root, _, files in os.walk(self.bokehjsdir()):
             for fname in files:
                 if fname.endswith(".js"):
@@ -785,7 +784,7 @@ class Settings:
                 self._secret_key_bytes = key.encode("utf-8")
         return self._secret_key_bytes
 
-    def _try_load_config(self, locations: Sequence[str]) -> Dict[str, Any]:
+    def _try_load_config(self, locations: Sequence[str]) -> dict[str, Any]:
         for location in locations:
             try:
                 return yaml.load(open(location), Loader=yaml.SafeLoader)

--- a/bokeh/sphinxext/bokeh_model.py
+++ b/bokeh/sphinxext/bokeh_model.py
@@ -57,7 +57,6 @@ log = logging.getLogger(__name__)
 import importlib
 import json
 import warnings
-from typing import Dict
 
 # External imports
 from docutils.parsers.rst.directives import unchanged
@@ -151,7 +150,7 @@ def setup(app):
 # Private API
 # -----------------------------------------------------------------------------
 
-def to_json_rep(obj: Model) -> Dict[str, AnyRep]:
+def to_json_rep(obj: Model) -> dict[str, AnyRep]:
     serializer = Serializer()
 
     properties = obj.properties_with_values(include_defaults=True)

--- a/bokeh/themes/theme.py
+++ b/bokeh/themes/theme.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Type,
     overload,
 )
@@ -47,7 +46,7 @@ if TYPE_CHECKING:
 # whenever we cache that there's nothing themed for a class, we
 # use this same dict instance, so we don't have a zillion empty
 # dicts in our caches.
-_empty_dict: Dict[str, Unknown] = {}
+_empty_dict: dict[str, Unknown] = {}
 
 __all__ = (
     'Theme',
@@ -145,20 +144,20 @@ class Theme:
 
     '''
 
-    _by_class_cache: Dict[str, Dict[str, Unknown]]
+    _by_class_cache: dict[str, dict[str, Unknown]]
 
-    _line_defaults: Dict[str, Unknown]
-    _fill_defaults: Dict[str, Unknown]
-    _text_defaults: Dict[str, Unknown]
+    _line_defaults: dict[str, Unknown]
+    _fill_defaults: dict[str, Unknown]
+    _text_defaults: dict[str, Unknown]
 
-    _json: Dict[str, Any]
+    _json: dict[str, Any]
 
     @overload
     def __init__(self, filename: PathLike) -> None: ...
     @overload
-    def __init__(self, json: Dict[str, Any]) -> None: ...
+    def __init__(self, json: dict[str, Any]) -> None: ...
 
-    def __init__(self, filename: PathLike | None = None, json: Dict[str, Any] | None = None) -> None:
+    def __init__(self, filename: PathLike | None = None, json: dict[str, Any] | None = None) -> None:
         if (filename is not None) and (json is not None):
             raise ValueError("Theme should be constructed from a file or from json not both")
 
@@ -199,7 +198,7 @@ class Theme:
         # class.
         self._by_class_cache = {}
 
-    def _add_glyph_defaults(self, cls: Type[HasProps], props: Dict[str, Unknown]) -> None:
+    def _add_glyph_defaults(self, cls: Type[HasProps], props: dict[str, Unknown]) -> None:
         from ..models.glyphs import Glyph
         if issubclass(cls, Glyph):
             if hasattr(cls, "line_alpha"):
@@ -209,10 +208,10 @@ class Theme:
             if hasattr(cls, "text_alpha"):
                 props.update(self._text_defaults)
 
-    def _for_class(self, cls: Type[Model]) -> Dict[str, Unknown]:
+    def _for_class(self, cls: Type[Model]) -> dict[str, Unknown]:
         if cls.__name__ not in self._by_class_cache:
             attrs = self._json['attrs']
-            combined: Dict[str, Unknown] = {}
+            combined: dict[str, Unknown] = {}
             # we go in reverse order so that subclass props override base class
             for base in cls.__mro__[-2::-1]:
                 if not issubclass(base, HasProps):

--- a/bokeh/themes/theme.py
+++ b/bokeh/themes/theme.py
@@ -33,7 +33,7 @@ import yaml
 
 # Bokeh imports
 from ..core.has_props import HasProps
-from ..core.types import PathLike, Unknown
+from ..core.types import PathLike
 from ..util.deprecation import deprecated
 
 if TYPE_CHECKING:
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # whenever we cache that there's nothing themed for a class, we
 # use this same dict instance, so we don't have a zillion empty
 # dicts in our caches.
-_empty_dict: dict[str, Unknown] = {}
+_empty_dict: dict[str, Any] = {}
 
 __all__ = (
     'Theme',
@@ -144,11 +144,11 @@ class Theme:
 
     '''
 
-    _by_class_cache: dict[str, dict[str, Unknown]]
+    _by_class_cache: dict[str, dict[str, Any]]
 
-    _line_defaults: dict[str, Unknown]
-    _fill_defaults: dict[str, Unknown]
-    _text_defaults: dict[str, Unknown]
+    _line_defaults: dict[str, Any]
+    _fill_defaults: dict[str, Any]
+    _text_defaults: dict[str, Any]
 
     _json: dict[str, Any]
 
@@ -198,7 +198,7 @@ class Theme:
         # class.
         self._by_class_cache = {}
 
-    def _add_glyph_defaults(self, cls: Type[HasProps], props: dict[str, Unknown]) -> None:
+    def _add_glyph_defaults(self, cls: Type[HasProps], props: dict[str, Any]) -> None:
         from ..models.glyphs import Glyph
         if issubclass(cls, Glyph):
             if hasattr(cls, "line_alpha"):
@@ -208,10 +208,10 @@ class Theme:
             if hasattr(cls, "text_alpha"):
                 props.update(self._text_defaults)
 
-    def _for_class(self, cls: Type[Model]) -> dict[str, Unknown]:
+    def _for_class(self, cls: Type[Model]) -> dict[str, Any]:
         if cls.__name__ not in self._by_class_cache:
             attrs = self._json['attrs']
-            combined: dict[str, Unknown] = {}
+            combined: dict[str, Any] = {}
             # we go in reverse order so that subclass props override base class
             for base in cls.__mro__[-2::-1]:
                 if not issubclass(base, HasProps):

--- a/bokeh/transform.py
+++ b/bokeh/transform.py
@@ -29,6 +29,9 @@ from typing import (
     Union,
 )
 
+# External imports
+from typing_extensions import TypeAlias
+
 # Bokeh imports
 from .core.property.vectorization import Expr, Field
 from .models.expressions import CumSum, Stack
@@ -69,9 +72,9 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 if TYPE_CHECKING:
-    ColorLike = Union[str, Color, Tuple[int, int, int], Tuple[int, int, int, float]]
+    ColorLike: TypeAlias = Union[str, Color, Tuple[int, int, int], Tuple[int, int, int, float]]
 
-    Factors = Union[Sequence[str], Sequence[Tuple[str, str]], Sequence[Tuple[str, str, str]]]
+    Factors: TypeAlias = Union[Sequence[str], Sequence[Tuple[str, str]], Sequence[Tuple[str, str, str]]]
 
 def cumsum(field_name: str, include_zero: bool = False) -> Expr:
     ''' Create a ``DataSpec`` dict to generate a ``CumSum`` expression

--- a/bokeh/util/browser.py
+++ b/bokeh/util/browser.py
@@ -23,12 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import webbrowser
 from os.path import abspath
-from typing import (
-    Dict,
-    Literal,
-    Protocol,
-    cast,
-)
+from typing import Literal, Protocol, cast
 
 # Bokeh imports
 from ..settings import settings
@@ -40,7 +35,7 @@ from ..settings import settings
 BrowserTarget = Literal["same", "window", "tab"]
 TargetCode = Literal[0, 1, 2]
 
-NEW_PARAM: Dict[BrowserTarget, TargetCode] = {"same": 0, "window": 1, "tab": 2}
+NEW_PARAM: dict[BrowserTarget, TargetCode] = {"same": 0, "window": 1, "tab": 2}
 
 __all__ = (
     'DummyWebBrowser',

--- a/bokeh/util/callback_manager.py
+++ b/bokeh/util/callback_manager.py
@@ -37,7 +37,6 @@ from typing import (
 from typing_extensions import TypeAlias
 
 # Bokeh imports
-from ..core.types import Unknown
 from ..events import Event, ModelEvent
 from ..util.functions import get_param_info
 
@@ -67,7 +66,7 @@ EventCallbackWithEvent: TypeAlias = Callable[[Event], None]
 EventCallbackWithoutEvent: TypeAlias = Callable[[], None]
 EventCallback: TypeAlias = Union[EventCallbackWithEvent, EventCallbackWithoutEvent]
 
-PropertyCallback: TypeAlias = Callable[[str, Unknown, Unknown], None]
+PropertyCallback: TypeAlias = Callable[[str, Any, Any], None]
 
 class EventCallbackManager:
     ''' A mixin class to provide an interface for registering and
@@ -172,7 +171,7 @@ class PropertyCallbackManager:
         for callback in callbacks:
             _callbacks.remove(callback)
 
-    def trigger(self, attr: str, old: Unknown, new: Unknown,
+    def trigger(self, attr: str, old: Any, new: Any,
             hint: DocumentPatchedEvent | None = None, setter: Setter | None = None) -> None:
         ''' Trigger callbacks for ``attr`` on this object.
 

--- a/bokeh/util/callback_manager.py
+++ b/bokeh/util/callback_manager.py
@@ -27,13 +27,14 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
     Sequence,
     Type,
     Union,
     cast,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..core.types import Unknown
@@ -62,11 +63,11 @@ __all__ = (
 # TODO (bev) the situation with no-argument Button callbacks is a mess. We
 # should migrate to all callbacks receving the event as the param, even if that
 # means auto-magically wrapping user-supplied callbacks for awhile.
-EventCallbackWithEvent = Callable[[Event], None]
-EventCallbackWithoutEvent = Callable[[], None]
-EventCallback = Union[EventCallbackWithEvent, EventCallbackWithoutEvent]
+EventCallbackWithEvent: TypeAlias = Callable[[Event], None]
+EventCallbackWithoutEvent: TypeAlias = Callable[[], None]
+EventCallback: TypeAlias = Union[EventCallbackWithEvent, EventCallbackWithoutEvent]
 
-PropertyCallback = Callable[[str, Unknown, Unknown], None]
+PropertyCallback: TypeAlias = Callable[[str, Unknown, Unknown], None]
 
 class EventCallbackManager:
     ''' A mixin class to provide an interface for registering and
@@ -76,8 +77,8 @@ class EventCallbackManager:
 
     document: Document | None
     id: ID
-    subscribed_events: List[str]
-    _event_callbacks: Dict[str, List[EventCallback]]
+    subscribed_events: list[str]
+    _event_callbacks: dict[str, list[EventCallback]]
 
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)
@@ -135,7 +136,7 @@ class PropertyCallbackManager:
     '''
 
     document: Document | None
-    _callbacks: Dict[str, List[PropertyCallback]]
+    _callbacks: dict[str, list[PropertyCallback]]
 
     def __init__(self, *args: Any, **kw: Any) -> None:
         super().__init__(*args, **kw)

--- a/bokeh/util/compiler.py
+++ b/bokeh/util/compiler.py
@@ -38,10 +38,7 @@ from typing import (
     Any,
     Callable,
     Dict,
-    List,
     Sequence,
-    Set,
-    Tuple,
     Type,
 )
 
@@ -89,7 +86,7 @@ class CompilationError(RuntimeError):
     ''' A ``RuntimeError`` subclass for reporting JS compilation errors.
 
     '''
-    def __init__(self, error: Dict[str, str] | str) -> None:
+    def __init__(self, error: dict[str, str] | str) -> None:
         super().__init__()
         if isinstance(error, dict):
             self.line = error.get("line")
@@ -270,7 +267,7 @@ class CustomModel:
         return impl
 
     @property
-    def dependencies(self) -> Dict[str, str]:
+    def dependencies(self) -> dict[str, str]:
         return getattr(self.cls, "__dependencies__", {})
 
     @property
@@ -288,7 +285,7 @@ def set_cache_hook(hook: Callable[[CustomModel, Implementation], AttrDict | None
     global _CACHING_IMPLEMENTATION
     _CACHING_IMPLEMENTATION = hook
 
-def calc_cache_key(custom_models: Dict[str, CustomModel]) -> str:
+def calc_cache_key(custom_models: dict[str, CustomModel]) -> str:
     ''' Generate a key to cache a custom extension implementation with.
 
     There is no metadata other than the Model classes, so this is the only
@@ -302,7 +299,7 @@ def calc_cache_key(custom_models: Dict[str, CustomModel]) -> str:
     encoded_names = ",".join(sorted(model_names)).encode('utf-8')
     return hashlib.sha256(encoded_names).hexdigest()
 
-_bundle_cache: Dict[str, str] = {}
+_bundle_cache: dict[str, str] = {}
 
 def bundle_models(models: Sequence[Type[HasProps]] | None) -> str | None:
     """Create a bundle of selected `models`. """
@@ -439,7 +436,7 @@ def _npmjs_path() -> str:
 def _crlf_cr_2_lf(s: str) -> str:
     return re.sub(r"\\r\\n|\\r|\\n", r"\\n", s)
 
-def _run(app: str, argv: List[str], input: Dict[str, Any] | None = None) -> str:
+def _run(app: str, argv: list[str], input: dict[str, Any] | None = None) -> str:
     proc = Popen([app] + argv, stdout=PIPE, stderr=PIPE, stdin=PIPE)
     (stdout, errout) = proc.communicate(input=None if input is None else json.dumps(input).encode())
 
@@ -448,13 +445,13 @@ def _run(app: str, argv: List[str], input: Dict[str, Any] | None = None) -> str:
     else:
         return _crlf_cr_2_lf(stdout.decode('utf-8'))
 
-def _run_nodejs(argv: List[str], input: Dict[str, Any] | None = None) -> str:
+def _run_nodejs(argv: list[str], input: dict[str, Any] | None = None) -> str:
     return _run(_nodejs_path(), argv, input)
 
-def _run_npmjs(argv: List[str], input: Dict[str, Any] | None = None) -> str:
+def _run_npmjs(argv: list[str], input: dict[str, Any] | None = None) -> str:
     return _run(_npmjs_path(), argv, input)
 
-def _version(run_app: Callable[[List[str], Dict[str, Any] | None], str]) -> str | None:
+def _version(run_app: Callable[[list[str], dict[str, Any] | None], str]) -> str | None:
     try:
         version = run_app(["--version"], None)  # explicit None to make mypy happy
     except RuntimeError:
@@ -468,9 +465,9 @@ def _model_cache_no_op(model: CustomModel, implementation: Implementation) -> At
 
 _CACHING_IMPLEMENTATION = _model_cache_no_op
 
-def _get_custom_models(models: Sequence[Type[HasProps]] | None) -> Dict[str, CustomModel] | None:
+def _get_custom_models(models: Sequence[Type[HasProps]] | None) -> dict[str, CustomModel] | None:
     """Returns CustomModels for models with a custom `__implementation__`"""
-    custom_models: Dict[str, CustomModel] = dict()
+    custom_models: dict[str, CustomModel] = dict()
 
     for cls in models or HasProps.model_class_reverse_map.values():
         impl = getattr(cls, "__implementation__", None)
@@ -481,12 +478,12 @@ def _get_custom_models(models: Sequence[Type[HasProps]] | None) -> Dict[str, Cus
 
     return custom_models if custom_models else None
 
-def _compile_models(custom_models: Dict[str, CustomModel]) -> Dict[str, AttrDict]:
+def _compile_models(custom_models: dict[str, CustomModel]) -> dict[str, AttrDict]:
     """Returns the compiled implementation of supplied `models`. """
     ordered_models = sorted(custom_models.values(), key=lambda model: model.full_name)
     custom_impls = {}
 
-    dependencies: List[Tuple[str, str]] = []
+    dependencies: list[tuple[str, str]] = []
     for model in ordered_models:
         dependencies.extend(list(model.dependencies.items()))
 
@@ -506,7 +503,7 @@ def _compile_models(custom_models: Dict[str, CustomModel]) -> Dict[str, AttrDict
 
     return custom_impls
 
-def _bundle_models(custom_models: Dict[str, CustomModel]) -> str:
+def _bundle_models(custom_models: dict[str, CustomModel]) -> str:
     """ Create a JavaScript bundle with selected `models`. """
     exports = []
     modules = []
@@ -524,7 +521,7 @@ def _bundle_models(custom_models: Dict[str, CustomModel]) -> str:
 
     extra_modules = {}
 
-    def resolve_modules(to_resolve: Set[str], root: str) -> Dict[str, str]:
+    def resolve_modules(to_resolve: set[str], root: str) -> dict[str, str]:
         resolved = {}
         for module in to_resolve:
             if module.startswith(("./", "../")):
@@ -568,7 +565,7 @@ def _bundle_models(custom_models: Dict[str, CustomModel]) -> str:
 
         return resolved
 
-    def resolve_deps(deps : List[str], root: str) -> Dict[str, str]:
+    def resolve_deps(deps : list[str], root: str) -> dict[str, str]:
         custom_modules = {model.module for model in custom_models.values()}
         missing = set(deps) - known_modules - custom_modules
         return resolve_modules(missing, root)

--- a/bokeh/util/dataclasses.py
+++ b/bokeh/util/dataclasses.py
@@ -25,10 +25,12 @@ from dataclasses import dataclass, field, fields
 from typing import (
     Any,
     Iterable,
-    Tuple,
     TypeVar,
     Union,
 )
+
+# External imports
+from typing_extensions import TypeAlias
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -59,9 +61,9 @@ class _UnspecifiedType:
 Unspecified = _UnspecifiedType()
 
 _T = TypeVar("_T")
-NotRequired = Union[_UnspecifiedType, _T]
+NotRequired: TypeAlias = Union[_UnspecifiedType, _T]
 
-def entries(obj: Any) -> Iterable[Tuple[str, Any]]:
+def entries(obj: Any) -> Iterable[tuple[str, Any]]:
     """ Iterate over a dataclass' fields and their values. """
     if is_dataclass(obj):
         for f in fields(obj):

--- a/bokeh/util/datatypes.py
+++ b/bokeh/util/datatypes.py
@@ -22,9 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from typing import (
-    Dict,
     Generic,
-    List,
     Set,
     TypeVar,
     cast,
@@ -52,7 +50,7 @@ class MultiValuedDict(Generic[K, V]):
 
     '''
 
-    _dict: Dict[K, V | Set[V]]
+    _dict: dict[K, V | set[V]]
 
     def __init__(self) -> None:
         '''
@@ -77,11 +75,11 @@ class MultiValuedDict(Generic[K, V]):
         if existing is None:
             self._dict[key] = value
         elif isinstance(existing, set):
-            cast(Set[V], existing).add(value) # XXX: V does not exclude `Set[_]`
+            cast(Set[V], existing).add(value) # XXX: V does not exclude `set[_]`
         else:
             self._dict[key] = {existing, value}
 
-    def get_all(self, k: K) -> List[V]:
+    def get_all(self, k: K) -> list[V]:
         '''
 
         '''

--- a/bokeh/util/deprecation.py
+++ b/bokeh/util/deprecation.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 import warnings  # lgtm [py/import-and-import-from]
 from typing import Tuple, overload
 
+# External imports
+from typing_extensions import TypeAlias
+
 # Bokeh imports
 from .warnings import BokehDeprecationWarning
 
@@ -33,7 +36,7 @@ __all__ = (
     'warn',
 )
 
-Version = Tuple[int, int, int]
+Version: TypeAlias = Tuple[int, int, int]
 
 #-----------------------------------------------------------------------------
 # General API

--- a/bokeh/util/functions.py
+++ b/bokeh/util/functions.py
@@ -21,12 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    List,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from inspect import Signature
@@ -55,7 +50,7 @@ __all__ = (
 # Code
 #-----------------------------------------------------------------------------
 
-def get_param_info(sig: Signature) -> Tuple[List[str], List[Any]]:
+def get_param_info(sig: Signature) -> tuple[list[str], list[Any]]:
     ''' Find parameters with defaults and return them.
 
     Arguments:

--- a/bokeh/util/hex.py
+++ b/bokeh/util/hex.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, Tuple
+from typing import Any
 
 # External imports
 import numpy as np
@@ -47,7 +47,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def axial_to_cartesian(q: Any, r: Any, size: float, orientation: str, aspect_scale: float = 1) -> Tuple[Any, Any]:
+def axial_to_cartesian(q: Any, r: Any, size: float, orientation: str, aspect_scale: float = 1) -> tuple[Any, Any]:
     ''' Map axial *(q,r)* coordinates to cartesian *(x,y)* coordinates of
     tiles centers.
 
@@ -98,7 +98,7 @@ def axial_to_cartesian(q: Any, r: Any, size: float, orientation: str, aspect_sca
 
     return (x, y)
 
-def cartesian_to_axial(x: Any, y: Any, size: float, orientation: str, aspect_scale: float = 1) -> Tuple[Any, Any]:
+def cartesian_to_axial(x: Any, y: Any, size: float, orientation: str, aspect_scale: float = 1) -> tuple[Any, Any]:
     ''' Map Cartesion *(x,y)* points to axial *(q,r)* coordinates of enclosing
     tiles.
 
@@ -213,7 +213,7 @@ def hexbin(x: Any, y: Any, size: float, orientation: str = "pointytop", aspect_s
 # Private API
 #-----------------------------------------------------------------------------
 
-def _round_hex(q: Any, r: Any) -> Tuple[Any, Any]:
+def _round_hex(q: Any, r: Any) -> tuple[Any, Any]:
     ''' Round floating point axial hex coordinates to integer *(q,r)*
     coordinates.
 

--- a/bokeh/util/options.py
+++ b/bokeh/util/options.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, Dict
+from typing import Any
 
 # Bokeh imports
 from ..core.has_props import HasProps, Local
@@ -64,10 +64,10 @@ class Options(HasProps, Local):
 
     '''
 
-    def __init__(self, kw: Dict[str, Any]) -> None:
+    def __init__(self, kw: dict[str, Any]) -> None:
 
         # remove any items that match our declared properties
-        props: Dict[str, Any] = {}
+        props: dict[str, Any] = {}
         for k in self.properties():
             if k in kw:
                 props[k] = kw.pop(k)

--- a/bokeh/util/serialization.py
+++ b/bokeh/util/serialization.py
@@ -32,12 +32,7 @@ import datetime as dt
 import uuid
 from functools import lru_cache
 from threading import Lock
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Set,
-    Type,
-)
+from typing import TYPE_CHECKING, Any, Type
 
 # External imports
 import numpy as np
@@ -58,7 +53,7 @@ from .string import format_docstring
 #-----------------------------------------------------------------------------
 
 @lru_cache(None)
-def _compute_datetime_types() -> Set[type]:
+def _compute_datetime_types() -> set[type]:
     result = {dt.time, dt.datetime, np.datetime64}
     pd = import_optional('pandas')
     if pd:

--- a/bokeh/util/string.py
+++ b/bokeh/util/string.py
@@ -23,12 +23,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import re
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    overload,
-)
+from typing import Any, Iterable, overload
 from urllib.parse import quote_plus
 
 #-----------------------------------------------------------------------------
@@ -138,7 +133,7 @@ def format_docstring(docstring: str | None, *args: Any, **kwargs: Any) -> str | 
     return None if docstring is None else docstring.format(*args, **kwargs)
 
 
-def format_url_query_arguments(url: str, arguments: Dict[str, str] | None = None) -> str:
+def format_url_query_arguments(url: str, arguments: dict[str, str] | None = None) -> str:
     ''' Format a base URL with optional query arguments
 
     Args:

--- a/bokeh/util/token.py
+++ b/bokeh/util/token.py
@@ -36,6 +36,9 @@ import time
 import zlib
 from typing import Any, Dict
 
+# External imports
+from typing_extensions import TypeAlias
+
 # Bokeh imports
 from ..core.types import ID
 from ..settings import settings
@@ -60,7 +63,7 @@ _TOKEN_ZLIB_KEY = "__bk__zlib_"
 # General API
 #-----------------------------------------------------------------------------
 
-TokenPayload = Dict[str, Any]
+TokenPayload: TypeAlias = Dict[str, Any]
 
 def generate_secret_key() -> str:
     ''' Generate a new securely-generated secret key appropriate for SHA-256

--- a/bokeh/util/tornado.py
+++ b/bokeh/util/tornado.py
@@ -39,6 +39,7 @@ from typing import (
 import tornado
 from tornado import gen
 from tornado.ioloop import IOLoop
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from ..core.types import ID
@@ -74,17 +75,17 @@ def fixup_windows_event_loop_policy() -> None:
 # Private API
 #-----------------------------------------------------------------------------
 
-CallbackSync = Callable[[], None]
-CallbackAsync = Callable[[], Awaitable[None]]
-Callback = Union[CallbackSync, CallbackAsync]
+CallbackSync: TypeAlias = Callable[[], None]
+CallbackAsync: TypeAlias = Callable[[], Awaitable[None]]
+Callback: TypeAlias = Union[CallbackSync, CallbackAsync]
 
-InvokeResult = Union[Awaitable[None], Awaitable[List[Any]], Awaitable[Dict[Any, Any]]]
+InvokeResult: TypeAlias = Union[Awaitable[None], Awaitable[List[Any]], Awaitable[Dict[Any, Any]]]
 
-Remover = Callable[[], None]
+Remover: TypeAlias = Callable[[], None]
 
-Removers = Dict[ID, Remover]
+Removers: TypeAlias = Dict[ID, Remover]
 
-RemoversByCallable = Dict[Callback, Set[ID]]
+RemoversByCallable: TypeAlias = Dict[Callback, Set[ID]]
 
 class _AsyncPeriodic:
     ''' Like ioloop.PeriodicCallback except the 'func' can be async and return

--- a/conftest.py
+++ b/conftest.py
@@ -21,7 +21,7 @@ import _pytest
 import pytest
 
 
-def pytest_collection_modifyitems(items: List[_pytest.nodes.Item]) -> None:
+def pytest_collection_modifyitems(items: list[_pytest.nodes.Item]) -> None:
     for item in items:
         if iscoroutinefunction(item.obj):
             item.add_marker(pytest.mark.asyncio)

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
+from __future__ import annotations
 
 pytest_plugins = (
     "bokeh._testing.plugins.ipython",
@@ -14,7 +15,6 @@ pytest_plugins = (
 
 # Standard library imports
 from inspect import iscoroutinefunction
-from typing import List
 
 # External imports
 import _pytest

--- a/release/action.py
+++ b/release/action.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 # Standard library imports
 from typing import Callable, Sequence, Union
 
+# External imports
+from typing_extensions import TypeAlias
+
 # Bokeh imports
 from .enums import ActionResult
 from .ui import failed, passed, skipped
 
-UIResultFuncType = Callable[[str, Union[Sequence[str], None]], str]
-
+UIResultFuncType: TypeAlias = Callable[[str, Union[Sequence[str], None]], str]
 
 class ActionReturn:
     """"""

--- a/release/build.py
+++ b/release/build.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 # Standard library imports
 import json
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 # Bokeh imports
 from .action import FAILED, PASSED, ActionReturn
@@ -136,17 +136,17 @@ def pack_deployment_tarball(config: Config, system: System) -> ActionReturn:
 
 
 def update_bokehjs_versions(config: Config, system: System) -> ActionReturn:
-    def update_package_json(content: Dict[str, Any]) -> None:
+    def update_package_json(content: dict[str, Any]) -> None:
         content["version"] = config.js_version
 
-    def update_package_lock_json(content: Dict[str, Any]) -> None:
+    def update_package_lock_json(content: dict[str, Any]) -> None:
         assert content["lockfileVersion"] == 2, "Expected lock file v2"
         content["version"] = config.js_version
         for pkg in content["packages"].values():
             if pkg.get("name", "").startswith("@bokeh/"):
                 pkg["version"] = config.js_version
 
-    files: Dict[str, Callable[[Dict[str, Any]], None]] = {
+    files: dict[str, Callable[[dict[str, Any]], None]] = {
         "package.json": update_package_json,
         "make/package.json": update_package_json,
         "src/compiler/package.json": update_package_json,

--- a/release/config.py
+++ b/release/config.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 # Standard library imports
 import re
-from typing import Dict, Set, Tuple
 
 # Bokeh imports
 from .enums import VersionType
@@ -35,14 +34,14 @@ class Config:
         self.version: str = version
 
         self.base_version: str = groups[0]
-        self.base_version_tuple: Tuple[str, ...] = tuple(groups[1:4])
+        self.base_version_tuple: tuple[str, ...] = tuple(groups[1:4])
         self.ext: str | None = groups[4]
         self.ext_type: str = groups[5]
         self.ext_number: str = groups[6]
 
-        self._secrets: Dict[str, str] = {}
+        self._secrets: dict[str, str] = {}
 
-        self._modified: Set[str] = set()
+        self._modified: set[str] = set()
 
     def add_secret(self, name: str, secret: str) -> None:
         """"""
@@ -55,11 +54,11 @@ class Config:
         self._modified.add(path)
 
     @property
-    def secrets(self) -> Dict[str, str]:
+    def secrets(self) -> dict[str, str]:
         return self._secrets
 
     @property
-    def modified(self) -> Set[str]:
+    def modified(self) -> set[str]:
         return self._modified
 
     @property

--- a/release/logger.py
+++ b/release/logger.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 # Standard library imports
 import re
-from typing import List, Tuple
 
 __all__ = ("LOG", "Log", "Scrubber")
 
@@ -47,15 +46,15 @@ class Log:
     """"""
 
     def __init__(self) -> None:
-        self._scrubbers: List[Scrubber] = []
-        self._record: List[str] = []
+        self._scrubbers: list[Scrubber] = []
+        self._record: list[str] = []
 
     def add_scrubber(self, scrubber: Scrubber) -> None:
         """"""
         self._scrubbers.append(scrubber)
         self._scrubbers.sort(key=len)
 
-    def record(self, *lines: str) -> Tuple[int, int]:
+    def record(self, *lines: str) -> tuple[int, int]:
         """"""
         if len(lines) == 1 and "\n" in lines[0]:
             lines = tuple(lines[0].split("\n"))

--- a/release/stages.py
+++ b/release/stages.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 # Standard library imports
 from typing import Tuple
 
+# External imports
+from typing_extensions import TypeAlias
+
 # Bokeh imports
 from .build import (
     build_bokehjs,
@@ -76,7 +79,7 @@ __all__ = (
     "DEPLOY_STEPS",
 )
 
-StepListType = Tuple[StepType, ...]
+StepListType: TypeAlias = Tuple[StepType, ...]
 
 BUILD_CHECKS: StepListType = (
     check_aws_present,

--- a/release/system.py
+++ b/release/system.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 # Standard library imports
 import os
 from subprocess import PIPE, STDOUT, run as stdlib_run
-from typing import Any, List
+from typing import Any
 
 # Bokeh imports
 from .logger import LOG
@@ -26,7 +26,7 @@ class System:
 
     def __init__(self, dry_run: bool = False) -> None:
         self.dry_run: bool = dry_run
-        self._pushd_state: List[str] = []
+        self._pushd_state: list[str] = []
 
     def run(self, cmd: str, **kw: Any) -> str:
         """"""

--- a/tests/codebase/test_code_quality.py
+++ b/tests/codebase/test_code_quality.py
@@ -27,7 +27,7 @@ from os.path import (
     split,
     splitext,
 )
-from typing import IO, List, Tuple
+from typing import IO
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -89,8 +89,8 @@ exclude_exts = (
 
 exclude_dirs = ()
 
-def collect_errors() -> List[str]:
-    errors: List[Tuple[str, str, int]] = []
+def collect_errors() -> list[str]:
+    errors: list[tuple[str, str, int]] = []
 
     def test_this_file(fname: str, test_file: IO[str]) -> None:
         line = None

--- a/tests/codebase/test_json.py
+++ b/tests/codebase/test_json.py
@@ -19,7 +19,6 @@ import pytest ; pytest
 
 # Standard library imports
 import json
-from typing import List
 
 # Bokeh imports
 from bokeh._testing.util.project import TOP_PATH
@@ -39,7 +38,7 @@ def test_json() -> None:
     ''' Assures that JSON files are properly formatted
 
     '''
-    bad: List[str] = []
+    bad: list[str] = []
 
     for path in paths:
         f = open(TOP_PATH/path)

--- a/tests/codebase/test_no_request_host.py
+++ b/tests/codebase/test_no_request_host.py
@@ -19,7 +19,7 @@ import pytest ; pytest
 
 # Standard library imports
 from subprocess import check_output
-from typing import IO, List, Tuple
+from typing import IO
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -39,8 +39,8 @@ def test_no_request_host() -> None:
 
 message = "File contains refers to 'request.host': {path}, line {line_no}."
 
-def collect_errors() -> List[str]:
-    errors: List[Tuple[str, str, int]] = []
+def collect_errors() -> list[str]:
+    errors: list[tuple[str, str, int]] = []
 
     def test_this_file(fname: str, test_file: IO[str]) -> None:
         for line_no, line in enumerate(test_file, 1):

--- a/tests/codebase/test_windows_reserved_filenames.py
+++ b/tests/codebase/test_windows_reserved_filenames.py
@@ -20,7 +20,6 @@ import pytest ; pytest
 # Standard library imports
 import os
 from os.path import join, splitext
-from typing import List
 
 # Bokeh imports
 from bokeh._testing.util.project import TOP_PATH
@@ -36,7 +35,7 @@ def test_windows_reserved_filenames() -> None:
     names are not present in the codebase.
 
     '''
-    bad: List[str] = []
+    bad: list[str] = []
     for path, _, files in os.walk(TOP_PATH):
 
         for file in files:

--- a/tests/integration/tools/test_box_edit_tool.py
+++ b/tests/integration/tools/test_box_edit_tool.py
@@ -19,7 +19,6 @@ import pytest ; pytest
 
 # Standard library imports
 import time
-from typing import Tuple
 
 # External imports
 from flaky import flaky
@@ -63,7 +62,7 @@ def _make_plot(dimensions="both", num_objects: int = 0) -> Plot:
     plot.toolbar_sticky = False
     return plot
 
-def _make_server_plot(expected, num_objects: int = 0) -> Tuple[ModifyDoc, Plot]:
+def _make_server_plot(expected, num_objects: int = 0) -> tuple[ModifyDoc, Plot]:
     plot = Plot(height=400, width=400, x_range=Range1d(0, 3), y_range=Range1d(0, 3), min_border=0)
     def modify_doc(doc):
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], width=[0.5, 0.5], height=[0.5, 0.5]))

--- a/tests/integration/tools/test_freehand_draw_tool.py
+++ b/tests/integration/tools/test_freehand_draw_tool.py
@@ -19,7 +19,6 @@ import pytest ; pytest
 
 # Standard library imports
 import time
-from typing import Tuple
 
 # External imports
 from flaky import flaky
@@ -60,7 +59,7 @@ def _make_plot(num_objects=0):
     plot.toolbar_sticky = False
     return plot
 
-def _make_server_plot(expected, num_objects=0) -> Tuple[ModifyDoc, Plot]:
+def _make_server_plot(expected, num_objects=0) -> tuple[ModifyDoc, Plot]:
     plot = Plot(height=400, width=400, x_range=Range1d(0, 3), y_range=Range1d(0, 3), min_border=0)
     def modify_doc(doc):
         source = ColumnDataSource(dict(xs=[], ys=[]))

--- a/tests/integration/tools/test_point_draw_tool.py
+++ b/tests/integration/tools/test_point_draw_tool.py
@@ -19,7 +19,6 @@ import pytest ; pytest
 
 # Standard library imports
 import time
-from typing import Tuple
 
 # External imports
 from flaky import flaky
@@ -60,7 +59,7 @@ def _make_plot(num_objects=0, add=True, drag=True):
     plot.toolbar_sticky = False
     return plot
 
-def _make_server_plot(expected) -> Tuple[ModifyDoc, Plot]:
+def _make_server_plot(expected) -> tuple[ModifyDoc, Plot]:
     plot = Plot(height=400, width=400, x_range=Range1d(0, 3), y_range=Range1d(0, 3), min_border=0)
     def modify_doc(doc):
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1]))

--- a/tests/integration/tools/test_poly_draw_tool.py
+++ b/tests/integration/tools/test_poly_draw_tool.py
@@ -19,7 +19,6 @@ import pytest ; pytest
 
 # Standard library imports
 import time
-from typing import Tuple
 
 # External imports
 from flaky import flaky
@@ -65,7 +64,7 @@ def _make_plot(num_objects=0, drag=True, vertices=False):
     plot.toolbar_sticky = False
     return plot
 
-def _make_server_plot(expected) -> Tuple[ModifyDoc, Plot]:
+def _make_server_plot(expected) -> tuple[ModifyDoc, Plot]:
     plot = Plot(height=400, width=400, x_range=Range1d(0, 3), y_range=Range1d(0, 3), min_border=0)
     def modify_doc(doc):
         source = ColumnDataSource(dict(xs=[[1, 2]], ys=[[1, 1]]))

--- a/tests/integration/tools/test_poly_edit_tool.py
+++ b/tests/integration/tools/test_poly_edit_tool.py
@@ -19,7 +19,6 @@ import pytest ; pytest
 
 # Standard library imports
 import time
-from typing import Tuple
 
 # External imports
 from flaky import flaky
@@ -66,7 +65,7 @@ def _make_plot() -> Plot:
     plot.toolbar_sticky = False
     return plot
 
-def _make_server_plot(expected) -> Tuple[ModifyDoc, Plot, ColumnDataSource]:
+def _make_server_plot(expected) -> tuple[ModifyDoc, Plot, ColumnDataSource]:
     data = {"xs": [[1, 2], [1.6, 2.45]],
             "ys": [[1, 1], [1.5, 0.75]]}
     source = ColumnDataSource(data)

--- a/tests/integration/widgets/test_autocomplete_input.py
+++ b/tests/integration/widgets/test_autocomplete_input.py
@@ -17,9 +17,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Tuple
-
 # External imports
 from flaky import flaky
 from selenium.webdriver.common.by import By
@@ -52,7 +49,7 @@ pytest_plugins = (
     "bokeh._testing.plugins.project",
 )
 
-def mk_modify_doc(input_box: AutocompleteInput) -> Tuple[ModifyDoc, Plot]:
+def mk_modify_doc(input_box: AutocompleteInput) -> tuple[ModifyDoc, Plot]:
     plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
     def modify_doc(doc):
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))

--- a/tests/integration/widgets/test_numeric_input.py
+++ b/tests/integration/widgets/test_numeric_input.py
@@ -17,9 +17,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Tuple
-
 # External imports
 from flaky import flaky
 
@@ -45,7 +42,7 @@ pytest_plugins = (
     "bokeh._testing.plugins.project",
 )
 
-def mk_modify_doc(num_input: NumericInput) -> Tuple[ModifyDoc, Plot]:
+def mk_modify_doc(num_input: NumericInput) -> tuple[ModifyDoc, Plot]:
     plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
     def modify_doc(doc):
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))

--- a/tests/integration/widgets/test_password_input.py
+++ b/tests/integration/widgets/test_password_input.py
@@ -17,9 +17,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Tuple
-
 # External imports
 from flaky import flaky
 
@@ -45,7 +42,7 @@ pytest_plugins = (
     "bokeh._testing.plugins.project",
 )
 
-def mk_modify_doc(text_input: PasswordInput) -> Tuple[ModifyDoc, Plot]:
+def mk_modify_doc(text_input: PasswordInput) -> tuple[ModifyDoc, Plot]:
     plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
     def modify_doc(doc):
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))

--- a/tests/integration/widgets/test_text_input.py
+++ b/tests/integration/widgets/test_text_input.py
@@ -17,9 +17,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Tuple
-
 # External imports
 from flaky import flaky
 
@@ -45,7 +42,7 @@ pytest_plugins = (
     "bokeh._testing.plugins.project",
 )
 
-def mk_modify_doc(text_input: TextInput) -> Tuple[ModifyDoc, Plot]:
+def mk_modify_doc(text_input: TextInput) -> tuple[ModifyDoc, Plot]:
     plot = Plot(height=400, width=400, x_range=Range1d(0, 1), y_range=Range1d(0, 1), min_border=0)
     def modify_doc(doc):
         source = ColumnDataSource(dict(x=[1, 2], y=[1, 1], val=["a", "b"]))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -32,10 +32,8 @@ from os.path import (
 from types import FrameType
 from typing import (
     Iterator,
-    List,
     Literal,
     NoReturn,
-    Tuple,
     Union,
 )
 
@@ -43,6 +41,7 @@ from typing import (
 import _pytest.config
 import _pytest.mark
 import _pytest.python
+from typing_extensions import TypeAlias
 
 # Bokeh imports
 from bokeh._testing.util.examples import Example, Flags, collect_examples
@@ -69,13 +68,13 @@ pytest_plugins = (
 
 BASE_DIR = abspath(dirname(dirname(__file__)))
 
-_examples: List[Example] | None = None
+_examples: list[Example] | None = None
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-def get_all_examples(config: _pytest.config.Config) -> List[Example]:
+def get_all_examples(config: _pytest.config.Config) -> list[Example]:
     global _examples
     if _examples is None:
         _examples = collect_examples(join(BASE_DIR, "tests", "examples.yaml"))
@@ -91,7 +90,7 @@ def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
         config = metafunc.config
         examples = get_all_examples(config)
 
-        def marks(example: Example) -> List[_pytest.mark.MarkDecorator]:
+        def marks(example: Example) -> list[_pytest.mark.MarkDecorator]:
             result = []
             if example.is_skip:
                 result.append(pytest.mark.skip(reason=f"skipping {example.relpath}"))
@@ -110,8 +109,8 @@ def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
             metafunc.parametrize('notebook_example,example,config', params)
 
 @pytest.fixture(scope="session", autouse=True)
-def report() -> Iterator[List[Example]]:
-    report: List[Example] = []
+def report() -> Iterator[list[Example]]:
+    report: list[Example] = []
     yield report
 
     images = ""
@@ -144,7 +143,7 @@ def report() -> Iterator[List[Example]]:
     with open(join(BASE_DIR, "examples-report.html"), "w") as f:
         f.write(html)
 
-def test_file_examples(file_example: Example, example: Example, report: List[Example], config: _pytest.config.Config, bokeh_server: str) -> None:
+def test_file_examples(file_example: Example, example: Example, report: list[Example], config: _pytest.config.Config, bokeh_server: str) -> None:
     if config.option.verbose:
         print()
     (status, duration, out, err) = _run_example(example)
@@ -169,7 +168,7 @@ def test_file_examples(file_example: Example, example: Example, report: List[Exa
     else:
         _run_in_browser(example, "file://%s.html" % example.path_no_ext, report, config.option.verbose)
 
-def test_server_examples(server_example: Example, example: Example, report: List[Example], config: _pytest.config.Config, bokeh_server: str) -> None:
+def test_server_examples(server_example: Example, example: Example, report: list[Example], config: _pytest.config.Config, bokeh_server: str) -> None:
     if config.option.verbose:
         print()
     app = build_single_handler_application(example.path)
@@ -216,7 +215,7 @@ def _print_webengine_output(result: JSResult) -> None:
         for _line in error['text'].split("\n"):
             fail(_line, label="JS")
 
-def _run_in_browser(example: Example, url: str, report: List[Example], verbose: bool = False) -> None:
+def _run_in_browser(example: Example, url: str, report: list[Example], verbose: bool = False) -> None:
     start = time.time()
     result = run_in_chrome(url)
     end = time.time()
@@ -243,9 +242,9 @@ def _run_in_browser(example: Example, url: str, report: List[Example], verbose: 
 
     assert no_errors, f"{example.relpath} failed with {len(errors)} errors"
 
-ProcStatus = Union[int, Literal["timeout"]]
+ProcStatus: TypeAlias = Union[int, Literal["timeout"]]
 
-def _run_example(example: Example) -> Tuple[ProcStatus, float, str, str]:
+def _run_example(example: Example) -> tuple[ProcStatus, float, str, str]:
     code = f"""\
 __file__ = filename = {example.path!r}
 

--- a/tests/unit/bokeh/application/handlers/test_directory.py
+++ b/tests/unit/bokeh/application/handlers/test_directory.py
@@ -17,7 +17,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 # External imports
 import jinja2
@@ -143,7 +143,7 @@ class Test_DirectoryHandler:
 
         doc = Document()
         source = nbformat.v4.new_notebook()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             handler.modify_document(doc)
@@ -166,7 +166,7 @@ class Test_DirectoryHandler:
         code = script_adds_two_roots('SomeModelInNbTestDirectory',
                                      'AnotherModelInNbTestDirectory')
         source.cells.append(nbformat.v4.new_code_cell(code))
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             handler.modify_document(doc)
@@ -252,7 +252,7 @@ some.foo = 57
 
     async def test_directory_with_server_lifecycle(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             result['handler'] = handler
@@ -277,7 +277,7 @@ some.foo = 57
 
     async def test_directory_with_app_hooks(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             result['handler'] = handler
@@ -315,7 +315,7 @@ some.foo = 57
 
     async def test_directory_with_request_handler(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             result['handler'] = handler
@@ -337,7 +337,7 @@ some.foo = 57
 
     def test_directory_with_static(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             result['handler'] = handler
@@ -358,7 +358,7 @@ some.foo = 57
 
     def test_directory_without_static(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             result['handler'] = handler
@@ -377,7 +377,7 @@ some.foo = 57
 
     def test_directory_with_template(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             result['handler'] = handler
@@ -396,7 +396,7 @@ some.foo = 57
 
     def test_directory_without_template(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             result['handler'] = handler
@@ -414,7 +414,7 @@ some.foo = 57
 
     def test_safe_to_fork(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             assert handler.safe_to_fork
@@ -430,7 +430,7 @@ some.foo = 57
 
     def test_url_path(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahd.DirectoryHandler(filename=filename)
             assert handler.safe_to_fork

--- a/tests/unit/bokeh/application/handlers/test_server_lifecycle.py
+++ b/tests/unit/bokeh/application/handlers/test_server_lifecycle.py
@@ -16,9 +16,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Dict
-
 # Bokeh imports
 from bokeh._testing.util.filesystem import with_file_contents
 from bokeh.application.handlers.handler import Handler
@@ -56,7 +53,7 @@ class Test_ServerLifecycleHandler:
 
     async def test_empty_lifecycle(self) -> None:
         doc = Document()
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             handler.modify_document(doc)
@@ -72,7 +69,7 @@ class Test_ServerLifecycleHandler:
         assert not doc.roots
 
     def test_lifecycle_bad_syntax(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             result['handler'] = handler
@@ -83,7 +80,7 @@ class Test_ServerLifecycleHandler:
         assert 'Invalid syntax' in handler.error
 
     def test_lifecycle_runtime_error(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             result['handler'] = handler
@@ -94,7 +91,7 @@ class Test_ServerLifecycleHandler:
         assert 'nope' in handler.error
 
     def test_lifecycle_bad_server_loaded_signature(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             result['handler'] = handler
@@ -111,7 +108,7 @@ def on_server_loaded(a,b):
         assert "Traceback" in handler.error_detail
 
     def test_lifecycle_bad_server_unloaded_signature(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             result['handler'] = handler
@@ -128,7 +125,7 @@ def on_server_unloaded(a,b):
         assert "Traceback" in handler.error_detail
 
     def test_lifecycle_bad_session_created_signature(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             result['handler'] = handler
@@ -143,7 +140,7 @@ def on_session_created(a,b):
         assert 'func(a, b)' in handler.error
 
     def test_lifecycle_bad_session_destroyed_signature(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             result['handler'] = handler
@@ -158,7 +155,7 @@ def on_session_destroyed(a,b):
         assert 'func(a, b)' in handler.error
 
     async def test_calling_lifecycle_hooks(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = result['handler'] = bahs.ServerLifecycleHandler(filename=filename)
             if handler.failed:
@@ -172,7 +169,7 @@ def on_session_destroyed(a,b):
         assert "on_session_destroyed" == await handler.on_session_destroyed(None)
 
     def test_url_path(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             result['handler'] = handler
@@ -187,7 +184,7 @@ def on_server_unloaded(server_context):
         assert url_path is not None and url_path.startswith("/")
 
     def test_url_path_failed(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = bahs.ServerLifecycleHandler(filename=filename)
             result['handler'] = handler

--- a/tests/unit/bokeh/application/handlers/test_server_request_handler.py
+++ b/tests/unit/bokeh/application/handlers/test_server_request_handler.py
@@ -16,9 +16,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Dict
-
 # Bokeh imports
 from bokeh._testing.util.filesystem import with_file_contents
 from bokeh.application.handlers.handler import Handler
@@ -52,7 +49,7 @@ class Test_ServerRequestHandler:
     # Public methods ----------------------------------------------------------
 
     def test_request_bad_syntax(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = basrh.ServerRequestHandler(filename=filename)
             result['handler'] = handler
@@ -63,7 +60,7 @@ class Test_ServerRequestHandler:
         assert 'Invalid syntax' in handler.error
 
     def test_request_runtime_error(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = basrh.ServerRequestHandler(filename=filename)
             result['handler'] = handler
@@ -74,7 +71,7 @@ class Test_ServerRequestHandler:
         assert 'nope' in handler.error
 
     def test_lifecycle_bad_process_request_signature(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = basrh.ServerRequestHandler(filename=filename)
             result['handler'] = handler
@@ -89,7 +86,7 @@ def process_request(a,b):
         assert 'func(a, b)' in handler.error
 
     def test_url_path(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = basrh.ServerRequestHandler(filename=filename)
             result['handler'] = handler
@@ -101,7 +98,7 @@ def process_request(a,b):
         assert url_path is not None and url_path.startswith("/")
 
     async def test_empty_request_handler(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = basrh.ServerRequestHandler(filename=filename)
             result['handler'] = handler
@@ -113,7 +110,7 @@ def process_request(a,b):
         assert payload == {}
 
     async def test_calling_request_handler(self) -> None:
-        result: Dict[str, Handler] = {}
+        result: dict[str, Handler] = {}
         def load(filename: str):
             handler = result['handler'] = basrh.ServerRequestHandler(filename=filename)
             if handler.failed:

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -106,7 +106,7 @@ class Test_PropertyDescriptor:
         f.baz
         f.quux
 
-        calls: tp.List[str] = []
+        calls: list[str] = []
 
         def cb(attr: str, old: tp.Any, new: tp.Any) -> None:
             calls.append(attr)

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -20,7 +20,7 @@ import pytest ; pytest
 import datetime as dt
 import sys
 from array import array as TypedArray
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 # External imports
 import numpy as np
@@ -209,7 +209,7 @@ class TestSerializer:
         assert encoder.buffers == []
 
     def test_dict_circular(self) -> None:
-        val: Dict[Any, Any] = {float("nan"): [1, 2]}
+        val: dict[Any, Any] = {float("nan"): [1, 2]}
         val[float("inf")] = val
 
         encoder = Serializer()

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -20,7 +20,6 @@ import pytest ; pytest
 import hashlib
 import re
 from os.path import abspath, join, split
-from typing import List
 
 # Bokeh imports
 from bokeh.embed import file_html
@@ -56,7 +55,7 @@ def compute_sha256(data):
     sha256.update(data)
     return sha256.hexdigest()
 
-def get_html_lines(resource_mode: ResourcesMode) -> List[str]:
+def get_html_lines(resource_mode: ResourcesMode) -> list[str]:
     p = figure()
     p.scatter(x=[], y=[])
     html = file_html(p, resources=Resources(resource_mode))
@@ -84,7 +83,7 @@ def test_no_white_space_in_top_of_html() -> None:
     assert(any_character.search(lines[0]) is not None)
 
 def test_dont_start_script_on_same_line_after_another_ends() -> None:
-    modes: List[ResourcesMode] = ["inline", "cdn", "server", "relative", "absolute"]
+    modes: list[ResourcesMode] = ["inline", "cdn", "server", "relative", "absolute"]
     for mode in modes:
         lines = get_html_lines(mode)
         for line in lines:

--- a/tests/unit/bokeh/document/test_locking.py
+++ b/tests/unit/bokeh/document/test_locking.py
@@ -18,7 +18,6 @@ import pytest ; pytest
 
 # Standard library imports
 import asyncio
-from typing import List
 
 # Bokeh imports
 from bokeh.document.document import Document
@@ -38,7 +37,7 @@ import bokeh.document.locking as locking # isort:skip
 def test_next_tick_callback_works() -> None:
     d = locking.UnlockedDocumentProxy(Document())
     assert curdoc() is not d
-    curdoc_from_cb: List[Document] = []
+    curdoc_from_cb: list[Document] = []
     def cb():
         curdoc_from_cb.append(curdoc())
     callback_obj = d.add_next_tick_callback(cb)
@@ -60,7 +59,7 @@ def test_other_attrs_raise() -> None:
 def test_without_document_lock() -> None:
     d = Document()
     assert curdoc() is not d
-    curdoc_from_cb: List[Document] = []
+    curdoc_from_cb: list[Document] = []
     @locking.without_document_lock
     def cb():
         curdoc_from_cb.append(curdoc())

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -19,12 +19,7 @@ import pytest ; pytest
 # Standard library imports
 from collections import OrderedDict
 from copy import deepcopy
-from typing import (
-    Any,
-    Dict,
-    Set,
-    Tuple,
-)
+from typing import Any
 
 # External imports
 import bs4
@@ -102,7 +97,7 @@ class Test_autoload_static:
     @pytest.mark.parametrize("version", ["1.4.0rc1", "2.0.0dev3"])
     @pytest.mark.selenium
     def test_js_dev_cdn(self, version: str, monkeypatch: pytest.MonkeyPatch, driver: WebDriver,
-            test_file_path_and_url: Tuple[str, str], test_plot: figure) -> None:
+            test_file_path_and_url: tuple[str, str], test_plot: figure) -> None:
         monkeypatch.setattr(buv, "__version__", "1.4.0rc1")
         monkeypatch.setattr(resources, "__version__", "1.4.0rc1")
         js, tag = bes.autoload_static(test_plot, CDN, "some/path")
@@ -123,7 +118,7 @@ class Test_autoload_static:
 
     @pytest.mark.selenium
     def test_js_release_cdn(self, monkeypatch: pytest.MonkeyPatch, driver: WebDriver,
-            test_file_path_and_url: Tuple[str, str], test_plot: figure) -> None:
+            test_file_path_and_url: tuple[str, str], test_plot: figure) -> None:
         monkeypatch.setattr(buv, "__version__", "2.0.0")
         monkeypatch.setattr(resources, "__version__", "2.0.0")
         r = deepcopy(CDN)
@@ -149,7 +144,7 @@ class Test_autoload_static:
 
     @pytest.mark.selenium
     def test_js_release_dev_cdn(self, monkeypatch: pytest.MonkeyPatch, driver: WebDriver,
-            test_file_path_and_url: Tuple[str, str], test_plot: figure) -> None:
+            test_file_path_and_url: tuple[str, str], test_plot: figure) -> None:
         monkeypatch.setattr(buv, "__version__", "2.0.0-foo")
         monkeypatch.setattr(resources, "__version__", "2.0.0-foo")
         js, tag = bes.autoload_static(test_plot, CDN, "some/path")
@@ -172,7 +167,7 @@ class Test_autoload_static:
 
     @pytest.mark.selenium
     def test_js_release_server(self, monkeypatch: pytest.MonkeyPatch, driver: WebDriver,
-            test_file_path_and_url: Tuple[str, str], test_plot: figure) -> None:
+            test_file_path_and_url: tuple[str, str], test_plot: figure) -> None:
         monkeypatch.setattr(buv, "__version__", "2.0.0")
         monkeypatch.setattr(resources, "__version__", "2.0.0")
         js, tag = bes.autoload_static(test_plot, resources.Resources(mode="server"), "some/path")
@@ -293,7 +288,7 @@ class Test_file_html:
     def test_return_type(self, test_plot: figure) -> None:
 
         class fake_template:
-            def __init__(self, tester: Any, user_template_variables: Set[str] | None = None) -> None:
+            def __init__(self, tester: Any, user_template_variables: set[str] | None = None) -> None:
                 self.tester = tester
                 self.template_variables = {
                     "title",
@@ -307,7 +302,7 @@ class Test_file_html:
                 if user_template_variables is not None:
                     self.template_variables.update(user_template_variables)
 
-            def render(self, template_variables: Dict[str, Any]) -> str:
+            def render(self, template_variables: dict[str, Any]) -> str:
                 assert self.template_variables.issubset(set(template_variables.keys()))
                 return "template result"
 

--- a/tests/unit/bokeh/io/test_export.py
+++ b/tests/unit/bokeh/io/test_export.py
@@ -17,7 +17,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING
 
 # External imports
 from flaky import flaky
@@ -65,7 +65,7 @@ def webdriver(request: pytest.FixtureRequest):
 @flaky(max_runs=10)
 @pytest.mark.selenium
 @pytest.mark.parametrize("dimensions", [(14, 14), (44, 44), (144, 144), (444, 444), (1444, 1444)])
-def test_get_screenshot_as_png(webdriver: WebDriver, dimensions: Tuple[int, int]) -> None:
+def test_get_screenshot_as_png(webdriver: WebDriver, dimensions: tuple[int, int]) -> None:
     width, height = dimensions
     border = 5
 
@@ -90,7 +90,7 @@ def test_get_screenshot_as_png(webdriver: WebDriver, dimensions: Tuple[int, int]
 @flaky(max_runs=10)
 @pytest.mark.selenium
 @pytest.mark.parametrize("dimensions", [(14, 14), (44, 44), (144, 144), (444, 444), (1444, 1444)])
-def test_get_screenshot_as_png_with_glyph(webdriver: WebDriver, dimensions: Tuple[int, int]) -> None:
+def test_get_screenshot_as_png_with_glyph(webdriver: WebDriver, dimensions: tuple[int, int]) -> None:
     width, height = dimensions
     border = 5
 
@@ -154,7 +154,7 @@ def test_get_svg_no_svg_present(webdriver: WebDriver) -> None:
     with silenced(MISSING_RENDERERS):
         svgs = bie.get_svg(layout, driver=webdriver)
 
-    def output(data: str) -> List[str]:
+    def output(data: str) -> list[str]:
         return [
             '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="20" height="20">'
                 '<defs/>'

--- a/tests/unit/bokeh/io/test_notebook__io.py
+++ b/tests/unit/bokeh/io/test_notebook__io.py
@@ -18,7 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 import json
-from typing import Any, Set
+from typing import Any
 
 # External imports
 from mock import MagicMock, PropertyMock, patch
@@ -63,7 +63,7 @@ def test_show_doc_no_server(mock_notebook_content: MagicMock,
 
     class Obj:
         id = None
-        def references(self) -> Set[Any]:
+        def references(self) -> set[Any]:
             return set()
 
     assert mock__publish_display_data.call_count == 0

--- a/tests/unit/bokeh/models/test_plots.py
+++ b/tests/unit/bokeh/models/test_plots.py
@@ -18,7 +18,6 @@ import pytest ; pytest
 
 # Standard library imports
 from math import isnan
-from typing import Tuple
 
 # External imports
 import mock
@@ -59,7 +58,7 @@ You are attempting to set `plot.legend.location` on a plot that has zero legends
 Before legend properties can be set, you must add a Legend explicitly, or call a glyph method with a legend parameter set.
 """
 
-def create_plot_and_tools(prefilled: bool = False) -> Tuple[Plot, PanTool, ResetTool]:
+def create_plot_and_tools(prefilled: bool = False) -> tuple[Plot, PanTool, ResetTool]:
     if prefilled:
         pan = PanTool()
         reset = ResetTool()

--- a/tests/unit/bokeh/server/_util_server.py
+++ b/tests/unit/bokeh/server/_util_server.py
@@ -18,12 +18,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-)
+from typing import TYPE_CHECKING, Any
 
 # External imports
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
@@ -61,14 +56,14 @@ def url(server: Server, prefix: str = "") -> str:
 def ws_url(server: Server, prefix: str = "") -> str:
     return f"ws://localhost:{server.port}{prefix}/ws"
 
-async def http_get(io_loop: IOLoop, url: str, headers: Dict[str, str] | None = None) -> Any:
+async def http_get(io_loop: IOLoop, url: str, headers: dict[str, str] | None = None) -> Any:
     http_client = AsyncHTTPClient()
     if not headers:
         headers = {}
     return await http_client.fetch(url, headers=headers)
 
 async def websocket_open(io_loop: IOLoop, url: str, origin: str | None = None,
-        subprotocols: List[str] = []) -> WebSocketClientConnection:
+        subprotocols: list[str] = []) -> WebSocketClientConnection:
     request = HTTPRequest(url)
     if origin is not None:
         request.headers["Origin"] = origin

--- a/tests/unit/bokeh/test_objects.py
+++ b/tests/unit/bokeh/test_objects.py
@@ -16,9 +16,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Set, Tuple
-
 # Bokeh imports
 from bokeh.core.properties import (
     Any,
@@ -42,7 +39,7 @@ from bokeh.model import Model
 # General API
 #-----------------------------------------------------------------------------
 
-def large_plot(n: int) -> Tuple[Model, Set[Model]]:
+def large_plot(n: int) -> tuple[Model, set[Model]]:
     from bokeh.models import (
         BoxSelectTool,
         BoxZoomTool,
@@ -63,7 +60,7 @@ def large_plot(n: int) -> Tuple[Model, Set[Model]]:
     )
 
     col = Column()
-    objects: Set[Model] = {col}
+    objects: set[Model] = {col}
 
     for i in range(n):
         source = ColumnDataSource(data=dict(x=[0, i + 1], y=[0, i + 1]))

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -22,7 +22,6 @@ import re
 import subprocess
 import sys
 from copy import deepcopy
-from typing import List
 
 # External imports
 import bs4
@@ -46,7 +45,7 @@ import bokeh.resources as resources  # isort:skip
 if os.environ.get("BOKEH_RESOURCES"):
     raise RuntimeError("Cannot run the unit tests with BOKEH_RESOURCES set")
 
-LOG_LEVELS: List[LogLevel] = ["trace", "debug", "info", "warn", "error", "fatal"]
+LOG_LEVELS: list[LogLevel] = ["trace", "debug", "info", "warn", "error", "fatal"]
 
 DEFAULT_LOG_JS_RAW = 'Bokeh.set_log_level("info");'
 

--- a/tests/unit/bokeh/util/test_dataclasses.py
+++ b/tests/unit/bokeh/util/test_dataclasses.py
@@ -16,9 +16,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import List
-
 # Module under test
 import bokeh.util.dataclasses as dc # isort:skip
 
@@ -33,7 +30,7 @@ import bokeh.util.dataclasses as dc # isort:skip
 @dc.dataclass
 class X:
     f0: int
-    f1: List[int]
+    f1: list[int]
     f2: X | None = None
     f3: dc.NotRequired[bool | None] = dc.Unspecified
 


### PR DESCRIPTION
This makes consistent usage of `|` (instead of `Union[]`) and lowercase built-in types where applicable. I marked type aliases with `TypeAlias` marker in the near vicinity of changes. Type aliases are the biggest contributor of non-applicable cases. Others include extending built-ins and casting, but those are very rare, and some can be replaced with better code. I also removed `Unknown` type (in favour of `Any`), as this ended up being a failed experiment.

This change greatly simplifies interaction between typings' types and bokeh's property types, as there is no confusion anymore (as long as type aliases are not involved) what `List`, etc., refers to.