### PR TITLE
Drop `serialized=False/readonly=True` for `NotSerialized/Readonly`

### DIFF
--- a/bokeh/core/properties.py
+++ b/bokeh/core/properties.py
@@ -150,6 +150,7 @@ Special Properties
 .. autoclass:: Include
 .. autoclass:: Nullable
 .. autoclass:: NonNullable
+.. autoclass:: NotSerialized
 .. autoclass:: Override
 .. autoclass:: Required
 
@@ -239,6 +240,7 @@ __all__ = (
     'NonNegative',
     'NonNegativeInt',
     'NonNullable',
+    'NotSerialized',
     'Nothing',
     'Null',
     'NullStringSpec',
@@ -372,6 +374,8 @@ from .property.primitive import String; String
 from .property.readonly import Readonly; Readonly
 
 from .property.required import Required; Required
+
+from .property.serialized import NotSerialized; NotSerialized
 
 from .property.string import MathString; MathString
 from .property.string import Regex; Regex

--- a/bokeh/core/property/any.py
+++ b/bokeh/core/property/any.py
@@ -57,14 +57,6 @@ class Any(Property[typing.Any]):
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
 
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
-
     Example:
 
         .. code-block:: python
@@ -88,9 +80,8 @@ class Any(Property[typing.Any]):
     """
 
     # TODO: default should be explicitly defined by the user (i.e. intrinsic here)
-    def __init__(self, default: Init[typing.Any] = None, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False) -> None:
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, default: Init[typing.Any] = None, help: str | None = None) -> None:
+        super().__init__(default=default, help=help)
 
 class AnyRef(Any):
     """ Accept all values and force reference discovery. """

--- a/bokeh/core/property/container.py
+++ b/bokeh/core/property/container.py
@@ -76,9 +76,9 @@ class Seq(ContainerProperty[T]):
     """
 
     def __init__(self, item_type: TypeOrInst[Property[T]], *, default: Init[T] = Undefined,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
+            help: str | None = None) -> None:
         self.item_type = self._validate_type_param(item_type)
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+        super().__init__(default=default, help=help)
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.item_type})"
@@ -317,8 +317,8 @@ class NonEmpty(SingleParameterizedProperty[TSeq]):
     """ Allows only non-empty containers. """
 
     def __init__(self, type_param: TypeOrInst[TSeq], *, default: Init[TSeq] = Intrinsic,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
-        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+            help: str | None = None) -> None:
+        super().__init__(type_param, default=default, help=help)
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)

--- a/bokeh/core/property/dataspec.py
+++ b/bokeh/core/property/dataspec.py
@@ -42,6 +42,7 @@ from .primitive import (
     Null,
     String,
 )
