### PR TITLE
Test out codecov action

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -183,7 +183,13 @@ jobs:
           sampledata: 'cache'
 
       - name: Run tests
-        run: pytest -v --tb=short --driver chrome --color=yes tests/integration
+        run: pytest -v --cov=bokeh --cov-report=xml --tb=short --driver chrome --color=yes tests/integration
+
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v3
+        with:
+          flags: integration
+          verbose: true
 
   unit-test:
     needs: build
@@ -195,6 +201,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10']
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v2
@@ -210,7 +219,14 @@ jobs:
         run: if [[ ! "$(python --version | cut -d' ' -f2)" == "${{ matrix.python-version }}"* ]]; then exit 1; fi
 
       - name: Run tests
-        run: pytest --cov=bokeh --color=yes tests/unit
+        run: pytest --cov=bokeh --cov-report=xml --color=yes tests/unit
+
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: OS,PYTHON
+          flags: unit
+          verbose: true
 
   minimal-deps:
     needs: build
@@ -220,6 +236,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+    env:
+      OS: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -232,7 +250,14 @@ jobs:
           sampledata: 'none' # no sampledata for minimal tests
 
       - name: Run tests
-        run: pytest -m "not sampledata" --cov=bokeh --color=yes tests/unit
+        run: pytest -m "not sampledata" --cov=bokeh --cov-report=xml --color=yes tests/unit
+
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: OS
+          flags: unit,minimal
+          verbose: true
 
   documentation:
     needs: build

--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -14,7 +14,7 @@ defaults:
 jobs:
 
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check Maintainer

--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -14,7 +14,7 @@ defaults:
 jobs:
 
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check Maintainer

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # coverage reports
 /.coverage
+/coverage.xml
 
 # ipython files
 **/.ipynb_checkpoints


### PR DESCRIPTION
cc @bokeh/core This PR adds support for the GH codecov upload action and applies it to the Python unit and integration tests. You can see our repo reports at

https://app.codecov.io/gh/bokeh/bokeh

Additionally, codecov can add a comment to the top of PRs (AFAICT it adds a single comment and updates that as needed). There are plenty of options we can play with, but I am inclined to merge this PR as-is to see how it perfoms and then we can consider what if any tweaks we want to make. 

FYI @mattpap codecov can accept and merge reports for multiple languages, so we could potentially generate BokehJS coverage reports as well in the future. 
