### PR TITLE
Pin pydata sphinx theme version

### DIFF
--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -34,7 +34,7 @@ dependencies:
   - pip:
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme >=0.9
+    - pydata_sphinx_theme ==0.9
     - sphinx >5.1
     - sphinx-copybutton
     - sphinx-design

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -62,10 +62,10 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.971
+    - mypy >==0.971
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme >=0.9
+    - pydata_sphinx_theme ==0.9
     - requests-unixsocket >= 0.3.0
     - sphinx >5.1
     - sphinx-copybutton

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -62,7 +62,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >==0.971
+    - mypy >=0.971
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -62,10 +62,10 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.971
+    - mypy >==0.971
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme >=0.9
+    - pydata_sphinx_theme ==0.9
     - requests-unixsocket >= 0.3.0
     - sphinx >5.1
     - sphinx-copybutton

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -62,7 +62,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >==0.971
+    - mypy >=0.971
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -62,10 +62,10 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.971
+    - mypy >==0.971
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme >=0.9
+    - pydata_sphinx_theme ==0.9
     - requests-unixsocket >= 0.3.0
     - sphinx >5.1
     - sphinx-copybutton

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -62,7 +62,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >==0.971
+    - mypy >=0.971
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -54,7 +54,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >==0.971
+    - mypy >=0.971
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -54,10 +54,10 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.971
+    - mypy >==0.971
     # docs
     - autoclasstoc
-    - pydata_sphinx_theme >=0.9
+    - pydata_sphinx_theme ==0.9
     - requests-unixsocket >= 0.3.0
     - sphinx >5.1
     - sphinx-copybutton


### PR DESCRIPTION
This pins the pydata sphinx theme version to 0.9 (the newer version 1.0 doesn't work with our current customizations). This is a temporary fix - we should update our customizations to be compatible with version 1.0!