### PR TITLE
grammatically updated the tech docs

### DIFF
--- a/sphinx/source/docs/user_guide.rst
+++ b/sphinx/source/docs/user_guide.rst
@@ -30,7 +30,7 @@ User guide
 
 In this user guide, you will find detailed descriptions and examples that
 describe many common tasks that you can accomplish with Bokeh. To get started
-with Bokeh, you should first completed the steps described in
+with Bokeh, you should first complete the steps described in
 :ref:`first_steps_installing`.
 
 .. tip::


### PR DESCRIPTION
I've grammatically updated the tech docs.


Changed from "with Bokeh, you should first **completed** the steps described in" to "with Bokeh, you should first **complete** the steps described in".