### PR TITLE
Consider undeprecating *on_click helpers

### DIFF
--- a/src/bokeh/models/widgets/buttons.py
+++ b/src/bokeh/models/widgets/buttons.py
@@ -39,7 +39,6 @@ from ...core.properties import (
     Tuple,
 )
 from ...events import ButtonClick, MenuItemClick
-from ...util.deprecation import deprecated
 from ..callbacks import Callback
 from ..ui.icons import BuiltinIcon, Icon
 from ..ui.tooltips import Tooltip
@@ -137,12 +136,10 @@ class Button(AbstractButton):
             None
 
         '''
-        deprecated((3, 0, 0), 'on_click(handler)', 'on_event("button_click", handler)')
         self.on_event(ButtonClick, handler)
 
     def js_on_click(self, handler: Callback) -> None:
         ''' Set up a JavaScript handler for button clicks. '''
-        deprecated((3, 0, 0), 'js_on_click(handler)', 'js_on_event("button_click", handler)')
         self.js_on_event(ButtonClick, handler)
 
 class Toggle(AbstractButton):
@@ -169,12 +166,10 @@ class Toggle(AbstractButton):
         Returns:
             None
         """
-        deprecated((3, 0, 0), 'on_click(handler)', 'on_event("button_click", handler)')
         self.on_change('active', lambda attr, old, new: handler(new))
 
     def js_on_click(self, handler: Callback) -> None:
         """ Set up a JavaScript handler for button state changes (clicks). """
-        deprecated((3, 0, 0), 'js_on_click(handler)', 'js_on_event("button_click", handler)')
         self.js_on_change('active', handler)
 
 class Dropdown(AbstractButton):
@@ -206,13 +201,11 @@ class Dropdown(AbstractButton):
             None
 
         '''
-        deprecated((3, 0, 0), 'on_click(handler)', 'on_event("button_click", handler) OR on_event("menu_item_click", handler)')
         self.on_event(ButtonClick, handler)
         self.on_event(MenuItemClick, handler)
 
     def js_on_click(self, handler: Callback) -> None:
         ''' Set up a JavaScript handler for button or menu item clicks. '''
-        deprecated((3, 0, 0), 'js_on_click(handler)', 'js_on_event("button_click", handler) OR js_on_event("menu_item_click", handler)')
         self.js_on_event(ButtonClick, handler)
         self.js_on_event(MenuItemClick, handler)
 


### PR DESCRIPTION
ref: https://github.com/bokeh/bokeh/discussions/12360

@mattpap this PR undeprecates the *\*on_click* for all of Button, Toggle, and Dropdown, but perhaps only Button is advised.