### PR TITLE
Test out CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ branch-2.*, branch-3.*, main ]
+  pull_request:
+    branches: [ branch-2.*, branch-3.* ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
LGTM is shutting down soon:

https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

AFAICT the  replacement is more or less the [GitHub CodeQL action](https://github.com/github/codeql-action)

Need to figure out how to configure a more extensive set of queries that is closer to the full suite of LGTM queries. 

Will test this out, if it seems reasonable I will go ahead and remove LGTM related files in this same PR. 