+from .serialized import NotSerialized
 from .singletons import Undefined
 from .struct import Optional, Struct
 from .vectorization import (
@@ -411,7 +412,7 @@ class UnitsSpec(NumberSpec):
     def __init__(self, default, units_enum, units_default, *, help: str | None = None) -> None:
         super().__init__(default=default, help=help)
 
-        units_type = Enum(units_enum, default=units_default, serialized=False, help=f"""
+        units_type = NotSerialized(Enum(units_enum), default=units_default, help=f"""
         Units to use for the associated property: {nice_join(units_enum)}
         """)
         self._units_type = self._validate_type_param(units_type, help_allowed=True)

--- a/bokeh/core/property/descriptors.py
+++ b/bokeh/core/property/descriptors.py
@@ -281,7 +281,7 @@ class PropertyDescriptor(Generic[T]):
             class_name = obj.__class__.__name__
             raise RuntimeError(f"Cannot set a property value {self.name!r} on a {class_name} instance before HasProps.__init__")
 
-        if self.property._readonly and obj._initialized:
+        if self.property.readonly and obj._initialized:
             # Allow to set a value during object initialization (e.g. value -> value_throttled)
             class_name = obj.__class__.__name__
             raise RuntimeError(f"{class_name}.{self.name} is a readonly property")
@@ -707,7 +707,7 @@ class ColumnDataPropertyDescriptor(PropertyDescriptor):
             class_name = obj.__class__.__name__
             raise RuntimeError(f"Cannot set a property value {self.name!r} on a {class_name} instance before HasProps.__init__")
 
-        if self.property._readonly and obj._initialized:
+        if self.property.readonly and obj._initialized:
             # Allow to set a value during object initialization (e.g. value -> value_throttled)
             class_name = obj.__class__.__name__
             raise RuntimeError(f"{class_name}.{self.name} is a readonly property")

--- a/bokeh/core/property/either.py
+++ b/bokeh/core/property/either.py
@@ -69,10 +69,10 @@ class Either(ParameterizedProperty):
 
     """
 
-    def __init__(self, tp1, tp2, *type_params, default=Intrinsic, help: str | None = None, serialized=None, readonly=False) -> None:
+    def __init__(self, tp1, tp2, *type_params, default=Intrinsic, help: str | None = None) -> None:
         type_params = list(map(self._validate_type_param, (tp1, tp2) + type_params))
         default = default if default is not Intrinsic else type_params[0]._raw_default()
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+        super().__init__(default=default, help=help)
         self._type_params = type_params
         for tp in self._type_params:
             self.alternatives.extend(tp.alternatives)

--- a/bokeh/core/property/enum.py
+++ b/bokeh/core/property/enum.py
@@ -54,20 +54,17 @@ class Enum(String):
     """
 
     @overload
-    def __init__(self, enum: enums.Enumeration, *, default: Init[str] = ...,
-        help: str | None = ..., serialized: bool | None = ..., readonly: bool = ...) -> None: ...
+    def __init__(self, enum: enums.Enumeration, *, default: Init[str] = ..., help: str | None = ...) -> None: ...
     @overload
-    def __init__(self, enum: str, *values: str, default: Init[str] = ...,
-        help: str | None = ..., serialized: bool | None = ..., readonly: bool = ...) -> None: ...
+    def __init__(self, enum: str, *values: str, default: Init[str] = ..., help: str | None = ...) -> None: ...
 
-    def __init__(self, enum: str | enums.Enumeration, *values: str, default: Init[str] = Intrinsic,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
+    def __init__(self, enum: str | enums.Enumeration, *values: str, default: Init[str] = Intrinsic, help: str | None = None) -> None:
         if not (not values and isinstance(enum, enums.Enumeration)):
             enum = enums.enumeration(enum, *values)
         self._enum = enum
 
         default = default if default is not Intrinsic else enum._default
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+        super().__init__(default=default, help=help)
 
     def __str__(self) -> str:
         class_name = self.__class__.__name__

--- a/bokeh/core/property/factors.py
+++ b/bokeh/core/property/factors.py
@@ -54,18 +54,16 @@ FactorSeqType: TypeAlias = tp.Union[tp.Sequence[str], tp.Sequence[tp.Tuple[str, 
 class Factor(SingleParameterizedProperty[FactorType]):
     """ Represents a single categorical factor. """
 
-    def __init__(self, default: Init[FactorType] = Intrinsic, *,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
+    def __init__(self, default: Init[FactorType] = Intrinsic, *, help: str | None = None) -> None:
         type_param = Either(L1Factor, L2Factor, L3Factor)
-        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+        super().__init__(type_param, default=default, help=help)
 
 class FactorSeq(SingleParameterizedProperty[FactorSeqType]):
     """ Represents a collection of categorical factors. """
 
-    def __init__(self, default: Init[FactorSeqType] = Intrinsic, *,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
+    def __init__(self, default: Init[FactorSeqType] = Intrinsic, *, help: str | None = None) -> None:
         type_param = Either(Seq(L1Factor), Seq(L2Factor), Seq(L3Factor))
-        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+        super().__init__(type_param, default=default, help=help)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/instance.py
+++ b/bokeh/core/property/instance.py
@@ -57,18 +57,11 @@ T = TypeVar("T", bound=Serializable)
 #-----------------------------------------------------------------------------
 
 class Instance(Property[T]):
-    """ Accept values that are instances of serializable types (e.g. |HasProps|).
+    """ Accept values that are instances of serializable types (e.g. |HasProps|). """
 
-    Args:
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
-
-    """
     _instance_type: Type[T] | Callable[[], Type[T]] | str
 
-    def __init__(self, instance_type: Type[T] | Callable[[], Type[T]] | str, default: Init[T] = Undefined,
-            help: str | None = None, readonly: bool = False, serialized: bool | None = None):
+    def __init__(self, instance_type: Type[T] | Callable[[], Type[T]] | str, default: Init[T] = Undefined, help: str | None = None):
         if not (isinstance(instance_type, (type, str)) or callable(instance_type)):
             raise ValueError(f"expected a type, fn() -> type, or string, got {instance_type}")
 
@@ -77,7 +70,7 @@ class Instance(Property[T]):
 
         self._instance_type = instance_type
 
-        super().__init__(default=default, help=help, readonly=readonly, serialized=serialized)
+        super().__init__(default=default, help=help)
 
     @staticmethod
     def _assert_serializable(instance_type: Type[Any]) -> None:

--- a/bokeh/core/property/json.py
+++ b/bokeh/core/property/json.py
@@ -55,15 +55,8 @@ class JSON(String):
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
 
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
-
     """
+
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
 

--- a/bokeh/core/property/nothing.py
+++ b/bokeh/core/property/nothing.py
@@ -39,9 +39,8 @@ __all__ = (
 class Nothing(Property[NoReturn]):
     """ The bottom type of bokeh's type system. It doesn't accept any values. """
 
-    def __init__(self, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False) -> None:
-        super().__init__(default=Undefined, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, *, help: str | None = None) -> None:
+        super().__init__(default=Undefined, help=help)
 
     def validate(self, value: Any, detail: bool = True) -> None:
         raise ValueError("no value is allowed")

--- a/bokeh/core/property/nullable.py
+++ b/bokeh/core/property/nullable.py
@@ -51,9 +51,8 @@ T = TypeVar("T")
 class Nullable(SingleParameterizedProperty[Union[T, None]]):
     """ A property accepting ``None`` or a value of some other type. """
 
-    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T | None] = None,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
-        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T | None] = None, help: str | None = None) -> None:
+        super().__init__(type_param, default=default, help=help)
 
     def transform(self, value: Any) -> T | None:
         return None if value is None else super().transform(value)
