### PR TITLE
BokehJS maths improvements

### DIFF
--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -478,7 +478,7 @@ export class AxisView extends GuideRendererView {
 
   get ranges(): [Range, Range] {
     const i = this.dimension
-    const j = (i + 1) % 2
+    const j = 1 - i
     const {ranges} = this.coordinates
     return [ranges[i], ranges[j]]
   }
@@ -513,7 +513,7 @@ export class AxisView extends GuideRendererView {
 
   get rule_coords(): Coords {
     const i = this.dimension
-    const j = (i + 1) % 2
+    const j = 1 - i
     const [range] = this.ranges
     const [start, end] = this.computed_bounds
 
@@ -534,7 +534,7 @@ export class AxisView extends GuideRendererView {
 
   get tick_coords(): TickCoords {
     const i = this.dimension
-    const j = (i + 1) % 2
+    const j = 1 - i
     const [range] = this.ranges
     const [start, end] = this.computed_bounds
 

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -34,7 +34,7 @@ export class CategoricalAxisView extends AxisView {
       return
 
     const dim = this.dimension
-    const alt = (dim + 1) % 2
+    const alt = 1 - dim
 
     const coords: Coords = [[], []]
 
@@ -125,7 +125,7 @@ export class CategoricalAxisView extends AxisView {
 
   override get tick_coords(): CategoricalTickCoords {
     const i = this.dimension
-    const j = (i + 1) % 2
+    const j = 1 - i
     const [range] = this.ranges as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -76,7 +76,7 @@ export class GridView extends GuideRendererView {
   // {{{ TODO: state
   ranges(): [Range, Range] {
     const i = this.model.dimension
-    const j = (i + 1) % 2
+    const j = 1 - i
     const {ranges} = this.coordinates
     return [ranges[i], ranges[j]]
   }
@@ -120,7 +120,7 @@ export class GridView extends GuideRendererView {
 
   grid_coords(location: "major" | "minor", exclude_ends: boolean = true): [number[][], number[][]] {
     const i = this.model.dimension
-    const j = (i + 1) % 2
+    const j = 1 - i
     const [range, cross_range] = this.ranges()
 
     const [start, end] = (() => {

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -28,7 +28,7 @@ export class LogColorMapper extends ContinuousColorMapper {
   protected scan(data: Arrayable<number>, n: number): LogScanData {
     const low = this.low != null ? this.low : min(data)
     const high = this.high != null ? this.high : max(data)
-    const scale = n / (Math.log(high) - Math.log(low))  // subtract the low offset
+    const scale = n / Math.log(high / low)  // subtract the low offset
     return {max: high, min: low, scale}
   }
 

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -185,16 +185,16 @@ export class DataRange1d extends DataRange {
       let center, span: number
       if (max == min) {
         span = this.default_span + 0.001
-        center = Math.log(min) / Math.log(10)
+        center = Math.log10(min)
       } else {
         let log_min, log_max: number
         if (this.range_padding_units == "percent") {
-          log_min = Math.log(min) / Math.log(10)
-          log_max = Math.log(max) / Math.log(10)
+          log_min = Math.log10(min)
+          log_max = Math.log10(max)
           span = (log_max - log_min)*(1 + range_padding)
         } else {
-          log_min = Math.log(min - range_padding) / Math.log(10)
-          log_max = Math.log(max + range_padding) / Math.log(10)
+          log_min = Math.log10(min - range_padding)
+          log_max = Math.log10(max + range_padding)
           span = log_max - log_min
         }
         center = (log_min + log_max) / 2.0

--- a/bokehjs/src/lib/models/scales/log_scale.ts
+++ b/bokehjs/src/lib/models/scales/log_scale.ts
@@ -44,7 +44,7 @@ export class LogScale extends ContinuousScale {
       if (start == 0)
         [start, end] = [1, 10]
       else {
-        const log_val = Math.log(start) / Math.log(10)
+        const log_val = Math.log10(start)
         start = 10**Math.floor(log_val)
 
         if (Math.ceil(log_val) != Math.floor(log_val))
@@ -72,7 +72,7 @@ export class LogScale extends ContinuousScale {
       inter_factor = Math.log(end)
       inter_offset = 0
     } else {
-      inter_factor = Math.log(end) - Math.log(start)
+      inter_factor = Math.log(end / start)
       inter_offset = Math.log(start)
     }
 


### PR DESCRIPTION
Whilst looking at the colormapper/axis/scale bokehjs code I identified some changes to equations that are functionally identical but result in less code that should be faster to run.

There are 3 changes:

1. Where there is a `dimension` `i` that can only be `0` or `1`, the other dimension `j` is given by `j = 1-i` rather than the longer `j = (i+1)%2`.
2. `log(a) - log(b)` is more simply expressed as `log(a/b)` and this only requires one `log` calculation rather than two.
3. `log(a) / log(10)` is more simply expressed as `log10(a)`.

The log identities are listed at https://en.wikipedia.org/wiki/List_of_logarithmic_identities.
