### PR TITLE
Remove double colons from field lists

### DIFF
--- a/ci/environment-release-build.yml
+++ b/ci/environment-release-build.yml
@@ -46,7 +46,7 @@ dependencies:
     # docs
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
-    - sphinx >=5,<5.1
+    - sphinx >5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/ci/environment-test-3.10.yml
+++ b/ci/environment-test-3.10.yml
@@ -67,7 +67,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5,<5.1
+    - sphinx >5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/ci/environment-test-3.8.yml
+++ b/ci/environment-test-3.8.yml
@@ -67,7 +67,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5,<5.1
+    - sphinx >5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/ci/environment-test-3.9.yml
+++ b/ci/environment-test-3.9.yml
@@ -67,7 +67,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5,<5.1
+    - sphinx >5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/ci/environment-test-minimal-deps.yml
+++ b/ci/environment-test-minimal-deps.yml
@@ -59,7 +59,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >=0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5,<5.1
+    - sphinx >5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design

--- a/environment.yml
+++ b/environment.yml
@@ -80,7 +80,7 @@ dependencies:
     - autoclasstoc
     - pydata_sphinx_theme >= 0.9
     - requests-unixsocket >= 0.3.0
-    - sphinx >=5,<5.1
+    - sphinx >5.1
     - sphinx-copybutton
     - sphinxext-opengraph
     - sphinx-design


### PR DESCRIPTION
Fix https://github.com/pydata/pydata-sphinx-theme/issues/860 and addresses a checkbox here #12203.

See https://github.com/sphinx-doc/sphinx/issues/10594

You need 5.1.1+ due to a napoleon issue (#12265):
https://github.com/sphinx-doc/sphinx/issues/10594