@@ -84,10 +83,9 @@ class NonNullable(Required[T]):
         Use ``bokeh.core.property.required.Required`` instead.
     """
 
-    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Undefined,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
+    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Undefined, help: str | None = None) -> None:
         deprecated((3, 0, 0), "NonNullable(Type)", "Required(Type)")
-        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+        super().__init__(type_param, default=default, help=help)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/numeric.py
+++ b/bokeh/core/property/numeric.py
@@ -59,9 +59,8 @@ T = TypeVar("T", bound=Union[int, float])
 class NonNegative(SingleParameterizedProperty[T]):
     """ A property accepting a value of some other type while having undefined default. """
 
-    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Intrinsic,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
-        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Intrinsic, help: str | None = None) -> None:
+        super().__init__(type_param, default=default, help=help)
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
@@ -72,9 +71,8 @@ class NonNegative(SingleParameterizedProperty[T]):
 class Positive(SingleParameterizedProperty[T]):
     """ A property accepting a value of some other type while having undefined default. """
 
-    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Intrinsic,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
-        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Intrinsic, help: str | None = None) -> None:
+        super().__init__(type_param, default=default, help=help)
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
@@ -91,10 +89,9 @@ class NonNegativeInt(Int):
         Use ``NonNegative(Int)`` instead.
     """
 
