### PR TITLE
Pin sphinx to version >=5,<5.1

### DIFF
--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -46,7 +46,7 @@ dependencies:
     # docs
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
-    - sphinx >=5
+    - sphinx >=5,<5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -68,7 +68,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5
+    - sphinx >=5,<5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -68,7 +68,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5
+    - sphinx >=5,<5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -68,7 +68,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5
+    - sphinx >=5,<5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/ci/environment-test-minimal-deps.yml
+++ b/ci/environment-test-minimal-deps.yml
@@ -59,7 +59,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5
+    - sphinx >=5,<5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/environment.yml
+++ b/environment.yml
@@ -80,7 +80,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >= 0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5
+    - sphinx >=5,<5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design


### PR DESCRIPTION
Otherwise fails with:
```
sphinx.errors.ExtensionError: Handler <function _process_docstring at 0x7fb3ba4ab550> for
event 'autodoc-process-docstring' threw an exception (exception: pop from an empty deque)
```