### PR TITLE
Add attribute suggestions for `figure(**kwargs)`

### DIFF
--- a/src/bokeh/core/properties.py
+++ b/src/bokeh/core/properties.py
@@ -151,6 +151,7 @@ Special Properties
 .. autoclass:: Nullable
 .. autoclass:: NonNullable
 .. autoclass:: NotSerialized
+.. autoclass:: Object
 .. autoclass:: Override
 .. autoclass:: Required
 
@@ -246,6 +247,7 @@ __all__ = (
     'NullStringSpec',
     'Nullable',
     'NumberSpec',
+    'Object',
     'Override',
     'PandasDataFrame',
     'PandasGroupBy',
@@ -336,10 +338,11 @@ from .property.enum import Enum; Enum
 from .property.factors import Factor; Factor
 from .property.factors import FactorSeq; FactorSeq
 
-from .property.include import Include ; Include
+from .property.include import Include; Include
 
 from .property.instance import Instance; Instance
 from .property.instance import InstanceDefault; InstanceDefault
+from .property.instance import Object; Object
 
 from .property.json import JSON; JSON
 

--- a/src/bokeh/core/property/alias.py
+++ b/src/bokeh/core/property/alias.py
@@ -67,7 +67,7 @@ class Alias(Property[T]): # lgtm [py/missing-call-to-init]
     """
 
     name: str
-    help: str | None
+    _help: str | None
 
     # Alias is somewhat a quasi-property
     readonly: ClassVar[bool] = False
@@ -76,7 +76,7 @@ class Alias(Property[T]): # lgtm [py/missing-call-to-init]
 
     def __init__(self, aliased_name: str, *, help: str | None = None) -> None:
         self.aliased_name = aliased_name
-        self.help = help
+        self._help = help
 
     def make_descriptors(self, base_name: str) -> list[PropertyDescriptor[T]]:
         """ Return a list of ``AliasPropertyDescriptor`` instances to

--- a/src/bokeh/core/property/bases.py
+++ b/src/bokeh/core/property/bases.py
@@ -105,7 +105,7 @@ class Property(PropertyDescriptorFactory[T]):
 
     _self_serialized: bool
 
-    alternatives: list[tuple[Property[Any], Callable[[Property[Any]], T]]]
+    alternatives: list[tuple[Property[Any], Callable[[Any], T]]]
     assertions: list[tuple[Callable[[HasProps, T], bool], str | Callable[[HasProps, str, T], None]]]
 
     def __init__(self, *, default: Init[T] = Intrinsic, help: str | None = None) -> None:
@@ -122,6 +122,14 @@ class Property(PropertyDescriptorFactory[T]):
 
         self.alternatives = []
         self.assertions = []
+
+    @property
+    def default(self) -> Init[T]:
+        return self._default
+
+    @property
+    def help(self) -> str | None:
+        return self._help
 
     def __str__(self) -> str:
         return self.__class__.__name__
@@ -380,7 +388,7 @@ class Property(PropertyDescriptorFactory[T]):
     def has_ref(self) -> bool:
         return False
 
-    def accepts(self, tp: TypeOrInst[Property[Any]], converter: Callable[[Property[Any]], T]) -> Property[T]:
+    def accepts(self, tp: TypeOrInst[Property[Any]], converter: Callable[[Any], T]) -> Property[T]:
         """ Declare that other types may be converted to this property type.
 
         Args:
@@ -437,6 +445,19 @@ class ParameterizedProperty(Property[T]):
 
     """
 
+    _type_params: list[Property[Any]]
+
+    def __init__(self, *type_params: TypeOrInst[Property[T]], default: Init[T] = Intrinsic, help: str | None = None) -> None:
+        _type_params = [ self._validate_type_param(param) for param in type_params ]
+        default = default if default is not Intrinsic else _type_params[0]._raw_default()
+        self._type_params = _type_params
+        super().__init__(default=default, help=help)
+
+    def __str__(self) -> str:
+        class_name = self.__class__.__name__
+        item_types = ", ".join(str(x) for x in self.type_params)
+        return f"{class_name}({item_types})"
+
     def __call__(self, *, default: Init[T] = Intrinsic, help: str | None = None) -> ParameterizedProperty[T]:
         """ Clone this property and allow to override ``default`` and ``help``. """
         default = self._default if default is Intrinsic else default
@@ -469,7 +490,7 @@ class ParameterizedProperty(Property[T]):
 
     @property
     def type_params(self) -> list[Property[Any]]:
-        raise NotImplementedError("abstract method")
+        return self._type_params
 
     @property
     def has_ref(self) -> bool:
@@ -485,17 +506,12 @@ class ParameterizedProperty(Property[T]):
 class SingleParameterizedProperty(ParameterizedProperty[T]):
     """ A parameterized property with a single type parameter. """
 
-    def __init__(self, type_param: TypeOrInst[Property[Any]], *, default: Init[T] = Intrinsic, help: str | None = None):
-        self.type_param = self._validate_type_param(type_param)
-        default = default if default is not Intrinsic else self.type_param._raw_default()
-        super().__init__(default=default, help=help)
-
     @property
-    def type_params(self) -> list[Property[Any]]:
-        return [self.type_param]
+    def type_param(self) -> Property[T]:
+        return self._type_params[0]
 
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}({self.type_param})"
+    def __init__(self, type_param: TypeOrInst[Property[Any]], *, default: Init[T] = Intrinsic, help: str | None = None):
+        super().__init__(type_param, default=default, help=help)
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail=detail)