-    def __init__(self, default: Init[int] = Intrinsic, *,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
+    def __init__(self, default: Init[int] = Intrinsic, *, help: str | None = None) -> None:
         deprecated((3, 0, 0), "NonNegativeInt", "NonNegative(Int)")
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+        super().__init__(default=default, help=help)
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
@@ -111,10 +108,9 @@ class PositiveInt(Int):
         Use ``Positive(Int)`` instead.
     """
 
-    def __init__(self, default: Init[int] = Intrinsic, *,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
+    def __init__(self, default: Init[int] = Intrinsic, *, help: str | None = None) -> None:
         deprecated((3, 0, 0), "Positive", "Positive(Int)")
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+        super().__init__(default=default, help=help)
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
@@ -215,14 +211,6 @@ class Size(Float):
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
 
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
-
     Example:
 
         .. code-block:: python
@@ -263,14 +251,6 @@ class Percent(Float):
             A documentation string for this property. It will be automatically
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
-
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
 
     Example:
 
@@ -317,14 +297,6 @@ class Angle(Float):
             A documentation string for this property. It will be automatically
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
-
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
 
     """
 

--- a/bokeh/core/property/primitive.py
+++ b/bokeh/core/property/primitive.py
@@ -59,9 +59,8 @@ class Null(PrimitiveProperty[None]):
 
     _underlying_type = (type(None),)
 
-    def __init__(self, default: Init[None] = None, *, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False):
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, default: Init[None] = None, *, help: str | None = None) -> None:
+        super().__init__(default=default, help=help)
 
 class Bool(PrimitiveProperty[bool]):
     """ Accept boolean values.
@@ -74,14 +73,6 @@ class Bool(PrimitiveProperty[bool]):
             A documentation string for this property. It will be automatically
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
-
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
 
     Example:
 
@@ -103,9 +94,8 @@ class Bool(PrimitiveProperty[bool]):
 
     _underlying_type = bokeh_bool_types
 
-    def __init__(self, default: Init[bool] = False, *, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False):
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, default: Init[bool] = False, *, help: str | None = None) -> None:
+        super().__init__(default=default, help=help)
 
 class Complex(PrimitiveProperty[complex]):
     """ Accept complex floating point values.
@@ -119,21 +109,12 @@ class Complex(PrimitiveProperty[complex]):
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
 
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
-
     """
 
     _underlying_type = (numbers.Complex,)
 
-    def __init__(self, default: Init[complex] = 0j, *, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False):
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, default: Init[complex] = 0j, *, help: str | None = None) -> None:
+        super().__init__(default=default, help=help)
 
 class Int(PrimitiveProperty[int]):
     """ Accept signed integer values.
@@ -146,14 +127,6 @@ class Int(PrimitiveProperty[int]):
             A documentation string for this property. It will be automatically
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
-
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
 
     Example:
 
@@ -175,9 +148,8 @@ class Int(PrimitiveProperty[int]):
 
     _underlying_type = bokeh_integer_types
 
-    def __init__(self, default: Init[int] = 0, *, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False):
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, default: Init[int] = 0, *, help: str | None = None) -> None:
+        super().__init__(default=default, help=help)
 
 class Float(PrimitiveProperty[float]):
     """ Accept floating point values.
@@ -190,14 +162,6 @@ class Float(PrimitiveProperty[float]):
             A documentation string for this property. It will be automatically
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
-
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
 
     Example:
 
@@ -220,9 +184,8 @@ class Float(PrimitiveProperty[float]):
 
     _underlying_type = (numbers.Real,)
 
-    def __init__(self, default: Init[float] = 0.0, *, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False):
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, default: Init[float] = 0.0, *, help: str | None = None) -> None:
+        super().__init__(default=default, help=help)
 
 class Bytes(PrimitiveProperty[bytes]):
     """ Accept bytes values.
