### PR TITLE
Add post install status to bokeh-release-build

### DIFF
--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -46,7 +46,15 @@ jobs:
         shell: bash -l {0}
         run: python -c 'import bokeh; bokeh.sampledata.download(progress=False)'
 
-      - name: Install NPM
+      - name: Post install status
+        shell: bash -l {0}
+        run: |
+          echo "$(which node) @ $(node --version)"
+          echo "$(which npm) @ $(npm --version)"
+          conda info
+          conda list
+
+      - name: Upgrade NPM
         shell: bash -l {0}
         run: |
           npm install --location=global npm@8


### PR DESCRIPTION
To help figure out current issues with `bokeh-release-build`. It looks like wrong version of nodejs is picked up when upgrading npm.