--- a/src/bokeh/core/property/struct.py
+++ b/src/bokeh/core/property/struct.py
@@ -46,12 +46,13 @@ class Optional(Generic[T]):
     def __init__(self, type_param: Property[T]):
         self.type_param = type_param
 
-class Struct(ParameterizedProperty):
+class Struct(ParameterizedProperty[T]):
     """ Accept values that are structures.
 
 
     """
 
+    _fields: dict[str, Property[Any]]
     _optional: set[str]
 
     def __init__(self, **fields) -> None:
@@ -69,6 +70,12 @@ class Struct(ParameterizedProperty):
             self._fields[name] = self._validate_type_param(type, help_allowed=True) # XXX
 
         super().__init__(default=default, help=help)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return super().__eq__(other) and self._fields == other._fields and self._optional == other._optional
+        else:
+            return False
 
     @property
     def type_params(self):

--- a/src/bokeh/core/property/text_like.py
+++ b/src/bokeh/core/property/text_like.py
@@ -25,10 +25,10 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 # Bokeh imports
-from .bases import Init, Property
+from .bases import Init
 from .either import Either
 from .instance import Instance
 from .singletons import Intrinsic
@@ -55,8 +55,7 @@ class TextLike(Either):
     """
 
     def __init__(self, default: Init[str | BaseText] = Intrinsic, help: str | None = None) -> None:
-        types: list[Property[Any]] = [MathString(), Instance("bokeh.models.text.BaseText")]
-        super().__init__(*types, default=default, help=help)
+        super().__init__(MathString(), Instance("bokeh.models.text.BaseText"), default=default, help=help)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -47,8 +47,7 @@ from ..core.properties import (
     InstanceDefault,
     Int,
     Nullable,
-    PandasDataFrame,
-    PandasGroupBy,
+    Object,
     Readonly,
     Required,
     Seq,
@@ -205,9 +204,9 @@ class ColumnDataSource(ColumnarDataSource):
     objects. In these cases, the behaviour is identical to passing the objects
     to the ``ColumnDataSource`` initializer.
     """).accepts(
-        PandasDataFrame, lambda x: ColumnDataSource._data_from_df(x)
+        Object("pandas.DataFrame"), lambda x: ColumnDataSource._data_from_df(x)
     ).accepts(
-        PandasGroupBy, lambda x: ColumnDataSource._data_from_groupby(x)
+        Object("pandas.core.groupby.GroupBy"), lambda x: ColumnDataSource._data_from_groupby(x)
     ).asserts(lambda _, data: len({len(x) for x in data.values()}) <= 1,
                  lambda obj, name, data: warnings.warn(
                     "ColumnDataSource's columns must be of the same length. " +

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -544,7 +544,7 @@ class ColumnDataSource(ColumnarDataSource):
 
         if needs_length_check:
             lengths: set[int] = set()
-            arr_types = (np.ndarray, pd.Series) if pd else np.ndarray
+            arr_types = (np.ndarray, pd.Series)
             for _, x in new_data.items():
                 if isinstance(x, arr_types):
                     if len(x.shape) != 1:

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -174,6 +174,12 @@ class figure(Plot, GlyphAPI):
 
     def __init__(self, *arg, **kw) -> None:
         opts = FigureOptions(kw)
+
+        names = self.properties()
+        for name in kw.keys():
+            if name not in names:
+                self._raise_attribute_error_with_matches(name, names | opts.properties())
+
         super().__init__(*arg, **kw)
 
         self.x_range = get_range(opts.x_range)

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -25,6 +25,7 @@ from numpy.typing import ArrayLike
 from ..core.enums import HorizontalLocation, MarkerType, VerticalLocation
 from ..core.properties import (
     Auto,
+    Datetime,
     Either,
     Enum,
     Float,
@@ -37,6 +38,7 @@ from ..core.properties import (
     Seq,
     String,
     TextLike,
+    TimeDelta,
     Tuple,
 )
 from ..models import (
@@ -792,23 +794,35 @@ class BaseFigureOptions(Options):
     and added.
     """)
 
+RangeLike = Either(
+    Instance(Range),
+    Either(
+        Tuple(Float, Float),
+        Tuple(Datetime, Datetime),
+        Tuple(TimeDelta, TimeDelta),
+    ),
+    Seq(String),
+    Object("pandas.Series"),
+    Object("pandas.core.groupby.GroupBy"),
+)
+
+AxisType = Nullable(Either(Auto, Enum("linear", "log", "datetime", "mercator")))
+
 class FigureOptions(BaseFigureOptions):
 
-    x_range = Either(Instance(Range), Tuple(Float, Float), Seq(String),
-        Object("pandas.Series"), Object("pandas.core.groupby.GroupBy"), default=InstanceDefault(DataRange1d), help="""
+    x_range = RangeLike(default=InstanceDefault(DataRange1d), help="""
     Customize the x-range of the plot.
     """)
 
-    y_range = Either(Instance(Range), Tuple(Float, Float), Seq(String),
-        Object("pandas.Series"), Object("pandas.core.groupby.GroupBy"), default=InstanceDefault(DataRange1d), help="""
+    y_range = RangeLike(default=InstanceDefault(DataRange1d), help="""
     Customize the y-range of the plot.
     """)
 
-    x_axis_type = Nullable(Either(Auto, Enum("linear", "log", "datetime", "mercator")), default="auto", help="""
+    x_axis_type = AxisType(default="auto", help="""
     The type of the x-axis.
     """)
 
-    y_axis_type = Nullable(Either(Auto, Enum("linear", "log", "datetime", "mercator")), default="auto", help="""
+    y_axis_type = AxisType(default="auto", help="""
     The type of the y-axis.
     """)
 

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -794,11 +794,13 @@ class BaseFigureOptions(Options):
 
 class FigureOptions(BaseFigureOptions):
 
-    x_range = Either(Instance(Range), Tuple(Float, Float), Seq(String), Instance("pandas.Series"), default=InstanceDefault(DataRange1d), help="""
+    x_range = Either(Instance(Range), Tuple(Float, Float), Seq(String),
+        Object("pandas.Series"), Object("pandas.core.groupby.GroupBy"), default=InstanceDefault(DataRange1d), help="""
     Customize the x-range of the plot.
     """)
 
-    y_range = Either(Instance(Range), Tuple(Float, Float), Seq(String), Instance("pandas.Series"), default=InstanceDefault(DataRange1d), help="""
+    y_range = Either(Instance(Range), Tuple(Float, Float), Seq(String),
+        Object("pandas.Series"), Object("pandas.core.groupby.GroupBy"), default=InstanceDefault(DataRange1d), help="""
     Customize the y-range of the plot.
     """)
 

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -24,14 +24,14 @@ from numpy.typing import ArrayLike
 # Bokeh imports
 from ..core.enums import HorizontalLocation, MarkerType, VerticalLocation
 from ..core.properties import (
-    Any,
     Auto,
     Either,
     Enum,
+    Float,
     Instance,
+    InstanceDefault,
     Int,
     List,
-    Null,
     Nullable,
     Seq,
     String,
@@ -41,6 +41,7 @@ from ..core.properties import (
 from ..models import (
     ColumnDataSource,
     CoordinateMapping,
+    DataRange1d,
     GraphRenderer,
     Plot,
     Range,
@@ -755,27 +756,27 @@ class BaseFigureOptions(Options):
     A label for the y-axis.
     """)
 
-    active_drag = Either(Null, Auto, String, Instance(Drag), default="auto", help="""
+    active_drag = Nullable(Either(Auto, String, Instance(Drag)), default="auto", help="""
     Which drag tool should initially be active.
     """)
 
-    active_inspect = Either(Null, Auto, String, Instance(InspectTool), Seq(Instance(InspectTool)), default="auto", help="""
+    active_inspect = Nullable(Either(Auto, String, Instance(InspectTool), Seq(Instance(InspectTool))), default="auto", help="""
     Which drag tool should initially be active.
     """)
 
-    active_scroll = Either(Null, Auto, String, Instance(Scroll), default="auto", help="""
+    active_scroll = Nullable(Either(Auto, String, Instance(Scroll)), default="auto", help="""
     Which scroll tool should initially be active.
     """)
 
-    active_tap = Either(Null, Auto, String, Instance(Tap), default="auto", help="""
+    active_tap = Nullable(Either(Auto, String, Instance(Tap)), default="auto", help="""
     Which tap tool should initially be active.
     """)
 
-    active_multi = Either(Null, Auto, String, Instance(GestureTool), default="auto", help="""
+    active_multi = Nullable(Either(Auto, String, Instance(GestureTool)), default="auto", help="""
     Specify an active multi-gesture tool, for instance an edit tool or a range tool.
     """)
 
-    tooltips = Either(Null, Instance(Template), String, List(Tuple(String, String)), help="""
+    tooltips = Nullable(Either(Instance(Template), String, List(Tuple(String, String))), help="""
     An optional argument to configure tooltips for the Figure. This argument
     accepts the same values as the ``HoverTool.tooltips`` property. If a hover
     tool is specified in the ``tools`` argument, this value will override that
@@ -786,19 +787,19 @@ class BaseFigureOptions(Options):
 
 class FigureOptions(BaseFigureOptions):
 
-    x_range = Any(help="""
+    x_range = Either(Instance(Range), Tuple(Float, Float), Seq(String), Instance("pandas.Series"), default=InstanceDefault(DataRange1d), help="""
     Customize the x-range of the plot.
     """)
 
-    y_range = Any(help="""
+    y_range = Either(Instance(Range), Tuple(Float, Float), Seq(String), Instance("pandas.Series"), default=InstanceDefault(DataRange1d), help="""
     Customize the y-range of the plot.
     """)
 
-    x_axis_type = Either(Null, Auto, Enum("linear", "log", "datetime", "mercator"), default="auto", help="""
+    x_axis_type = Nullable(Either(Auto, Enum("linear", "log", "datetime", "mercator")), default="auto", help="""
     The type of the x-axis.
     """)
 
-    y_axis_type = Either(Null, Auto, Enum("linear", "log", "datetime", "mercator"), default="auto", help="""
+    y_axis_type = Nullable(Either(Auto, Enum("linear", "log", "datetime", "mercator")), default="auto", help="""
     The type of the y-axis.
     """)
 

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -33,6 +33,7 @@ from ..core.properties import (
     Int,
     List,
     Nullable,
+    Object,
     Seq,
     String,
     TextLike,

--- a/src/bokeh/plotting/_plot.py
+++ b/src/bokeh/plotting/_plot.py
@@ -70,7 +70,7 @@ def get_range(range_input):
         return FactorRange(factors=sorted(list(range_input.groups.keys())))
     if isinstance(range_input, Range):
         return range_input
-    if pd and isinstance(range_input, pd.Series):
+    if isinstance(range_input, pd.Series):
         range_input = range_input.values
     if isinstance(range_input, (Sequence, np.ndarray)):
         if all(isinstance(x, str) for x in range_input):

--- a/src/bokeh/plotting/_plot.py
+++ b/src/bokeh/plotting/_plot.py
@@ -19,14 +19,25 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from collections.abc import Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Type,
+)
 
 # External imports
 import numpy as np
+from typing_extensions import TypeAlias
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 # Bokeh imports
 from ..core.properties import Datetime
 from ..core.property.singletons import Intrinsic
 from ..models import (
+    Axis,
     CategoricalAxis,
     CategoricalScale,
     ContinuousTicker,
@@ -41,7 +52,12 @@ from ..models import (
     MercatorAxis,
     Range,
     Range1d,
+    Scale,
 )
+
+if TYPE_CHECKING:
+    from ..models.plots import Plot
+    from ..models.text import BaseText
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -61,7 +77,7 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-def get_range(range_input):
+def get_range(range_input: Range | tuple[float, float] | Sequence[str] | pd.Series[Any] | None) -> Range:
     import pandas as pd
 
     if range_input is None:
@@ -85,9 +101,13 @@ def get_range(range_input):
                 return Range1d(start=start, end=end)
             except ValueError:  # @mattpap suggests ValidationError instead
                 pass
-    raise ValueError("Unrecognized range input: '%s'" % str(range_input))
+    raise ValueError(f"Unrecognized range input: '{range_input}'")
 
-def get_scale(range_input, axis_type):
+AxisType: TypeAlias = Literal["linear", "log", "datetime", "mercator", "auto"]
+AxisLocation: TypeAlias = Literal["above", "below", "left", "right"]
+Dim: TypeAlias = Literal[0, 1]
+
+def get_scale(range_input: Range, axis_type: AxisType | None) -> Scale:
     if isinstance(range_input, (DataRange1d, Range1d)) and axis_type in ["linear", "datetime", "mercator", "auto", None]:
         return LinearScale()
     elif isinstance(range_input, (DataRange1d, Range1d)) and axis_type == "log":
@@ -95,9 +115,10 @@ def get_scale(range_input, axis_type):
     elif isinstance(range_input, FactorRange):
         return CategoricalScale()
     else:
-        raise ValueError("Unable to determine proper scale for: '%s'" % str(range_input))
+        raise ValueError(f"Unable to determine proper scale for: '{range_input}'")
 
-def process_axis_and_grid(plot, axis_type, axis_location, minor_ticks, axis_label, rng, dim):
+def process_axis_and_grid(plot: Plot, axis_type: AxisType | None, axis_location: AxisLocation | None,
+        minor_ticks: int | Literal["auto"] | None, axis_label: str | BaseText | None, rng: Range, dim: Dim) -> None:
     axiscls, axiskw = _get_axis_class(axis_type, rng, dim)
 
     if axiscls:
@@ -119,7 +140,7 @@ def process_axis_and_grid(plot, axis_type, axis_location, minor_ticks, axis_labe
 # Private API
 #-----------------------------------------------------------------------------
 
-def _get_axis_class(axis_type, range_input, dim):
+def _get_axis_class(axis_type: AxisType | None, range_input: Range, dim: Dim) -> tuple[Type[Axis] | None, Any]:
     if axis_type is None:
         return None, {}
     elif axis_type == "linear":
@@ -129,7 +150,7 @@ def _get_axis_class(axis_type, range_input, dim):
     elif axis_type == "datetime":
         return DatetimeAxis, {}
     elif axis_type == "mercator":
-        return MercatorAxis, {'dimension': 'lon' if dim == 0 else 'lat'}
+        return MercatorAxis, dict(dimension='lon' if dim == 0 else 'lat')
     elif axis_type == "auto":
         if isinstance(range_input, FactorRange):
             return CategoricalAxis, {}
@@ -146,9 +167,9 @@ def _get_axis_class(axis_type, range_input, dim):
                 pass
         return LinearAxis, {}
     else:
-        raise ValueError("Unrecognized axis_type: '%r'" % axis_type)
+        raise ValueError(f"Unrecognized axis_type: '{axis_type!r}'")
 
-def _get_num_minor_ticks(axis_class, num_minor_ticks):
+def _get_num_minor_ticks(axis_class: Type[Axis], num_minor_ticks: int | Literal["auto"] | None) -> int:
     if isinstance(num_minor_ticks, int):
         if num_minor_ticks <= 1:
             raise ValueError("num_minor_ticks must be > 1")

--- a/src/bokeh/plotting/_plot.py
+++ b/src/bokeh/plotting/_plot.py
@@ -32,6 +32,7 @@ from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     import pandas as pd
+    from pandas.core.groupby import GroupBy
 
 # Bokeh imports
 from ..core.properties import Datetime
@@ -77,12 +78,13 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-def get_range(range_input: Range | tuple[float, float] | Sequence[str] | pd.Series[Any] | None) -> Range:
+def get_range(range_input: Range | tuple[float, float] | Sequence[str] | pd.Series[Any] | GroupBy | None) -> Range:
     import pandas as pd
+    from pandas.core.groupby import GroupBy
 
     if range_input is None:
         return DataRange1d()
-    if isinstance(range_input, pd.core.groupby.GroupBy):
+    if isinstance(range_input, GroupBy):
         return FactorRange(factors=sorted(list(range_input.groups.keys())))
     if isinstance(range_input, Range):
         return range_input

--- a/tests/unit/bokeh/core/property/test_container.py
+++ b/tests/unit/bokeh/core/property/test_container.py
@@ -296,19 +296,33 @@ class Test_Seq:
 
 
 class Test_Tuple:
-    def test_Tuple(self) -> None:
-        with pytest.raises(TypeError):
-            bcpc.Tuple()
-
-        with pytest.raises(TypeError):
-            bcpc.Tuple(Int)
 
     def test_valid(self) -> None:
+        prop0 = bcpc.Tuple()
+        assert prop0.is_valid(())
+
+        prop1 = bcpc.Tuple(Int)
+        assert prop1.is_valid((0,))
+
+        prop2 = bcpc.Tuple(Int, Int)
+        assert prop2.is_valid((0, 0))
+
         prop = bcpc.Tuple(Int, String, bcpc.List(Int))
 
         assert prop.is_valid((1, "", [1, 2, 3]))
 
     def test_invalid(self) -> None:
+        prop0 = bcpc.Tuple()
+        assert not prop0.is_valid((0,))
+
+        prop1 = bcpc.Tuple(Int)
+        assert not prop1.is_valid(())
+        assert not prop1.is_valid((0, 0))
+
+        prop2 = bcpc.Tuple(Int, Int)
+        assert not prop2.is_valid(())
+        assert not prop2.is_valid((0,))
+
         prop = bcpc.Tuple(Int, String, bcpc.List(Int))
 
         assert not prop.is_valid(None)

--- a/tests/unit/bokeh/core/property/test_either.py
+++ b/tests/unit/bokeh/core/property/test_either.py
@@ -49,7 +49,7 @@ ALL = (
 class Test_Either:
     def test_init(self) -> None:
         with pytest.raises(TypeError):
-            bcpe.Either()
+            bcpe.Either() # type: ignore
 
     def test_valid(self) -> None:
         prop = bcpe.Either(Interval(Int, 0, 100), Regex("^x*$"), List(Int))

--- a/tests/unit/bokeh/core/property/test_instance.py
+++ b/tests/unit/bokeh/core/property/test_instance.py
@@ -16,6 +16,10 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# External imports
+from pandas import DataFrame, Series
+from pandas.core.groupby import GroupBy
+
 # Bokeh imports
 from bokeh.core.has_props import HasProps
 from tests.support.util.api import verify_all
@@ -32,6 +36,7 @@ import bokeh.core.property.instance as bcpi # isort:skip
 ALL = (
     'Instance',
     'InstanceDefault',
+    'Object',
 )
 
 #-----------------------------------------------------------------------------
@@ -59,6 +64,64 @@ class Test_InstanceDefault:
     def test___repr__(self) -> None:
         m = bcpi.InstanceDefault(_TestModel, x=10, z=[10])
         assert repr(m) == "<Instance: _util_property._TestModel(x=10, z=[10])>"
+
+class Test_Object:
+
+    def test_valid(self) -> None:
+        prop0 = bcpi.Object(Series)
+        assert prop0.is_valid(Series([1, 2, 3]))
+        prop1 = bcpi.Object("pandas.Series")
+        assert prop1.is_valid(Series([1, 2, 3]))
+
+        prop2 = bcpi.Object(DataFrame)
+        assert prop2.is_valid(DataFrame())
+        prop3 = bcpi.Object("pandas.DataFrame")
+        assert prop3.is_valid(DataFrame())
+
+        prop4 = bcpi.Object(GroupBy)
+        assert prop4.is_valid(GroupBy(DataFrame()))
+        prop5 = bcpi.Object("pandas.core.groupby.GroupBy")
+        assert prop5.is_valid(GroupBy(DataFrame()))
+
+    def test_invalid(self) -> None:
+        prop0 = bcpi.Object(Series)
+        assert not prop0.is_valid(DataFrame())
+        assert not prop0.is_valid(GroupBy(DataFrame()))
+        assert not prop0.is_valid({})
+        assert not prop0.is_valid(object())
+        assert not prop0.is_valid(_TestModel())
+        prop1 = bcpi.Object("pandas.Series")
+        assert not prop1.is_valid(DataFrame())
+        assert not prop1.is_valid(GroupBy(DataFrame()))
+        assert not prop1.is_valid({})
+        assert not prop1.is_valid(object())
+        assert not prop1.is_valid(_TestModel())
+
+        prop2 = bcpi.Object(DataFrame)
+        assert not prop2.is_valid(Series([1, 2, 3]))
+        assert not prop2.is_valid(GroupBy(DataFrame()))
+        assert not prop2.is_valid({})
+        assert not prop2.is_valid(object())
+        assert not prop2.is_valid(_TestModel())
+        prop3 = bcpi.Object("pandas.DataFrame")
+        assert not prop3.is_valid(Series([1, 2, 3]))
+        assert not prop3.is_valid(GroupBy(DataFrame()))
+        assert not prop3.is_valid({})
+        assert not prop3.is_valid(object())
+        assert not prop3.is_valid(_TestModel())
+
+        prop4 = bcpi.Object(GroupBy)
+        assert not prop4.is_valid(Series([1, 2, 3]))
+        assert not prop4.is_valid(DataFrame())
+        assert not prop4.is_valid({})
+        assert not prop4.is_valid(object())
+        assert not prop4.is_valid(_TestModel())
+        prop5 = bcpi.Object("pandas.core.groupby.GroupBy")
+        assert not prop5.is_valid(Series([1, 2, 3]))
+        assert not prop5.is_valid(DataFrame())
+        assert not prop5.is_valid({})
+        assert not prop5.is_valid(object())
+        assert not prop5.is_valid(_TestModel())
 
 class Test_Instance:
     def test_init(self) -> None:
@@ -93,6 +156,7 @@ class Test_Instance:
         assert not prop.is_valid({})
         assert not prop.is_valid(_TestModel2())
         assert not prop.is_valid(_TestHasProps())
+        assert not prop.is_valid(object())
 
     def test_has_ref(self) -> None:
         prop = bcpi.Instance(_TestModel)

--- a/tests/unit/bokeh/core/property/test_nullable.py
+++ b/tests/unit/bokeh/core/property/test_nullable.py
@@ -18,6 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 import warnings
+from typing import TYPE_CHECKING, Union
 
 # Bokeh imports
 from bokeh.core.properties import (
@@ -32,6 +33,9 @@ from bokeh.util.warnings import BokehDeprecationWarning
 from tests.support.util.api import verify_all
 
 from _util_property import _TestHasProps, _TestModel
+
+if TYPE_CHECKING:
+    from bokeh.core.has_props import HasProps
 
 # Module under test
 import bokeh.core.property.nullable as bcpn # isort:skip
@@ -58,6 +62,93 @@ class Test_Nullable:
 
         prop0 = bcpn.Nullable(Int(), help="help")
         assert prop0._help == prop0.__doc__ == "help"
+
+    def test_eq(self) -> None:
+        assert (bcpn.Nullable(Int) == Union[int, None]) is False
+
+        assert (bcpn.Nullable(Int) == bcpn.Nullable(Int)) is True
+        assert (bcpn.Nullable(Int()) == bcpn.Nullable(Int)) is True
+        assert (bcpn.Nullable(Int) == bcpn.Nullable(Int())) is True
+        assert (bcpn.Nullable(Int()) == bcpn.Nullable(Int())) is True
+
+        assert (bcpn.Nullable(Int(0)) == bcpn.Nullable(Int())) is True
+        assert (bcpn.Nullable(Int()) == bcpn.Nullable(Int(0))) is True
+        assert (bcpn.Nullable(Int(0)) == bcpn.Nullable(Int(0))) is True
+
+        assert (bcpn.Nullable(Int(1)) == bcpn.Nullable(Int(0))) is False
+        assert (bcpn.Nullable(Int(0)) == bcpn.Nullable(Int(1))) is False
+        assert (bcpn.Nullable(Int(1)) == bcpn.Nullable(Int(1))) is True
+
+        assert (bcpn.Nullable(Int, help="helpful") == bcpn.Nullable(Int)) is False
+        assert (bcpn.Nullable(Int) == bcpn.Nullable(Int, help="helpful")) is False
+        assert (bcpn.Nullable(Int, help="helpful") == bcpn.Nullable(Int, help="helpful")) is True
+
+        assert (bcpn.Nullable(Int, default=10) == bcpn.Nullable(Int)) is False
+        assert (bcpn.Nullable(Int) == bcpn.Nullable(Int, default=10)) is False
+        assert (bcpn.Nullable(Int, default=10) == bcpn.Nullable(Int, default=10)) is True
+
+        def f(s: str) -> int:
+            return int(s)
+
+        assert (bcpn.Nullable(Int).accepts(String, f) == bcpn.Nullable(Int)) is False
+        assert (bcpn.Nullable(Int) == bcpn.Nullable(Int).accepts(String, f)) is False
+        assert (bcpn.Nullable(Int).accepts(String, f) == bcpn.Nullable(Int).accepts(String, f)) is True
+
+        def g(_o: HasProps, v: int | None) -> bool:
+            return v is not None and v >= 0
+
+        assert (bcpn.Nullable(Int).asserts(g, ">= 0") == bcpn.Nullable(Int)) is False
+        assert (bcpn.Nullable(Int) == bcpn.Nullable(Int).asserts(g, ">= 0")) is False
+        assert (bcpn.Nullable(Int).asserts(g, ">= 0") == bcpn.Nullable(Int).asserts(g, ">= 0")) is True
+
+    def test_clone(self) -> None:
+        p0 = bcpn.Nullable(Int)
+        c0 = p0()
+
+        assert c0.default is None
+        assert c0.help is None
+        assert c0.alternatives == []
+        assert c0.assertions == []
+
+        assert p0 is not c0
+        assert p0 == c0
+        assert c0.type_params == p0.type_params
+
+        p1 = bcpn.Nullable(Int, default=10, help="helpful")
+        c1 = p1()
+
+        assert c1.default == 10
+        assert c1.help == "helpful"
+        assert c1.alternatives == []
+        assert c1.assertions == []
+
+        assert p1 is not c1
+        assert p1 == c1
+        assert c1.type_params == p1.type_params
+
+        p2 = bcpn.Nullable(Int)
+        c2 = p2(default=20, help="helpful")
+
+        assert c2.default == 20
+        assert c2.help == "helpful"
+        assert c2.alternatives == []
+        assert c2.assertions == []
+
+        assert p2 is not c2
+        assert p2 != c2
+        assert c2.type_params == p2.type_params
+
+        p3 = bcpn.Nullable(Int, default=10, help="helpful")
+        c3 = p3(default=20, help="unhelpful")
+
+        assert c3.default == 20
+        assert c3.help == "unhelpful"
+        assert c3.alternatives == []
+        assert c3.assertions == []
+
+        assert p3 is not c3
+        assert p3 != c3
+        assert c3.type_params == p3.type_params
 
     def test_valid(self) -> None:
         prop = bcpn.Nullable(List(Int))

--- a/tests/unit/bokeh/core/property/test_primitive.py
+++ b/tests/unit/bokeh/core/property/test_primitive.py
@@ -16,6 +16,9 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import TYPE_CHECKING
+
 # External imports
 import numpy as np
 
@@ -23,6 +26,9 @@ import numpy as np
 from tests.support.util.api import verify_all
 
 from _util_property import _TestHasProps, _TestModel
+
+if TYPE_CHECKING:
+    from bokeh.core.has_props import HasProps
 
 # Module under test
 import bokeh.core.property.primitive as bcpp # isort:skip
@@ -47,6 +53,7 @@ ALL = (
 
 
 class Test_Bool:
+
     def test_valid(self) -> None:
         prop = bcpp.Bool()
 
@@ -237,6 +244,80 @@ class Test_Float:
 
 
 class Test_Int:
+
+    def test_eq(self) -> None:
+        assert (bcpp.Int() == int) is False
+
+        assert (bcpp.Int() == bcpp.Int()) is True
+        assert (bcpp.Int(default=0) == bcpp.Int()) is True
+
+        assert (bcpp.Int(default=1) == bcpp.Int()) is False
+        assert (bcpp.Int() == bcpp.Int(default=1)) is False
+        assert (bcpp.Int(default=1) == bcpp.Int(default=1)) is True
+
+        assert (bcpp.Int(help="heplful") == bcpp.Int()) is False
+        assert (bcpp.Int() == bcpp.Int(help="heplful")) is False
+        assert (bcpp.Int(help="heplful") == bcpp.Int(help="heplful")) is True
+
+        def f(s: str) -> int:
+            return int(s)
+
+        assert (bcpp.Int().accepts(bcpp.String, f) == bcpp.Int()) is False
+        assert (bcpp.Int() == bcpp.Int().accepts(bcpp.String, f)) is False
+        assert (bcpp.Int().accepts(bcpp.String, f) == bcpp.Int().accepts(bcpp.String, f)) is True
+
+        def g(_o: HasProps, v: int) -> bool:
+            return v >= 0
+
+        assert (bcpp.Int().asserts(g, ">= 0") == bcpp.Int()) is False
+        assert (bcpp.Int() == bcpp.Int().asserts(g, ">= 0")) is False
+        assert (bcpp.Int().asserts(g, ">= 0") == bcpp.Int().asserts(g, ">= 0")) is True
+
+    def test_clone(self) -> None:
+        p0 = bcpp.Int()
+        c0 = p0()
+
+        assert c0.default == 0
+        assert c0.help is None
+        assert c0.alternatives == []
+        assert c0.assertions == []
+
+        assert p0 is not c0
+        assert p0 == c0
+
+        p1 = bcpp.Int(default=10, help="helpful")
+        c1 = p1()
+
+        assert c1.default == 10
+        assert c1.help == "helpful"
+        assert c1.alternatives == []
+        assert c1.assertions == []
+
+        assert p1 is not c1
+        assert p1 == c1
+
+        p2 = bcpp.Int()
+        c2 = p2(default=20, help="helpful")
+
+        assert c2.default == 20
+        assert c2.help == "helpful"
+        assert c2.alternatives == []
+        assert c2.assertions == []
+
+        assert p2 is not c2
+        assert p2 != c2
+
+        p3 = bcpp.Int(default=10, help="helpful")
+        c3 = p3(default=20, help="unhelpful")
+
+        assert c3.default == 20
+        assert c3.help == "unhelpful"
+        assert c3.alternatives == []
+        assert c3.assertions == []
+
+        assert p3 is not c3
+        assert p3 != c3
+
     def test_valid(self) -> None:
         prop = bcpp.Int()
 

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -101,6 +101,7 @@ ALL = (
     'NullStringSpec',
     'Nullable',
     'NumberSpec',
+    'Object',
     'Override',
     'PandasDataFrame',
     'PandasGroupBy',

--- a/tests/unit/bokeh/plotting/test_figure.py
+++ b/tests/unit/bokeh/plotting/test_figure.py
@@ -52,7 +52,18 @@ from bokeh.plotting import _figure as bpf # isort:skip
 #-----------------------------------------------------------------------------
 
 
-class Testfigure:
+class Test_figure:
+
+    def test_init(self) -> None:
+        f0 = bpf.figure(x_axis_type="linear")
+        assert isinstance(f0, bpf.figure)
+
+        with pytest.raises(ValueError, match="linear"): # TODO: ValidationError
+            bpf.figure(x_axis_type="lnear")
+
+        with pytest.raises(AttributeError, match="x_axis_type"):
+            bpf.figure(x_axis_typ="linear")
+
     def test_basic(self) -> None:
         p = bpf.figure()
         q = bpf.figure()


### PR DESCRIPTION
```py
In [1]: from bokeh.plotting import figure

In [2]: figure(x_axis_typ="linear")
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 figure(x_axis_typ="linear")

File ~/repo/bokeh/src/bokeh/plotting/_figure.py:181, in figure.__init__(self, *arg, **kw)
    179 for name in kw.keys():
    180     if name not in names:
--> 181         self._raise_attribute_error_with_matches(name, names | opts.properties())
    183 super().__init__(*arg, **kw)
    185 self.x_range = get_range(opts.x_range)

File ~/repo/bokeh/src/bokeh/core/has_props.py:339, in HasProps._raise_attribute_error_with_matches(self, name, properties)
    336 if not matches:
    337     matches, text = sorted(properties), "possible"
--> 339 raise AttributeError(f"unexpected attribute {name!r} to {self.__class__.__name__}, {text} attributes are {nice_join(matches)}")

AttributeError: unexpected attribute 'x_axis_typ' to figure, similar attributes are x_axis_type, y_axis_type or x_axis_location
```

fixes #5241