@@ -231,9 +194,8 @@ class Bytes(PrimitiveProperty[bytes]):
 
     _underlying_type = (bytes,)
 
-    def __init__(self, default: Init[bytes] = b"", *, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False):
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, default: Init[bytes] = b"", *, help: str | None = None) -> None:
+        super().__init__(default=default, help=help)
 
 class String(PrimitiveProperty[str]):
     """ Accept string values.
@@ -246,14 +208,6 @@ class String(PrimitiveProperty[str]):
             A documentation string for this property. It will be automatically
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
-
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
 
     Example:
 
@@ -275,9 +229,8 @@ class String(PrimitiveProperty[str]):
 
     _underlying_type = (str,)
 
-    def __init__(self, default: Init[str] = "", *, help: str | None = None,
-            serialized: bool | None = None, readonly: bool = False):
-        super().__init__(default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, default: Init[str] = "", *, help: str | None = None) -> None:
+        super().__init__(default=default, help=help)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/readonly.py
+++ b/bokeh/core/property/readonly.py
@@ -47,9 +47,10 @@ T = TypeVar("T")
 class Readonly(SingleParameterizedProperty[T]):
     """ A property that can't be manually modified by the user. """
 
-    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Intrinsic,
-            help: str | None = None, serialized: bool | None = None) -> None:
-        super().__init__(type_param, default=default, help=help, readonly=True, serialized=serialized)
+    _readonly = True
+
+    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Intrinsic, help: str | None = None) -> None:
+        super().__init__(type_param, default=default, help=help)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/required.py
+++ b/bokeh/core/property/required.py
@@ -48,9 +48,8 @@ T = TypeVar("T")
 class Required(SingleParameterizedProperty[T]):
     """ A property accepting a value of some other type while having undefined default. """
 
-    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Undefined,
-            help: str | None = None, serialized: bool | None = None, readonly: bool = False) -> None:
-        super().__init__(type_param, default=default, help=help, serialized=serialized, readonly=readonly)
+    def __init__(self, type_param: TypeOrInst[Property[T]], *, default: Init[T] = Undefined, help: str | None = None) -> None:
+        super().__init__(type_param, default=default, help=help)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/bokeh/core/property/string.py
+++ b/bokeh/core/property/string.py
@@ -56,14 +56,6 @@ class Regex(String):
             used by the :ref:`bokeh.sphinxext.bokeh_prop` extension when
             generating Spinx documentation. (default: None)
 
-        serialized (bool, optional) :
-            Whether attributes created from this property should be included
-            in serialization (default: True)
-
-        readonly (bool, optional) :
-            Whether attributes created from this property are read-only.
-            (default: False)
-
     Example:
 
         .. code-block:: python
