### PR TITLE
Add support for async `expect().to.throw()`

### DIFF
--- a/bokehjs/src/lib/core/util/types.ts
+++ b/bokehjs/src/lib/core/util/types.ts
@@ -47,7 +47,8 @@ export function isPrimitive(obj: unknown): obj is Primitive {
 }
 
 export function isFunction(obj: unknown): obj is Function {
-  return toString.call(obj) === "[object Function]"
+  const rep = toString.call(obj)
+  return rep === "[object Function]" || rep === "[object AsyncFunction]"
 }
 
 export function isArray<T>(obj: unknown): obj is T[] {

--- a/bokehjs/test/unit/core/util/types.ts
+++ b/bokehjs/test/unit/core/util/types.ts
@@ -77,6 +77,8 @@ describe("core/util/types module", () => {
     expect(isFunction(() => 0)).to.be.true
     expect(isFunction(new Function("return 1"))).to.be.true
     expect(isFunction(new X())).to.be.false
+    expect(isFunction(() => new Promise(() => {}))).to.be.true
+    expect(isFunction(async () => 0)).to.be.true
   })
 
   it("should support isArray() function", () => {


### PR DESCRIPTION
This allows tests like this:
```ts
await expect(async () =>
  await build_view(frame, {parent: null})
).to.throw()
```
Extracted from PR #12083.