### PR TITLE
Support themes on Python side for ContourColorBar

### DIFF
--- a/bokeh/themes/_caliber.py
+++ b/bokeh/themes/_caliber.py
@@ -45,7 +45,7 @@ json = {
             "background_fill_alpha": 0.25
         },
 
-        "ColorBar": {
+        "BaseColorBar": {
             "title_text_color": "#5B5B5B",
             "title_text_font": "Calibri Light",
             "title_text_font_size": "1.15em",

--- a/bokeh/themes/_contrast.py
+++ b/bokeh/themes/_contrast.py
@@ -54,7 +54,7 @@ json = {
             "background_fill_color": "#000000"
         },
 
-        "ColorBar": {
+        "BaseColorBar": {
             "title_text_color": "#E0E0E0",
             "title_text_font": "Helvetica",
             "title_text_font_size": "1.025em",

--- a/bokeh/themes/_dark_minimal.py
+++ b/bokeh/themes/_dark_minimal.py
@@ -54,7 +54,7 @@ json = {
             "background_fill_color": "#20262B"
         },
 
-        "ColorBar": {
+        "BaseColorBar": {
             "title_text_color": "#E0E0E0",
             "title_text_font": "Helvetica",
             "title_text_font_size": "1.025em",

--- a/bokeh/themes/_light_minimal.py
+++ b/bokeh/themes/_light_minimal.py
@@ -41,7 +41,7 @@ json = {
             "background_fill_alpha": 0.25
         },
 
-        "ColorBar": {
+        "BaseColorBar": {
             "title_text_color": "#5B5B5B",
             "title_text_font": "Helvetica",
             "title_text_font_size": "1.025em",

--- a/bokeh/themes/_night_sky.py
+++ b/bokeh/themes/_night_sky.py
@@ -54,7 +54,7 @@ json = {
             "background_fill_color": "#2C001E"
         },
 
-        "ColorBar": {
+        "BaseColorBar": {
             "title_text_color": "#E0E0E0",
             "title_text_font": "Helvetica",
             "title_text_font_size": "1.025em",

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -167,6 +167,9 @@ Renames
 
 * ``copy_to_clipboard`` icon was renamed to ``copy``
 
+* ``Theme`` support for color bars has had the key changed from ``ColorBar`` to
+  ``BaseColorBar`` so that it also supports ``ContourColorBar``.
+
 Runtime dependencies
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/unit/bokeh/test_themes.py
+++ b/tests/unit/bokeh/test_themes.py
@@ -282,7 +282,7 @@ class TestThemes:
         doc = Document()
         doc.add_root(obj)
         doc.theme = built_in_themes[LIGHT_MINIMAL]
-        assert "#5B5B5B" == doc.theme._json['attrs']['ColorBar']['title_text_color']
+        assert "#5B5B5B" == doc.theme._json['attrs']['BaseColorBar']['title_text_color']
 
     def test_setting_built_in_theme_str(self) -> None:
         obj = SomeModel()


### PR DESCRIPTION
- [x] issues: fixes #12250
- [ ] tests added / passed
- [x] release document entry (if new feature or API change)

The addition of `ContourColorBar` changed the class hierarchy for color bars. I updated the bokehjs themes for this at the time, but did not update the Python themes. This PR fixes it.

Before and after screenshots using code from #12250:
![before](https://user-images.githubusercontent.com/580326/179948190-1b84036a-0e60-480e-8539-74e00e465786.png) ![after](https://user-images.githubusercontent.com/580326/179948199-09e95bcc-2bff-4d64-8da2-fe0e212bc475.png)

I haven't added a test for this as I see no easy way of doing so. A bokehjs integration test with PNG output does not help as that already worked. A visual test from Python would work for this but that is not something that we do. Hence the manual test images above.
