### PR TITLE
Add package validation helper

### DIFF
--- a/src/bokeh/util/package.py
+++ b/src/bokeh/util/package.py
@@ -103,7 +103,7 @@ def validate(*, version: str | None = None, build_dir: str | None = None) -> lis
 
 # Support basic ``python -m bokeh.util.package <version> <build_dir>`` usage
 #
-# No serious arg parging, only intended for use in CI
+# No serious arg parsing, only intended for use in CI
 if __name__ == "__main__":
     import sys
     version = sys.argv[1] if len(sys.argv) >= 2 else None

--- a/src/bokeh/util/package.py
+++ b/src/bokeh/util/package.py
@@ -1,0 +1,114 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2022, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+""" This module is intended for use in  CI workflows to help with validating
+built sdist, wheel, and conda packages.
+
+"""
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations
+
+import logging # isort:skip
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import filecmp
+from pathlib import Path
+
+# Bokeh imports
+from .. import __version__, resources
+from .version import is_full_release
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = ('validate',)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+def validate(*, version: str | None = None, build_dir: str | None = None) -> list[str]:
+    """ Perform some basic package validation checks for the installed package.
+
+    Args:
+        version (str | None, optional) :
+            A version to compare against the package's reported version
+
+        build_dir (str | None, optional) :
+            A path to a JS build dir to make detailed BokehJS file comparisons
+
+    Returns:
+        list[str]
+            A list of all errors encountered
+
+    """
+    errors = []
+
+    if version is None:
+        # This can happen under certain circumstances
+        if __version__ == "0.0.0":
+            errors.append("Invalid version 0.0.0")
+    elif version != __version__:
+        errors.append(f"Version mismatch: given version ({version}) != package version ({__version__})")
+
+    if is_full_release(__version__) and __version__ != "0.0.0":
+        try:
+            resources.verify_sri_hashes()
+        except RuntimeError as e:
+            errors.append(f"SRI hashes for BokehJS files could not be verified: {e}")
+
+    r = resources.Resources(mode="absolute")
+    rmin = resources.Resources(mode="absolute", minified=True)
+    package_js_paths = r.js_files + rmin.js_files
+
+    for path in package_js_paths:
+        package_path = Path(path)
+        if not package_path.exists():
+            errors.append(f"missing BokehJS file: {path}")
+        elif package_path.stat().st_size == 0:
+            errors.append(f"Empty BokehJS file: {path}")
+        elif build_dir is not None:
+            build_path = Path(build_dir) / "js" / package_path.name
+            try:
+                if not filecmp.cmp(build_path, package_path):
+                    errors.append(f"BokehJS package file differs from build dir file: {package_path}")
+            except FileNotFoundError:
+                errors.append(f"missing build dir file: {build_path}")
+
+    return errors
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------
+
+# Support basic ``python -m bokeh.util.package <version> <build_dir>`` usage
+#
+# No serious arg parging, only intended for use in CI
+if __name__ == "__main__":
+    import sys
+    version = sys.argv[1] if len(sys.argv) >= 2 else None
+    build_dir = sys.argv[2] if len(sys.argv) >= 3 else None
+    errors = validate(version=version, build_dir=build_dir)
+    for error in errors:
+        print(error)
+    sys.exit(len(errors) != 0)

--- a/tests/unit/bokeh/util/test_package.py
+++ b/tests/unit/bokeh/util/test_package.py
@@ -73,8 +73,8 @@ def test_version_mismatch_full_no_given(mock_vsrih: MagicMock, monkeypatch: pyte
 
 def test_version_missing_build_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(bup, '__version__', "0.1.2.rc12")
-    errors = bup.validate(build_dir="/foo/bar")
-    assert any(err.startswith("missing build dir file: /foo/bar/js") for err in errors)
+    errors = bup.validate(build_dir="/foobuild")
+    assert any("foobuild" in err for err in errors)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/util/test_package.py
+++ b/tests/unit/bokeh/util/test_package.py
@@ -1,0 +1,89 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2022, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# External imports
+from mock import MagicMock, patch
+
+# Module under test
+import bokeh.util.package as bup # isort:skip
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+def test_zero_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bup, '__version__', "0.0.0")
+    errors = bup.validate()
+    assert "Invalid version 0.0.0" in errors
+
+    errors = bup.validate(version=None)
+    assert "Invalid version 0.0.0" in errors
+
+@pytest.mark.parametrize('v', ("1.2.3", "1.2.3.dev2", "1.4.5.rc3"))
+def test_version_mismatch_dev_with_given(v: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bup, '__version__', "0.1.2.dev12")
+    errors = bup.validate(version=v)
+    assert f"Version mismatch: given version ({v}) != package version ({bup.__version__})" in errors
+
+@pytest.mark.parametrize('v', ("1.2.3", "1.2.3.dev2", "1.4.5.rc3"))
+def test_version_mismatch_rc_with_given(v: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bup, '__version__', "0.1.2.rc12")
+    errors = bup.validate(version=v)
+    assert f"Version mismatch: given version ({v}) != package version ({bup.__version__})" in errors
+
+@pytest.mark.parametrize('v', ("1.2.3", "1.2.3.dev2", "1.4.5.rc3"))
+@patch('bokeh.resources.verify_sri_hashes')
+def test_version_mismatch_full_with_given(mock_vsrih: MagicMock, v: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bup, '__version__', "0.1.2")
+    errors = bup.validate(version=v)
+    assert f"Version mismatch: given version ({v}) != package version ({bup.__version__})" in errors
+
+def test_version_mismatch_dev_no_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bup, '__version__', "0.1.2.dev12")
+    bup.validate()
+
+def test_version_mismatch_rc_no_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bup, '__version__', "0.1.2.rc12")
+    bup.validate()
+
+@patch('bokeh.resources.verify_sri_hashes')
+def test_version_mismatch_full_no_given(mock_vsrih: MagicMock, monkeypatch: pytest.MonkeyPatch,) -> None:
+    monkeypatch.setattr(bup, '__version__', "0.1.2")
+    bup.validate()
+    assert mock_vsrih.called
+
+def test_version_missing_build_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bup, '__version__', "0.1.2.rc12")
+    errors = bup.validate(build_dir="/foo/bar")
+    assert any(err.startswith("missing build dir file: /foo/bar/js") for err in errors)
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a helper module `bokeh.util.package` that can assist with minimal baseline validation of built packages:

* check that the package reported version is good/as expected
* check that BokehJS files are present / as expected

I intend to use this in CI for the test and release build steps. I will install all three packages (sdist, wheel, and conda) into clean envs and run this validator on them. (I'll update the workflows separately in a later PR) 

cc @bokeh/core are there any other checks that would be good to add? 