### PR TITLE
Cleanup / condense project configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,46 +1,30 @@
+[tool.pytest.ini_options]
+addopts = "--no-success-flaky-report"
+asyncio_mode = "strict"
+norecursedirs = "build _build node_modules"
+python_files = "*_tests.py *_test.py test_*.py"
+markers = [
+    "sampledata: a test for bokeh.sampledata",
+    "selenium: a test as requiring selenium",
+]
+
 [tool.mypy]
 python_version = "3.8"
 mypy_path = "typings/"
 files = ["typings", "bokeh", "release", "tests"]
 
+strict = true
+
 pretty = true
+show_column_numbers = true
 show_error_codes = true
 show_error_context = true
-show_column_numbers = true
-
-namespace_packages = true
-ignore_missing_imports = false
 
 disallow_any_unimported = true
-disallow_any_expr = false
-disallow_any_decorated = false
-disallow_any_explicit = false
-disallow_any_generics = true
-disallow_subclassing_any = true
-
-disallow_untyped_calls = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-disallow_untyped_decorators = true
-no_implicit_optional = true
-strict_optional = true
-
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_no_return = true
+implicit_reexport = true
+namespace_packages = true
 warn_return_any = false
 warn_unreachable = true
-
-show_none_errors = true
-ignore_errors = false
-
-allow_untyped_globals = false
-allow_redefinition = false
-implicit_reexport = true
-strict_equality = true
-
-warn_unused_configs = true
 
 # For now enable each typed module individually.
 [[tool.mypy.overrides]]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,18 +15,6 @@ ignore = E,W
 select = F,E101,E111,E501,Y
 max-line-length = 165
 
-[doc8]
-ignore=D001
-
-[tool:pytest]
-addopts = --no-success-flaky-report
-asyncio_mode = strict
-norecursedirs = build _build node_modules
-python_files = *_tests.py *_test.py test_*.py
-markers =
-    sampledata: a test for bokeh.sampledata
-    selenium: a test as requiring selenium
-
 [versioneer]
 VCS = git
 versionfile_source = bokeh/_version.py


### PR DESCRIPTION
This PR moves a little closer to consolidating project config in `pyproject.toml` and being able to get rid of `setup.cfg` eventually:

* removes unused `doc8` section
* moves `pytest` config to `pyproject.toml`

Additionally the `mypy` config in `pyproject.toml` was cleaned-up and `strict=true` was added. Values that we redundant (due to `strict` mode, or because they are already the standard default) were removed. 