### PR TITLE
Provide method to modify Server before start

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -81,6 +81,7 @@ jobs:
         run: pytest --color=yes tests/codebase
 
       - name: MyPy
+        if: success() || failure()
         run: mypy --version && mypy
 
   examples:

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -425,7 +425,7 @@ import argparse
 import os
 from fnmatch import fnmatch
 from glob import glob
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 # External imports
 from tornado.autoreload import watch
@@ -442,6 +442,9 @@ from bokeh.util.strings import format_docstring, nice_join
 # Bokeh imports
 from ..subcommand import Argument, Subcommand
 from ..util import build_single_handler_applications, die, report_server_init_errors
+
+if TYPE_CHECKING:
+    from bokeh.server import Server
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -783,6 +786,9 @@ class Serve(Subcommand):
         Should modify and return a copy of the ``server_kwargs`` dictionary.
         '''
         return dict(server_kwargs)
+    
+    def customize_server(self, server: Server) -> Server:
+        return server
 
     def invoke(self, args: argparse.Namespace) -> None:
         '''
@@ -967,6 +973,9 @@ class Serve(Subcommand):
                     log.info("Bokeh app running at: %s" % url)
 
                 log.info("Starting Bokeh server with process id: %d" % os.getpid())
+
+            server = self.customize_server(server)
+
             server.run_until_shutdown()
 
 #-----------------------------------------------------------------------------

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -444,7 +444,7 @@ from ..subcommand import Argument, Subcommand
 from ..util import build_single_handler_applications, die, report_server_init_errors
 
 if TYPE_CHECKING:
-    from bokeh.server import Server
+    from bokeh.server.server import Server
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -786,7 +786,7 @@ class Serve(Subcommand):
         Should modify and return a copy of the ``server_kwargs`` dictionary.
         '''
         return dict(server_kwargs)
-    
+
     def customize_server(self, server: Server) -> Server:
         '''Allows subclasses to customize the ``server``.
 

--- a/bokeh/command/subcommands/serve.py
+++ b/bokeh/command/subcommands/serve.py
@@ -788,6 +788,10 @@ class Serve(Subcommand):
         return dict(server_kwargs)
     
     def customize_server(self, server: Server) -> Server:
+        '''Allows subclasses to customize the ``server``.
+
+        Should apply modifications to the server and wrap it or return the same instance.
+        '''
         return server
 
     def invoke(self, args: argparse.Namespace) -> None:


### PR DESCRIPTION
In Panel we extend the `bokeh serve` command in quite significant ways already but it's always been quite difficult to perform any modifications of the `Server` object before we actually run it. Here I implement a `customize_server` (in line with the `customize_applications` and `customize_kwargs` methods that already exist).