### PR TITLE
Include only own and overriden defaults in defaults.yaml

### DIFF
--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -5,7 +5,7 @@ import {ExpectationError} from "../unit/assertions"
 
 import {HasProps} from "@bokehjs/core/has_props"
 import {unset} from "@bokehjs/core/properties"
-import {isArray, isPlainObject} from "@bokehjs/core/util/types"
+import {isString, isArray, isPlainObject} from "@bokehjs/core/util/types"
 import {entries, dict} from "@bokehjs/core/util/object"
 import {is_equal} from "@bokehjs/core/util/eq"
 import {to_string} from "@bokehjs/core/util/pretty"
@@ -19,6 +19,8 @@ import "@bokehjs/models/widgets/tables/main"
 
 import yaml from "js-yaml"
 
+type KV<T = unknown> = {[key: string]: T}
+
 const tuple = new yaml.Type("tag:yaml.org,2002:python/tuple", {
   kind: "sequence",
   resolve: (_data) => true,
@@ -29,7 +31,34 @@ const schema = yaml.DEFAULT_SCHEMA.extend(tuple)
 import defaults_yaml from "./defaults.yaml"
 const all_defaults = dict(yaml.load(defaults_yaml, {schema}) as KV<KV<unknown>>)
 
-type KV<T = unknown> = {[key: string]: T}
+function _resolve_defaults(_name: string, defaults: KV) {
+  const {__extends__} = defaults
+  delete defaults.__extends__
+
+  const bases = (() => {
+    if (isArray(__extends__))
+      return __extends__ as string[]
+    else if (isString(__extends__))
+      return [__extends__]
+    else if (__extends__ == null)
+      return []
+    else
+      throw new Error(`invalid __extends__: ${__extends__}`)
+  })()
+
+  let new_defaults: KV = {}
+  for (const base of bases) {
+    const base_defaults = all_defaults.get(base)!
+    new_defaults = {...new_defaults, ...base_defaults}
+  }
+
+  return {...new_defaults, ...defaults}
+}
+
+for (const [name, defaults] of all_defaults) {
+  const new_defaults = _resolve_defaults(name, defaults)
+  all_defaults.set(name, new_defaults)
+}
 
 class DefaultsSerializer extends Serializer {
 

--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -124,7 +124,8 @@ function check_matching_defaults(context: string[], name: string, python_default
       }
 
       if (is_object(js_v) && is_object(py_v) && js_v.name == py_v.name) {
-        check_matching_defaults([...context, `${name}.${k}`], js_v.name, py_v.attributes, js_v.attributes)
+        const py_attrs = {...get_defaults(py_v.name), ...py_v.attributes}
+        check_matching_defaults([...context, `${name}.${k}`], js_v.name, py_attrs, js_v.attributes)
         continue
       }
 
@@ -154,7 +155,8 @@ function check_matching_defaults(context: string[], name: string, python_default
               const py_vi = py_v[i]
 
               if (is_object(js_vi) && is_object(py_vi) && js_vi.name == py_vi.name) {
-                if (!check_matching_defaults([...context, `${name}.${k}[${i}]`], js_vi.name, py_vi.attributes, js_vi.attributes)) {
+                const py_attrs = {...get_defaults(py_vi.name), ...py_vi.attributes}
+                if (!check_matching_defaults([...context, `${name}.${k}[${i}]`], js_vi.name, py_attrs, js_vi.attributes)) {
                   equal = false
                   break
                 }

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -597,20 +597,24 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         themed_keys: set[str] = set()
         result: dict[str, Any] = {}
 
+        keys = self.properties(_with_props=True)
         if include_defaults:
-            keys = self.properties(_with_props=True)
+            selected_keys = set(keys)
         else:
             # TODO (bev) For now, include unstable default values. Things rely on Instances
             # always getting serialized, even defaults, and adding unstable defaults here
             # accomplishes that. Unmodified defaults for property value containers will be
             # weeded out below.
-            keys = set(self._property_values.keys()) | set(self._unstable_default_values.keys())
+            selected_keys = set(self._property_values.keys()) | set(self._unstable_default_values.keys())
             themed_values = self.themed_values()
             if themed_values is not None:
                 themed_keys = set(themed_values.keys())
-                keys |= themed_keys
+                selected_keys |= themed_keys
 
         for key in keys:
+            if key not in selected_keys:
+                continue
+
             descriptor = self.lookup(key)
             if not query(descriptor):
                 continue

--- a/tests/baselines/defaults.yaml
+++ b/tests/baselines/defaults.yaml
@@ -9,7 +9,8 @@ Model:
     type: map
     entries: []
   syncable: true
-DataModel: {}
+DataModel:
+  __extends__: Model
 FillProps:
   fill_color:
     type: value
@@ -122,16 +123,20 @@ ScalarTextProps:
   text_align: left
   text_baseline: bottom
   text_line_height: 1.2
-Callback: {}
+Callback:
+  __extends__: Model
 OpenURL:
+  __extends__: Callback
   url: http://
   same_tab: false
 CustomJS:
+  __extends__: Callback
   args:
     type: map
     entries: []
   code: ''
 SetValue:
+  __extends__: Callback
   obj:
     type: symbol
     name: unset
@@ -141,33 +146,43 @@ SetValue:
   value:
     type: symbol
     name: unset
-Filter: {}
-AllIndices: {}
+Filter:
+  __extends__: Model
+AllIndices:
+  __extends__: Filter
 InversionFilter:
+  __extends__: Filter
   operand:
     type: symbol
     name: unset
 IntersectionFilter:
+  __extends__: Filter
   operands:
     type: symbol
     name: unset
 UnionFilter:
+  __extends__: Filter
   operands:
     type: symbol
     name: unset
 DifferenceFilter:
+  __extends__: Filter
   operands:
     type: symbol
     name: unset
 SymmetricDifferenceFilter:
+  __extends__: Filter
   operands:
     type: symbol
     name: unset
 IndexFilter:
+  __extends__: Filter
   indices: null
 BooleanFilter:
+  __extends__: Filter
   booleans: null
 GroupFilter:
+  __extends__: Filter
   column_name:
     type: symbol
     name: unset
@@ -175,21 +190,27 @@ GroupFilter:
     type: symbol
     name: unset
 CustomJSFilter:
+  __extends__: Filter
   args:
     type: map
     entries: []
   code: ''
 Selection:
+  __extends__: Model
   indices: []
   line_indices: []
   multiline_indices:
     type: map
     entries: []
   image_indices: []
-SelectionPolicy: {}
-IntersectRenderers: {}
-UnionRenderers: {}
+SelectionPolicy:
+  __extends__: Model
+IntersectRenderers:
+  __extends__: SelectionPolicy
+UnionRenderers:
+  __extends__: SelectionPolicy
 DataSource:
+  __extends__: Model
   selected:
     type: object
     name: Selection
@@ -201,32 +222,39 @@ DataSource:
         entries: []
       image_indices: []
 ColumnarDataSource:
+  __extends__: DataSource
   selection_policy:
     type: object
     name: UnionRenderers
     attributes: {}
 ColumnDataSource:
+  __extends__: ColumnarDataSource
   data:
     type: map
     entries: []
 CDSView:
+  __extends__: Model
   filter:
     type: object
     name: AllIndices
     attributes: {}
 GeoJSONDataSource:
+  __extends__: ColumnarDataSource
   geojson:
     type: symbol
     name: unset
 WebDataSource:
+  __extends__: ColumnDataSource
   adapter: null
   max_size: null
   mode: replace
   data_url:
     type: symbol
     name: unset
-ServerSentDataSource: {}
+ServerSentDataSource:
+  __extends__: WebDataSource
 AjaxDataSource:
+  __extends__: WebDataSource
   polling_interval: null
   method: POST
   if_modified: false
@@ -234,22 +262,27 @@ AjaxDataSource:
   http_headers:
     type: map
     entries: []
-Transform: {}
+Transform:
+  __extends__: Model
 CustomJSTransform:
+  __extends__: Transform
   args:
     type: map
     entries: []
   func: ''
   v_func: ''
 Dodge:
+  __extends__: Transform
   value: 0
   range: null
 Jitter:
+  __extends__: Transform
   mean: 0
   width: 1
   distribution: uniform
   range: null
 Interpolator:
+  __extends__: Transform
   x:
     type: symbol
     name: unset
@@ -258,52 +291,71 @@ Interpolator:
     name: unset
   data: null
   clip: true
-LinearInterpolator: {}
+LinearInterpolator:
+  __extends__: Interpolator
 StepInterpolator:
+  __extends__: Interpolator
   mode: after
-Mapper: {}
+Mapper:
+  __extends__: Transform
 ColorMapper:
+  __extends__: Mapper
   palette:
     type: symbol
     name: unset
   nan_color: gray
 CategoricalMapper:
+  __extends__: Mapper
   factors:
     type: symbol
     name: unset
   start: 0
   end: null
-CategoricalColorMapper: {}
+CategoricalColorMapper:
+  __extends__:
+  - CategoricalMapper
+  - ColorMapper
 CategoricalMarkerMapper:
+  __extends__: CategoricalMapper
   markers:
     type: symbol
     name: unset
   default_value: circle
 CategoricalPatternMapper:
+  __extends__: CategoricalMapper
   patterns:
     type: symbol
     name: unset
   default_value: ' '
 ContinuousColorMapper:
+  __extends__: ColorMapper
   domain: []
   low: null
   high: null
   low_color: null
   high_color: null
-LinearColorMapper: {}
-LogColorMapper: {}
-ScanningColorMapper: {}
+LinearColorMapper:
+  __extends__: ContinuousColorMapper
+LogColorMapper:
+  __extends__: ContinuousColorMapper
+ScanningColorMapper:
+  __extends__: ContinuousColorMapper
 EqHistColorMapper:
+  __extends__: ScanningColorMapper
   bins: 65536
   rescale_discrete_levels: false
-Ticker: {}
+Ticker:
+  __extends__: Model
 ContinuousTicker:
+  __extends__: Ticker
   num_minor_ticks: 5
   desired_num_ticks: 6
 FixedTicker:
+  __extends__: ContinuousTicker
   ticks: []
   minor_ticks: []
 AdaptiveTicker:
+  __extends__: ContinuousTicker
   base: 10.0
   mantissas:
   - 1
@@ -312,26 +364,36 @@ AdaptiveTicker:
   min_interval: 0.0
   max_interval: null
 CompositeTicker:
+  __extends__: ContinuousTicker
   tickers: []
 SingleIntervalTicker:
+  __extends__: ContinuousTicker
   interval:
     type: symbol
     name: unset
 DaysTicker:
+  __extends__: SingleIntervalTicker
   num_minor_ticks: 0
   days: []
 MonthsTicker:
+  __extends__: SingleIntervalTicker
   months: []
-YearsTicker: {}
-BasicTicker: {}
+YearsTicker:
+  __extends__: SingleIntervalTicker
+BasicTicker:
+  __extends__: AdaptiveTicker
 LogTicker:
+  __extends__: AdaptiveTicker
   mantissas:
   - 1
   - 5
 MercatorTicker:
+  __extends__: BasicTicker
   dimension: null
-CategoricalTicker: {}
+CategoricalTicker:
+  __extends__: Ticker
 DatetimeTicker:
+  __extends__: CompositeTicker
   num_minor_ticks: 0
   tickers:
   - type: object
@@ -481,34 +543,44 @@ DatetimeTicker:
     name: YearsTicker
     attributes: {}
 BinnedTicker:
+  __extends__: Ticker
   mapper:
     type: symbol
     name: unset
   num_major_ticks: 8
-TickFormatter: {}
+TickFormatter:
+  __extends__: Model
 BasicTickFormatter:
+  __extends__: TickFormatter
   precision: auto
   use_scientific: true
   power_limit_high: 5
   power_limit_low: -3
 MercatorTickFormatter:
+  __extends__: BasicTickFormatter
   dimension: null
 NumeralTickFormatter:
+  __extends__: TickFormatter
   format: 0,0
   language: en
   rounding: round
 PrintfTickFormatter:
+  __extends__: TickFormatter
   format: '%s'
 LogTickFormatter:
+  __extends__: TickFormatter
   ticker: null
   min_exponent: 0
-CategoricalTickFormatter: {}
+CategoricalTickFormatter:
+  __extends__: TickFormatter
 CustomJSTickFormatter:
+  __extends__: TickFormatter
   args:
     type: map
     entries: []
   code: ''
 DatetimeTickFormatter:
+  __extends__: TickFormatter
   microseconds: '%fus'
   milliseconds: '%3Nms'
   seconds: '%Ss'
@@ -523,8 +595,10 @@ DatetimeTickFormatter:
   context: null
   context_which: start
   context_location: below
-Marking: {}
+Marking:
+  __extends__: Model
 Decoration:
+  __extends__: Model
   marking:
     type: symbol
     name: unset
@@ -532,14 +606,26 @@ Decoration:
     type: symbol
     name: unset
 Glyph:
+  __extends__: Model
   decorations: []
-XYGlyph: {}
-ConnectedXYGlyph: {}
-LineGlyph: {}
-FillGlyph: {}
-TextGlyph: {}
-HatchGlyph: {}
+XYGlyph:
+  __extends__: Glyph
+ConnectedXYGlyph:
+  __extends__: XYGlyph
+LineGlyph:
+  __extends__: Glyph
+FillGlyph:
+  __extends__: Glyph
+TextGlyph:
+  __extends__: Glyph
+HatchGlyph:
+  __extends__: Glyph
 Marker:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -599,6 +685,11 @@ Marker:
     type: map
     entries: []
 AnnularWedge:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -664,6 +755,11 @@ AnnularWedge:
     type: map
     entries: []
 Annulus:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -722,6 +818,9 @@ Annulus:
     type: map
     entries: []
 Arc:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
   x:
     type: field
     field: x
@@ -760,6 +859,7 @@ Arc:
     type: value
     value: 0
 Bezier:
+  __extends__: LineGlyph
   x0:
     type: field
     field: x0
@@ -806,6 +906,10 @@ Bezier:
     type: value
     value: 0
 Block:
+  __extends__:
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -864,11 +968,17 @@ Block:
     type: map
     entries: []
 Circle:
+  __extends__: Marker
   radius:
     type: value
     value: null
   radius_dimension: x
 Ellipse:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -930,6 +1040,10 @@ Ellipse:
     type: map
     entries: []
 HArea:
+  __extends__:
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x1:
     type: field
     field: x1
@@ -960,6 +1074,10 @@ HArea:
     type: map
     entries: []
 HBar:
+  __extends__:
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   y:
     type: field
     field: y
@@ -1018,6 +1136,10 @@ HBar:
     type: map
     entries: []
 HexTile:
+  __extends__:
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   size: 1.0
   aspect_scale: 1.0
   r:
@@ -1076,6 +1198,7 @@ HexTile:
     type: map
     entries: []
 ImageBase:
+  __extends__: XYGlyph
   x:
     type: field
     field: x
@@ -1095,6 +1218,7 @@ ImageBase:
   origin: bottom_left
   anchor: bottom_left
 Image:
+  __extends__: ImageBase
   image:
     type: field
     field: image
@@ -1103,10 +1227,12 @@ Image:
     name: LinearColorMapper
     attributes: {}
 ImageRGBA:
+  __extends__: ImageBase
   image:
     type: field
     field: image
 ImageURL:
+  __extends__: XYGlyph
   url:
     type: field
     field: url
@@ -1133,6 +1259,9 @@ ImageURL:
   retry_attempts: 0
   retry_timeout: 0
 Line:
+  __extends__:
+  - ConnectedXYGlyph
+  - LineGlyph
   x:
     type: field
     field: x
@@ -1147,6 +1276,7 @@ Line:
   line_dash: []
   line_dash_offset: 0
 MultiLine:
+  __extends__: LineGlyph
   xs:
     type: field
     field: xs
@@ -1175,6 +1305,10 @@ MultiLine:
     type: value
     value: 0
 MultiPolygons:
+  __extends__:
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   xs:
     type: field
     field: xs
@@ -1227,6 +1361,11 @@ MultiPolygons:
     type: map
     entries: []
 Patch:
+  __extends__:
+  - ConnectedXYGlyph
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -1251,6 +1390,10 @@ Patch:
     type: map
     entries: []
 Patches:
+  __extends__:
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   xs:
     type: field
     field: xs
@@ -1303,6 +1446,10 @@ Patches:
     type: map
     entries: []
 Quad:
+  __extends__:
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   left:
     type: field
     field: left
@@ -1361,6 +1508,7 @@ Quad:
     type: map
     entries: []
 Quadratic:
+  __extends__: LineGlyph
   x0:
     type: field
     field: x0
@@ -1401,6 +1549,9 @@ Quadratic:
     type: value
     value: 0
 Ray:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
   x:
     type: field
     field: x
@@ -1435,6 +1586,11 @@ Ray:
     type: value
     value: 0
 Rect:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -1497,10 +1653,12 @@ Rect:
     type: map
     entries: []
 Scatter:
+  __extends__: Marker
   marker:
     type: value
     value: circle
 Segment:
+  __extends__: LineGlyph
   x0:
     type: field
     field: x0
@@ -1535,6 +1693,9 @@ Segment:
     type: value
     value: 0
 Step:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
   x:
     type: field
     field: x
@@ -1550,6 +1711,9 @@ Step:
   line_dash_offset: 0
   mode: before
 Text:
+  __extends__:
+  - XYGlyph
+  - TextGlyph
   x:
     type: field
     field: x
@@ -1596,6 +1760,9 @@ Text:
     type: value
     value: 1.2
 VArea:
+  __extends__:
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -1626,6 +1793,10 @@ VArea:
     type: map
     entries: []
 VBar:
+  __extends__:
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -1684,6 +1855,11 @@ VBar:
     type: map
     entries: []
 Wedge:
+  __extends__:
+  - XYGlyph
+  - LineGlyph
+  - FillGlyph
+  - HatchGlyph
   x:
     type: field
     field: x
@@ -1745,17 +1921,23 @@ Wedge:
   hatch_extra:
     type: map
     entries: []
-LabelingPolicy: {}
-AllLabels: {}
+LabelingPolicy:
+  __extends__: Model
+AllLabels:
+  __extends__: LabelingPolicy
 NoOverlap:
+  __extends__: LabelingPolicy
   min_distance: 5
 CustomLabelingPolicy:
+  __extends__: LabelingPolicy
   args:
     type: map
     entries: []
   code: ''
-Range: {}
+Range:
+  __extends__: Model
 Range1d:
+  __extends__: Range
   start: 0
   end: 1
   reset_start: null
@@ -1764,8 +1946,10 @@ Range1d:
   min_interval: null
   max_interval: null
 DataRange:
+  __extends__: Range
   renderers: []
 DataRange1d:
+  __extends__: DataRange
   range_padding: 0.1
   range_padding_units: percent
   start:
@@ -1783,6 +1967,7 @@ DataRange1d:
   default_span: 2.0
   only_visible: false
 FactorRange:
+  __extends__: Range
   factors: []
   factor_padding: 0.0
   subgroup_padding: 0.8
@@ -1794,12 +1979,18 @@ FactorRange:
   bounds: null
   min_interval: null
   max_interval: null
-Scale: {}
-ContinuousScale: {}
-LinearScale: {}
-LogScale: {}
-CategoricalScale: {}
+Scale:
+  __extends__: Transform
+ContinuousScale:
+  __extends__: Scale
+LinearScale:
+  __extends__: ContinuousScale
+LogScale:
+  __extends__: ContinuousScale
+CategoricalScale:
+  __extends__: Scale
 CoordinateMapping:
+  __extends__: Model
   x_source:
     type: object
     name: DataRange1d
@@ -1854,21 +2045,27 @@ CoordinateMapping:
   y_target:
     type: symbol
     name: unset
-Expression: {}
+Expression:
+  __extends__: Model
 CustomJSExpr:
+  __extends__: Expression
   args:
     type: map
     entries: []
   code: ''
 CumSum:
+  __extends__: Expression
   field:
     type: symbol
     name: unset
   include_zero: false
 Stack:
+  __extends__: Expression
   fields: []
-ScalarExpression: {}
+ScalarExpression:
+  __extends__: Model
 Minimum:
+  __extends__: ScalarExpression
   field:
     type: symbol
     name: unset
@@ -1876,14 +2073,17 @@ Minimum:
     type: number
     value: +inf
 Maximum:
+  __extends__: ScalarExpression
   field:
     type: symbol
     name: unset
   initial:
     type: number
     value: -inf
-CoordinateTransform: {}
+CoordinateTransform:
+  __extends__: Expression
 PolarTransform:
+  __extends__: CoordinateTransform
   radius:
     type: field
     field: radius
@@ -1892,29 +2092,44 @@ PolarTransform:
     field: angle
   direction: anticlock
 XYComponent:
+  __extends__: Expression
   transform:
     type: symbol
     name: unset
-XComponent: {}
-YComponent: {}
-LayoutProvider: {}
+XComponent:
+  __extends__: XYComponent
+YComponent:
+  __extends__: XYComponent
+LayoutProvider:
+  __extends__: Model
 StaticLayoutProvider:
+  __extends__: LayoutProvider
   graph_layout:
     type: map
     entries: []
 GraphCoordinates:
+  __extends__: CoordinateTransform
   layout:
     type: symbol
     name: unset
-NodeCoordinates: {}
-EdgeCoordinates: {}
-GraphHitTestPolicy: {}
-EdgesOnly: {}
-NodesOnly: {}
-NodesAndLinkedEdges: {}
-EdgesAndLinkedNodes: {}
-NodesAndAdjacentNodes: {}
+NodeCoordinates:
+  __extends__: GraphCoordinates
+EdgeCoordinates:
+  __extends__: GraphCoordinates
+GraphHitTestPolicy:
+  __extends__: Model
+EdgesOnly:
+  __extends__: GraphHitTestPolicy
+NodesOnly:
+  __extends__: GraphHitTestPolicy
+NodesAndLinkedEdges:
+  __extends__: GraphHitTestPolicy
+EdgesAndLinkedNodes:
+  __extends__: GraphHitTestPolicy
+NodesAndAdjacentNodes:
+  __extends__: GraphHitTestPolicy
 TileSource:
+  __extends__: Model
   url: ''
   tile_size: 256
   min_zoom: 0
@@ -1931,19 +2146,26 @@ TileSource:
     name: unset
   initial_resolution: null
 MercatorTileSource:
+  __extends__: TileSource
   x_origin_offset: 20037508.34
   y_origin_offset: 20037508.34
   initial_resolution: 156543.03392804097
   snap_to_zoom: false
   wrap_around: true
-TMSTileSource: {}
-WMTSTileSource: {}
-QUADKEYTileSource: {}
+TMSTileSource:
+  __extends__: MercatorTileSource
+WMTSTileSource:
+  __extends__: MercatorTileSource
+QUADKEYTileSource:
+  __extends__: MercatorTileSource
 BBoxTileSource:
+  __extends__: MercatorTileSource
   use_latlon: false
 RendererGroup:
+  __extends__: Model
   visible: true
 Renderer:
+  __extends__: Model
   level: image
   visible: true
   coordinates: null
@@ -1951,6 +2173,7 @@ Renderer:
   y_range_name: default
   group: null
 TileRenderer:
+  __extends__: Renderer
   level: image
   tile_source:
     type: object
@@ -1960,8 +2183,10 @@ TileRenderer:
   smoothing: true
   render_parents: true
 DataRenderer:
+  __extends__: Renderer
   level: glyph
 GlyphRenderer:
+  __extends__: DataRenderer
   data_source:
     type: symbol
     name: unset
@@ -1982,6 +2207,7 @@ GlyphRenderer:
   muted_glyph: auto
   muted: false
 GraphRenderer:
+  __extends__: DataRenderer
   layout_provider:
     type: symbol
     name: unset
@@ -2090,8 +2316,10 @@ GraphRenderer:
     name: NodesOnly
     attributes: {}
 GuideRenderer:
+  __extends__: Renderer
   level: guide
 Axis:
+  __extends__: GuideRenderer
   bounds: auto
   ticker:
     type: symbol
@@ -2154,8 +2382,10 @@ Axis:
   minor_tick_in: 0
   minor_tick_out: 4
   fixed_location: null
-ContinuousAxis: {}
+ContinuousAxis:
+  __extends__: Axis
 LinearAxis:
+  __extends__: ContinuousAxis
   ticker:
     type: object
     name: BasicTicker
@@ -2169,6 +2399,7 @@ LinearAxis:
       power_limit_high: 5
       power_limit_low: -3
 LogAxis:
+  __extends__: ContinuousAxis
   ticker:
     type: object
     name: LogTicker
@@ -2183,6 +2414,7 @@ LogAxis:
       ticker: null
       min_exponent: 0
 CategoricalAxis:
+  __extends__: Axis
   ticker:
     type: object
     name: CategoricalTicker
@@ -2219,6 +2451,7 @@ CategoricalAxis:
   subgroup_text_line_height: 1.2
   subgroup_label_orientation: parallel
 DatetimeAxis:
+  __extends__: LinearAxis
   ticker:
     type: object
     name: DatetimeTicker
@@ -2390,6 +2623,7 @@ DatetimeAxis:
       context_which: start
       context_location: below
 MercatorAxis:
+  __extends__: LinearAxis
   ticker:
     type: object
     name: MercatorTicker
@@ -2401,6 +2635,7 @@ MercatorAxis:
     attributes:
       dimension: lat
 Styles:
+  __extends__: Model
   align_content: null
   align_items: null
   align_self: null
@@ -2715,49 +2950,67 @@ Styles:
   writing_mode: null
   z_index: null
 UIElement:
+  __extends__: Model
   visible: true
   classes: []
   styles:
     type: map
     entries: []
   stylesheets: []
-bokeh.models.dom.DOMNode: {}
+bokeh.models.dom.DOMNode:
+  __extends__: Model
 bokeh.models.dom.Text:
+  __extends__: bokeh.models.dom.DOMNode
   content: ''
 bokeh.models.dom.DOMElement:
+  __extends__: bokeh.models.dom.DOMNode
   style: null
   children: []
-bokeh.models.dom.Span: {}
-bokeh.models.dom.Div: {}
-bokeh.models.dom.Table: {}
-bokeh.models.dom.TableRow: {}
-bokeh.models.dom.Action: {}
+bokeh.models.dom.Span:
+  __extends__: bokeh.models.dom.DOMElement
+bokeh.models.dom.Div:
+  __extends__: bokeh.models.dom.DOMElement
+bokeh.models.dom.Table:
+  __extends__: bokeh.models.dom.DOMElement
+bokeh.models.dom.TableRow:
+  __extends__: bokeh.models.dom.DOMElement
+bokeh.models.dom.Action:
+  __extends__: Model
 bokeh.models.dom.Template:
+  __extends__: bokeh.models.dom.DOMElement
   actions: []
 bokeh.models.dom.ToggleGroup:
+  __extends__: bokeh.models.dom.Action
   groups: []
-bokeh.models.dom.Placeholder: {}
+bokeh.models.dom.Placeholder:
+  __extends__: bokeh.models.dom.DOMNode
 bokeh.models.dom.ValueOf:
+  __extends__: bokeh.models.dom.Placeholder
   obj:
     type: symbol
     name: unset
   attr:
     type: symbol
     name: unset
-bokeh.models.dom.Index: {}
+bokeh.models.dom.Index:
+  __extends__: bokeh.models.dom.Placeholder
 bokeh.models.dom.ValueRef:
+  __extends__: bokeh.models.dom.Placeholder
   field:
     type: symbol
     name: unset
 bokeh.models.dom.ColorRef:
+  __extends__: bokeh.models.dom.ValueRef
   hex: true
   swatch: true
 bokeh.models.dom.HTML:
+  __extends__: Model
   html:
     type: symbol
     name: unset
   refs: []
 Dialog:
+  __extends__: UIElement
   title: null
   content:
     type: symbol
@@ -2767,24 +3020,31 @@ Dialog:
   closable: true
   draggable: true
 Icon:
+  __extends__: Model
   size: 1em
 BuiltinIcon:
+  __extends__: Icon
   icon_name:
     type: symbol
     name: unset
   color: gray
 SVGIcon:
+  __extends__: Icon
   svg:
     type: symbol
     name: unset
 TablerIcon:
+  __extends__: Icon
   icon_name:
     type: symbol
     name: unset
 Inspector:
+  __extends__: UIElement
   target: null
-MenuItem: {}
+MenuItem:
+  __extends__: UIElement
 Action:
+  __extends__: MenuItem
   icon: null
   label:
     type: symbol
@@ -2792,34 +3052,45 @@ Action:
   description: null
   menu: null
 CheckAction:
+  __extends__: Action
   checked: false
 Section:
+  __extends__: MenuItem
   items: []
-Divider: {}
+Divider:
+  __extends__: MenuItem
 Menu:
+  __extends__: UIElement
   items: []
   reversed: false
   orientation: vertical
 Pane:
+  __extends__: UIElement
   children: []
-Selector: {}
+Selector:
+  __extends__: Model
 ByID:
+  __extends__: Selector
   query:
     type: symbol
     name: unset
 ByClass:
+  __extends__: Selector
   query:
     type: symbol
     name: unset
 ByCSS:
+  __extends__: Selector
   query:
     type: symbol
     name: unset
 ByXPath:
+  __extends__: Selector
   query:
     type: symbol
     name: unset
 Tooltip:
+  __extends__: UIElement
   visible: false
   position: null
   target: auto
@@ -2831,11 +3102,14 @@ Tooltip:
   closable: false
   interactive: true
 Canvas:
+  __extends__: UIElement
   hidpi: true
   output_backend: canvas
 Annotation:
+  __extends__: Renderer
   level: annotation
 DataAnnotation:
+  __extends__: Annotation
   source:
     type: object
     name: ColumnDataSource
@@ -2844,10 +3118,12 @@ DataAnnotation:
         type: map
         entries: []
 ArrowHead:
+  __extends__: Marking
   size:
     type: value
     value: 25
 OpenHead:
+  __extends__: ArrowHead
   line_color:
     type: value
     value: black
@@ -2870,6 +3146,7 @@ OpenHead:
     type: value
     value: 0
 NormalHead:
+  __extends__: ArrowHead
   line_color:
     type: value
     value: black
@@ -2898,6 +3175,7 @@ NormalHead:
     type: value
     value: 1.0
 TeeHead:
+  __extends__: ArrowHead
   line_color:
     type: value
     value: black
@@ -2920,6 +3198,7 @@ TeeHead:
     type: value
     value: 0
 VeeHead:
+  __extends__: ArrowHead
   line_color:
     type: value
     value: black
@@ -2948,6 +3227,7 @@ VeeHead:
     type: value
     value: 1.0
 Arrow:
+  __extends__: DataAnnotation
   x_start:
     type: field
     field: x_start
@@ -3010,6 +3290,7 @@ Arrow:
     type: value
     value: 0
 BoxAnnotation:
+  __extends__: Annotation
   left: null
   left_units: data
   right: null
@@ -3036,6 +3317,7 @@ BoxAnnotation:
     type: map
     entries: []
 Band:
+  __extends__: DataAnnotation
   lower:
     type: field
     field: lower
@@ -3056,6 +3338,7 @@ Band:
   fill_color: '#fff9ba'
   fill_alpha: 0.4
 PolyAnnotation:
+  __extends__: Annotation
   xs: []
   xs_units: data
   ys: []
@@ -3078,6 +3361,7 @@ PolyAnnotation:
     type: map
     entries: []
 Slope:
+  __extends__: Annotation
   gradient: null
   y_intercept: null
   line_color: black
@@ -3088,6 +3372,7 @@ Slope:
   line_dash: []
   line_dash_offset: 0
 Span:
+  __extends__: Annotation
   location: null
   location_units: data
   dimension: width
@@ -3099,6 +3384,7 @@ Span:
   line_dash: []
   line_dash_offset: 0
 Whisker:
+  __extends__: DataAnnotation
   level: underlay
   lower:
     type: field
@@ -3181,8 +3467,10 @@ Whisker:
   line_dash_offset:
     type: value
     value: 0
-HTMLAnnotation: {}
+HTMLAnnotation:
+  __extends__: Annotation
 HTMLLabel:
+  __extends__: HTMLAnnotation
   x:
     type: symbol
     name: unset
@@ -3215,6 +3503,9 @@ HTMLLabel:
   border_line_dash: []
   border_line_dash_offset: 0
 HTMLLabelSet:
+  __extends__:
+  - HTMLAnnotation
+  - DataAnnotation
   x:
     type: field
     field: x
@@ -3290,6 +3581,7 @@ HTMLLabelSet:
     type: value
     value: 0
 HTMLTitle:
+  __extends__: HTMLAnnotation
   text: ''
   vertical_align: bottom
   align: left
@@ -3312,10 +3604,12 @@ HTMLTitle:
   border_line_dash: []
   border_line_dash_offset: 0
 ToolbarPanel:
+  __extends__: HTMLAnnotation
   toolbar:
     type: symbol
     name: unset
 TextAnnotation:
+  __extends__: Annotation
   text: ''
   text_color: '#444444'
   text_outline_color: null
@@ -3336,6 +3630,7 @@ TextAnnotation:
   border_line_dash: []
   border_line_dash_offset: 0
 Label:
+  __extends__: TextAnnotation
   x:
     type: symbol
     name: unset
@@ -3349,6 +3644,7 @@ Label:
   x_offset: 0
   y_offset: 0
 LabelSet:
+  __extends__: DataAnnotation
   x:
     type: field
     field: x
@@ -3424,6 +3720,7 @@ LabelSet:
     type: value
     value: 0
 Title:
+  __extends__: TextAnnotation
   text_font_size: 13px
   text_font_style: bold
   text_line_height: 1.0
@@ -3432,6 +3729,7 @@ Title:
   offset: 0
   standoff: 10
 BaseColorBar:
+  __extends__: Annotation
   location: top_right
   orientation: auto
   height: auto
@@ -3505,12 +3803,14 @@ BaseColorBar:
   background_fill_color: '#ffffff'
   background_fill_alpha: 0.95
 ColorBar:
+  __extends__: BaseColorBar
   color_mapper:
     type: symbol
     name: unset
   display_low: null
   display_high: null
 ContourColorBar:
+  __extends__: BaseColorBar
   fill_renderer:
     type: symbol
     name: unset
@@ -3519,6 +3819,7 @@ ContourColorBar:
     name: unset
   levels: []
 LegendItem:
+  __extends__: Model
   label:
     type: value
     value: null
@@ -3526,6 +3827,7 @@ LegendItem:
   index: null
   visible: true
 Legend:
+  __extends__: Annotation
   location: top_right
   orientation: vertical
   title: null
@@ -3570,6 +3872,7 @@ Legend:
   spacing: 3
   items: []
 ContourRenderer:
+  __extends__: DataRenderer
   line_renderer:
     type: symbol
     name: unset
@@ -3578,6 +3881,7 @@ ContourRenderer:
     name: unset
   levels: []
 Grid:
+  __extends__: GuideRenderer
   level: underlay
   dimension: 0
   bounds: auto
@@ -3609,6 +3913,7 @@ Grid:
     type: map
     entries: []
 LayoutDOM:
+  __extends__: UIElement
   disabled: false
   width: null
   height: null
@@ -3626,26 +3931,34 @@ LayoutDOM:
   css_classes: []
   context_menu: null
   resizable: false
-Spacer: {}
+Spacer:
+  __extends__: LayoutDOM
 GridBox:
+  __extends__: LayoutDOM
   children: []
   rows: null
   cols: null
   spacing: 0
 HBox:
+  __extends__: LayoutDOM
   children: []
   cols: null
   spacing: 0
 VBox:
+  __extends__: LayoutDOM
   children: []
   rows: null
   spacing: 0
 FlexBox:
+  __extends__: LayoutDOM
   children: []
   spacing: 0
-Row: {}
-Column: {}
+Row:
+  __extends__: FlexBox
+Column:
+  __extends__: FlexBox
 TabPanel:
+  __extends__: Model
   title: ''
   child:
     type: symbol
@@ -3653,40 +3966,54 @@ TabPanel:
   closable: false
   disabled: false
 Tabs:
+  __extends__: LayoutDOM
   tabs: []
   tabs_location: above
   active: 0
 GroupBox:
+  __extends__: LayoutDOM
   title: null
   child:
     type: symbol
     name: unset
   checkable: false
 ScrollBox:
+  __extends__: LayoutDOM
   child:
     type: symbol
     name: unset
   horizontal_scrollbar: auto
   vertical_scrollbar: auto
 Tool:
+  __extends__: Model
   icon: null
   description: null
 ToolProxy:
+  __extends__: Model
   tools: []
   active: false
   disabled: false
-ActionTool: {}
-PlotActionTool: {}
-GestureTool: {}
-Drag: {}
-Scroll: {}
-Tap: {}
+ActionTool:
+  __extends__: Tool
+PlotActionTool:
+  __extends__: ActionTool
+GestureTool:
+  __extends__: Tool
+Drag:
+  __extends__: GestureTool
+Scroll:
+  __extends__: GestureTool
+Tap:
+  __extends__: GestureTool
 SelectTool:
+  __extends__: GestureTool
   renderers: auto
   mode: replace
 InspectTool:
+  __extends__: GestureTool
   toggleable: true
 Toolbar:
+  __extends__: UIElement
   logo: normal
   autohide: false
   tools: []
@@ -3696,8 +4023,10 @@ Toolbar:
   active_tap: auto
   active_multi: auto
 PanTool:
+  __extends__: Drag
   dimensions: both
 RangeTool:
+  __extends__: Drag
   x_range: null
   x_interaction: true
   y_range: null
@@ -3734,30 +4063,41 @@ RangeTool:
         type: map
         entries: []
 WheelPanTool:
+  __extends__: Scroll
   dimension: width
 WheelZoomTool:
+  __extends__: Scroll
   dimensions: both
   maintain_focus: true
   zoom_on_axis: true
   speed: 0.0016666666666666668
 CustomAction:
+  __extends__: ActionTool
   description: Perform a Custom Action
   callback: null
 SaveTool:
+  __extends__: ActionTool
   filename: null
-CopyTool: {}
-ResetTool: {}
+CopyTool:
+  __extends__: ActionTool
+ResetTool:
+  __extends__: PlotActionTool
 TapTool:
+  __extends__:
+  - Tap
+  - SelectTool
   behavior: select
   gesture: tap
   callback: null
 CrosshairTool:
+  __extends__: InspectTool
   overlay: auto
   dimensions: both
   line_color: black
   line_alpha: 1.0
   line_width: 1
 BoxZoomTool:
+  __extends__: Drag
   dimensions: both
   overlay:
     type: object
@@ -3793,13 +4133,18 @@ BoxZoomTool:
   match_aspect: false
   origin: corner
 ZoomInTool:
+  __extends__: PlotActionTool
   dimensions: both
   factor: 0.1
 ZoomOutTool:
+  __extends__: PlotActionTool
   dimensions: both
   factor: 0.1
   maintain_focus: true
 BoxSelectTool:
+  __extends__:
+  - Drag
+  - SelectTool
   select_every_mousemove: false
   dimensions: both
   overlay:
@@ -3835,6 +4180,9 @@ BoxSelectTool:
         entries: []
   origin: corner
 LassoSelectTool:
+  __extends__:
+  - Drag
+  - SelectTool
   select_every_mousemove: true
   overlay:
     type: object
@@ -3864,6 +4212,9 @@ LassoSelectTool:
         type: map
         entries: []
 PolySelectTool:
+  __extends__:
+  - Tap
+  - SelectTool
   overlay:
     type: object
     name: PolyAnnotation
@@ -3892,11 +4243,13 @@ PolySelectTool:
         type: map
         entries: []
 CustomJSHover:
+  __extends__: Model
   args:
     type: map
     entries: []
   code: ''
 HoverTool:
+  __extends__: InspectTool
   renderers: auto
   callback: null
   tooltips:
@@ -3917,38 +4270,70 @@ HoverTool:
   attachment: horizontal
   show_arrow: true
 HelpTool:
+  __extends__: ActionTool
   description: Click the question mark to learn more about Bokeh plot tools.
   redirect: https://docs.bokeh.org/en/latest/docs/user_guide/tools.html
-SettingsTool: {}
-FullscreenTool: {}
-UndoTool: {}
-RedoTool: {}
+SettingsTool:
+  __extends__: ActionTool
+FullscreenTool:
+  __extends__: ActionTool
+UndoTool:
+  __extends__: PlotActionTool
+RedoTool:
+  __extends__: PlotActionTool
 EditTool:
+  __extends__: GestureTool
   empty_value:
     type: symbol
     name: unset
   renderers: []
 PolyTool:
+  __extends__: EditTool
   vertex_renderer: null
 BoxEditTool:
+  __extends__:
+  - EditTool
+  - Drag
+  - Tap
   dimensions: both
   num_objects: 0
 PointDrawTool:
+  __extends__:
+  - EditTool
+  - Drag
+  - Tap
   add: true
   drag: true
   num_objects: 0
 PolyDrawTool:
+  __extends__:
+  - PolyTool
+  - Drag
+  - Tap
   drag: true
   num_objects: 0
 FreehandDrawTool:
+  __extends__:
+  - EditTool
+  - Drag
+  - Tap
   num_objects: 0
-PolyEditTool: {}
+PolyEditTool:
+  __extends__:
+  - PolyTool
+  - Drag
+  - Tap
 LineEditTool:
+  __extends__:
+  - EditTool
+  - Drag
+  - Tap
   intersection_renderer:
     type: symbol
     name: unset
   dimensions: both
 Plot:
+  __extends__: LayoutDOM
   width: 600
   height: 600
   x_range:
@@ -4078,6 +4463,7 @@ Plot:
   reset_policy: standard
   hold_render: false
 GridPlot:
+  __extends__: LayoutDOM
   toolbar:
     type: object
     name: Toolbar
@@ -4096,6 +4482,7 @@ GridPlot:
   cols: null
   spacing: 0
 MapOptions:
+  __extends__: Model
   lat:
     type: symbol
     name: unset
@@ -4103,13 +4490,16 @@ MapOptions:
     type: symbol
     name: unset
   zoom: 12
-MapPlot: {}
+MapPlot:
+  __extends__: Plot
 GMapOptions:
+  __extends__: MapOptions
   map_type: roadmap
   scale_control: false
   styles: null
   tilt: 45
 GMapPlot:
+  __extends__: MapPlot
   x_range:
     type: object
     name: Range1d
@@ -4142,44 +4532,61 @@ GMapPlot:
     name: unset
   api_version: weekly
 BaseText:
+  __extends__: Model
   text:
     type: symbol
     name: unset
-MathText: {}
-Ascii: {}
-MathML: {}
+MathText:
+  __extends__: BaseText
+Ascii:
+  __extends__: MathText
+MathML:
+  __extends__: MathText
 TeX:
+  __extends__: MathText
   macros:
     type: map
     entries: []
   inline: false
-PlainText: {}
+PlainText:
+  __extends__: BaseText
 Texture:
+  __extends__: Model
   repetition: repeat
 CanvasTexture:
+  __extends__: Texture
   code:
     type: symbol
     name: unset
 ImageURLTexture:
+  __extends__: Texture
   url:
     type: symbol
     name: unset
-Widget: {}
+Widget:
+  __extends__: LayoutDOM
 ButtonLike:
   button_type: default
 AbstractButton:
+  __extends__:
+  - Widget
+  - ButtonLike
   label: Button
   icon: null
 Button:
+  __extends__: AbstractButton
   label: Button
 Toggle:
+  __extends__: AbstractButton
   label: Toggle
   active: false
 Dropdown:
+  __extends__: AbstractButton
   label: Dropdown
   split: false
   menu: []
 HelpButton:
+  __extends__: AbstractButton
   button_type: default
   label: ''
   icon:
@@ -4192,29 +4599,41 @@ HelpButton:
     type: symbol
     name: unset
 AbstractGroup:
+  __extends__: Widget
   labels: []
 ToggleButtonGroup:
+  __extends__:
+  - AbstractGroup
+  - ButtonLike
   orientation: horizontal
 ToggleInputGroup:
+  __extends__: AbstractGroup
   inline: false
 CheckboxGroup:
+  __extends__: ToggleInputGroup
   active: []
 RadioGroup:
+  __extends__: ToggleInputGroup
   active: null
 CheckboxButtonGroup:
+  __extends__: ToggleButtonGroup
   active: []
 RadioButtonGroup:
+  __extends__: ToggleButtonGroup
   active: null
 InputWidget:
+  __extends__: Widget
   title: ''
   description: null
 FileInput:
+  __extends__: InputWidget
   value: ''
   mime_type: ''
   filename: ''
   accept: ''
   multiple: false
 NumericInput:
+  __extends__: InputWidget
   value: null
   low: null
   high: null
@@ -4222,44 +4641,56 @@ NumericInput:
   mode: int
   format: null
 Spinner:
+  __extends__: NumericInput
   mode: float
   value_throttled: null
   step: 1
   page_step_multiplier: 10
   wheel_wait: 100
 ToggleInput:
+  __extends__: Widget
   active: false
 Checkbox:
+  __extends__: ToggleInput
   label: ''
 Switch:
+  __extends__: ToggleInput
   width: 32
 TextLikeInput:
+  __extends__: InputWidget
   value: ''
   value_input: ''
   placeholder: ''
   max_length: null
 TextInput:
+  __extends__: TextLikeInput
   prefix: null
   suffix: null
 TextAreaInput:
+  __extends__: TextLikeInput
   max_length: 500
   cols: 20
   rows: 2
-PasswordInput: {}
+PasswordInput:
+  __extends__: TextInput
 AutocompleteInput:
+  __extends__: TextInput
   completions: []
   max_completions: null
   min_characters: 2
   case_sensitive: true
   restrict: true
 Select:
+  __extends__: InputWidget
   options: []
   value: ''
 MultiSelect:
+  __extends__: InputWidget
   options: []
   value: []
   size: 4
 MultiChoice:
+  __extends__: InputWidget
   options: []
   value: []
   delete_button: true
@@ -4269,6 +4700,7 @@ MultiChoice:
   placeholder: null
   solid: true
 DatePicker:
+  __extends__: InputWidget
   value:
     type: symbol
     name: unset
@@ -4279,15 +4711,21 @@ DatePicker:
   position: auto
   inline: false
 ColorPicker:
+  __extends__: InputWidget
   color: '#000000'
 Markup:
+  __extends__: Widget
   text: ''
   disable_math: false
-Paragraph: {}
+Paragraph:
+  __extends__: Markup
 Div:
+  __extends__: Markup
   render_as_text: false
-PreText: {}
+PreText:
+  __extends__: Paragraph
 AbstractSlider:
+  __extends__: Widget
   width: 300
   orientation: horizontal
   title: ''
@@ -4297,6 +4735,7 @@ AbstractSlider:
   tooltips: true
   bar_color: '#e6e6e6'
 Slider:
+  __extends__: AbstractSlider
   format: 0[.]00
   start:
     type: symbol
@@ -4312,6 +4751,7 @@ Slider:
     name: unset
   step: 1
 RangeSlider:
+  __extends__: AbstractSlider
   format: 0[.]00
   value:
     type: symbol
@@ -4327,6 +4767,7 @@ RangeSlider:
     name: unset
   step: 1
 DateSlider:
+  __extends__: AbstractSlider
   format: '%d %b %Y'
   value:
     type: symbol
@@ -4342,6 +4783,7 @@ DateSlider:
     name: unset
   step: 1
 DateRangeSlider:
+  __extends__: AbstractSlider
   format: '%d %b %Y'
   value:
     type: symbol
@@ -4357,6 +4799,7 @@ DateRangeSlider:
     name: unset
   step: 1
 DatetimeRangeSlider:
+  __extends__: AbstractSlider
   format: '%d %b %Y %H:%M:%S'
   value:
     type: symbol
@@ -4371,47 +4814,70 @@ DatetimeRangeSlider:
     type: symbol
     name: unset
   step: 3600000
-CellFormatter: {}
-CellEditor: {}
+CellFormatter:
+  __extends__: Model
+CellEditor:
+  __extends__: Model
 RowAggregator:
+  __extends__: Model
   field_: ''
 StringFormatter:
+  __extends__: CellFormatter
   font_style: normal
   text_align: left
   text_color: null
   nan_format: '-'
 ScientificFormatter:
+  __extends__: StringFormatter
   precision: 10
   power_limit_high: 5
   power_limit_low: -3
 NumberFormatter:
+  __extends__: StringFormatter
   format: 0,0
   language: en
   rounding: round
 BooleanFormatter:
+  __extends__: CellFormatter
   icon: check
 DateFormatter:
+  __extends__: StringFormatter
   format: ISO-8601
 HTMLTemplateFormatter:
+  __extends__: CellFormatter
   template: <%= value %>
 StringEditor:
+  __extends__: CellEditor
   completions: []
-TextEditor: {}
+TextEditor:
+  __extends__: CellEditor
 SelectEditor:
+  __extends__: CellEditor
   options: []
-PercentEditor: {}
-CheckboxEditor: {}
+PercentEditor:
+  __extends__: CellEditor
+CheckboxEditor:
+  __extends__: CellEditor
 IntEditor:
+  __extends__: CellEditor
   step: 1
 NumberEditor:
+  __extends__: CellEditor
   step: 0.01
-TimeEditor: {}
-DateEditor: {}
-AvgAggregator: {}
-MinAggregator: {}
-MaxAggregator: {}
-SumAggregator: {}
+TimeEditor:
+  __extends__: CellEditor
+DateEditor:
+  __extends__: CellEditor
+AvgAggregator:
+  __extends__: RowAggregator
+MinAggregator:
+  __extends__: RowAggregator
+MaxAggregator:
+  __extends__: RowAggregator
+SumAggregator:
+  __extends__: RowAggregator
 TableColumn:
+  __extends__: Model
   field:
     type: symbol
     name: unset
@@ -4434,6 +4900,7 @@ TableColumn:
   default_sort: ascending
   visible: true
 TableWidget:
+  __extends__: Widget
   source:
     type: object
     name: ColumnDataSource
@@ -4450,6 +4917,7 @@ TableWidget:
         name: AllIndices
         attributes: {}
 DataTable:
+  __extends__: TableWidget
   width: 600
   height: 400
   autosize_mode: force_fit
@@ -4469,10 +4937,12 @@ DataTable:
   header_row: true
   row_height: 25
 GroupingInfo:
+  __extends__: Model
   getter: ''
   aggregators: []
   collapsed: false
 DataCube:
+  __extends__: DataTable
   grouping: []
   target:
     type: symbol

--- a/tests/baselines/defaults.yaml
+++ b/tests/baselines/defaults.yaml
@@ -215,12 +215,8 @@ DataSource:
     type: object
     name: Selection
     attributes:
-      indices: []
       line_indices: []
-      multiline_indices:
-        type: map
-        entries: []
-      image_indices: []
+      indices: []
 ColumnarDataSource:
   __extends__: DataSource
   selection_policy:
@@ -399,17 +395,15 @@ DatetimeTicker:
   - type: object
     name: AdaptiveTicker
     attributes:
-      base: 10.0
       mantissas:
       - 1
       - 2
       - 5
-      min_interval: 0.0
+      num_minor_ticks: 0
       max_interval: 500.0
   - type: object
     name: AdaptiveTicker
     attributes:
-      base: 60
       mantissas:
       - 1
       - 2
@@ -418,12 +412,13 @@ DatetimeTicker:
       - 15
       - 20
       - 30
+      num_minor_ticks: 0
+      base: 60
       min_interval: 1000.0
       max_interval: 1800000.0
   - type: object
     name: AdaptiveTicker
     attributes:
-      base: 24
       mantissas:
       - 1
       - 2
@@ -431,12 +426,13 @@ DatetimeTicker:
       - 6
       - 8
       - 12
+      num_minor_ticks: 0
+      base: 24
       min_interval: 3600000.0
       max_interval: 43200000.0
   - type: object
     name: DaysTicker
     attributes:
-      num_minor_ticks: 0
       days:
       - 1
       - 2
@@ -472,7 +468,6 @@ DatetimeTicker:
   - type: object
     name: DaysTicker
     attributes:
-      num_minor_ticks: 0
       days:
       - 1
       - 4
@@ -487,7 +482,6 @@ DatetimeTicker:
   - type: object
     name: DaysTicker
     attributes:
-      num_minor_ticks: 0
       days:
       - 1
       - 8
@@ -496,7 +490,6 @@ DatetimeTicker:
   - type: object
     name: DaysTicker
     attributes:
-      num_minor_ticks: 0
       days:
       - 1
       - 15
@@ -1225,7 +1218,17 @@ Image:
   color_mapper:
     type: object
     name: LinearColorMapper
-    attributes: {}
+    attributes:
+      palette:
+      - '#000000'
+      - '#252525'
+      - '#525252'
+      - '#737373'
+      - '#969696'
+      - '#bdbdbd'
+      - '#d9d9d9'
+      - '#f0f0f0'
+      - '#ffffff'
 ImageRGBA:
   __extends__: ImageBase
   image:
@@ -1994,43 +1997,11 @@ CoordinateMapping:
   x_source:
     type: object
     name: DataRange1d
-    attributes:
-      range_padding: 0.1
-      range_padding_units: percent
-      start:
-        type: number
-        value: nan
-      end:
-        type: number
-        value: nan
-      bounds: null
-      min_interval: null
-      max_interval: null
-      flipped: false
-      follow: null
-      follow_interval: null
-      default_span: 2.0
-      only_visible: false
+    attributes: {}
   y_source:
     type: object
     name: DataRange1d
-    attributes:
-      range_padding: 0.1
-      range_padding_units: percent
-      start:
-        type: number
-        value: nan
-      end:
-        type: number
-        value: nan
-      bounds: null
-      min_interval: null
-      max_interval: null
-      flipped: false
-      follow: null
-      follow_interval: null
-      default_span: 2.0
-      only_visible: false
+    attributes: {}
   x_scale:
     type: object
     name: LinearScale
@@ -2215,16 +2186,6 @@ GraphRenderer:
     type: object
     name: GlyphRenderer
     attributes:
-      data_source:
-        type: object
-        name: ColumnDataSource
-        attributes:
-          data:
-            type: map
-            entries:
-            - !!python/tuple
-              - index
-              - []
       view:
         type: object
         name: CDSView
@@ -2236,20 +2197,43 @@ GraphRenderer:
       glyph:
         type: object
         name: Circle
+        attributes: {}
+      data_source:
+        type: object
+        name: ColumnDataSource
         attributes:
-          radius:
-            type: value
-            value: null
-          radius_dimension: x
-      selection_glyph: auto
-      nonselection_glyph: auto
-      hover_glyph: null
-      muted_glyph: auto
-      muted: false
+          data:
+            type: map
+            entries:
+            - !!python/tuple
+              - index
+              - []
+          selection_policy:
+            type: object
+            name: UnionRenderers
+            attributes: {}
+          selected:
+            type: object
+            name: Selection
+            attributes:
+              line_indices: []
+              indices: []
   edge_renderer:
     type: object
     name: GlyphRenderer
     attributes:
+      view:
+        type: object
+        name: CDSView
+        attributes:
+          filter:
+            type: object
+            name: AllIndices
+            attributes: {}
+      glyph:
+        type: object
+        name: MultiLine
+        attributes: {}
       data_source:
         type: object
         name: ColumnDataSource
@@ -2263,50 +2247,16 @@ GraphRenderer:
             - !!python/tuple
               - end
               - []
-      view:
-        type: object
-        name: CDSView
-        attributes:
-          filter:
+          selection_policy:
             type: object
-            name: AllIndices
+            name: UnionRenderers
             attributes: {}
-      glyph:
-        type: object
-        name: MultiLine
-        attributes:
-          xs:
-            type: field
-            field: xs
-          ys:
-            type: field
-            field: ys
-          line_color:
-            type: value
-            value: black
-          line_alpha:
-            type: value
-            value: 1.0
-          line_width:
-            type: value
-            value: 1
-          line_join:
-            type: value
-            value: bevel
-          line_cap:
-            type: value
-            value: butt
-          line_dash:
-            type: value
-            value: []
-          line_dash_offset:
-            type: value
-            value: 0
-      selection_glyph: auto
-      nonselection_glyph: auto
-      hover_glyph: null
-      muted_glyph: auto
-      muted: false
+          selected:
+            type: object
+            name: Selection
+            attributes:
+              line_indices: []
+              indices: []
   selection_policy:
     type: object
     name: NodesOnly
@@ -2389,15 +2339,15 @@ LinearAxis:
   ticker:
     type: object
     name: BasicTicker
-    attributes: {}
+    attributes:
+      mantissas:
+      - 1
+      - 2
+      - 5
   formatter:
     type: object
     name: BasicTickFormatter
-    attributes:
-      precision: auto
-      use_scientific: true
-      power_limit_high: 5
-      power_limit_low: -3
+    attributes: {}
 LogAxis:
   __extends__: ContinuousAxis
   ticker:
@@ -2410,9 +2360,7 @@ LogAxis:
   formatter:
     type: object
     name: LogTickFormatter
-    attributes:
-      ticker: null
-      min_exponent: 0
+    attributes: {}
 CategoricalAxis:
   __extends__: Axis
   ticker:
@@ -2456,22 +2404,19 @@ DatetimeAxis:
     type: object
     name: DatetimeTicker
     attributes:
-      num_minor_ticks: 0
       tickers:
       - type: object
         name: AdaptiveTicker
         attributes:
-          base: 10.0
           mantissas:
           - 1
           - 2
           - 5
-          min_interval: 0.0
+          num_minor_ticks: 0
           max_interval: 500.0
       - type: object
         name: AdaptiveTicker
         attributes:
-          base: 60
           mantissas:
           - 1
           - 2
@@ -2480,12 +2425,13 @@ DatetimeAxis:
           - 15
           - 20
           - 30
+          num_minor_ticks: 0
+          base: 60
           min_interval: 1000.0
           max_interval: 1800000.0
       - type: object
         name: AdaptiveTicker
         attributes:
-          base: 24
           mantissas:
           - 1
           - 2
@@ -2493,12 +2439,13 @@ DatetimeAxis:
           - 6
           - 8
           - 12
+          num_minor_ticks: 0
+          base: 24
           min_interval: 3600000.0
           max_interval: 43200000.0
       - type: object
         name: DaysTicker
         attributes:
-          num_minor_ticks: 0
           days:
           - 1
           - 2
@@ -2534,7 +2481,6 @@ DatetimeAxis:
       - type: object
         name: DaysTicker
         attributes:
-          num_minor_ticks: 0
           days:
           - 1
           - 4
@@ -2549,7 +2495,6 @@ DatetimeAxis:
       - type: object
         name: DaysTicker
         attributes:
-          num_minor_ticks: 0
           days:
           - 1
           - 8
@@ -2558,7 +2503,6 @@ DatetimeAxis:
       - type: object
         name: DaysTicker
         attributes:
-          num_minor_ticks: 0
           days:
           - 1
           - 15
@@ -2607,21 +2551,7 @@ DatetimeAxis:
   formatter:
     type: object
     name: DatetimeTickFormatter
-    attributes:
-      microseconds: '%fus'
-      milliseconds: '%3Nms'
-      seconds: '%Ss'
-      minsec: :%M:%S
-      minutes: :%M
-      hourmin: '%H:%M'
-      hours: '%Hh'
-      days: '%m/%d'
-      months: '%m/%Y'
-      years: '%Y'
-      strip_leading_zeros: true
-      context: null
-      context_which: start
-      context_location: below
+    attributes: {}
 MercatorAxis:
   __extends__: LinearAxis
   ticker:
@@ -2629,6 +2559,10 @@ MercatorAxis:
     name: MercatorTicker
     attributes:
       dimension: lat
+      mantissas:
+      - 1
+      - 2
+      - 5
   formatter:
     type: object
     name: MercatorTickFormatter
@@ -3117,6 +3051,16 @@ DataAnnotation:
       data:
         type: map
         entries: []
+      selection_policy:
+        type: object
+        name: UnionRenderers
+        attributes: {}
+      selected:
+        type: object
+        name: Selection
+        attributes:
+          line_indices: []
+          indices: []
 ArrowHead:
   __extends__: Marking
   size:
@@ -3246,28 +3190,7 @@ Arrow:
   end:
     type: object
     name: OpenHead
-    attributes:
-      line_color:
-        type: value
-        value: black
-      line_alpha:
-        type: value
-        value: 1.0
-      line_width:
-        type: value
-        value: 1
-      line_join:
-        type: value
-        value: bevel
-      line_cap:
-        type: value
-        value: butt
-      line_dash:
-        type: value
-        value: []
-      line_dash_offset:
-        type: value
-        value: 0
+    attributes: {}
   line_color:
     type: value
     value: black
@@ -3393,27 +3316,9 @@ Whisker:
     type: object
     name: TeeHead
     attributes:
-      line_color:
+      size:
         type: value
-        value: black
-      line_alpha:
-        type: value
-        value: 1.0
-      line_width:
-        type: value
-        value: 1
-      line_join:
-        type: value
-        value: bevel
-      line_cap:
-        type: value
-        value: butt
-      line_dash:
-        type: value
-        value: []
-      line_dash_offset:
-        type: value
-        value: 0
+        value: 10
   upper:
     type: field
     field: upper
@@ -3421,27 +3326,9 @@ Whisker:
     type: object
     name: TeeHead
     attributes:
-      line_color:
+      size:
         type: value
-        value: black
-      line_alpha:
-        type: value
-        value: 1.0
-      line_width:
-        type: value
-        value: 1
-      line_join:
-        type: value
-        value: bevel
-      line_cap:
-        type: value
-        value: butt
-      line_dash:
-        type: value
-        value: []
-      line_dash_offset:
-        type: value
-        value: 0
+        value: 10
   base:
     type: field
     field: base
@@ -3754,8 +3641,7 @@ BaseColorBar:
   major_label_policy:
     type: object
     name: NoOverlap
-    attributes:
-      min_distance: 5
+    attributes: {}
   margin: 30
   padding: 10
   major_label_text_color: '#444444'
@@ -4035,33 +3921,16 @@ RangeTool:
     type: object
     name: BoxAnnotation
     attributes:
-      left: null
-      left_units: data
-      right: null
-      right_units: data
-      bottom: null
-      bottom_units: data
-      top: null
-      top_units: data
+      level: overlay
       line_color: black
-      line_alpha: 1.0
-      line_width: 0.5
-      line_join: bevel
-      line_cap: butt
       line_dash:
       - 2
       - 2
-      line_dash_offset: 0
-      fill_color: lightgrey
       fill_alpha: 0.5
-      hatch_color: black
-      hatch_alpha: 1.0
-      hatch_scale: 12.0
-      hatch_pattern: null
-      hatch_weight: 1.0
-      hatch_extra:
-        type: map
-        entries: []
+      fill_color: lightgrey
+      line_width: 0.5
+      line_alpha: 1.0
+      syncable: false
 WheelPanTool:
   __extends__: Scroll
   dimension: width
@@ -4103,33 +3972,21 @@ BoxZoomTool:
     type: object
     name: BoxAnnotation
     attributes:
-      left: null
-      left_units: canvas
-      right: null
-      right_units: canvas
-      bottom: null
-      bottom_units: canvas
-      top: null
+      visible: false
+      level: overlay
       top_units: canvas
       line_color: black
-      line_alpha: 1.0
-      line_width: 2
-      line_join: bevel
-      line_cap: butt
       line_dash:
       - 4
       - 4
-      line_dash_offset: 0
-      fill_color: lightgrey
       fill_alpha: 0.5
-      hatch_color: black
-      hatch_alpha: 1.0
-      hatch_scale: 12.0
-      hatch_pattern: null
-      hatch_weight: 1.0
-      hatch_extra:
-        type: map
-        entries: []
+      left_units: canvas
+      fill_color: lightgrey
+      bottom_units: canvas
+      right_units: canvas
+      line_width: 2
+      line_alpha: 1.0
+      syncable: false
   match_aspect: false
   origin: corner
 ZoomInTool:
@@ -4151,33 +4008,21 @@ BoxSelectTool:
     type: object
     name: BoxAnnotation
     attributes:
-      left: null
-      left_units: canvas
-      right: null
-      right_units: canvas
-      bottom: null
-      bottom_units: canvas
-      top: null
+      visible: false
+      level: overlay
       top_units: canvas
       line_color: black
-      line_alpha: 1.0
-      line_width: 2
-      line_join: bevel
-      line_cap: butt
       line_dash:
       - 4
       - 4
-      line_dash_offset: 0
-      fill_color: lightgrey
       fill_alpha: 0.5
-      hatch_color: black
-      hatch_alpha: 1.0
-      hatch_scale: 12.0
-      hatch_pattern: null
-      hatch_weight: 1.0
-      hatch_extra:
-        type: map
-        entries: []
+      left_units: canvas
+      fill_color: lightgrey
+      bottom_units: canvas
+      right_units: canvas
+      line_width: 2
+      line_alpha: 1.0
+      syncable: false
   origin: corner
 LassoSelectTool:
   __extends__:
@@ -4188,29 +4033,21 @@ LassoSelectTool:
     type: object
     name: PolyAnnotation
     attributes:
-      xs: []
-      xs_units: canvas
-      ys: []
-      ys_units: canvas
+      visible: false
+      level: overlay
       line_color: black
-      line_alpha: 1.0
-      line_width: 2
-      line_join: bevel
-      line_cap: butt
+      xs: []
       line_dash:
       - 4
       - 4
-      line_dash_offset: 0
-      fill_color: lightgrey
       fill_alpha: 0.5
-      hatch_color: black
-      hatch_alpha: 1.0
-      hatch_scale: 12.0
-      hatch_pattern: null
-      hatch_weight: 1.0
-      hatch_extra:
-        type: map
-        entries: []
+      fill_color: lightgrey
+      ys: []
+      xs_units: canvas
+      ys_units: canvas
+      line_width: 2
+      line_alpha: 1.0
+      syncable: false
 PolySelectTool:
   __extends__:
   - Tap
@@ -4219,29 +4056,21 @@ PolySelectTool:
     type: object
     name: PolyAnnotation
     attributes:
-      xs: []
-      xs_units: canvas
-      ys: []
-      ys_units: canvas
+      visible: false
+      level: overlay
       line_color: black
-      line_alpha: 1.0
-      line_width: 2
-      line_join: bevel
-      line_cap: butt
+      xs: []
       line_dash:
       - 4
       - 4
-      line_dash_offset: 0
-      fill_color: lightgrey
       fill_alpha: 0.5
-      hatch_color: black
-      hatch_alpha: 1.0
-      hatch_scale: 12.0
-      hatch_pattern: null
-      hatch_weight: 1.0
-      hatch_extra:
-        type: map
-        entries: []
+      fill_color: lightgrey
+      ys: []
+      xs_units: canvas
+      ys_units: canvas
+      line_width: 2
+      line_alpha: 1.0
+      syncable: false
 CustomJSHover:
   __extends__: Model
   args:
@@ -4339,43 +4168,11 @@ Plot:
   x_range:
     type: object
     name: DataRange1d
-    attributes:
-      range_padding: 0.1
-      range_padding_units: percent
-      start:
-        type: number
-        value: nan
-      end:
-        type: number
-        value: nan
-      bounds: null
-      min_interval: null
-      max_interval: null
-      flipped: false
-      follow: null
-      follow_interval: null
-      default_span: 2.0
-      only_visible: false
+    attributes: {}
   y_range:
     type: object
     name: DataRange1d
-    attributes:
-      range_padding: 0.1
-      range_padding_units: percent
-      start:
-        type: number
-        value: nan
-      end:
-        type: number
-        value: nan
-      bounds: null
-      min_interval: null
-      max_interval: null
-      flipped: false
-      follow: null
-      follow_interval: null
-      default_span: 2.0
-      only_visible: false
+    attributes: {}
   x_scale:
     type: object
     name: LinearScale
@@ -4400,14 +4197,7 @@ Plot:
   title:
     type: object
     name: Title
-    attributes:
-      text_font_size: 13px
-      text_font_style: bold
-      text_line_height: 1.0
-      vertical_align: bottom
-      align: left
-      offset: 0
-      standoff: 10
+    attributes: {}
   title_location: above
   outline_line_color: '#e5e5e5'
   outline_line_alpha: 1.0
@@ -4420,15 +4210,7 @@ Plot:
   toolbar:
     type: object
     name: Toolbar
-    attributes:
-      logo: normal
-      autohide: false
-      tools: []
-      active_drag: auto
-      active_inspect: auto
-      active_scroll: auto
-      active_tap: auto
-      active_multi: auto
+    attributes: {}
   toolbar_location: right
   toolbar_sticky: true
   toolbar_inner: false
@@ -4467,15 +4249,7 @@ GridPlot:
   toolbar:
     type: object
     name: Toolbar
-    attributes:
-      logo: normal
-      autohide: false
-      tools: []
-      active_drag: auto
-      active_inspect: auto
-      active_scroll: auto
-      active_tap: auto
-      active_multi: auto
+    attributes: {}
   toolbar_location: above
   children: []
   rows: null
@@ -4503,25 +4277,11 @@ GMapPlot:
   x_range:
     type: object
     name: Range1d
-    attributes:
-      start: 0
-      end: 1
-      reset_start: null
-      reset_end: null
-      bounds: null
-      min_interval: null
-      max_interval: null
+    attributes: {}
   y_range:
     type: object
     name: Range1d
-    attributes:
-      start: 0
-      end: 1
-      reset_start: null
-      reset_end: null
-      bounds: null
-      min_interval: null
-      max_interval: null
+    attributes: {}
   background_fill_alpha: 0.0
   border_fill_color: '#ffffff'
   map_options:
@@ -4593,8 +4353,8 @@ HelpButton:
     type: object
     name: BuiltinIcon
     attributes:
+      size: 18
       icon_name: help
-      color: gray
   tooltip:
     type: symbol
     name: unset
@@ -4886,16 +4646,11 @@ TableColumn:
   formatter:
     type: object
     name: StringFormatter
-    attributes:
-      font_style: normal
-      text_align: left
-      text_color: null
-      nan_format: '-'
+    attributes: {}
   editor:
     type: object
     name: StringEditor
-    attributes:
-      completions: []
+    attributes: {}
   sortable: true
   default_sort: ascending
   visible: true
@@ -4908,6 +4663,16 @@ TableWidget:
       data:
         type: map
         entries: []
+      selection_policy:
+        type: object
+        name: UnionRenderers
+        attributes: {}
+      selected:
+        type: object
+        name: Selection
+        attributes:
+          line_indices: []
+          indices: []
   view:
     type: object
     name: CDSView

--- a/tests/baselines/defaults.yaml
+++ b/tests/baselines/defaults.yaml
@@ -9,17 +9,7 @@ Model:
     type: map
     entries: []
   syncable: true
-DataModel:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+DataModel: {}
 FillProps:
   fill_color:
     type: value
@@ -132,56 +122,16 @@ ScalarTextProps:
   text_align: left
   text_baseline: bottom
   text_line_height: 1.2
-Callback:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Callback: {}
 OpenURL:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   url: http://
   same_tab: false
 CustomJS:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   args:
     type: map
     entries: []
   code: ''
 SetValue:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   obj:
     type: symbol
     name: unset
@@ -191,133 +141,33 @@ SetValue:
   value:
     type: symbol
     name: unset
-Filter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-AllIndices:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Filter: {}
+AllIndices: {}
 InversionFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   operand:
     type: symbol
     name: unset
 IntersectionFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   operands:
     type: symbol
     name: unset
 UnionFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   operands:
     type: symbol
     name: unset
 DifferenceFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   operands:
     type: symbol
     name: unset
 SymmetricDifferenceFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   operands:
     type: symbol
     name: unset
 IndexFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   indices: null
 BooleanFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   booleans: null
 GroupFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   column_name:
     type: symbol
     name: unset
@@ -325,95 +175,25 @@ GroupFilter:
     type: symbol
     name: unset
 CustomJSFilter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   args:
     type: map
     entries: []
   code: ''
 Selection:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   indices: []
   line_indices: []
   multiline_indices:
     type: map
     entries: []
   image_indices: []
-SelectionPolicy:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-IntersectRenderers:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-UnionRenderers:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+SelectionPolicy: {}
+IntersectRenderers: {}
+UnionRenderers: {}
 DataSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   selected:
     type: object
     name: Selection
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       indices: []
       line_indices: []
       multiline_indices:
@@ -421,333 +201,32 @@ DataSource:
         entries: []
       image_indices: []
 ColumnarDataSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  selected:
-    type: object
-    name: Selection
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      indices: []
-      line_indices: []
-      multiline_indices:
-        type: map
-        entries: []
-      image_indices: []
   selection_policy:
     type: object
     name: UnionRenderers
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
 ColumnDataSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  selected:
-    type: object
-    name: Selection
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      indices: []
-      line_indices: []
-      multiline_indices:
-        type: map
-        entries: []
-      image_indices: []
-  selection_policy:
-    type: object
-    name: UnionRenderers
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
   data:
     type: map
     entries: []
 CDSView:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   filter:
     type: object
     name: AllIndices
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
 GeoJSONDataSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  selected:
-    type: object
-    name: Selection
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      indices: []
-      line_indices: []
-      multiline_indices:
-        type: map
-        entries: []
-      image_indices: []
-  selection_policy:
-    type: object
-    name: UnionRenderers
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
   geojson:
     type: symbol
     name: unset
 WebDataSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  selected:
-    type: object
-    name: Selection
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      indices: []
-      line_indices: []
-      multiline_indices:
-        type: map
-        entries: []
-      image_indices: []
-  selection_policy:
-    type: object
-    name: UnionRenderers
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  data:
-    type: map
-    entries: []
   adapter: null
   max_size: null
   mode: replace
   data_url:
     type: symbol
     name: unset
-ServerSentDataSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  selected:
-    type: object
-    name: Selection
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      indices: []
-      line_indices: []
-      multiline_indices:
-        type: map
-        entries: []
-      image_indices: []
-  selection_policy:
-    type: object
-    name: UnionRenderers
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  data:
-    type: map
-    entries: []
-  adapter: null
-  max_size: null
-  mode: replace
-  data_url:
-    type: symbol
-    name: unset
+ServerSentDataSource: {}
 AjaxDataSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  selected:
-    type: object
-    name: Selection
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      indices: []
-      line_indices: []
-      multiline_indices:
-        type: map
-        entries: []
-      image_indices: []
-  selection_policy:
-    type: object
-    name: UnionRenderers
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  data:
-    type: map
-    entries: []
-  adapter: null
-  max_size: null
-  mode: replace
-  data_url:
-    type: symbol
-    name: unset
   polling_interval: null
   method: POST
   if_modified: false
@@ -755,72 +234,22 @@ AjaxDataSource:
   http_headers:
     type: map
     entries: []
-Transform:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Transform: {}
 CustomJSTransform:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   args:
     type: map
     entries: []
   func: ''
   v_func: ''
 Dodge:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   value: 0
   range: null
 Jitter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   mean: 0
   width: 1
   distribution: uniform
   range: null
 Interpolator:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   x:
     type: symbol
     name: unset
@@ -829,301 +258,52 @@ Interpolator:
     name: unset
   data: null
   clip: true
-LinearInterpolator:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  x:
-    type: symbol
-    name: unset
-  y:
-    type: symbol
-    name: unset
-  data: null
-  clip: true
+LinearInterpolator: {}
 StepInterpolator:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  x:
-    type: symbol
-    name: unset
-  y:
-    type: symbol
-    name: unset
-  data: null
-  clip: true
   mode: after
-Mapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Mapper: {}
 ColorMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   palette:
     type: symbol
     name: unset
   nan_color: gray
 CategoricalMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   factors:
     type: symbol
     name: unset
   start: 0
   end: null
-CategoricalColorMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  palette:
-    type: symbol
-    name: unset
-  nan_color: gray
-  factors:
-    type: symbol
-    name: unset
-  start: 0
-  end: null
+CategoricalColorMapper: {}
 CategoricalMarkerMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  factors:
-    type: symbol
-    name: unset
-  start: 0
-  end: null
   markers:
     type: symbol
     name: unset
   default_value: circle
 CategoricalPatternMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  factors:
-    type: symbol
-    name: unset
-  start: 0
-  end: null
   patterns:
     type: symbol
     name: unset
   default_value: ' '
 ContinuousColorMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  palette:
-    type: symbol
-    name: unset
-  nan_color: gray
   domain: []
   low: null
   high: null
   low_color: null
   high_color: null
-LinearColorMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  palette:
-    type: symbol
-    name: unset
-  nan_color: gray
-  domain: []
-  low: null
-  high: null
-  low_color: null
-  high_color: null
-LogColorMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  palette:
-    type: symbol
-    name: unset
-  nan_color: gray
-  domain: []
-  low: null
-  high: null
-  low_color: null
-  high_color: null
-ScanningColorMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  palette:
-    type: symbol
-    name: unset
-  nan_color: gray
-  domain: []
-  low: null
-  high: null
-  low_color: null
-  high_color: null
+LinearColorMapper: {}
+LogColorMapper: {}
+ScanningColorMapper: {}
 EqHistColorMapper:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  palette:
-    type: symbol
-    name: unset
-  nan_color: gray
-  domain: []
-  low: null
-  high: null
-  low_color: null
-  high_color: null
   bins: 65536
   rescale_discrete_levels: false
-Ticker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Ticker: {}
 ContinuousTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   num_minor_ticks: 5
   desired_num_ticks: 6
 FixedTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
   ticks: []
   minor_ticks: []
 AdaptiveTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
   base: 10.0
   mantissas:
   - 1
@@ -1132,185 +312,31 @@ AdaptiveTicker:
   min_interval: 0.0
   max_interval: null
 CompositeTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
   tickers: []
 SingleIntervalTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
   interval:
     type: symbol
     name: unset
 DaysTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   num_minor_ticks: 0
-  desired_num_ticks: 6
-  interval:
-    type: symbol
-    name: unset
   days: []
 MonthsTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
-  interval:
-    type: symbol
-    name: unset
   months: []
-YearsTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
-  interval:
-    type: symbol
-    name: unset
-BasicTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
-  base: 10.0
-  mantissas:
-  - 1
-  - 2
-  - 5
-  min_interval: 0.0
-  max_interval: null
+YearsTicker: {}
+BasicTicker: {}
 LogTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
-  base: 10.0
   mantissas:
   - 1
   - 5
-  min_interval: 0.0
-  max_interval: null
 MercatorTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  num_minor_ticks: 5
-  desired_num_ticks: 6
-  base: 10.0
-  mantissas:
-  - 1
-  - 2
-  - 5
-  min_interval: 0.0
-  max_interval: null
   dimension: null
-CategoricalTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+CategoricalTicker: {}
 DatetimeTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   num_minor_ticks: 0
-  desired_num_ticks: 6
   tickers:
   - type: object
     name: AdaptiveTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 0
-      desired_num_ticks: 6
       base: 10.0
       mantissas:
       - 1
@@ -1321,18 +347,6 @@ DatetimeTicker:
   - type: object
     name: AdaptiveTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 0
-      desired_num_ticks: 6
       base: 60
       mantissas:
       - 1
@@ -1347,18 +361,6 @@ DatetimeTicker:
   - type: object
     name: AdaptiveTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 0
-      desired_num_ticks: 6
       base: 24
       mantissas:
       - 1
@@ -1372,18 +374,7 @@ DatetimeTicker:
   - type: object
     name: DaysTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       num_minor_ticks: 0
-      desired_num_ticks: 6
       days:
       - 1
       - 2
@@ -1419,18 +410,7 @@ DatetimeTicker:
   - type: object
     name: DaysTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       num_minor_ticks: 0
-      desired_num_ticks: 6
       days:
       - 1
       - 4
@@ -1445,18 +425,7 @@ DatetimeTicker:
   - type: object
     name: DaysTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       num_minor_ticks: 0
-      desired_num_ticks: 6
       days:
       - 1
       - 8
@@ -1465,36 +434,13 @@ DatetimeTicker:
   - type: object
     name: DaysTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       num_minor_ticks: 0
-      desired_num_ticks: 6
       days:
       - 1
       - 15
   - type: object
     name: MonthsTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 5
-      desired_num_ticks: 6
       months:
       - 0
       - 1
@@ -1511,18 +457,6 @@ DatetimeTicker:
   - type: object
     name: MonthsTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 5
-      desired_num_ticks: 6
       months:
       - 0
       - 2
@@ -1533,18 +467,6 @@ DatetimeTicker:
   - type: object
     name: MonthsTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 5
-      desired_num_ticks: 6
       months:
       - 0
       - 4
@@ -1552,169 +474,41 @@ DatetimeTicker:
   - type: object
     name: MonthsTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 5
-      desired_num_ticks: 6
       months:
       - 0
       - 6
   - type: object
     name: YearsTicker
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 5
-      desired_num_ticks: 6
+    attributes: {}
 BinnedTicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   mapper:
     type: symbol
     name: unset
   num_major_ticks: 8
-TickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+TickFormatter: {}
 BasicTickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   precision: auto
   use_scientific: true
   power_limit_high: 5
   power_limit_low: -3
 MercatorTickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  precision: auto
-  use_scientific: true
-  power_limit_high: 5
-  power_limit_low: -3
   dimension: null
 NumeralTickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   format: 0,0
   language: en
   rounding: round
 PrintfTickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   format: '%s'
 LogTickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   ticker: null
   min_exponent: 0
-CategoricalTickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+CategoricalTickFormatter: {}
 CustomJSTickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   args:
     type: map
     entries: []
   code: ''
 DatetimeTickFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   microseconds: '%fus'
   milliseconds: '%3Nms'
   seconds: '%Ss'
@@ -1729,28 +523,8 @@ DatetimeTickFormatter:
   context: null
   context_which: start
   context_location: below
-Marking:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Marking: {}
 Decoration:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   marking:
     type: symbol
     name: unset
@@ -1758,101 +532,14 @@ Decoration:
     type: symbol
     name: unset
 Glyph:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   decorations: []
-XYGlyph:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-ConnectedXYGlyph:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-LineGlyph:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-FillGlyph:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-TextGlyph:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-HatchGlyph:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
+XYGlyph: {}
+ConnectedXYGlyph: {}
+LineGlyph: {}
+FillGlyph: {}
+TextGlyph: {}
+HatchGlyph: {}
 Marker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -1912,17 +599,6 @@ Marker:
     type: map
     entries: []
 AnnularWedge:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -1988,17 +664,6 @@ AnnularWedge:
     type: map
     entries: []
 Annulus:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -2057,17 +722,6 @@ Annulus:
     type: map
     entries: []
 Arc:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -2106,17 +760,6 @@ Arc:
     type: value
     value: 0
 Bezier:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x0:
     type: field
     field: x0
@@ -2163,17 +806,6 @@ Bezier:
     type: value
     value: 0
 Block:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -2232,91 +864,11 @@ Block:
     type: map
     entries: []
 Circle:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-  x:
-    type: field
-    field: x
-  y:
-    type: field
-    field: y
-  hit_dilation: 1.0
-  size:
-    type: value
-    value: 4
-  angle:
-    type: value
-    value: 0.0
-  line_color:
-    type: value
-    value: black
-  line_alpha:
-    type: value
-    value: 1.0
-  line_width:
-    type: value
-    value: 1
-  line_join:
-    type: value
-    value: bevel
-  line_cap:
-    type: value
-    value: butt
-  line_dash:
-    type: value
-    value: []
-  line_dash_offset:
-    type: value
-    value: 0
-  fill_color:
-    type: value
-    value: gray
-  fill_alpha:
-    type: value
-    value: 1.0
-  hatch_color:
-    type: value
-    value: black
-  hatch_alpha:
-    type: value
-    value: 1.0
-  hatch_scale:
-    type: value
-    value: 12.0
-  hatch_pattern:
-    type: value
-    value: null
-  hatch_weight:
-    type: value
-    value: 1.0
-  hatch_extra:
-    type: map
-    entries: []
   radius:
     type: value
     value: null
   radius_dimension: x
 Ellipse:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -2378,17 +930,6 @@ Ellipse:
     type: map
     entries: []
 HArea:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x1:
     type: field
     field: x1
@@ -2419,17 +960,6 @@ HArea:
     type: map
     entries: []
 HBar:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   y:
     type: field
     field: y
@@ -2488,17 +1018,6 @@ HBar:
     type: map
     entries: []
 HexTile:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   size: 1.0
   aspect_scale: 1.0
   r:
@@ -2557,17 +1076,6 @@ HexTile:
     type: map
     entries: []
 ImageBase:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -2587,113 +1095,18 @@ ImageBase:
   origin: bottom_left
   anchor: bottom_left
 Image:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-  x:
-    type: field
-    field: x
-  y:
-    type: field
-    field: y
-  dw:
-    type: field
-    field: dw
-  dh:
-    type: field
-    field: dh
-  global_alpha:
-    type: value
-    value: 1.0
-  dilate: false
-  origin: bottom_left
-  anchor: bottom_left
   image:
     type: field
     field: image
   color_mapper:
     type: object
     name: LinearColorMapper
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      palette:
-      - '#000000'
-      - '#252525'
-      - '#525252'
-      - '#737373'
-      - '#969696'
-      - '#bdbdbd'
-      - '#d9d9d9'
-      - '#f0f0f0'
-      - '#ffffff'
-      nan_color: gray
-      domain: []
-      low: null
-      high: null
-      low_color: null
-      high_color: null
+    attributes: {}
 ImageRGBA:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-  x:
-    type: field
-    field: x
-  y:
-    type: field
-    field: y
-  dw:
-    type: field
-    field: dw
-  dh:
-    type: field
-    field: dh
-  global_alpha:
-    type: value
-    value: 1.0
-  dilate: false
-  origin: bottom_left
-  anchor: bottom_left
   image:
     type: field
     field: image
 ImageURL:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   url:
     type: field
     field: url
@@ -2720,17 +1133,6 @@ ImageURL:
   retry_attempts: 0
   retry_timeout: 0
 Line:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -2745,17 +1147,6 @@ Line:
   line_dash: []
   line_dash_offset: 0
 MultiLine:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   xs:
     type: field
     field: xs
@@ -2784,17 +1175,6 @@ MultiLine:
     type: value
     value: 0
 MultiPolygons:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   xs:
     type: field
     field: xs
@@ -2847,17 +1227,6 @@ MultiPolygons:
     type: map
     entries: []
 Patch:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -2882,17 +1251,6 @@ Patch:
     type: map
     entries: []
 Patches:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   xs:
     type: field
     field: xs
@@ -2945,17 +1303,6 @@ Patches:
     type: map
     entries: []
 Quad:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   left:
     type: field
     field: left
@@ -3014,17 +1361,6 @@ Quad:
     type: map
     entries: []
 Quadratic:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x0:
     type: field
     field: x0
@@ -3065,17 +1401,6 @@ Quadratic:
     type: value
     value: 0
 Ray:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -3110,17 +1435,6 @@ Ray:
     type: value
     value: 0
 Rect:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -3183,90 +1497,10 @@ Rect:
     type: map
     entries: []
 Scatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
-  x:
-    type: field
-    field: x
-  y:
-    type: field
-    field: y
-  hit_dilation: 1.0
-  size:
-    type: value
-    value: 4
-  angle:
-    type: value
-    value: 0.0
-  line_color:
-    type: value
-    value: black
-  line_alpha:
-    type: value
-    value: 1.0
-  line_width:
-    type: value
-    value: 1
-  line_join:
-    type: value
-    value: bevel
-  line_cap:
-    type: value
-    value: butt
-  line_dash:
-    type: value
-    value: []
-  line_dash_offset:
-    type: value
-    value: 0
-  fill_color:
-    type: value
-    value: gray
-  fill_alpha:
-    type: value
-    value: 1.0
-  hatch_color:
-    type: value
-    value: black
-  hatch_alpha:
-    type: value
-    value: 1.0
-  hatch_scale:
-    type: value
-    value: 12.0
-  hatch_pattern:
-    type: value
-    value: null
-  hatch_weight:
-    type: value
-    value: 1.0
-  hatch_extra:
-    type: map
-    entries: []
   marker:
     type: value
     value: circle
 Segment:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x0:
     type: field
     field: x0
@@ -3301,17 +1535,6 @@ Segment:
     type: value
     value: 0
 Step:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -3327,17 +1550,6 @@ Step:
   line_dash_offset: 0
   mode: before
 Text:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -3384,17 +1596,6 @@ Text:
     type: value
     value: 1.2
 VArea:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -3425,17 +1626,6 @@ VArea:
     type: map
     entries: []
 VBar:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -3494,17 +1684,6 @@ VBar:
     type: map
     entries: []
 Wedge:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  decorations: []
   x:
     type: field
     field: x
@@ -3566,77 +1745,17 @@ Wedge:
   hatch_extra:
     type: map
     entries: []
-LabelingPolicy:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-AllLabels:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+LabelingPolicy: {}
+AllLabels: {}
 NoOverlap:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   min_distance: 5
 CustomLabelingPolicy:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   args:
     type: map
     entries: []
   code: ''
-Range:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Range: {}
 Range1d:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   start: 0
   end: 1
   reset_start: null
@@ -3645,29 +1764,8 @@ Range1d:
   min_interval: null
   max_interval: null
 DataRange:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   renderers: []
 DataRange1d:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  renderers: []
   range_padding: 0.1
   range_padding_units: percent
   start:
@@ -3685,16 +1783,6 @@ DataRange1d:
   default_span: 2.0
   only_visible: false
 FactorRange:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   factors: []
   factor_padding: 0.0
   subgroup_padding: 0.8
@@ -3706,87 +1794,16 @@ FactorRange:
   bounds: null
   min_interval: null
   max_interval: null
-Scale:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-ContinuousScale:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-LinearScale:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-LogScale:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-CategoricalScale:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Scale: {}
+ContinuousScale: {}
+LinearScale: {}
+LogScale: {}
+CategoricalScale: {}
 CoordinateMapping:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   x_source:
     type: object
     name: DataRange1d
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      renderers: []
       range_padding: 0.1
       range_padding_units: percent
       start:
@@ -3807,17 +1824,6 @@ CoordinateMapping:
     type: object
     name: DataRange1d
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      renderers: []
       range_padding: 0.1
       range_padding_units: percent
       start:
@@ -3837,112 +1843,32 @@ CoordinateMapping:
   x_scale:
     type: object
     name: LinearScale
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
   y_scale:
     type: object
     name: LinearScale
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
   x_target:
     type: symbol
     name: unset
   y_target:
     type: symbol
     name: unset
-Expression:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Expression: {}
 CustomJSExpr:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   args:
     type: map
     entries: []
   code: ''
 CumSum:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   field:
     type: symbol
     name: unset
   include_zero: false
 Stack:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   fields: []
-ScalarExpression:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+ScalarExpression: {}
 Minimum:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   field:
     type: symbol
     name: unset
@@ -3950,44 +1876,14 @@ Minimum:
     type: number
     value: +inf
 Maximum:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   field:
     type: symbol
     name: unset
   initial:
     type: number
     value: -inf
-CoordinateTransform:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+CoordinateTransform: {}
 PolarTransform:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   radius:
     type: field
     field: radius
@@ -3996,191 +1892,29 @@ PolarTransform:
     field: angle
   direction: anticlock
 XYComponent:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   transform:
     type: symbol
     name: unset
-XComponent:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  transform:
-    type: symbol
-    name: unset
-YComponent:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  transform:
-    type: symbol
-    name: unset
-LayoutProvider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+XComponent: {}
+YComponent: {}
+LayoutProvider: {}
 StaticLayoutProvider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   graph_layout:
     type: map
     entries: []
 GraphCoordinates:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   layout:
     type: symbol
     name: unset
-NodeCoordinates:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  layout:
-    type: symbol
-    name: unset
-EdgeCoordinates:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  layout:
-    type: symbol
-    name: unset
-GraphHitTestPolicy:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-EdgesOnly:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-NodesOnly:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-NodesAndLinkedEdges:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-EdgesAndLinkedNodes:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-NodesAndAdjacentNodes:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+NodeCoordinates: {}
+EdgeCoordinates: {}
+GraphHitTestPolicy: {}
+EdgesOnly: {}
+NodesOnly: {}
+NodesAndLinkedEdges: {}
+EdgesAndLinkedNodes: {}
+NodesAndAdjacentNodes: {}
 TileSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   url: ''
   tile_size: 256
   min_zoom: 0
@@ -4197,149 +1931,19 @@ TileSource:
     name: unset
   initial_resolution: null
 MercatorTileSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  url: ''
-  tile_size: 256
-  min_zoom: 0
-  max_zoom: 30
-  extra_url_vars:
-    type: map
-    entries: []
-  attribution: ''
   x_origin_offset: 20037508.34
   y_origin_offset: 20037508.34
   initial_resolution: 156543.03392804097
   snap_to_zoom: false
   wrap_around: true
-TMSTileSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  url: ''
-  tile_size: 256
-  min_zoom: 0
-  max_zoom: 30
-  extra_url_vars:
-    type: map
-    entries: []
-  attribution: ''
-  x_origin_offset: 20037508.34
-  y_origin_offset: 20037508.34
-  initial_resolution: 156543.03392804097
-  snap_to_zoom: false
-  wrap_around: true
-WMTSTileSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  url: ''
-  tile_size: 256
-  min_zoom: 0
-  max_zoom: 30
-  extra_url_vars:
-    type: map
-    entries: []
-  attribution: ''
-  x_origin_offset: 20037508.34
-  y_origin_offset: 20037508.34
-  initial_resolution: 156543.03392804097
-  snap_to_zoom: false
-  wrap_around: true
-QUADKEYTileSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  url: ''
-  tile_size: 256
-  min_zoom: 0
-  max_zoom: 30
-  extra_url_vars:
-    type: map
-    entries: []
-  attribution: ''
-  x_origin_offset: 20037508.34
-  y_origin_offset: 20037508.34
-  initial_resolution: 156543.03392804097
-  snap_to_zoom: false
-  wrap_around: true
+TMSTileSource: {}
+WMTSTileSource: {}
+QUADKEYTileSource: {}
 BBoxTileSource:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  url: ''
-  tile_size: 256
-  min_zoom: 0
-  max_zoom: 30
-  extra_url_vars:
-    type: map
-    entries: []
-  attribution: ''
-  x_origin_offset: 20037508.34
-  y_origin_offset: 20037508.34
-  initial_resolution: 156543.03392804097
-  snap_to_zoom: false
-  wrap_around: true
   use_latlon: false
 RendererGroup:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   visible: true
 Renderer:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   level: image
   visible: true
   coordinates: null
@@ -4347,86 +1951,17 @@ Renderer:
   y_range_name: default
   group: null
 TileRenderer:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   level: image
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   tile_source:
     type: object
     name: WMTSTileSource
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      url: ''
-      tile_size: 256
-      min_zoom: 0
-      max_zoom: 30
-      extra_url_vars:
-        type: map
-        entries: []
-      attribution: ''
-      x_origin_offset: 20037508.34
-      y_origin_offset: 20037508.34
-      initial_resolution: 156543.03392804097
-      snap_to_zoom: false
-      wrap_around: true
+    attributes: {}
   alpha: 1.0
   smoothing: true
   render_parents: true
 DataRenderer:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   level: glyph
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
 GlyphRenderer:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: glyph
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   data_source:
     type: symbol
     name: unset
@@ -4434,30 +1969,10 @@ GlyphRenderer:
     type: object
     name: CDSView
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       filter:
         type: object
         name: AllIndices
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
+        attributes: {}
   glyph:
     type: symbol
     name: unset
@@ -4467,22 +1982,6 @@ GlyphRenderer:
   muted_glyph: auto
   muted: false
 GraphRenderer:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: glyph
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   layout_provider:
     type: symbol
     name: unset
@@ -4490,70 +1989,10 @@ GraphRenderer:
     type: object
     name: GlyphRenderer
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      level: glyph
-      visible: true
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
       data_source:
         type: object
         name: ColumnDataSource
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          selected:
-            type: object
-            name: Selection
-            attributes:
-              name: null
-              tags: []
-              js_event_callbacks:
-                type: map
-                entries: []
-              subscribed_events: []
-              js_property_callbacks:
-                type: map
-                entries: []
-              syncable: true
-              indices: []
-              line_indices: []
-              multiline_indices:
-                type: map
-                entries: []
-              image_indices: []
-          selection_policy:
-            type: object
-            name: UnionRenderers
-            attributes:
-              name: null
-              tags: []
-              js_event_callbacks:
-                type: map
-                entries: []
-              subscribed_events: []
-              js_property_callbacks:
-                type: map
-                entries: []
-              syncable: true
           data:
             type: map
             entries:
@@ -4564,103 +2003,14 @@ GraphRenderer:
         type: object
         name: CDSView
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
           filter:
             type: object
             name: AllIndices
-            attributes:
-              name: null
-              tags: []
-              js_event_callbacks:
-                type: map
-                entries: []
-              subscribed_events: []
-              js_property_callbacks:
-                type: map
-                entries: []
-              syncable: true
+            attributes: {}
       glyph:
         type: object
         name: Circle
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          decorations: []
-          x:
-            type: field
-            field: x
-          y:
-            type: field
-            field: y
-          hit_dilation: 1.0
-          size:
-            type: value
-            value: 4
-          angle:
-            type: value
-            value: 0.0
-          line_color:
-            type: value
-            value: black
-          line_alpha:
-            type: value
-            value: 1.0
-          line_width:
-            type: value
-            value: 1
-          line_join:
-            type: value
-            value: bevel
-          line_cap:
-            type: value
-            value: butt
-          line_dash:
-            type: value
-            value: []
-          line_dash_offset:
-            type: value
-            value: 0
-          fill_color:
-            type: value
-            value: gray
-          fill_alpha:
-            type: value
-            value: 1.0
-          hatch_color:
-            type: value
-            value: black
-          hatch_alpha:
-            type: value
-            value: 1.0
-          hatch_scale:
-            type: value
-            value: 12.0
-          hatch_pattern:
-            type: value
-            value: null
-          hatch_weight:
-            type: value
-            value: 1.0
-          hatch_extra:
-            type: map
-            entries: []
           radius:
             type: value
             value: null
@@ -4674,70 +2024,10 @@ GraphRenderer:
     type: object
     name: GlyphRenderer
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      level: glyph
-      visible: true
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
       data_source:
         type: object
         name: ColumnDataSource
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          selected:
-            type: object
-            name: Selection
-            attributes:
-              name: null
-              tags: []
-              js_event_callbacks:
-                type: map
-                entries: []
-              subscribed_events: []
-              js_property_callbacks:
-                type: map
-                entries: []
-              syncable: true
-              indices: []
-              line_indices: []
-              multiline_indices:
-                type: map
-                entries: []
-              image_indices: []
-          selection_policy:
-            type: object
-            name: UnionRenderers
-            attributes:
-              name: null
-              tags: []
-              js_event_callbacks:
-                type: map
-                entries: []
-              subscribed_events: []
-              js_property_callbacks:
-                type: map
-                entries: []
-              syncable: true
           data:
             type: map
             entries:
@@ -4751,45 +2041,14 @@ GraphRenderer:
         type: object
         name: CDSView
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
           filter:
             type: object
             name: AllIndices
-            attributes:
-              name: null
-              tags: []
-              js_event_callbacks:
-                type: map
-                entries: []
-              subscribed_events: []
-              js_property_callbacks:
-                type: map
-                entries: []
-              syncable: true
+            attributes: {}
       glyph:
         type: object
         name: MultiLine
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          decorations: []
           xs:
             type: field
             field: xs
@@ -4825,65 +2084,14 @@ GraphRenderer:
   selection_policy:
     type: object
     name: NodesOnly
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
   inspection_policy:
     type: object
     name: NodesOnly
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
 GuideRenderer:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   level: guide
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
 Axis:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: guide
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   bounds: auto
   ticker:
     type: symbol
@@ -4910,17 +2118,7 @@ Axis:
   major_label_policy:
     type: object
     name: AllLabels
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
   major_label_text_color: '#444444'
   major_label_text_outline_color: null
   major_label_text_alpha: 1.0
@@ -4956,451 +2154,43 @@ Axis:
   minor_tick_in: 0
   minor_tick_out: 4
   fixed_location: null
-ContinuousAxis:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: guide
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  bounds: auto
-  ticker:
-    type: symbol
-    name: unset
-  formatter:
-    type: symbol
-    name: unset
-  axis_label: null
-  axis_label_standoff: 5
-  axis_label_text_color: '#444444'
-  axis_label_text_outline_color: null
-  axis_label_text_alpha: 1.0
-  axis_label_text_font: helvetica
-  axis_label_text_font_size: 13px
-  axis_label_text_font_style: italic
-  axis_label_text_align: left
-  axis_label_text_baseline: bottom
-  axis_label_text_line_height: 1.2
-  major_label_standoff: 5
-  major_label_orientation: horizontal
-  major_label_overrides:
-    type: map
-    entries: []
-  major_label_policy:
-    type: object
-    name: AllLabels
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  major_label_text_color: '#444444'
-  major_label_text_outline_color: null
-  major_label_text_alpha: 1.0
-  major_label_text_font: helvetica
-  major_label_text_font_size: 11px
-  major_label_text_font_style: normal
-  major_label_text_align: center
-  major_label_text_baseline: alphabetic
-  major_label_text_line_height: 1.2
-  axis_line_color: black
-  axis_line_alpha: 1.0
-  axis_line_width: 1
-  axis_line_join: bevel
-  axis_line_cap: butt
-  axis_line_dash: []
-  axis_line_dash_offset: 0
-  major_tick_line_color: black
-  major_tick_line_alpha: 1.0
-  major_tick_line_width: 1
-  major_tick_line_join: bevel
-  major_tick_line_cap: butt
-  major_tick_line_dash: []
-  major_tick_line_dash_offset: 0
-  major_tick_in: 2
-  major_tick_out: 6
-  minor_tick_line_color: black
-  minor_tick_line_alpha: 1.0
-  minor_tick_line_width: 1
-  minor_tick_line_join: bevel
-  minor_tick_line_cap: butt
-  minor_tick_line_dash: []
-  minor_tick_line_dash_offset: 0
-  minor_tick_in: 0
-  minor_tick_out: 4
-  fixed_location: null
+ContinuousAxis: {}
 LinearAxis:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: guide
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  bounds: auto
   ticker:
     type: object
     name: BasicTicker
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 5
-      desired_num_ticks: 6
-      base: 10.0
-      mantissas:
-      - 1
-      - 2
-      - 5
-      min_interval: 0.0
-      max_interval: null
+    attributes: {}
   formatter:
     type: object
     name: BasicTickFormatter
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       precision: auto
       use_scientific: true
       power_limit_high: 5
       power_limit_low: -3
-  axis_label: null
-  axis_label_standoff: 5
-  axis_label_text_color: '#444444'
-  axis_label_text_outline_color: null
-  axis_label_text_alpha: 1.0
-  axis_label_text_font: helvetica
-  axis_label_text_font_size: 13px
-  axis_label_text_font_style: italic
-  axis_label_text_align: left
-  axis_label_text_baseline: bottom
-  axis_label_text_line_height: 1.2
-  major_label_standoff: 5
-  major_label_orientation: horizontal
-  major_label_overrides:
-    type: map
-    entries: []
-  major_label_policy:
-    type: object
-    name: AllLabels
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  major_label_text_color: '#444444'
-  major_label_text_outline_color: null
-  major_label_text_alpha: 1.0
-  major_label_text_font: helvetica
-  major_label_text_font_size: 11px
-  major_label_text_font_style: normal
-  major_label_text_align: center
-  major_label_text_baseline: alphabetic
-  major_label_text_line_height: 1.2
-  axis_line_color: black
-  axis_line_alpha: 1.0
-  axis_line_width: 1
-  axis_line_join: bevel
-  axis_line_cap: butt
-  axis_line_dash: []
-  axis_line_dash_offset: 0
-  major_tick_line_color: black
-  major_tick_line_alpha: 1.0
-  major_tick_line_width: 1
-  major_tick_line_join: bevel
-  major_tick_line_cap: butt
-  major_tick_line_dash: []
-  major_tick_line_dash_offset: 0
-  major_tick_in: 2
-  major_tick_out: 6
-  minor_tick_line_color: black
-  minor_tick_line_alpha: 1.0
-  minor_tick_line_width: 1
-  minor_tick_line_join: bevel
-  minor_tick_line_cap: butt
-  minor_tick_line_dash: []
-  minor_tick_line_dash_offset: 0
-  minor_tick_in: 0
-  minor_tick_out: 4
-  fixed_location: null
 LogAxis:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: guide
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  bounds: auto
   ticker:
     type: object
     name: LogTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 5
-      desired_num_ticks: 6
-      base: 10.0
       mantissas:
       - 1
       - 5
-      min_interval: 0.0
-      max_interval: null
   formatter:
     type: object
     name: LogTickFormatter
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       ticker: null
       min_exponent: 0
-  axis_label: null
-  axis_label_standoff: 5
-  axis_label_text_color: '#444444'
-  axis_label_text_outline_color: null
-  axis_label_text_alpha: 1.0
-  axis_label_text_font: helvetica
-  axis_label_text_font_size: 13px
-  axis_label_text_font_style: italic
-  axis_label_text_align: left
-  axis_label_text_baseline: bottom
-  axis_label_text_line_height: 1.2
-  major_label_standoff: 5
-  major_label_orientation: horizontal
-  major_label_overrides:
-    type: map
-    entries: []
-  major_label_policy:
-    type: object
-    name: AllLabels
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  major_label_text_color: '#444444'
-  major_label_text_outline_color: null
-  major_label_text_alpha: 1.0
-  major_label_text_font: helvetica
-  major_label_text_font_size: 11px
-  major_label_text_font_style: normal
-  major_label_text_align: center
-  major_label_text_baseline: alphabetic
-  major_label_text_line_height: 1.2
-  axis_line_color: black
-  axis_line_alpha: 1.0
-  axis_line_width: 1
-  axis_line_join: bevel
-  axis_line_cap: butt
-  axis_line_dash: []
-  axis_line_dash_offset: 0
-  major_tick_line_color: black
-  major_tick_line_alpha: 1.0
-  major_tick_line_width: 1
-  major_tick_line_join: bevel
-  major_tick_line_cap: butt
-  major_tick_line_dash: []
-  major_tick_line_dash_offset: 0
-  major_tick_in: 2
-  major_tick_out: 6
-  minor_tick_line_color: black
-  minor_tick_line_alpha: 1.0
-  minor_tick_line_width: 1
-  minor_tick_line_join: bevel
-  minor_tick_line_cap: butt
-  minor_tick_line_dash: []
-  minor_tick_line_dash_offset: 0
-  minor_tick_in: 0
-  minor_tick_out: 4
-  fixed_location: null
 CategoricalAxis:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: guide
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  bounds: auto
   ticker:
     type: object
     name: CategoricalTicker
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
   formatter:
     type: object
     name: CategoricalTickFormatter
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  axis_label: null
-  axis_label_standoff: 5
-  axis_label_text_color: '#444444'
-  axis_label_text_outline_color: null
-  axis_label_text_alpha: 1.0
-  axis_label_text_font: helvetica
-  axis_label_text_font_size: 13px
-  axis_label_text_font_style: italic
-  axis_label_text_align: left
-  axis_label_text_baseline: bottom
-  axis_label_text_line_height: 1.2
-  major_label_standoff: 5
-  major_label_orientation: horizontal
-  major_label_overrides:
-    type: map
-    entries: []
-  major_label_policy:
-    type: object
-    name: AllLabels
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  major_label_text_color: '#444444'
-  major_label_text_outline_color: null
-  major_label_text_alpha: 1.0
-  major_label_text_font: helvetica
-  major_label_text_font_size: 11px
-  major_label_text_font_style: normal
-  major_label_text_align: center
-  major_label_text_baseline: alphabetic
-  major_label_text_line_height: 1.2
-  axis_line_color: black
-  axis_line_alpha: 1.0
-  axis_line_width: 1
-  axis_line_join: bevel
-  axis_line_cap: butt
-  axis_line_dash: []
-  axis_line_dash_offset: 0
-  major_tick_line_color: black
-  major_tick_line_alpha: 1.0
-  major_tick_line_width: 1
-  major_tick_line_join: bevel
-  major_tick_line_cap: butt
-  major_tick_line_dash: []
-  major_tick_line_dash_offset: 0
-  major_tick_in: 2
-  major_tick_out: 6
-  minor_tick_line_color: black
-  minor_tick_line_alpha: 1.0
-  minor_tick_line_width: 1
-  minor_tick_line_join: bevel
-  minor_tick_line_cap: butt
-  minor_tick_line_dash: []
-  minor_tick_line_dash_offset: 0
-  minor_tick_in: 0
-  minor_tick_out: 4
-  fixed_location: null
+    attributes: {}
   separator_line_color: lightgrey
   separator_line_alpha: 1.0
   separator_line_width: 2
@@ -5429,55 +2219,15 @@ CategoricalAxis:
   subgroup_text_line_height: 1.2
   subgroup_label_orientation: parallel
 DatetimeAxis:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: guide
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  bounds: auto
   ticker:
     type: object
     name: DatetimeTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       num_minor_ticks: 0
-      desired_num_ticks: 6
       tickers:
       - type: object
         name: AdaptiveTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          num_minor_ticks: 0
-          desired_num_ticks: 6
           base: 10.0
           mantissas:
           - 1
@@ -5488,18 +2238,6 @@ DatetimeAxis:
       - type: object
         name: AdaptiveTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          num_minor_ticks: 0
-          desired_num_ticks: 6
           base: 60
           mantissas:
           - 1
@@ -5514,18 +2252,6 @@ DatetimeAxis:
       - type: object
         name: AdaptiveTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          num_minor_ticks: 0
-          desired_num_ticks: 6
           base: 24
           mantissas:
           - 1
@@ -5539,18 +2265,7 @@ DatetimeAxis:
       - type: object
         name: DaysTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
           num_minor_ticks: 0
-          desired_num_ticks: 6
           days:
           - 1
           - 2
@@ -5586,18 +2301,7 @@ DatetimeAxis:
       - type: object
         name: DaysTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
           num_minor_ticks: 0
-          desired_num_ticks: 6
           days:
           - 1
           - 4
@@ -5612,18 +2316,7 @@ DatetimeAxis:
       - type: object
         name: DaysTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
           num_minor_ticks: 0
-          desired_num_ticks: 6
           days:
           - 1
           - 8
@@ -5632,36 +2325,13 @@ DatetimeAxis:
       - type: object
         name: DaysTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
           num_minor_ticks: 0
-          desired_num_ticks: 6
           days:
           - 1
           - 15
       - type: object
         name: MonthsTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          num_minor_ticks: 5
-          desired_num_ticks: 6
           months:
           - 0
           - 1
@@ -5678,18 +2348,6 @@ DatetimeAxis:
       - type: object
         name: MonthsTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          num_minor_ticks: 5
-          desired_num_ticks: 6
           months:
           - 0
           - 2
@@ -5700,18 +2358,6 @@ DatetimeAxis:
       - type: object
         name: MonthsTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          num_minor_ticks: 5
-          desired_num_ticks: 6
           months:
           - 0
           - 4
@@ -5719,50 +2365,16 @@ DatetimeAxis:
       - type: object
         name: MonthsTicker
         attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          num_minor_ticks: 5
-          desired_num_ticks: 6
           months:
           - 0
           - 6
       - type: object
         name: YearsTicker
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          num_minor_ticks: 5
-          desired_num_ticks: 6
+        attributes: {}
   formatter:
     type: object
     name: DatetimeTickFormatter
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       microseconds: '%fus'
       milliseconds: '%3Nms'
       seconds: '%Ss'
@@ -5777,208 +2389,18 @@ DatetimeAxis:
       context: null
       context_which: start
       context_location: below
-  axis_label: null
-  axis_label_standoff: 5
-  axis_label_text_color: '#444444'
-  axis_label_text_outline_color: null
-  axis_label_text_alpha: 1.0
-  axis_label_text_font: helvetica
-  axis_label_text_font_size: 13px
-  axis_label_text_font_style: italic
-  axis_label_text_align: left
-  axis_label_text_baseline: bottom
-  axis_label_text_line_height: 1.2
-  major_label_standoff: 5
-  major_label_orientation: horizontal
-  major_label_overrides:
-    type: map
-    entries: []
-  major_label_policy:
-    type: object
-    name: AllLabels
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  major_label_text_color: '#444444'
-  major_label_text_outline_color: null
-  major_label_text_alpha: 1.0
-  major_label_text_font: helvetica
-  major_label_text_font_size: 11px
-  major_label_text_font_style: normal
-  major_label_text_align: center
-  major_label_text_baseline: alphabetic
-  major_label_text_line_height: 1.2
-  axis_line_color: black
-  axis_line_alpha: 1.0
-  axis_line_width: 1
-  axis_line_join: bevel
-  axis_line_cap: butt
-  axis_line_dash: []
-  axis_line_dash_offset: 0
-  major_tick_line_color: black
-  major_tick_line_alpha: 1.0
-  major_tick_line_width: 1
-  major_tick_line_join: bevel
-  major_tick_line_cap: butt
-  major_tick_line_dash: []
-  major_tick_line_dash_offset: 0
-  major_tick_in: 2
-  major_tick_out: 6
-  minor_tick_line_color: black
-  minor_tick_line_alpha: 1.0
-  minor_tick_line_width: 1
-  minor_tick_line_join: bevel
-  minor_tick_line_cap: butt
-  minor_tick_line_dash: []
-  minor_tick_line_dash_offset: 0
-  minor_tick_in: 0
-  minor_tick_out: 4
-  fixed_location: null
 MercatorAxis:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: guide
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  bounds: auto
   ticker:
     type: object
     name: MercatorTicker
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      num_minor_ticks: 5
-      desired_num_ticks: 6
-      base: 10.0
-      mantissas:
-      - 1
-      - 2
-      - 5
-      min_interval: 0.0
-      max_interval: null
       dimension: lat
   formatter:
     type: object
     name: MercatorTickFormatter
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      precision: auto
-      use_scientific: true
-      power_limit_high: 5
-      power_limit_low: -3
       dimension: lat
-  axis_label: null
-  axis_label_standoff: 5
-  axis_label_text_color: '#444444'
-  axis_label_text_outline_color: null
-  axis_label_text_alpha: 1.0
-  axis_label_text_font: helvetica
-  axis_label_text_font_size: 13px
-  axis_label_text_font_style: italic
-  axis_label_text_align: left
-  axis_label_text_baseline: bottom
-  axis_label_text_line_height: 1.2
-  major_label_standoff: 5
-  major_label_orientation: horizontal
-  major_label_overrides:
-    type: map
-    entries: []
-  major_label_policy:
-    type: object
-    name: AllLabels
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  major_label_text_color: '#444444'
-  major_label_text_outline_color: null
-  major_label_text_alpha: 1.0
-  major_label_text_font: helvetica
-  major_label_text_font_size: 11px
-  major_label_text_font_style: normal
-  major_label_text_align: center
-  major_label_text_baseline: alphabetic
-  major_label_text_line_height: 1.2
-  axis_line_color: black
-  axis_line_alpha: 1.0
-  axis_line_width: 1
-  axis_line_join: bevel
-  axis_line_cap: butt
-  axis_line_dash: []
-  axis_line_dash_offset: 0
-  major_tick_line_color: black
-  major_tick_line_alpha: 1.0
-  major_tick_line_width: 1
-  major_tick_line_join: bevel
-  major_tick_line_cap: butt
-  major_tick_line_dash: []
-  major_tick_line_dash_offset: 0
-  major_tick_in: 2
-  major_tick_out: 6
-  minor_tick_line_color: black
-  minor_tick_line_alpha: 1.0
-  minor_tick_line_width: 1
-  minor_tick_line_join: bevel
-  minor_tick_line_cap: butt
-  minor_tick_line_dash: []
-  minor_tick_line_dash_offset: 0
-  minor_tick_in: 0
-  minor_tick_out: 4
-  fixed_location: null
 Styles:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   align_content: null
   align_items: null
   align_self: null
@@ -6293,248 +2715,49 @@ Styles:
   writing_mode: null
   z_index: null
 UIElement:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   visible: true
   classes: []
   styles:
     type: map
     entries: []
   stylesheets: []
-bokeh.models.dom.DOMNode:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+bokeh.models.dom.DOMNode: {}
 bokeh.models.dom.Text:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   content: ''
 bokeh.models.dom.DOMElement:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   style: null
   children: []
-bokeh.models.dom.Span:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  style: null
-  children: []
-bokeh.models.dom.Div:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  style: null
-  children: []
-bokeh.models.dom.Table:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  style: null
-  children: []
-bokeh.models.dom.TableRow:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  style: null
-  children: []
-bokeh.models.dom.Action:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+bokeh.models.dom.Span: {}
+bokeh.models.dom.Div: {}
+bokeh.models.dom.Table: {}
+bokeh.models.dom.TableRow: {}
+bokeh.models.dom.Action: {}
 bokeh.models.dom.Template:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  style: null
-  children: []
   actions: []
 bokeh.models.dom.ToggleGroup:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   groups: []
-bokeh.models.dom.Placeholder:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+bokeh.models.dom.Placeholder: {}
 bokeh.models.dom.ValueOf:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   obj:
     type: symbol
     name: unset
   attr:
     type: symbol
     name: unset
-bokeh.models.dom.Index:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+bokeh.models.dom.Index: {}
 bokeh.models.dom.ValueRef:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   field:
     type: symbol
     name: unset
 bokeh.models.dom.ColorRef:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  field:
-    type: symbol
-    name: unset
   hex: true
   swatch: true
 bokeh.models.dom.HTML:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   html:
     type: symbol
     name: unset
   refs: []
 Dialog:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   title: null
   content:
     type: symbol
@@ -6544,115 +2767,24 @@ Dialog:
   closable: true
   draggable: true
 Icon:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   size: 1em
 BuiltinIcon:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  size: 1em
   icon_name:
     type: symbol
     name: unset
   color: gray
 SVGIcon:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  size: 1em
   svg:
     type: symbol
     name: unset
 TablerIcon:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  size: 1em
   icon_name:
     type: symbol
     name: unset
 Inspector:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   target: null
-MenuItem:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
+MenuItem: {}
 Action:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   icon: null
   label:
     type: symbol
@@ -6660,186 +2792,35 @@ Action:
   description: null
   menu: null
 CheckAction:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  icon: null
-  label:
-    type: symbol
-    name: unset
-  description: null
-  menu: null
   checked: false
 Section:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   items: []
-Divider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
+Divider: {}
 Menu:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   items: []
   reversed: false
   orientation: vertical
 Pane:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   children: []
-Selector:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+Selector: {}
 ByID:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   query:
     type: symbol
     name: unset
 ByClass:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   query:
     type: symbol
     name: unset
 ByCSS:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   query:
     type: symbol
     name: unset
 ByXPath:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   query:
     type: symbol
     name: unset
 Tooltip:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   visible: false
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   position: null
   target: auto
   content:
@@ -6850,137 +2831,23 @@ Tooltip:
   closable: false
   interactive: true
 Canvas:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   hidpi: true
   output_backend: canvas
 Annotation:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
 DataAnnotation:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   source:
     type: object
     name: ColumnDataSource
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
       data:
         type: map
         entries: []
 ArrowHead:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   size:
     type: value
     value: 25
 OpenHead:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  size:
-    type: value
-    value: 25
   line_color:
     type: value
     value: black
@@ -7003,19 +2870,6 @@ OpenHead:
     type: value
     value: 0
 NormalHead:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  size:
-    type: value
-    value: 25
   line_color:
     type: value
     value: black
@@ -7044,19 +2898,6 @@ NormalHead:
     type: value
     value: 1.0
 TeeHead:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  size:
-    type: value
-    value: 25
   line_color:
     type: value
     value: black
@@ -7079,19 +2920,6 @@ TeeHead:
     type: value
     value: 0
 VeeHead:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  size:
-    type: value
-    value: 25
   line_color:
     type: value
     value: black
@@ -7120,73 +2948,6 @@ VeeHead:
     type: value
     value: 1.0
 Arrow:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  source:
-    type: object
-    name: ColumnDataSource
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-      data:
-        type: map
-        entries: []
   x_start:
     type: field
     field: x_start
@@ -7206,19 +2967,6 @@ Arrow:
     type: object
     name: OpenHead
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      size:
-        type: value
-        value: 25
       line_color:
         type: value
         value: black
@@ -7262,22 +3010,6 @@ Arrow:
     type: value
     value: 0
 BoxAnnotation:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   left: null
   left_units: data
   right: null
@@ -7304,73 +3036,6 @@ BoxAnnotation:
     type: map
     entries: []
 Band:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  source:
-    type: object
-    name: ColumnDataSource
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-      data:
-        type: map
-        entries: []
   lower:
     type: field
     field: lower
@@ -7391,22 +3056,6 @@ Band:
   fill_color: '#fff9ba'
   fill_alpha: 0.4
 PolyAnnotation:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   xs: []
   xs_units: data
   ys: []
@@ -7429,22 +3078,6 @@ PolyAnnotation:
     type: map
     entries: []
 Slope:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   gradient: null
   y_intercept: null
   line_color: black
@@ -7455,22 +3088,6 @@ Slope:
   line_dash: []
   line_dash_offset: 0
 Span:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   location: null
   location_units: data
   dimension: width
@@ -7482,73 +3099,7 @@ Span:
   line_dash: []
   line_dash_offset: 0
 Whisker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   level: underlay
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  source:
-    type: object
-    name: ColumnDataSource
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-      data:
-        type: map
-        entries: []
   lower:
     type: field
     field: lower
@@ -7556,19 +3107,6 @@ Whisker:
     type: object
     name: TeeHead
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      size:
-        type: value
-        value: 10
       line_color:
         type: value
         value: black
@@ -7597,19 +3135,6 @@ Whisker:
     type: object
     name: TeeHead
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      size:
-        type: value
-        value: 10
       line_color:
         type: value
         value: black
@@ -7656,40 +3181,8 @@ Whisker:
   line_dash_offset:
     type: value
     value: 0
-HTMLAnnotation:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
+HTMLAnnotation: {}
 HTMLLabel:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   x:
     type: symbol
     name: unset
@@ -7722,73 +3215,6 @@ HTMLLabel:
   border_line_dash: []
   border_line_dash_offset: 0
 HTMLLabelSet:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  source:
-    type: object
-    name: ColumnDataSource
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-      data:
-        type: map
-        entries: []
   x:
     type: field
     field: x
@@ -7864,22 +3290,6 @@ HTMLLabelSet:
     type: value
     value: 0
 HTMLTitle:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   text: ''
   vertical_align: bottom
   align: left
@@ -7902,42 +3312,10 @@ HTMLTitle:
   border_line_dash: []
   border_line_dash_offset: 0
 ToolbarPanel:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   toolbar:
     type: symbol
     name: unset
 TextAnnotation:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   text: ''
   text_color: '#444444'
   text_outline_color: null
@@ -7958,41 +3336,6 @@ TextAnnotation:
   border_line_dash: []
   border_line_dash_offset: 0
 Label:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  text: ''
-  text_color: '#444444'
-  text_outline_color: null
-  text_alpha: 1.0
-  text_font: helvetica
-  text_font_size: 16px
-  text_font_style: normal
-  text_align: left
-  text_baseline: bottom
-  text_line_height: 1.2
-  background_fill_color: null
-  background_fill_alpha: 1.0
-  border_line_color: null
-  border_line_alpha: 1.0
-  border_line_width: 1
-  border_line_join: bevel
-  border_line_cap: butt
-  border_line_dash: []
-  border_line_dash_offset: 0
   x:
     type: symbol
     name: unset
@@ -8006,73 +3349,6 @@ Label:
   x_offset: 0
   y_offset: 0
 LabelSet:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  source:
-    type: object
-    name: ColumnDataSource
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-      data:
-        type: map
-        entries: []
   x:
     type: field
     field: x
@@ -8148,62 +3424,14 @@ LabelSet:
     type: value
     value: 0
 Title:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  text: ''
-  text_color: '#444444'
-  text_outline_color: null
-  text_alpha: 1.0
-  text_font: helvetica
   text_font_size: 13px
   text_font_style: bold
-  text_align: left
-  text_baseline: bottom
   text_line_height: 1.0
-  background_fill_color: null
-  background_fill_alpha: 1.0
-  border_line_color: null
-  border_line_alpha: 1.0
-  border_line_width: 1
-  border_line_join: bevel
-  border_line_cap: butt
-  border_line_dash: []
-  border_line_dash_offset: 0
   vertical_align: bottom
   align: left
   offset: 0
   standoff: 10
 BaseColorBar:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   location: top_right
   orientation: auto
   height: auto
@@ -8229,16 +3457,6 @@ BaseColorBar:
     type: object
     name: NoOverlap
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       min_distance: 5
   margin: 30
   padding: 10
@@ -8287,208 +3505,12 @@ BaseColorBar:
   background_fill_color: '#ffffff'
   background_fill_alpha: 0.95
 ColorBar:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  location: top_right
-  orientation: auto
-  height: auto
-  width: auto
-  scale_alpha: 1.0
-  title: null
-  title_text_color: '#444444'
-  title_text_outline_color: null
-  title_text_alpha: 1.0
-  title_text_font: helvetica
-  title_text_font_size: 13px
-  title_text_font_style: italic
-  title_text_align: left
-  title_text_baseline: bottom
-  title_text_line_height: 1.2
-  title_standoff: 2
-  ticker: auto
-  formatter: auto
-  major_label_overrides:
-    type: map
-    entries: []
-  major_label_policy:
-    type: object
-    name: NoOverlap
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      min_distance: 5
-  margin: 30
-  padding: 10
-  major_label_text_color: '#444444'
-  major_label_text_outline_color: null
-  major_label_text_alpha: 1.0
-  major_label_text_font: helvetica
-  major_label_text_font_size: 11px
-  major_label_text_font_style: normal
-  major_label_text_align: left
-  major_label_text_baseline: bottom
-  major_label_text_line_height: 1.2
-  label_standoff: 5
-  major_tick_line_color: '#ffffff'
-  major_tick_line_alpha: 1.0
-  major_tick_line_width: 1
-  major_tick_line_join: bevel
-  major_tick_line_cap: butt
-  major_tick_line_dash: []
-  major_tick_line_dash_offset: 0
-  major_tick_in: 5
-  major_tick_out: 0
-  minor_tick_line_color: null
-  minor_tick_line_alpha: 1.0
-  minor_tick_line_width: 1
-  minor_tick_line_join: bevel
-  minor_tick_line_cap: butt
-  minor_tick_line_dash: []
-  minor_tick_line_dash_offset: 0
-  minor_tick_in: 0
-  minor_tick_out: 0
-  bar_line_color: null
-  bar_line_alpha: 1.0
-  bar_line_width: 1
-  bar_line_join: bevel
-  bar_line_cap: butt
-  bar_line_dash: []
-  bar_line_dash_offset: 0
-  border_line_color: null
-  border_line_alpha: 1.0
-  border_line_width: 1
-  border_line_join: bevel
-  border_line_cap: butt
-  border_line_dash: []
-  border_line_dash_offset: 0
-  background_fill_color: '#ffffff'
-  background_fill_alpha: 0.95
   color_mapper:
     type: symbol
     name: unset
   display_low: null
   display_high: null
 ContourColorBar:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
-  location: top_right
-  orientation: auto
-  height: auto
-  width: auto
-  scale_alpha: 1.0
-  title: null
-  title_text_color: '#444444'
-  title_text_outline_color: null
-  title_text_alpha: 1.0
-  title_text_font: helvetica
-  title_text_font_size: 13px
-  title_text_font_style: italic
-  title_text_align: left
-  title_text_baseline: bottom
-  title_text_line_height: 1.2
-  title_standoff: 2
-  ticker: auto
-  formatter: auto
-  major_label_overrides:
-    type: map
-    entries: []
-  major_label_policy:
-    type: object
-    name: NoOverlap
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      min_distance: 5
-  margin: 30
-  padding: 10
-  major_label_text_color: '#444444'
-  major_label_text_outline_color: null
-  major_label_text_alpha: 1.0
-  major_label_text_font: helvetica
-  major_label_text_font_size: 11px
-  major_label_text_font_style: normal
-  major_label_text_align: left
-  major_label_text_baseline: bottom
-  major_label_text_line_height: 1.2
-  label_standoff: 5
-  major_tick_line_color: '#ffffff'
-  major_tick_line_alpha: 1.0
-  major_tick_line_width: 1
-  major_tick_line_join: bevel
-  major_tick_line_cap: butt
-  major_tick_line_dash: []
-  major_tick_line_dash_offset: 0
-  major_tick_in: 5
-  major_tick_out: 0
-  minor_tick_line_color: null
-  minor_tick_line_alpha: 1.0
-  minor_tick_line_width: 1
-  minor_tick_line_join: bevel
-  minor_tick_line_cap: butt
-  minor_tick_line_dash: []
-  minor_tick_line_dash_offset: 0
-  minor_tick_in: 0
-  minor_tick_out: 0
-  bar_line_color: null
-  bar_line_alpha: 1.0
-  bar_line_width: 1
-  bar_line_join: bevel
-  bar_line_cap: butt
-  bar_line_dash: []
-  bar_line_dash_offset: 0
-  border_line_color: null
-  border_line_alpha: 1.0
-  border_line_width: 1
-  border_line_join: bevel
-  border_line_cap: butt
-  border_line_dash: []
-  border_line_dash_offset: 0
-  background_fill_color: '#ffffff'
-  background_fill_alpha: 0.95
   fill_renderer:
     type: symbol
     name: unset
@@ -8497,16 +3519,6 @@ ContourColorBar:
     name: unset
   levels: []
 LegendItem:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   label:
     type: value
     value: null
@@ -8514,22 +3526,6 @@ LegendItem:
   index: null
   visible: true
 Legend:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: annotation
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   location: top_right
   orientation: vertical
   title: null
@@ -8574,22 +3570,6 @@ Legend:
   spacing: 3
   items: []
 ContourRenderer:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  level: glyph
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   line_renderer:
     type: symbol
     name: unset
@@ -8598,22 +3578,7 @@ ContourRenderer:
     name: unset
   levels: []
 Grid:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   level: underlay
-  visible: true
-  coordinates: null
-  x_range_name: default
-  y_range_name: default
-  group: null
   dimension: 0
   bounds: auto
   cross_bounds: auto
@@ -8644,22 +3609,6 @@ Grid:
     type: map
     entries: []
 LayoutDOM:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   disabled: false
   width: null
   height: null
@@ -8677,271 +3626,26 @@ LayoutDOM:
   css_classes: []
   context_menu: null
   resizable: false
-Spacer:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
+Spacer: {}
 GridBox:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   children: []
   rows: null
   cols: null
   spacing: 0
 HBox:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   children: []
   cols: null
   spacing: 0
 VBox:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   children: []
   rows: null
   spacing: 0
 FlexBox:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   children: []
   spacing: 0
-Row:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  children: []
-  spacing: 0
-Column:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  children: []
-  spacing: 0
+Row: {}
+Column: {}
 TabPanel:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   title: ''
   child:
     type: symbol
@@ -8949,271 +3653,40 @@ TabPanel:
   closable: false
   disabled: false
 Tabs:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   tabs: []
   tabs_location: above
   active: 0
 GroupBox:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   title: null
   child:
     type: symbol
     name: unset
   checkable: false
 ScrollBox:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   child:
     type: symbol
     name: unset
   horizontal_scrollbar: auto
   vertical_scrollbar: auto
 Tool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   icon: null
   description: null
 ToolProxy:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   tools: []
   active: false
   disabled: false
-ActionTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-PlotActionTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-GestureTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-Drag:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-Scroll:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-Tap:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
+ActionTool: {}
+PlotActionTool: {}
+GestureTool: {}
+Drag: {}
+Scroll: {}
+Tap: {}
 SelectTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   renderers: auto
   mode: replace
 InspectTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   toggleable: true
 Toolbar:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
   logo: normal
   autohide: false
   tools: []
@@ -9223,32 +3696,8 @@ Toolbar:
   active_tap: auto
   active_multi: auto
 PanTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   dimensions: both
 RangeTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   x_range: null
   x_interaction: true
   y_range: null
@@ -9257,22 +3706,6 @@ RangeTool:
     type: object
     name: BoxAnnotation
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: false
-      level: overlay
-      visible: true
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
       left: null
       left_units: data
       right: null
@@ -9301,161 +3734,35 @@ RangeTool:
         type: map
         entries: []
 WheelPanTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   dimension: width
 WheelZoomTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   dimensions: both
   maintain_focus: true
   zoom_on_axis: true
   speed: 0.0016666666666666668
 CustomAction:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
   description: Perform a Custom Action
   callback: null
 SaveTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   filename: null
-CopyTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-ResetTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
+CopyTool: {}
+ResetTool: {}
 TapTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  renderers: auto
-  mode: replace
   behavior: select
   gesture: tap
   callback: null
 CrosshairTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  toggleable: true
   overlay: auto
   dimensions: both
   line_color: black
   line_alpha: 1.0
   line_width: 1
 BoxZoomTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   dimensions: both
   overlay:
     type: object
     name: BoxAnnotation
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: false
-      level: overlay
-      visible: false
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
       left: null
       left_units: canvas
       right: null
@@ -9486,73 +3793,19 @@ BoxZoomTool:
   match_aspect: false
   origin: corner
 ZoomInTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   dimensions: both
   factor: 0.1
 ZoomOutTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   dimensions: both
   factor: 0.1
   maintain_focus: true
 BoxSelectTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  renderers: auto
-  mode: replace
   select_every_mousemove: false
   dimensions: both
   overlay:
     type: object
     name: BoxAnnotation
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: false
-      level: overlay
-      visible: false
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
       left: null
       left_units: canvas
       right: null
@@ -9582,41 +3835,11 @@ BoxSelectTool:
         entries: []
   origin: corner
 LassoSelectTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  renderers: auto
-  mode: replace
   select_every_mousemove: true
   overlay:
     type: object
     name: PolyAnnotation
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: false
-      level: overlay
-      visible: false
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
       xs: []
       xs_units: canvas
       ys: []
@@ -9641,40 +3864,10 @@ LassoSelectTool:
         type: map
         entries: []
 PolySelectTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  renderers: auto
-  mode: replace
   overlay:
     type: object
     name: PolyAnnotation
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: false
-      level: overlay
-      visible: false
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
       xs: []
       xs_units: canvas
       ys: []
@@ -9699,34 +3892,11 @@ PolySelectTool:
         type: map
         entries: []
 CustomJSHover:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   args:
     type: map
     entries: []
   code: ''
 HoverTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  toggleable: true
   renderers: auto
   callback: null
   tooltips:
@@ -9747,271 +3917,44 @@ HoverTool:
   attachment: horizontal
   show_arrow: true
 HelpTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
   description: Click the question mark to learn more about Bokeh plot tools.
   redirect: https://docs.bokeh.org/en/latest/docs/user_guide/tools.html
-SettingsTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-FullscreenTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-UndoTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-RedoTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
+SettingsTool: {}
+FullscreenTool: {}
+UndoTool: {}
+RedoTool: {}
 EditTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
   empty_value:
     type: symbol
     name: unset
   renderers: []
 PolyTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  empty_value:
-    type: symbol
-    name: unset
-  renderers: []
   vertex_renderer: null
 BoxEditTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  empty_value:
-    type: symbol
-    name: unset
-  renderers: []
   dimensions: both
   num_objects: 0
 PointDrawTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  empty_value:
-    type: symbol
-    name: unset
-  renderers: []
   add: true
   drag: true
   num_objects: 0
 PolyDrawTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  empty_value:
-    type: symbol
-    name: unset
-  renderers: []
-  vertex_renderer: null
   drag: true
   num_objects: 0
 FreehandDrawTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  empty_value:
-    type: symbol
-    name: unset
-  renderers: []
   num_objects: 0
-PolyEditTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  empty_value:
-    type: symbol
-    name: unset
-  renderers: []
-  vertex_renderer: null
+PolyEditTool: {}
 LineEditTool:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  icon: null
-  description: null
-  empty_value:
-    type: symbol
-    name: unset
-  renderers: []
   intersection_renderer:
     type: symbol
     name: unset
   dimensions: both
 Plot:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
   width: 600
   height: 600
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   x_range:
     type: object
     name: DataRange1d
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      renderers: []
       range_padding: 0.1
       range_padding_units: percent
       start:
@@ -10032,17 +3975,6 @@ Plot:
     type: object
     name: DataRange1d
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      renderers: []
       range_padding: 0.1
       range_padding_units: percent
       start:
@@ -10062,31 +3994,11 @@ Plot:
   x_scale:
     type: object
     name: LinearScale
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
   y_scale:
     type: object
     name: LinearScale
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
+    attributes: {}
   extra_x_ranges:
     type: map
     entries: []
@@ -10104,41 +4016,9 @@ Plot:
     type: object
     name: Title
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      level: annotation
-      visible: true
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
-      text: ''
-      text_color: '#444444'
-      text_outline_color: null
-      text_alpha: 1.0
-      text_font: helvetica
       text_font_size: 13px
       text_font_style: bold
-      text_align: left
-      text_baseline: bottom
       text_line_height: 1.0
-      background_fill_color: null
-      background_fill_alpha: 1.0
-      border_line_color: null
-      border_line_alpha: 1.0
-      border_line_width: 1
-      border_line_join: bevel
-      border_line_cap: butt
-      border_line_dash: []
-      border_line_dash_offset: 0
       vertical_align: bottom
       align: left
       offset: 0
@@ -10156,22 +4036,6 @@ Plot:
     type: object
     name: Toolbar
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      visible: true
-      classes: []
-      styles:
-        type: map
-        entries: []
-      stylesheets: []
       logo: normal
       autohide: false
       tools: []
@@ -10214,59 +4078,10 @@ Plot:
   reset_policy: standard
   hold_render: false
 GridPlot:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   toolbar:
     type: object
     name: Toolbar
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      visible: true
-      classes: []
-      styles:
-        type: map
-        entries: []
-      stylesheets: []
       logo: normal
       autohide: false
       tools: []
@@ -10281,16 +4096,6 @@ GridPlot:
   cols: null
   spacing: 0
 MapOptions:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   lat:
     type: symbol
     name: unset
@@ -10298,326 +4103,17 @@ MapOptions:
     type: symbol
     name: unset
   zoom: 12
-MapPlot:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: 600
-  height: 600
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  x_range:
-    type: object
-    name: DataRange1d
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      renderers: []
-      range_padding: 0.1
-      range_padding_units: percent
-      start:
-        type: number
-        value: nan
-      end:
-        type: number
-        value: nan
-      bounds: null
-      min_interval: null
-      max_interval: null
-      flipped: false
-      follow: null
-      follow_interval: null
-      default_span: 2.0
-      only_visible: false
-  y_range:
-    type: object
-    name: DataRange1d
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      renderers: []
-      range_padding: 0.1
-      range_padding_units: percent
-      start:
-        type: number
-        value: nan
-      end:
-        type: number
-        value: nan
-      bounds: null
-      min_interval: null
-      max_interval: null
-      flipped: false
-      follow: null
-      follow_interval: null
-      default_span: 2.0
-      only_visible: false
-  x_scale:
-    type: object
-    name: LinearScale
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  y_scale:
-    type: object
-    name: LinearScale
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  extra_x_ranges:
-    type: map
-    entries: []
-  extra_y_ranges:
-    type: map
-    entries: []
-  extra_x_scales:
-    type: map
-    entries: []
-  extra_y_scales:
-    type: map
-    entries: []
-  hidpi: true
-  title:
-    type: object
-    name: Title
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      level: annotation
-      visible: true
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
-      text: ''
-      text_color: '#444444'
-      text_outline_color: null
-      text_alpha: 1.0
-      text_font: helvetica
-      text_font_size: 13px
-      text_font_style: bold
-      text_align: left
-      text_baseline: bottom
-      text_line_height: 1.0
-      background_fill_color: null
-      background_fill_alpha: 1.0
-      border_line_color: null
-      border_line_alpha: 1.0
-      border_line_width: 1
-      border_line_join: bevel
-      border_line_cap: butt
-      border_line_dash: []
-      border_line_dash_offset: 0
-      vertical_align: bottom
-      align: left
-      offset: 0
-      standoff: 10
-  title_location: above
-  outline_line_color: '#e5e5e5'
-  outline_line_alpha: 1.0
-  outline_line_width: 1
-  outline_line_join: bevel
-  outline_line_cap: butt
-  outline_line_dash: []
-  outline_line_dash_offset: 0
-  renderers: []
-  toolbar:
-    type: object
-    name: Toolbar
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      visible: true
-      classes: []
-      styles:
-        type: map
-        entries: []
-      stylesheets: []
-      logo: normal
-      autohide: false
-      tools: []
-      active_drag: auto
-      active_inspect: auto
-      active_scroll: auto
-      active_tap: auto
-      active_multi: auto
-  toolbar_location: right
-  toolbar_sticky: true
-  toolbar_inner: false
-  left: []
-  right: []
-  above: []
-  below: []
-  center: []
-  frame_width: null
-  frame_height: null
-  frame_align: true
-  inner_width: 0
-  inner_height: 0
-  outer_width: 0
-  outer_height: 0
-  background_fill_color: '#ffffff'
-  background_fill_alpha: 1.0
-  border_fill_color: '#ffffff'
-  border_fill_alpha: 1.0
-  min_border_top: null
-  min_border_bottom: null
-  min_border_left: null
-  min_border_right: null
-  min_border: 5
-  lod_factor: 10
-  lod_threshold: 2000
-  lod_interval: 300
-  lod_timeout: 500
-  output_backend: canvas
-  match_aspect: false
-  aspect_scale: 1
-  reset_policy: standard
-  hold_render: false
+MapPlot: {}
 GMapOptions:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  lat:
-    type: symbol
-    name: unset
-  lng:
-    type: symbol
-    name: unset
-  zoom: 12
   map_type: roadmap
   scale_control: false
   styles: null
   tilt: 45
 GMapPlot:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: 600
-  height: 600
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   x_range:
     type: object
     name: Range1d
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       start: 0
       end: 1
       reset_start: null
@@ -10629,16 +4125,6 @@ GMapPlot:
     type: object
     name: Range1d
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       start: 0
       end: 1
       reset_start: null
@@ -10646,160 +4132,8 @@ GMapPlot:
       bounds: null
       min_interval: null
       max_interval: null
-  x_scale:
-    type: object
-    name: LinearScale
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  y_scale:
-    type: object
-    name: LinearScale
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-  extra_x_ranges:
-    type: map
-    entries: []
-  extra_y_ranges:
-    type: map
-    entries: []
-  extra_x_scales:
-    type: map
-    entries: []
-  extra_y_scales:
-    type: map
-    entries: []
-  hidpi: true
-  title:
-    type: object
-    name: Title
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      level: annotation
-      visible: true
-      coordinates: null
-      x_range_name: default
-      y_range_name: default
-      group: null
-      text: ''
-      text_color: '#444444'
-      text_outline_color: null
-      text_alpha: 1.0
-      text_font: helvetica
-      text_font_size: 13px
-      text_font_style: bold
-      text_align: left
-      text_baseline: bottom
-      text_line_height: 1.0
-      background_fill_color: null
-      background_fill_alpha: 1.0
-      border_line_color: null
-      border_line_alpha: 1.0
-      border_line_width: 1
-      border_line_join: bevel
-      border_line_cap: butt
-      border_line_dash: []
-      border_line_dash_offset: 0
-      vertical_align: bottom
-      align: left
-      offset: 0
-      standoff: 10
-  title_location: above
-  outline_line_color: '#e5e5e5'
-  outline_line_alpha: 1.0
-  outline_line_width: 1
-  outline_line_join: bevel
-  outline_line_cap: butt
-  outline_line_dash: []
-  outline_line_dash_offset: 0
-  renderers: []
-  toolbar:
-    type: object
-    name: Toolbar
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      visible: true
-      classes: []
-      styles:
-        type: map
-        entries: []
-      stylesheets: []
-      logo: normal
-      autohide: false
-      tools: []
-      active_drag: auto
-      active_inspect: auto
-      active_scroll: auto
-      active_tap: auto
-      active_multi: auto
-  toolbar_location: right
-  toolbar_sticky: true
-  toolbar_inner: false
-  left: []
-  right: []
-  above: []
-  below: []
-  center: []
-  frame_width: null
-  frame_height: null
-  frame_align: true
-  inner_width: 0
-  inner_height: 0
-  outer_width: 0
-  outer_height: 0
-  background_fill_color: '#ffffff'
   background_fill_alpha: 0.0
   border_fill_color: '#ffffff'
-  border_fill_alpha: 1.0
-  min_border_top: null
-  min_border_bottom: null
-  min_border_left: null
-  min_border_right: null
-  min_border: 5
-  lod_factor: 10
-  lod_threshold: 2000
-  lod_interval: 300
-  lod_timeout: 500
-  output_backend: canvas
-  match_aspect: false
-  aspect_scale: 1
-  reset_policy: standard
-  hold_render: false
   map_options:
     type: symbol
     name: unset
@@ -10808,749 +4142,79 @@ GMapPlot:
     name: unset
   api_version: weekly
 BaseText:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   text:
     type: symbol
     name: unset
-MathText:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  text:
-    type: symbol
-    name: unset
-Ascii:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  text:
-    type: symbol
-    name: unset
-MathML:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  text:
-    type: symbol
-    name: unset
+MathText: {}
+Ascii: {}
+MathML: {}
 TeX:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  text:
-    type: symbol
-    name: unset
   macros:
     type: map
     entries: []
   inline: false
-PlainText:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  text:
-    type: symbol
-    name: unset
+PlainText: {}
 Texture:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   repetition: repeat
 CanvasTexture:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  repetition: repeat
   code:
     type: symbol
     name: unset
 ImageURLTexture:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  repetition: repeat
   url:
     type: symbol
     name: unset
-Widget:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
+Widget: {}
 ButtonLike:
   button_type: default
 AbstractButton:
-  button_type: default
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   label: Button
   icon: null
 Button:
-  button_type: default
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   label: Button
-  icon: null
 Toggle:
-  button_type: default
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   label: Toggle
-  icon: null
   active: false
 Dropdown:
-  button_type: default
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   label: Dropdown
-  icon: null
   split: false
   menu: []
 HelpButton:
   button_type: default
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   label: ''
   icon:
     type: object
     name: BuiltinIcon
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      size: 18
       icon_name: help
       color: gray
   tooltip:
     type: symbol
     name: unset
 AbstractGroup:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   labels: []
 ToggleButtonGroup:
-  button_type: default
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  labels: []
   orientation: horizontal
 ToggleInputGroup:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  labels: []
   inline: false
 CheckboxGroup:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  labels: []
-  inline: false
   active: []
 RadioGroup:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  labels: []
-  inline: false
   active: null
 CheckboxButtonGroup:
-  button_type: default
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  labels: []
-  orientation: horizontal
   active: []
 RadioButtonGroup:
-  button_type: default
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  labels: []
-  orientation: horizontal
   active: null
 InputWidget:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   title: ''
   description: null
 FileInput:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
   value: ''
   mime_type: ''
   filename: ''
   accept: ''
   multiple: false
 NumericInput:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
   value: null
   low: null
   high: null
@@ -11558,483 +4222,44 @@ NumericInput:
   mode: int
   format: null
 Spinner:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
-  value: null
-  low: null
-  high: null
-  placeholder: ''
   mode: float
-  format: null
   value_throttled: null
   step: 1
   page_step_multiplier: 10
   wheel_wait: 100
 ToggleInput:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   active: false
 Checkbox:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  active: false
   label: ''
 Switch:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
   width: 32
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  active: false
 TextLikeInput:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
   value: ''
   value_input: ''
   placeholder: ''
   max_length: null
 TextInput:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
-  value: ''
-  value_input: ''
-  placeholder: ''
-  max_length: null
   prefix: null
   suffix: null
 TextAreaInput:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
-  value: ''
-  value_input: ''
-  placeholder: ''
   max_length: 500
   cols: 20
   rows: 2
-PasswordInput:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
-  value: ''
-  value_input: ''
-  placeholder: ''
-  max_length: null
-  prefix: null
-  suffix: null
+PasswordInput: {}
 AutocompleteInput:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
-  value: ''
-  value_input: ''
-  placeholder: ''
-  max_length: null
-  prefix: null
-  suffix: null
   completions: []
   max_completions: null
   min_characters: 2
   case_sensitive: true
   restrict: true
 Select:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
   options: []
   value: ''
 MultiSelect:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
   options: []
   value: []
   size: 4
 MultiChoice:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
   options: []
   value: []
   delete_button: true
@@ -12044,41 +4269,6 @@ MultiChoice:
   placeholder: null
   solid: true
 DatePicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
   value:
     type: symbol
     name: unset
@@ -12089,221 +4279,16 @@ DatePicker:
   position: auto
   inline: false
 ColorPicker:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  title: ''
-  description: null
   color: '#000000'
 Markup:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   text: ''
   disable_math: false
-Paragraph:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  text: ''
-  disable_math: false
+Paragraph: {}
 Div:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  text: ''
-  disable_math: false
   render_as_text: false
-PreText:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  text: ''
-  disable_math: false
+PreText: {}
 AbstractSlider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
   width: 300
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   orientation: horizontal
   title: ''
   show_value: true
@@ -12312,46 +4297,7 @@ AbstractSlider:
   tooltips: true
   bar_color: '#e6e6e6'
 Slider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: 300
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  orientation: horizontal
-  title: ''
-  show_value: true
   format: 0[.]00
-  direction: ltr
-  tooltips: true
-  bar_color: '#e6e6e6'
   start:
     type: symbol
     name: unset
@@ -12366,46 +4312,7 @@ Slider:
     name: unset
   step: 1
 RangeSlider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: 300
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  orientation: horizontal
-  title: ''
-  show_value: true
   format: 0[.]00
-  direction: ltr
-  tooltips: true
-  bar_color: '#e6e6e6'
   value:
     type: symbol
     name: unset
@@ -12420,46 +4327,7 @@ RangeSlider:
     name: unset
   step: 1
 DateSlider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: 300
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  orientation: horizontal
-  title: ''
-  show_value: true
   format: '%d %b %Y'
-  direction: ltr
-  tooltips: true
-  bar_color: '#e6e6e6'
   value:
     type: symbol
     name: unset
@@ -12474,46 +4342,7 @@ DateSlider:
     name: unset
   step: 1
 DateRangeSlider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: 300
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  orientation: horizontal
-  title: ''
-  show_value: true
   format: '%d %b %Y'
-  direction: ltr
-  tooltips: true
-  bar_color: '#e6e6e6'
   value:
     type: symbol
     name: unset
@@ -12528,46 +4357,7 @@ DateRangeSlider:
     name: unset
   step: 1
 DatetimeRangeSlider:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: 300
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  orientation: horizontal
-  title: ''
-  show_value: true
   format: '%d %b %Y %H:%M:%S'
-  direction: ltr
-  tooltips: true
-  bar_color: '#e6e6e6'
   value:
     type: symbol
     name: unset
@@ -12581,293 +4371,47 @@ DatetimeRangeSlider:
     type: symbol
     name: unset
   step: 3600000
-CellFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-CellEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+CellFormatter: {}
+CellEditor: {}
 RowAggregator:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   field_: ''
 StringFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   font_style: normal
   text_align: left
   text_color: null
   nan_format: '-'
 ScientificFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  font_style: normal
-  text_align: left
-  text_color: null
-  nan_format: '-'
   precision: 10
   power_limit_high: 5
   power_limit_low: -3
 NumberFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  font_style: normal
-  text_align: left
-  text_color: null
-  nan_format: '-'
   format: 0,0
   language: en
   rounding: round
 BooleanFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   icon: check
 DateFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  font_style: normal
-  text_align: left
-  text_color: null
-  nan_format: '-'
   format: ISO-8601
 HTMLTemplateFormatter:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   template: <%= value %>
 StringEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   completions: []
-TextEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+TextEditor: {}
 SelectEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   options: []
-PercentEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-CheckboxEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
+PercentEditor: {}
+CheckboxEditor: {}
 IntEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   step: 1
 NumberEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   step: 0.01
-TimeEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-DateEditor:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-AvgAggregator:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  field_: ''
-MinAggregator:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  field_: ''
-MaxAggregator:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  field_: ''
-SumAggregator:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  field_: ''
+TimeEditor: {}
+DateEditor: {}
+AvgAggregator: {}
+MinAggregator: {}
+MaxAggregator: {}
+SumAggregator: {}
 TableColumn:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   field:
     type: symbol
     name: unset
@@ -12877,16 +4421,6 @@ TableColumn:
     type: object
     name: StringFormatter
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       font_style: normal
       text_align: left
       text_color: null
@@ -12895,102 +4429,15 @@ TableColumn:
     type: object
     name: StringEditor
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       completions: []
   sortable: true
   default_sort: ascending
   visible: true
 TableWidget:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: null
-  height: null
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
   source:
     type: object
     name: ColumnDataSource
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
       data:
         type: map
         entries: []
@@ -12998,143 +4445,13 @@ TableWidget:
     type: object
     name: CDSView
     attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
       filter:
         type: object
         name: AllIndices
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
+        attributes: {}
 DataTable:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
   width: 600
   height: 400
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  source:
-    type: object
-    name: ColumnDataSource
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-      data:
-        type: map
-        entries: []
-  view:
-    type: object
-    name: CDSView
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      filter:
-        type: object
-        name: AllIndices
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
   autosize_mode: force_fit
   auto_edit: false
   columns: []
@@ -13152,148 +4469,10 @@ DataTable:
   header_row: true
   row_height: 25
 GroupingInfo:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
   getter: ''
   aggregators: []
   collapsed: false
 DataCube:
-  name: null
-  tags: []
-  js_event_callbacks:
-    type: map
-    entries: []
-  subscribed_events: []
-  js_property_callbacks:
-    type: map
-    entries: []
-  syncable: true
-  visible: true
-  classes: []
-  styles:
-    type: map
-    entries: []
-  stylesheets: []
-  disabled: false
-  width: 600
-  height: 400
-  min_width: null
-  min_height: null
-  max_width: null
-  max_height: null
-  margin: null
-  width_policy: auto
-  height_policy: auto
-  aspect_ratio: null
-  flow_mode: block
-  sizing_mode: null
-  align: auto
-  css_classes: []
-  context_menu: null
-  resizable: false
-  source:
-    type: object
-    name: ColumnDataSource
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      selected:
-        type: object
-        name: Selection
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-          indices: []
-          line_indices: []
-          multiline_indices:
-            type: map
-            entries: []
-          image_indices: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-      data:
-        type: map
-        entries: []
-  view:
-    type: object
-    name: CDSView
-    attributes:
-      name: null
-      tags: []
-      js_event_callbacks:
-        type: map
-        entries: []
-      subscribed_events: []
-      js_property_callbacks:
-        type: map
-        entries: []
-      syncable: true
-      filter:
-        type: object
-        name: AllIndices
-        attributes:
-          name: null
-          tags: []
-          js_event_callbacks:
-            type: map
-            entries: []
-          subscribed_events: []
-          js_property_callbacks:
-            type: map
-            entries: []
-          syncable: true
-  autosize_mode: force_fit
-  auto_edit: false
-  columns: []
-  fit_columns: null
-  frozen_columns: null
-  frozen_rows: null
-  sortable: true
-  reorderable: true
-  editable: false
-  selectable: true
-  index_position: 0
-  index_header: '#'
-  index_width: 40
-  scroll_to_selection: true
-  header_row: true
-  row_height: 25
   grouping: []
   target:
     type: symbol

--- a/tests/baselines/defaults.yaml
+++ b/tests/baselines/defaults.yaml
@@ -215,8 +215,8 @@ DataSource:
     type: object
     name: Selection
     attributes:
-      line_indices: []
       indices: []
+      line_indices: []
 ColumnarDataSource:
   __extends__: DataSource
   selection_policy:
@@ -395,15 +395,17 @@ DatetimeTicker:
   - type: object
     name: AdaptiveTicker
     attributes:
+      num_minor_ticks: 0
       mantissas:
       - 1
       - 2
       - 5
-      num_minor_ticks: 0
       max_interval: 500.0
   - type: object
     name: AdaptiveTicker
     attributes:
+      num_minor_ticks: 0
+      base: 60
       mantissas:
       - 1
       - 2
@@ -412,13 +414,13 @@ DatetimeTicker:
       - 15
       - 20
       - 30
-      num_minor_ticks: 0
-      base: 60
       min_interval: 1000.0
       max_interval: 1800000.0
   - type: object
     name: AdaptiveTicker
     attributes:
+      num_minor_ticks: 0
+      base: 24
       mantissas:
       - 1
       - 2
@@ -426,8 +428,6 @@ DatetimeTicker:
       - 6
       - 8
       - 12
-      num_minor_ticks: 0
-      base: 24
       min_interval: 3600000.0
       max_interval: 43200000.0
   - type: object
@@ -2186,6 +2186,26 @@ GraphRenderer:
     type: object
     name: GlyphRenderer
     attributes:
+      data_source:
+        type: object
+        name: ColumnDataSource
+        attributes:
+          selected:
+            type: object
+            name: Selection
+            attributes:
+              indices: []
+              line_indices: []
+          selection_policy:
+            type: object
+            name: UnionRenderers
+            attributes: {}
+          data:
+            type: map
+            entries:
+            - !!python/tuple
+              - index
+              - []
       view:
         type: object
         name: CDSView
@@ -2198,30 +2218,33 @@ GraphRenderer:
         type: object
         name: Circle
         attributes: {}
-      data_source:
-        type: object
-        name: ColumnDataSource
-        attributes:
-          data:
-            type: map
-            entries:
-            - !!python/tuple
-              - index
-              - []
-          selection_policy:
-            type: object
-            name: UnionRenderers
-            attributes: {}
-          selected:
-            type: object
-            name: Selection
-            attributes:
-              line_indices: []
-              indices: []
   edge_renderer:
     type: object
     name: GlyphRenderer
     attributes:
+      data_source:
+        type: object
+        name: ColumnDataSource
+        attributes:
+          selected:
+            type: object
+            name: Selection
+            attributes:
+              indices: []
+              line_indices: []
+          selection_policy:
+            type: object
+            name: UnionRenderers
+            attributes: {}
+          data:
+            type: map
+            entries:
+            - !!python/tuple
+              - start
+              - []
+            - !!python/tuple
+              - end
+              - []
       view:
         type: object
         name: CDSView
@@ -2234,29 +2257,6 @@ GraphRenderer:
         type: object
         name: MultiLine
         attributes: {}
-      data_source:
-        type: object
-        name: ColumnDataSource
-        attributes:
-          data:
-            type: map
-            entries:
-            - !!python/tuple
-              - start
-              - []
-            - !!python/tuple
-              - end
-              - []
-          selection_policy:
-            type: object
-            name: UnionRenderers
-            attributes: {}
-          selected:
-            type: object
-            name: Selection
-            attributes:
-              line_indices: []
-              indices: []
   selection_policy:
     type: object
     name: NodesOnly
@@ -2408,15 +2408,17 @@ DatetimeAxis:
       - type: object
         name: AdaptiveTicker
         attributes:
+          num_minor_ticks: 0
           mantissas:
           - 1
           - 2
           - 5
-          num_minor_ticks: 0
           max_interval: 500.0
       - type: object
         name: AdaptiveTicker
         attributes:
+          num_minor_ticks: 0
+          base: 60
           mantissas:
           - 1
           - 2
@@ -2425,13 +2427,13 @@ DatetimeAxis:
           - 15
           - 20
           - 30
-          num_minor_ticks: 0
-          base: 60
           min_interval: 1000.0
           max_interval: 1800000.0
       - type: object
         name: AdaptiveTicker
         attributes:
+          num_minor_ticks: 0
+          base: 24
           mantissas:
           - 1
           - 2
@@ -2439,8 +2441,6 @@ DatetimeAxis:
           - 6
           - 8
           - 12
-          num_minor_ticks: 0
-          base: 24
           min_interval: 3600000.0
           max_interval: 43200000.0
       - type: object
@@ -2558,11 +2558,11 @@ MercatorAxis:
     type: object
     name: MercatorTicker
     attributes:
-      dimension: lat
       mantissas:
       - 1
       - 2
       - 5
+      dimension: lat
   formatter:
     type: object
     name: MercatorTickFormatter
@@ -3048,19 +3048,19 @@ DataAnnotation:
     type: object
     name: ColumnDataSource
     attributes:
-      data:
-        type: map
-        entries: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes: {}
       selected:
         type: object
         name: Selection
         attributes:
-          line_indices: []
           indices: []
+          line_indices: []
+      selection_policy:
+        type: object
+        name: UnionRenderers
+        attributes: {}
+      data:
+        type: map
+        entries: []
 ArrowHead:
   __extends__: Marking
   size:
@@ -3921,16 +3921,16 @@ RangeTool:
     type: object
     name: BoxAnnotation
     attributes:
+      syncable: false
       level: overlay
       line_color: black
+      line_alpha: 1.0
+      line_width: 0.5
       line_dash:
       - 2
       - 2
-      fill_alpha: 0.5
       fill_color: lightgrey
-      line_width: 0.5
-      line_alpha: 1.0
-      syncable: false
+      fill_alpha: 0.5
 WheelPanTool:
   __extends__: Scroll
   dimension: width
@@ -3972,21 +3972,21 @@ BoxZoomTool:
     type: object
     name: BoxAnnotation
     attributes:
-      visible: false
+      syncable: false
       level: overlay
+      visible: false
+      left_units: canvas
+      right_units: canvas
+      bottom_units: canvas
       top_units: canvas
       line_color: black
+      line_alpha: 1.0
+      line_width: 2
       line_dash:
       - 4
       - 4
-      fill_alpha: 0.5
-      left_units: canvas
       fill_color: lightgrey
-      bottom_units: canvas
-      right_units: canvas
-      line_width: 2
-      line_alpha: 1.0
-      syncable: false
+      fill_alpha: 0.5
   match_aspect: false
   origin: corner
 ZoomInTool:
@@ -4008,21 +4008,21 @@ BoxSelectTool:
     type: object
     name: BoxAnnotation
     attributes:
-      visible: false
+      syncable: false
       level: overlay
+      visible: false
+      left_units: canvas
+      right_units: canvas
+      bottom_units: canvas
       top_units: canvas
       line_color: black
+      line_alpha: 1.0
+      line_width: 2
       line_dash:
       - 4
       - 4
-      fill_alpha: 0.5
-      left_units: canvas
       fill_color: lightgrey
-      bottom_units: canvas
-      right_units: canvas
-      line_width: 2
-      line_alpha: 1.0
-      syncable: false
+      fill_alpha: 0.5
   origin: corner
 LassoSelectTool:
   __extends__:
@@ -4033,21 +4033,21 @@ LassoSelectTool:
     type: object
     name: PolyAnnotation
     attributes:
-      visible: false
+      syncable: false
       level: overlay
-      line_color: black
+      visible: false
       xs: []
+      xs_units: canvas
+      ys: []
+      ys_units: canvas
+      line_color: black
+      line_alpha: 1.0
+      line_width: 2
       line_dash:
       - 4
       - 4
-      fill_alpha: 0.5
       fill_color: lightgrey
-      ys: []
-      xs_units: canvas
-      ys_units: canvas
-      line_width: 2
-      line_alpha: 1.0
-      syncable: false
+      fill_alpha: 0.5
 PolySelectTool:
   __extends__:
   - Tap
@@ -4056,21 +4056,21 @@ PolySelectTool:
     type: object
     name: PolyAnnotation
     attributes:
-      visible: false
+      syncable: false
       level: overlay
-      line_color: black
+      visible: false
       xs: []
+      xs_units: canvas
+      ys: []
+      ys_units: canvas
+      line_color: black
+      line_alpha: 1.0
+      line_width: 2
       line_dash:
       - 4
       - 4
-      fill_alpha: 0.5
       fill_color: lightgrey
-      ys: []
-      xs_units: canvas
-      ys_units: canvas
-      line_width: 2
-      line_alpha: 1.0
-      syncable: false
+      fill_alpha: 0.5
 CustomJSHover:
   __extends__: Model
   args:
@@ -4660,19 +4660,19 @@ TableWidget:
     type: object
     name: ColumnDataSource
     attributes:
-      data:
-        type: map
-        entries: []
-      selection_policy:
-        type: object
-        name: UnionRenderers
-        attributes: {}
       selected:
         type: object
         name: Selection
         attributes:
-          line_indices: []
           indices: []
+          line_indices: []
+      selection_policy:
+        type: object
+        name: UnionRenderers
+        attributes: {}
+      data:
+        type: map
+        entries: []
   view:
     type: object
     name: CDSView

--- a/tests/support/defaults.py
+++ b/tests/support/defaults.py
@@ -63,12 +63,10 @@ class DefaultsSerializer(Serializer):
 
     def _encode(self, obj: Any) -> AnyRep:
         if isinstance(obj, Model):
-            # filter only own properties and overrides
             def query(prop: PropertyDescriptor[Any]) -> bool:
-                return (prop.readonly or prop.serialized) and \
-                    (prop.name in obj.__class__.__properties__ or prop.name in obj.__class__.__overridden_defaults__)
+                return prop.readonly or prop.serialized
 
-            properties = obj.query_properties_with_values(query, include_defaults=True, include_undefined=True)
+            properties = obj.query_properties_with_values(query, include_defaults=False, include_undefined=True)
             attributes = {key: self.encode(val) for key, val in properties.items()}
             rep = ObjectRep(
                 type="object",

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -565,7 +565,26 @@ class Some2HasProps(hp.HasProps, hp.Local):
     f3 = String(default="xyz")
     f4 = List(Int, default=[1, 2, 3])
 
-def test_HasProps_properties_with_values_unstable():
+class Some3HasProps(hp.HasProps, hp.Local):
+    f4 = Int(default=4)
+    f3 = Int(default=3)
+    f2 = Int(default=2)
+    f1 = Int(default=1)
+
+def test_HasProps_properties_with_values_maintains_order() -> None:
+    v0 = Some3HasProps()
+    assert list(v0.properties_with_values(include_defaults=False).items()) == []
+    assert list(v0.properties_with_values(include_defaults=True).items()) == [("f4", 4), ("f3", 3), ("f2", 2), ("f1", 1)]
+
+    v1 = Some3HasProps(f1=10, f4=40)
+    assert list(v1.properties_with_values(include_defaults=False).items()) == [("f4", 40), ("f1", 10)]
+    assert list(v1.properties_with_values(include_defaults=True).items()) == [("f4", 40), ("f3", 3), ("f2", 2), ("f1", 10)]
+
+    v2 = Some3HasProps(f4=40, f1=10)
+    assert list(v2.properties_with_values(include_defaults=False).items()) == [("f4", 40), ("f1", 10)]
+    assert list(v2.properties_with_values(include_defaults=True) .items()) == [("f4", 40), ("f3", 3), ("f2", 2), ("f1", 10)]
+
+def test_HasProps_properties_with_values_unstable() -> None:
     v0 = Some0HasProps()
     assert v0.properties_with_values(include_defaults=False) == {}
 


### PR DESCRIPTION
Makes `defaults.yaml` much smaller and easier to reason about.