### PR TITLE
varying_alpha_palette helper function

### DIFF
--- a/bokeh/colors/color.py
+++ b/bokeh/colors/color.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 import colorsys
 from abc import ABCMeta, abstractmethod
 from math import sqrt
+from re import match
 from typing import Type, TypeVar
 
 # Bokeh imports
@@ -247,6 +248,38 @@ class RGB(Color):
 
         '''
         return value.to_rgb()
+
+    @classmethod
+    def from_hex_string(cls, hex_string: str) -> RGB:
+        ''' Create an RGB color from a RGB(A) hex string.
+
+        Args:
+            hex_string (str) :
+                String containing hex-encoded RGBA(A) values. Valid formats
+                are '#rrggbb', '#rrggbbaa', '#rgb' and '#rgba'.
+
+        Returns:
+            :class:`~bokeh.colors.RGB`
+
+        '''
+        if isinstance(hex_string, str):
+            # Hex color as #rrggbbaa or #rrggbb
+            if match(r"#([\da-fA-F]{2}){3,4}\Z", hex_string):
+                r = int(hex_string[1:3], 16)
+                g = int(hex_string[3:5], 16)
+                b = int(hex_string[5:7], 16)
+                a = int(hex_string[7:9], 16) / 255.0 if len(hex_string) > 7 else 1.0
+                return RGB(r, g, b, a)
+
+            # Hex color as #rgb or #rgba
+            if match(r"#[\da-fA-F]{3,4}\Z", hex_string):
+                r = int(hex_string[1]*2, 16)
+                g = int(hex_string[2]*2, 16)
+                b = int(hex_string[3]*2, 16)
+                a = int(hex_string[4]*2, 16) / 255.0 if len(hex_string) > 4 else 1.0
+                return RGB(r, g, b, a)
+
+        raise ValueError(f"'{hex_string}' is not an RGB(A) hex color string")
 
     @classmethod
     def from_rgb(cls, value: RGB) -> RGB:

--- a/bokeh/colors/util.py
+++ b/bokeh/colors/util.py
@@ -120,38 +120,55 @@ class NamedColor(RGB):
         super().__init__(r, g, b)
 
     @classmethod
-    def find(cls, name: str) -> NamedColor:
-        # If name not recognised, raises ValueError
-        index = cls.__all__.index(name)
+    def find(cls, name: str) -> NamedColor | None:
+        ''' Find and return a named color.
+
+        Args:
+            name (str) : Name of color to find.
+
+        Returns:
+            :class:`~bokeh.colors.NamedColor` or None if the name is not
+            recognised.
+
+        '''
+        try:
+            index = cls.__all__.index(name)
+        except ValueError:
+            return None
         return cls.colors[index]
+
+    @classmethod
+    def from_string(cls, color: str) -> RGB:
+        ''' Create an RGB color from a string.
+
+        Args:
+            color (str) :
+                String containing color. This may be a named color such as
+                "blue" or a hex RGB(A) string of one of the following formats:
+                '#rrggbb', '#rrggbbaa', '#rgb' or '#rgba'.
+
+        Returns:
+            :class:`~bokeh.colors.RGB`
+
+        '''
+
+        try:
+            # Is it a hex string?
+            return RGB.from_hex_string(color)
+        except ValueError:
+            # Is it a named color?
+            rgb = cls.find(color)
+
+            if rgb is None:
+                raise ValueError(f"Color '{color}' must be either a named color or an RGB(A) hex string")
+
+            return rgb
 
     def to_css(self) -> str:
         '''
 
         '''
         return self.name
-
-def _color_as_rgb_hex(color: str) -> str:
-    ''' Convert string color to RGB hex string.
-
-    Color may be a named color such as "blue", or a hex RGB(A) string such as
-    "#FFAA00", "#FFAA00FF", "#FA0" or "#FA0F". Returned string is always of
-    the form "#RRGGBB" with 2 characters for each of the R, G and B components
-    and no alpha component.
-
-    '''
-
-    if color.startswith("#"):
-        if len(color) in (7, 9):
-            return color[:7].upper()
-        elif len(color) in (4, 5):
-            return f"#{color[1]*2}{color[2]*2}{color[3]*2}".upper()
-        else:
-            raise ValueError(f"Unable to parse hex color string: '{color}'")
-    try:
-        return NamedColor.find(color).to_hex()
-    except ValueError:
-        raise ValueError(f"Color '{color}' must be either a named color or a hex RGB(A) string")
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/colors/util.py
+++ b/bokeh/colors/util.py
@@ -119,11 +119,39 @@ class NamedColor(RGB):
         self.name = name
         super().__init__(r, g, b)
 
+    @classmethod
+    def find(cls, name: str) -> NamedColor:
+        # If name not recognised, raises ValueError
+        index = cls.__all__.index(name)
+        return cls.colors[index]
+
     def to_css(self) -> str:
         '''
 
         '''
         return self.name
+
+def _color_as_rgb_hex(color: str) -> str:
+    ''' Convert string color to RGB hex string.
+
+    Color may be a named color such as "blue", or a hex RGB(A) string such as
+    "#FFAA00", "#FFAA00FF", "#FA0" or "#FA0F". Returned string is always of
+    the form "#RRGGBB" with 2 characters for each of the R, G and B components
+    and no alpha component.
+
+    '''
+
+    if color.startswith("#"):
+        if len(color) in (7, 9):
+            return color[:7].upper()
+        elif len(color) in (4, 5):
+            return f"#{color[1]*2}{color[2]*2}{color[3]*2}".upper()
+        else:
+            raise ValueError(f"Unable to parse hex color string: '{color}'")
+    try:
+        return NamedColor.find(color).to_hex()
+    except ValueError:
+        raise ValueError(f"Color '{color}' must be either a named color or a hex RGB(A) string")
 
 #-----------------------------------------------------------------------------
 # Code

--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -386,6 +386,7 @@ to generate palettes of arbitrary size.
 .. autofunction:: bokeh.palettes.inferno(n)
 .. autofunction:: bokeh.palettes.linear_palette(palette, n)
 .. autofunction:: bokeh.palettes.magma(n)
+.. autofunction:: bokeh.palettes.single_color_palette(palette, n, start_alpha, end_alpha)
 .. autofunction:: bokeh.palettes.viridis(n)
 
 Licenses
@@ -423,6 +424,9 @@ from typing import Dict, Tuple
 # External imports
 import numpy as np
 from typing_extensions import TypeAlias
+
+# Bokeh imports
+from .colors.util import _color_as_rgb_hex
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -1562,6 +1566,54 @@ def diverging_palette(palette1: Palette, palette2: Palette, n: int, midpoint: fl
 
     # return piecewise linear interpolation of colors
     return linear_palette(palette1, n1) + linear_palette(palette2, n2)
+
+def single_color_palette(color: str, n: int | None = None, start_alpha: int = 0, end_alpha: int = 255) -> Palette:
+    """ Generate a palette that is a single color with linearly varying alpha.
+
+    Alpha may vary from low to high or high to low, depending on the values of
+    ``start_alpha`` and ``end_alpha``.
+
+    Args:
+        color (str) :
+            Named color or RGB(A) hex color string. Any alpha component is
+            ignored.
+
+        n (int, optional) :
+            The size of the palette to generate. If not specified uses the
+            maximum number of colors such that adjacent colors differ by an
+            alpha of 1.
+
+        start_alpha (int, optional) :
+            Alpha component of the start of the palette, in the range 0 to 255
+
+        end_alpha (int, optional) :
+            Alpha component of the end of the palette, in the range 0 to 255
+
+    Returns:
+        seq[str] : a sequence of hex RGBA color strings
+
+    Raises:
+        ValueError if ``color`` is not recognisable as a string name or hex
+            RGB(A) string, or if ``start_alpha`` or ``end_alpha`` are outside
+            the range 0 to 255 inclusive.
+
+    """
+
+    if not (0 <= start_alpha <= 255):
+        raise ValueError(f"start_alpha {start_alpha} must be in the range 0 to 255")
+
+    if not (0 <= end_alpha <= 255):
+        raise ValueError(f"end_alpha {end_alpha} must be in the range 0 to 255")
+
+    if not n:
+        n = int(abs(end_alpha - start_alpha)) + 1
+
+    rgb = _color_as_rgb_hex(color)
+
+    diff_alpha = end_alpha - start_alpha
+    palette = tuple(rgb + f"{round(start_alpha + diff_alpha*i / (n-1.0)):02X}" for i in range(n))
+
+    return palette
 
 def magma(n: int) -> Palette:
     """ Generate a palette of colors or from the Magma palette.

--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -386,7 +386,7 @@ to generate palettes of arbitrary size.
 .. autofunction:: bokeh.palettes.inferno(n)
 .. autofunction:: bokeh.palettes.linear_palette(palette, n)
 .. autofunction:: bokeh.palettes.magma(n)
-.. autofunction:: bokeh.palettes.single_color_palette(palette, n, start_alpha, end_alpha)
+.. autofunction:: bokeh.palettes.varying_alpha_palette(palette, n, start_alpha, end_alpha)
 .. autofunction:: bokeh.palettes.viridis(n)
 
 Licenses
@@ -1567,7 +1567,7 @@ def diverging_palette(palette1: Palette, palette2: Palette, n: int, midpoint: fl
     # return piecewise linear interpolation of colors
     return linear_palette(palette1, n1) + linear_palette(palette2, n2)
 
-def single_color_palette(color: str, n: int | None = None, start_alpha: int = 0, end_alpha: int = 255) -> Palette:
+def varying_alpha_palette(color: str, n: int | None = None, start_alpha: int = 0, end_alpha: int = 255) -> Palette:
     """ Generate a palette that is a single color with linearly varying alpha.
 
     Alpha may vary from low to high or high to low, depending on the values of

--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -426,7 +426,7 @@ import numpy as np
 from typing_extensions import TypeAlias
 
 # Bokeh imports
-from .colors.util import _color_as_rgb_hex
+from .colors.util import NamedColor
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -1608,10 +1608,10 @@ def varying_alpha_palette(color: str, n: int | None = None, start_alpha: int = 0
     if not n:
         n = int(abs(end_alpha - start_alpha)) + 1
 
-    rgb = _color_as_rgb_hex(color)
+    rgb = NamedColor.from_string(color)
 
     diff_alpha = end_alpha - start_alpha
-    palette = tuple(rgb + f"{round(start_alpha + diff_alpha*i / (n-1.0)):02X}" for i in range(n))
+    palette = tuple(f"{rgb.to_hex()}{round(start_alpha + diff_alpha*i / (n-1.0)):02X}" for i in range(n))
 
     return palette
 

--- a/bokeh/palettes.py
+++ b/bokeh/palettes.py
@@ -1616,7 +1616,7 @@ def varying_alpha_palette(color: str, n: int | None = None, start_alpha: int = 0
     return palette
 
 def magma(n: int) -> Palette:
-    """ Generate a palette of colors or from the Magma palette.
+    """ Generate a palette of colors from the Magma palette.
 
     The full Magma palette that serves as input for deriving new palettes
     has 256 colors, and looks like:
@@ -1645,7 +1645,7 @@ def magma(n: int) -> Palette:
     return linear_palette(Magma256, n)
 
 def inferno(n: int) -> Palette:
-    """ Generate a palette of colors or from the Inferno palette.
+    """ Generate a palette of colors from the Inferno palette.
 
     The full Inferno palette that serves as input for deriving new palettes
     has 256 colors, and looks like:
@@ -1674,7 +1674,7 @@ def inferno(n: int) -> Palette:
     return linear_palette(Inferno256, n)
 
 def plasma(n: int) -> Palette:
-    """ Generate a palette of colors or from the Plasma palette.
+    """ Generate a palette of colors from the Plasma palette.
 
     The full Plasma palette that serves as input for deriving new palettes
     has 256 colors, and looks like:
@@ -1703,7 +1703,7 @@ def plasma(n: int) -> Palette:
     return linear_palette(Plasma256, n)
 
 def viridis(n: int) -> Palette:
-    """ Generate a palette of colors or from the Viridis palette.
+    """ Generate a palette of colors from the Viridis palette.
 
     The full Viridis palette that serves as input for deriving new palettes
     has 256 colors, and looks like:
@@ -1732,7 +1732,7 @@ def viridis(n: int) -> Palette:
     return linear_palette(Viridis256, n)
 
 def cividis(n: int) -> Palette:
-    """ Generate a palette of colors or from the Cividis palette.
+    """ Generate a palette of colors from the Cividis palette.
 
     The full Cividis palette that serves as input for deriving new palettes
     has 256 colors, and looks like:
@@ -1761,7 +1761,7 @@ def cividis(n: int) -> Palette:
     return linear_palette(Cividis256, n)
 
 def turbo(n: int) -> Palette:
-    """ Generate a palette of colors or from the Turbo palette.
+    """ Generate a palette of colors from the Turbo palette.
 
     Turbo is described here:
 
@@ -1794,7 +1794,7 @@ def turbo(n: int) -> Palette:
     return linear_palette(Turbo256, n)
 
 def grey(n: int) -> Palette:
-    """ Generate a palette of colors or from the Greys palette.
+    """ Generate a palette of colors from the Greys palette.
 
     The full Greys palette that serves as input for deriving new palettes
     has 256 colors, and looks like:

--- a/tests/unit/bokeh/colors/test_color__colors.py
+++ b/tests/unit/bokeh/colors/test_color__colors.py
@@ -235,6 +235,47 @@ class Test_RGB:
         assert c2.g == c.g
         assert c2.b == c.b
 
+    def test_from_hex_string(self) -> None:
+        # '#rrggbb'
+        c = bcc.RGB.from_hex_string("#A3B20F")
+        assert (c.r, c.g, c.b, c.a) == (163, 178, 15, 1.0)
+        c = bcc.RGB.from_hex_string("#a3b20f")
+        assert (c.r, c.g, c.b, c.a) == (163, 178, 15, 1.0)
+
+        # '#rrggbbaa'
+        c = bcc.RGB.from_hex_string("#A3B20FC0")
+        assert (c.r, c.g, c.b, c.a) == (163, 178, 15, 192/255.0)
+        c = bcc.RGB.from_hex_string("#a3b20fc0")
+        assert (c.r, c.g, c.b, c.a) == (163, 178, 15, 192/255.0)
+
+        # '#rgb'
+        c = bcc.RGB.from_hex_string("#7A3")
+        assert (c.r, c.g, c.b, c.a) == (119, 170, 51, 1.0)
+        c = bcc.RGB.from_hex_string("#7a3")
+        assert (c.r, c.g, c.b, c.a) == (119, 170, 51, 1.0)
+
+        # '#rgba'
+        c = bcc.RGB.from_hex_string("#7A3B")
+        assert (c.r, c.g, c.b, c.a) == (119, 170, 51, 187/255.0)
+        c = bcc.RGB.from_hex_string("#7a3b")
+        assert (c.r, c.g, c.b, c.a) == (119, 170, 51, 187/255.0)
+
+        # Invalid hex string
+        with pytest.raises(ValueError):
+            bcc.RGB.from_hex_string("#")
+        with pytest.raises(ValueError):
+            bcc.RGB.from_hex_string("#1")
+        with pytest.raises(ValueError):
+            bcc.RGB.from_hex_string("#12")
+        with pytest.raises(ValueError):
+            bcc.RGB.from_hex_string("#12345")
+        with pytest.raises(ValueError):
+            bcc.RGB.from_hex_string("#1234567")
+        with pytest.raises(ValueError):
+            bcc.RGB.from_hex_string("#123456789")
+        with pytest.raises(ValueError):
+            bcc.RGB.from_hex_string(" #abc")
+
     def test_from_hsl(self) -> None:
         c = bcc.HSL(10, 0.1, 0.2)
         c2 = bcc.RGB.from_hsl(c)

--- a/tests/unit/bokeh/colors/test_util__colors.py
+++ b/tests/unit/bokeh/colors/test_util__colors.py
@@ -56,8 +56,57 @@ class Test_NamedColor:
         c = bcu.NamedColor.find("cornflowerblue")
         assert c.name == "cornflowerblue"
 
+        assert bcu.NamedColor.find("bluey") == None
+
+    def test_from_string(self) -> None:
+        # Name
+        c = bcu.NamedColor.from_string("blue")
+        assert c.name == "blue"
+
+        # '#rrggbb'
+        c = bcu.NamedColor.from_string("#A3B20F")
+        assert (c.r, c.g, c.b, c.a) == (163, 178, 15, 1.0)
+        c = bcu.NamedColor.from_string("#a3b20f")
+        assert (c.r, c.g, c.b, c.a) == (163, 178, 15, 1.0)
+
+        # '#rrggbbaa'
+        c = bcu.NamedColor.from_string("#A3B20FC0")
+        assert (c.r, c.g, c.b, c.a) == (163, 178, 15, 192/255.0)
+        c = bcu.NamedColor.from_string("#a3b20fc0")
+        assert (c.r, c.g, c.b, c.a) == (163, 178, 15, 192/255.0)
+
+        # '#rgb'
+        c = bcu.NamedColor.from_string("#7A3")
+        assert (c.r, c.g, c.b, c.a) == (119, 170, 51, 1.0)
+        c = bcu.NamedColor.from_string("#7a3")
+        assert (c.r, c.g, c.b, c.a) == (119, 170, 51, 1.0)
+
+        # '#rgba'
+        c = bcu.NamedColor.from_string("#7A3B")
+        assert (c.r, c.g, c.b, c.a) == (119, 170, 51, 187/255.0)
+        c = bcu.NamedColor.from_string("#7a3b")
+        assert (c.r, c.g, c.b, c.a) == (119, 170, 51, 187/255.0)
+
+        # Invalid name
         with pytest.raises(ValueError):
-            bcu.NamedColor.find("bluey")
+            bcu.NamedColor.from_string("bluey")
+
+        # Invalid hex string
+        with pytest.raises(ValueError):
+            bcu.NamedColor.from_string("#")
+        with pytest.raises(ValueError):
+            bcu.NamedColor.from_string("#1")
+        with pytest.raises(ValueError):
+            bcu.NamedColor.from_string("#12")
+        with pytest.raises(ValueError):
+            bcu.NamedColor.from_string("#12345")
+        with pytest.raises(ValueError):
+            bcu.NamedColor.from_string("#1234567")
+        with pytest.raises(ValueError):
+            bcu.NamedColor.from_string("#123456789")
+        with pytest.raises(ValueError):
+            bcu.NamedColor.from_string(" #abc")
+
 
 class Test_ColorGroup:
     def test_len(self) -> None:
@@ -92,41 +141,6 @@ class Test_ColorGroup:
             _TestGroup[(1,)]
         with pytest.raises(ValueError):
             _TestGroup[[1,]]
-
-class Test_color_as_rgb_hex:
-    def test_name(self) -> None:
-        assert bcu._color_as_rgb_hex("blue") == "#0000FF"
-        assert bcu._color_as_rgb_hex("blueviolet") == "#8A2BE2"
-
-    def test_hex_rgb(self) -> None:
-        assert bcu._color_as_rgb_hex("#A3B20F") == "#A3B20F"
-        assert bcu._color_as_rgb_hex("#a3b20f") == "#A3B20F"
-        assert bcu._color_as_rgb_hex("#8A3") == "#88AA33"
-        assert bcu._color_as_rgb_hex("#8a3") == "#88AA33"
-
-    def test_hex_rgba(self) -> None:
-        assert bcu._color_as_rgb_hex("#A3B20FC0") == "#A3B20F"
-        assert bcu._color_as_rgb_hex("#a3b20fc0") == "#A3B20F"
-        assert bcu._color_as_rgb_hex("#8A3B") == "#88AA33"
-        assert bcu._color_as_rgb_hex("#8a3b") == "#88AA33"
-
-    def test_invalid_name(self) -> None:
-        with pytest.raises(ValueError):
-            bcu._color_as_rgb_hex("bluey")
-
-    def test_hex_wrong_length(self) -> None:
-        with pytest.raises(ValueError):
-            bcu._color_as_rgb_hex("#")
-        with pytest.raises(ValueError):
-            bcu._color_as_rgb_hex("#1")
-        with pytest.raises(ValueError):
-            bcu._color_as_rgb_hex("#12")
-        with pytest.raises(ValueError):
-            bcu._color_as_rgb_hex("#12345")
-        with pytest.raises(ValueError):
-            bcu._color_as_rgb_hex("#1234567")
-        with pytest.raises(ValueError):
-            bcu._color_as_rgb_hex("#123456789")
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/colors/test_util__colors.py
+++ b/tests/unit/bokeh/colors/test_util__colors.py
@@ -52,6 +52,13 @@ class Test_NamedColor:
         c = bcu.NamedColor("aliceblue", 240,  248,  255)
         assert c.to_css() == "aliceblue"
 
+    def test_find(self) -> None:
+        c = bcu.NamedColor.find("cornflowerblue")
+        assert c.name == "cornflowerblue"
+
+        with pytest.raises(ValueError):
+            bcu.NamedColor.find("bluey")
+
 class Test_ColorGroup:
     def test_len(self) -> None:
         assert len(_TestGroup) == 3
@@ -85,6 +92,41 @@ class Test_ColorGroup:
             _TestGroup[(1,)]
         with pytest.raises(ValueError):
             _TestGroup[[1,]]
+
+class Test_color_as_rgb_hex:
+    def test_name(self) -> None:
+        assert bcu._color_as_rgb_hex("blue") == "#0000FF"
+        assert bcu._color_as_rgb_hex("blueviolet") == "#8A2BE2"
+
+    def test_hex_rgb(self) -> None:
+        assert bcu._color_as_rgb_hex("#A3B20F") == "#A3B20F"
+        assert bcu._color_as_rgb_hex("#a3b20f") == "#A3B20F"
+        assert bcu._color_as_rgb_hex("#8A3") == "#88AA33"
+        assert bcu._color_as_rgb_hex("#8a3") == "#88AA33"
+
+    def test_hex_rgba(self) -> None:
+        assert bcu._color_as_rgb_hex("#A3B20FC0") == "#A3B20F"
+        assert bcu._color_as_rgb_hex("#a3b20fc0") == "#A3B20F"
+        assert bcu._color_as_rgb_hex("#8A3B") == "#88AA33"
+        assert bcu._color_as_rgb_hex("#8a3b") == "#88AA33"
+
+    def test_invalid_name(self) -> None:
+        with pytest.raises(ValueError):
+            bcu._color_as_rgb_hex("bluey")
+
+    def test_hex_wrong_length(self) -> None:
+        with pytest.raises(ValueError):
+            bcu._color_as_rgb_hex("#")
+        with pytest.raises(ValueError):
+            bcu._color_as_rgb_hex("#1")
+        with pytest.raises(ValueError):
+            bcu._color_as_rgb_hex("#12")
+        with pytest.raises(ValueError):
+            bcu._color_as_rgb_hex("#12345")
+        with pytest.raises(ValueError):
+            bcu._color_as_rgb_hex("#1234567")
+        with pytest.raises(ValueError):
+            bcu._color_as_rgb_hex("#123456789")
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/test_palettes.py
+++ b/tests/unit/bokeh/test_palettes.py
@@ -48,30 +48,30 @@ def test_palettes_dir() -> None:
     assert 'turbo' in dir(pal)
     assert not '__new__' in dir(pal)
 
-def test_single_color_palette() -> None:
-    assert pal.single_color_palette("blue", 3) == ("#0000FF00", "#0000FF80", "#0000FFFF")
-    assert pal.single_color_palette("red", 3, start_alpha=255, end_alpha=128) == ("#FF0000FF", "#FF0000C0", "#FF000080")
-    assert pal.single_color_palette("#123456", 3, start_alpha=205, end_alpha=205) == ("#123456CD", "#123456CD", "#123456CD")
-    assert pal.single_color_palette("#abc", 3) == ("#AABBCC00", "#AABBCC80", "#AABBCCFF")
+def test_varying_alpha_palette() -> None:
+    assert pal.varying_alpha_palette("blue", 3) == ("#0000FF00", "#0000FF80", "#0000FFFF")
+    assert pal.varying_alpha_palette("red", 3, start_alpha=255, end_alpha=128) == ("#FF0000FF", "#FF0000C0", "#FF000080")
+    assert pal.varying_alpha_palette("#123456", 3, start_alpha=205, end_alpha=205) == ("#123456CD", "#123456CD", "#123456CD")
+    assert pal.varying_alpha_palette("#abc", 3) == ("#AABBCC00", "#AABBCC80", "#AABBCCFF")
 
-    palette = pal.single_color_palette("blue")
+    palette = pal.varying_alpha_palette("blue")
     assert len(palette) == 256
     assert palette[::64] == ("#0000FF00", "#0000FF40", "#0000FF80", "#0000FFC0")
 
-    assert pal.single_color_palette("#654321", start_alpha=100, end_alpha=103) == ("#65432164", "#65432165", "#65432166", "#65432167")
+    assert pal.varying_alpha_palette("#654321", start_alpha=100, end_alpha=103) == ("#65432164", "#65432165", "#65432166", "#65432167")
 
     with pytest.raises(ValueError):
-        pal.single_color_palette("bluey")
+        pal.varying_alpha_palette("bluey")
     with pytest.raises(ValueError):
-        pal.single_color_palette("#8F")
+        pal.varying_alpha_palette("#8F")
     with pytest.raises(ValueError):
-        pal.single_color_palette("red", start_alpha=-1)
+        pal.varying_alpha_palette("red", start_alpha=-1)
     with pytest.raises(ValueError):
-        pal.single_color_palette("red", start_alpha=256)
+        pal.varying_alpha_palette("red", start_alpha=256)
     with pytest.raises(ValueError):
-        pal.single_color_palette("red", end_alpha=-1)
+        pal.varying_alpha_palette("red", end_alpha=-1)
     with pytest.raises(ValueError):
-        pal.single_color_palette("red", end_alpha=256)
+        pal.varying_alpha_palette("red", end_alpha=256)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/test_palettes.py
+++ b/tests/unit/bokeh/test_palettes.py
@@ -48,6 +48,31 @@ def test_palettes_dir() -> None:
     assert 'turbo' in dir(pal)
     assert not '__new__' in dir(pal)
 
+def test_single_color_palette() -> None:
+    assert pal.single_color_palette("blue", 3) == ("#0000FF00", "#0000FF80", "#0000FFFF")
+    assert pal.single_color_palette("red", 3, start_alpha=255, end_alpha=128) == ("#FF0000FF", "#FF0000C0", "#FF000080")
+    assert pal.single_color_palette("#123456", 3, start_alpha=205, end_alpha=205) == ("#123456CD", "#123456CD", "#123456CD")
+    assert pal.single_color_palette("#abc", 3) == ("#AABBCC00", "#AABBCC80", "#AABBCCFF")
+
+    palette = pal.single_color_palette("blue")
+    assert len(palette) == 256
+    assert palette[::64] == ("#0000FF00", "#0000FF40", "#0000FF80", "#0000FFC0")
+
+    assert pal.single_color_palette("#654321", start_alpha=100, end_alpha=103) == ("#65432164", "#65432165", "#65432166", "#65432167")
+
+    with pytest.raises(ValueError):
+        pal.single_color_palette("bluey")
+    with pytest.raises(ValueError):
+        pal.single_color_palette("#8F")
+    with pytest.raises(ValueError):
+        pal.single_color_palette("red", start_alpha=-1)
+    with pytest.raises(ValueError):
+        pal.single_color_palette("red", start_alpha=256)
+    with pytest.raises(ValueError):
+        pal.single_color_palette("red", end_alpha=-1)
+    with pytest.raises(ValueError):
+        pal.single_color_palette("red", end_alpha=256)
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
- [ ] issues: fixes #xxxx
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

This PR adds a new `single_color_palette` function to create a palette of a single color but linearly varying alpha. There are 2 use cases, datashader and contouring, listed in discussion #12202. Given the support for `alpha` within `fill_color` and so on, it is not difficult for users to create a palette themselves and pass it to `ColorMapper` or `figure.contour` but this function makes it a one-liner in user code.

Example code:
```python
from bokeh.models import ColorBar, ColumnDataSource, LinearColorMapper
from bokeh.palettes import single_color_palette
from bokeh.plotting import figure, show
import numpy as np

p = figure(width=300, height=150, background_fill_color="orange", border_fill_color="orange")
p.xgrid.visible = False
p.ygrid.visible = False

palette = single_color_palette("blue", n=6, start_alpha=40)

color_mapper = LinearColorMapper(palette)
cds = ColumnDataSource(data=dict(x=np.arange(11)))
p.circle(source=cds, x="x", y=0, size=20, line_width=0,
         fill_color=dict(field="x", transform=color_mapper))
color_bar = ColorBar(color_mapper=color_mapper, background_fill_color="orange")
p.add_layout(color_bar, "below")

show(p)
```
which generates this output:
![Screenshot 2022-07-26 at 17-04-42 Bokeh Plot](https://user-images.githubusercontent.com/580326/181055410-5ae029fe-eb1b-4bea-a76a-76f92abe43d2.png)
I am using the orange background here to make it clear that the `alpha` of the palette is varying.

Features:
- Palette `color` can be a named color or a hex RGB(A) string.
- `alpha` can be increasing or decreasing, controlled by `start_alpha` and `end_alpha`.
- You can specify number of colors `n` or let it choose a sensible maximum so that adjacent colors differ only by an `alpha` change of 1.

Design decisions, some of which may need discussion:
1. This is all on the Python side and I couldn't find an existing "convert generic color string to RGB hex" function so I've written one called `_color_as_rgb_hex`. It only does what I need it to and could be more generic. It could also do more validation, e.g. it assumes the characters after a `#` in a hex string are valid so it does not parse and check them.
2. I've added a `NamedColor.find` function to retrieve a `NamedColor` by name as they are all stored in class variables here.
3. Function name is `single_color_palette`. Other options are `varying_alpha_palette` or `single_color_varying_alpha_palette`.
4. I am using integers in the range 0 to 255 for `alpha` rather than floats in the range 0 to 1.