### PR TITLE
Use proper setuptools command extensions

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Build conda package
         run: bash scripts/ci/build_conda_pacakge.sh
 
+      - name: Verify conda install
+        run: bash scripts/ci/verify_conda_install.sh
+
       - name: Upload conda package
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Verify pip install from sdist
         run: bash scripts/ci/verify_pip_install_from_sdist.sh
 
+      - name: Verify pip install using sdist
+        run: bash scripts/ci/verify_pip_install_using_sdist.sh
+
+      - name: Verify pip install using wheel
+        run: bash scripts/ci/verify_pip_install_using_wheel.sh
+
       - name: Build conda package
         run: bash scripts/ci/build_conda_pacakge.sh
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,3 @@
-# Top-level Config
-include CHANGELOG
-prune tests
-
 # Package files and data
 graft src/bokeh/core/_templates
 graft src/bokeh/sampledata/_data

--- a/scripts/ci/build_conda_pacakge.sh
+++ b/scripts/ci/build_conda_pacakge.sh
@@ -7,7 +7,7 @@ git status
 
 export VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
 conda build conda/recipe --no-test --no-anaconda-upload --no-verify
-pushd /usr/share/miniconda3/envs/bk-test
+pushd $CONDA_PREFIX
 tar cvzf conda-bld-noarch.tgz conda-bld/noarch
 popd
-mv /usr/share/miniconda3/envs/bk-test/conda-bld-noarch.tgz /tmp
+mv $CONDA_PREFIX/conda-bld-noarch.tgz /tmp

--- a/scripts/ci/verify_conda_install.sh
+++ b/scripts/ci/verify_conda_install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x #echo on
+set -e #exit on error
+
+export VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
+
+conda install --no-deps "$CONDA_PREFIX/conda-bld/noarch/bokeh-$VERSION-py_0.tar.bz2"
+conda list bokeh
+bokeh info
+python -m bokeh.util.package $VERSION bokehjs/build

--- a/scripts/ci/verify_pip_install_from_sdist.sh
+++ b/scripts/ci/verify_pip_install_from_sdist.sh
@@ -3,9 +3,12 @@
 set -x #echo on
 set -e #exit on error
 
+export VERSION="$(echo $(basename "$(ls dist/*.tar.gz)" .tar.gz) | cut -d- -f2)"
+
 pushd dist
-tar xvzf bokeh-*.tar.gz
-cd `ls -d */ | cut -f1 -d'/'`
+tar xvzf "bokeh-$VERSION.tar.gz"
+cd "bokeh-$VERSION"
 pip install .
-bokeh info
 popd
+bokeh info
+python -m bokeh.util.package $VERSION bokehjs/build

--- a/scripts/ci/verify_pip_install_using_sdist.sh
+++ b/scripts/ci/verify_pip_install_using_sdist.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x #echo on
+set -e #exit on error
+
+export VERSION="$(echo $(basename "$(ls dist/*.tar.gz)" .tar.gz) | cut -d- -f2)"
+
+pushd dist
+pip install "bokeh-$VERSION.tar.gz"
+popd
+bokeh info
+python -m bokeh.util.package $VERSION bokehjs/build

--- a/scripts/ci/verify_pip_install_using_wheel.sh
+++ b/scripts/ci/verify_pip_install_using_wheel.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x #echo on
+set -e #exit on error
+
+export VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
+
+pushd dist
+pip install "bokeh-$VERSION-py3-none-any.whl"
+popd
+bokeh info
+python -m bokeh.util.package $VERSION bokehjs/build

--- a/src/bokeh/util/package.py
+++ b/src/bokeh/util/package.py
@@ -87,6 +87,9 @@ def validate(*, version: str | None = None, build_dir: str | None = None) -> lis
             except FileNotFoundError:
                 errors.append(f"missing build dir file: {build_path}")
 
+    if not Path(__file__).parents[1].joinpath("py.typed").exists():
+        errors.append("py.typed is missing")
+
     return errors
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
I am not entirely sure what is different from previous attempts at using proper setuptools commands, but this seems to work in all the following cases:
```
python -m build .
pip install -v . --config-settings quiet=true
pip install -v . -e --config-settings quiet=true

BOKEHJS_ACTION=install python -m build .
BOKEHJS_ACTION=install pip install -v . --config-settings quiet=true
BOKEHJS_ACTION=install pip install -v . -e --config-settings quiet=true
```
Assuming this passes basic CI and good report, I will go on to add a basic package build validation steps based on #12337 

Edit: OK, well, clearly not passing basic CI. I would like to figure out what this discrepancy is, so I will keep poking at this a little longer. 