@@ -81,6 +73,7 @@ class Regex(String):
             >>> m.prop = [1, 2, 3]  # ValueError !!
 
     """
+
     def __init__(self, regex: str, *, default: Init[str] = Undefined, help: str | None = None) -> None:
         self.regex = re.compile(regex)
         super().__init__(default=default, help=help)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ module = [
     "bokeh.core.property.primitive",
     "bokeh.core.property.readonly",
     "bokeh.core.property.required",
+    "bokeh.core.property.serialized",
     "bokeh.core.property.singletons",
     "bokeh.core.property.string",
     #"bokeh.core.property.struct",

--- a/sphinx/source/docs/releases/3.0.0.rst
+++ b/sphinx/source/docs/releases/3.0.0.rst
@@ -162,6 +162,18 @@ in ``Toolbar`` model.
 
 ``ToolButton`` abstract base class was merged into ``Tool`` model.
 
+``MyProperty(..., serialized=False)``
+.....................................
+
+``serialized`` argument was removed and ``serialized=False`` case was replaced
+width ``NotSerialized(MyProperty(...))``.
+
+``MyProperty(..., readonly=True)``
+..................................
+
+``readonly`` argument was removed and ``readonly=True`` case was replaced
+width ``Readonly(MyProperty(...))``.
+
 Renames
 ~~~~~~~
 

--- a/tests/unit/bokeh/core/property/test_bases.py
+++ b/tests/unit/bokeh/core/property/test_bases.py
@@ -16,6 +16,9 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # External imports
 import numpy as np
 from mock import MagicMock, patch
@@ -52,20 +55,26 @@ class TestProperty:
         assert mock_validate.call_args[0] == (None, False)
 
     def test_serialized_default(self) -> None:
-        p = bcpb.Property()
-        assert p.serialized is True
-        assert p.readonly is False
+        class NormalProp(bcpb.Property[Any]):
+            pass
 
-        # readonly=True sets serialized=False if unspecified
-        p = bcpb.Property(readonly=True)
-        assert p.serialized is False
-        assert p.readonly is True
+        class ReadonlyProp(bcpb.Property[Any]):
+            _readonly = True
 
-        # explicit serialized value always respected
-        p = bcpb.Property(readonly=True, serialized=True)
-        assert p.serialized is True
-        assert p.readonly is True
+        class NotSerializedProp(bcpb.Property[Any]):
+            _serialized = False
 
+        p0 = NormalProp()
+        assert p0.serialized is True
+        assert p0.readonly is False
+
+        p1 = ReadonlyProp()
+        assert p1.serialized is False
+        assert p1.readonly is True
+
+        p2 = NotSerializedProp()
+        assert p2.serialized is False
+        assert p2.readonly is False
 
     def test_assert_bools(self) -> None:
         hp = HasProps()

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -30,9 +30,11 @@ from bokeh.core.properties import (
     Instance,
     Int,
     List,
+    NotSerialized,
     Nullable,
     NumberSpec,
     Override,
+    Readonly,
     String,
 )
 from bokeh.models import Plot
@@ -93,6 +95,7 @@ ALL = (
     'NonNegative',
     'NonNegativeInt',
     'NonNullable',
+    'NotSerialized',
     'Nothing',
     'Null',
     'NullStringSpec',
@@ -309,11 +312,11 @@ class TestBasic:
         assert {"num", "mixin_num", "sub_num"} == set(sub.dataspecs())
 
     def test_not_serialized(self) -> None:
-        class NotSerialized(HasProps):
-            x = Int(12, serialized=False)
+        class NotSerializedModel(HasProps):
+            x = NotSerialized(Int(12))
             y = String("hello")
 
-        o = NotSerialized()
+        o = NotSerializedModel()
         assert o.x == 12
         assert o.y == 'hello'
 
@@ -338,12 +341,12 @@ class TestBasic:
         assert 'y' in o.properties_with_values(include_defaults=False)
 
     def test_readonly(self) -> None:
-        class Readonly(HasProps):
-            x = Int(12, readonly=True)    # with default
-            y = Nullable(Int(), readonly=True)        # without default
+        class ReadonlyModel(HasProps):
+            x = Readonly(Int(12))         # with default
+            y = Readonly(Nullable(Int())) # without default
             z = String("hello")
 
-        o = Readonly()
+        o = ReadonlyModel()
         assert o.x == 12
         assert o.y is None
         assert o.z == 'hello'


### PR DESCRIPTION
This is based on PR #12271, so only the last commit is relevant.

This PR removes `serialized` and `readonly` from properties' `__init__`, and replaces them with existing `Readonly()` and new `NotSerialized()`. Those `__init__` attributes only complicate the API, having to be passed through long inheritance chains, only to be used in `Property` base class. Due to this, many properties don't implement them at all or implement them incorrectly. However, they aren't being used anyway, especially since `Readonly()` was introduced. Thus my proposal is to drop them now. It should be a low impact breaking change.