### PR TITLE
Change type of `Model.subscribed_events` to `Set(String)`

### DIFF
--- a/bokehjs/src/lib/core/serialization/deserializer.ts
+++ b/bokehjs/src/lib/core/serialization/deserializer.ts
@@ -171,7 +171,7 @@ export class Deserializer {
 
   protected _decode_array(obj: ArrayRep): unknown[] {
     const decoded = []
-    for (const entry of obj.entries) {
+    for (const entry of obj.entries ?? []) {
       decoded.push(this._decode(entry))
     }
     return decoded
@@ -179,14 +179,14 @@ export class Deserializer {
 
   protected _decode_set(obj: SetRep): Set<unknown> {
     const decoded = new Set()
-    for (const entry of obj.entries) {
+    for (const entry of obj.entries ?? []) {
       decoded.add(this._decode(entry))
     }
     return decoded
   }
 
   protected _decode_map(obj: MapRep): Map<unknown, unknown> | {[key: string]: unknown} {
-    const decoded = map(obj.entries, ([key, val]) => [this._decode(key), this._decode(val)] as const)
+    const decoded = map(obj.entries ?? [], ([key, val]) => [this._decode(key), this._decode(val)] as const)
     const is_str = every(decoded, ([key]) => isString(key))
     if (is_str) {
       const obj: {[key: string]: unknown} = {} // Object.create(null)

--- a/bokehjs/src/lib/core/serialization/reps.ts
+++ b/bokehjs/src/lib/core/serialization/reps.ts
@@ -17,17 +17,17 @@ export type NumberRep = {
 
 export type ArrayRep = {
   type: "array"
-  entries: AnyVal[]
+  entries?: AnyVal[]
 }
 
 export type SetRep = {
   type: "set"
-  entries: AnyVal[]
+  entries?: AnyVal[]
 }
 
 export type MapRep = {
   type: "map"
-  entries: [AnyVal, AnyVal][]
+  entries?: [AnyVal, AnyVal][]
 }
 
 export type BytesRep = {

--- a/bokehjs/src/lib/core/serialization/serializer.ts
+++ b/bokehjs/src/lib/core/serialization/serializer.ts
@@ -125,7 +125,11 @@ export class Serializer {
       const data = this.binary ? new Buffer(obj) : new Base64Buffer(obj)
       return {type: "bytes", data}
     } else if (isPlainObject(obj)) {
-      return {type: "map", entries: [...map(entries(obj), ([key, val]) => [this.encode(key), this.encode(val)])]}
+      const items = entries(obj)
+      if (items.length == 0)
+        return {type: "map"}
+      else
+        return {type: "map", entries: [...map(items, ([key, val]) => [this.encode(key), this.encode(val)])]}
     /*
     } else if (isBasicObject(obj)) {
       return {type: "map", entries: [...map(entries(obj), ([key, val]) => [this.encode(key), this.encode(val)])]}
@@ -146,9 +150,15 @@ export class Serializer {
       else
         return obj
     } else if (obj instanceof Set) {
-      return {type: "set", entries: [...map(obj.values(), (val) => this.encode(val))]}
+      if (obj.size == 0)
+        return {type: "set"}
+      else
+        return {type: "set", entries: [...map(obj.values(), (val) => this.encode(val))]}
     } else if (obj instanceof Map) {
-      return {type: "map", entries: [...map(obj.entries(), ([key, val]) => [this.encode(key), this.encode(val)])]}
+      if (obj.size == 0)
+        return {type: "map"}
+      else
+        return {type: "map", entries: [...map(obj.entries(), ([key, val]) => [this.encode(key), this.encode(val)])]}
     } else if (isSymbol(obj) && obj.description != null) {
       return {type: "symbol", name: obj.description}
     } else

--- a/bokehjs/test/unit/core/serialization.ts
+++ b/bokehjs/test/unit/core/serialization.ts
@@ -91,8 +91,8 @@ describe("core/serialization module", () => {
     it("that supports plain objects", () => {
       const val0 = {}
       expect(to_serializable(val0)).to.be.equal({
-        rep: {type: "map", entries: []},
-        json: '{"type":"map","entries":[]}'},
+        rep: {type: "map"},
+        json: '{"type":"map"}'},
       )
       /*
       expect(to_serializable(val0)).to.be.equal({rep: {}, json: "{}"})
@@ -113,8 +113,8 @@ describe("core/serialization module", () => {
     it("that supports basic objects", () => {
       const val0 = Object.create(null)
       expect(to_serializable(val0)).to.be.equal({
-        rep: {type: "map", entries: []},
-        json: '{"type":"map","entries":[]}'},
+        rep: {type: "map"},
+        json: '{"type":"map"}'},
       )
       const val1 = Object.create(null)
       val1.key0 = 0
@@ -122,6 +122,32 @@ describe("core/serialization module", () => {
       expect(to_serializable(val1)).to.be.equal({
         rep: {type: "map", entries: [["key0", 0], ["key1", {type: "number", value: "nan"}]]},
         json: '{"type":"map","entries":[["key0",0],["key1",{"type":"number","value":"nan"}]]}',
+      })
+    })
+
+    it("that supports Map<K, V> instances", () => {
+      const val0 = new Map<number, string>()
+      expect(to_serializable(val0)).to.be.equal({
+        rep: {type: "map"},
+        json: '{"type":"map"}'},
+      )
+      const val1 = new Map([[1.1, "a"], [2.2, "b"]])
+      expect(to_serializable(val1)).to.be.equal({
+        rep: {type: "map", entries: [[1.1, "a"], [2.2, "b"]]},
+        json: '{"type":"map","entries":[[1.1,"a"],[2.2,"b"]]}',
+      })
+    })
+
+    it("that supports Set<V> instances", () => {
+      const val0 = new Set<number>()
+      expect(to_serializable(val0)).to.be.equal({
+        rep: {type: "set"},
+        json: '{"type":"set"}'},
+      )
+      const val1 = new Set([1.1, 2.2, 3.3])
+      expect(to_serializable(val1)).to.be.equal({
+        rep: {type: "set", entries: [1.1, 2.2, 3.3]},
+        json: '{"type":"set","entries":[1.1,2.2,3.3]}',
       })
     })
 

--- a/src/bokeh/core/properties.py
+++ b/src/bokeh/core/properties.py
@@ -117,6 +117,7 @@ Container Properties
 .. autoclass:: List
 .. autoclass:: RelativeDelta
 .. autoclass:: Seq
+.. autoclass:: Set
 .. autoclass:: Tuple
 .. autoclass:: RestrictedDict
 
@@ -261,6 +262,7 @@ __all__ = (
     'Required',
     'RestrictedDict',
     'Seq',
+    'Set',
     'Size',
     'SizeSpec',
     'String',
@@ -274,7 +276,7 @@ __all__ = (
     'field',
     'validate',
     'value',
-    'without_property_validation'
+    'without_property_validation',
 )
 
 #-----------------------------------------------------------------------------
@@ -299,6 +301,7 @@ from .property.container import Dict; Dict
 from .property.container import List; List
 from .property.container import NonEmpty; NonEmpty
 from .property.container import Seq; Seq
+from .property.container import Set; Set
 from .property.container import Tuple; Tuple
 from .property.container import RelativeDelta; RelativeDelta
 from .property.container import RestrictedDict; RestrictedDict

--- a/src/bokeh/core/property/bases.py
+++ b/src/bokeh/core/property/bases.py
@@ -496,6 +496,10 @@ class ParameterizedProperty(Property[T]):
     def has_ref(self) -> bool:
         return any(type_param.has_ref for type_param in self.type_params)
 
+    def _may_have_unstable_default(self) -> bool:
+        return super()._may_have_unstable_default() or \
+            any(type_param._may_have_unstable_default() for type_param in self.type_params)
+
     def replace(self, old: Type[Property[Any]], new: Property[Any]) -> Property[Any]:
         if self.__class__ == old:
             return new
@@ -522,9 +526,6 @@ class SingleParameterizedProperty(ParameterizedProperty[T]):
 
     def wrap(self, value: T) -> T:
         return self.type_param.wrap(value)
-
-    def _may_have_unstable_default(self) -> bool:
-        return super()._may_have_unstable_default() or self.type_param._may_have_unstable_default()
 
 class PrimitiveProperty(Property[T]):
     """ A base class for simple property types.

--- a/src/bokeh/core/property/container.py
+++ b/src/bokeh/core/property/container.py
@@ -43,7 +43,12 @@ from .descriptors import ColumnDataPropertyDescriptor
 from .enum import Enum
 from .numeric import Int
 from .singletons import Intrinsic, Undefined
-from .wrappers import PropertyValueColumnData, PropertyValueDict, PropertyValueList
+from .wrappers import (
+    PropertyValueColumnData,
+    PropertyValueDict,
+    PropertyValueList,
+    PropertyValueSet,
+)
 
 if TYPE_CHECKING:
     from ...document.events import DocumentPatchedEvent
@@ -121,7 +126,7 @@ class List(Seq[T]):
         # optional values. Also in Dict.
         super().__init__(item_type, default=default, help=help)
 
-    def wrap(self, value):
+    def wrap(self, value: list[T]) -> PropertyValueList[T]:
         """ Some property types need to wrap their values in special containers, etc.
 
         """
@@ -148,8 +153,18 @@ class Set(Seq[T]):
         # optional values. Also in Dict.
         super().__init__(item_type, default=default, help=help)
 
+    def wrap(self, value: set[T]) -> PropertyValueSet[T]:
+        """ Some property types need to wrap their values in special containers, etc. """
+        if isinstance(value, set):
+            if isinstance(value, PropertyValueSet):
+                return value
+            else:
+                return PropertyValueSet(value)
+        else:
+            return value
+
     @classmethod
-    def _is_seq(cls, value: Any):
+    def _is_seq(cls, value: Any) -> bool:
         return isinstance(value, set)
 
 class Array(Seq[T]):
@@ -158,7 +173,7 @@ class Array(Seq[T]):
     """
 
     @classmethod
-    def _is_seq(cls, value):
+    def _is_seq(cls, value: Any) -> bool:
         import numpy as np
         return isinstance(value, np.ndarray)
 

--- a/src/bokeh/core/property/container.py
+++ b/src/bokeh/core/property/container.py
@@ -61,6 +61,7 @@ __all__ = (
     'RelativeDelta',
     'RestrictedDict',
     'Seq',
+    'Set',
     'Tuple',
 )
 
@@ -101,8 +102,7 @@ class Seq(ContainerProperty[T]):
 
     @classmethod
     def _is_seq(cls, value: Any) -> bool:
-        return ((isinstance(value, Sequence) or cls._is_seq_like(value)) and
-                not isinstance(value, str))
+        return ((isinstance(value, Sequence) or cls._is_seq_like(value)) and not isinstance(value, str))
 
     @classmethod
     def _is_seq_like(cls, value: Any) -> bool:
@@ -115,8 +115,8 @@ class List(Seq[T]):
 
     """
 
-    def __init__(self, item_type: TypeOrInst[Property[T]], default: Init[T] = [], *, help: str | None = None) -> None:
-        # todo: refactor to not use mutable objects as default values.
+    def __init__(self, item_type: TypeOrInst[Property[T]], *, default: Init[T] = [], help: str | None = None) -> None:
+        # TODO: refactor to not use mutable objects as default values.
         # Left in place for now because we want to allow None to express
         # optional values. Also in Dict.
         super().__init__(item_type, default=default, help=help)
@@ -134,8 +134,23 @@ class List(Seq[T]):
             return value
 
     @classmethod
-    def _is_seq(cls, value):
+    def _is_seq(cls, value: Any):
         return isinstance(value, list)
+
+class Set(Seq[T]):
+    """ Accept Python ``set()`` values.
+
+    """
+
+    def __init__(self, item_type: TypeOrInst[Property[T]], *, default: Init[T] = set(), help: str | None = None) -> None:
+        # TODO: refactor to not use mutable objects as default values.
+        # Left in place for now because we want to allow None to express
+        # optional values. Also in Dict.
+        super().__init__(item_type, default=default, help=help)
+
+    @classmethod
+    def _is_seq(cls, value: Any):
+        return isinstance(value, set)
 
 class Array(Seq[T]):
     """ Accept NumPy array values.

--- a/src/bokeh/core/property/container.py
+++ b/src/bokeh/core/property/container.py
@@ -110,9 +110,6 @@ class Seq(ContainerProperty[T]):
                 and hasattr(value, "__getitem__") # NOTE: this is what makes it disallow set type
                 and not isinstance(value, Mapping))
 
-    def _new_instance(self, value):
-        return value
-
 class List(Seq[T]):
     """ Accept Python list values.
 
@@ -149,11 +146,6 @@ class Array(Seq[T]):
     def _is_seq(cls, value):
         import numpy as np
         return isinstance(value, np.ndarray)
-
-    def _new_instance(self, value):
-        import numpy as np
-        return np.array(value)
-
 
 class Dict(ContainerProperty[Any]):
     """ Accept Python dict values.

--- a/src/bokeh/core/property/either.py
+++ b/src/bokeh/core/property/either.py
@@ -105,10 +105,6 @@ class Either(ParameterizedProperty[Any]):
             value = tp.wrap(value)
         return value
 
-    def _may_have_unstable_default(self):
-        return super()._may_have_unstable_default() or \
-            any(tp._may_have_unstable_default() for tp in self.type_params)
-
     def replace(self, old: Type[Property[Any]], new: Property[Any]) -> Property[Any]:
         if self.__class__ == old:
             return new

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -275,6 +275,8 @@ class Serializer:
             return self._encode_tuple(obj)
         elif isinstance(obj, list):
             return self._encode_list(obj)
+        elif isinstance(obj, set):
+            return self._encode_set(obj)
         elif isinstance(obj, dict):
             return self._encode_dict(obj)
         elif isinstance(obj, bytes):
@@ -316,6 +318,12 @@ class Serializer:
 
     def _encode_list(self, obj: list[Any]) -> ArrayRepLike:
         return [self.encode(item) for item in obj]
+
+    def _encode_set(self, obj: set[Any]) -> SetRep:
+        return SetRep(
+            type="set",
+            entries=[self.encode(entry) for entry in obj],
+        )
 
     def _encode_dict(self, obj: dict[Any, Any]) -> MapRep:
         return MapRep(

--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -170,8 +170,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     """)
 
-    js_event_callbacks = p.Dict(p.String, p.List(p.Instance("bokeh.models.callbacks.Callback")),
-    help="""
+    js_event_callbacks = p.Dict(p.String, p.List(p.Instance("bokeh.models.callbacks.Callback")), help="""
     A mapping of event names to lists of ``CustomJS`` callbacks.
 
     Typically, rather then modifying this property directly, callbacks should be
@@ -181,12 +180,6 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
         callback = CustomJS(code="console.log('tap event occurred')")
         plot.js_on_event('tap', callback)
-    """)
-
-    subscribed_events = p.List(p.String, help="""
-    List of events that are subscribed to by Python callbacks. This is
-    the set of events that will be communicated from BokehJS back to
-    Python for this model.
     """)
 
     js_property_callbacks = p.Dict(p.String, p.List(p.Instance("bokeh.models.callbacks.Callback")), help="""
@@ -201,6 +194,12 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
         callback = CustomJS(code="console.log('stuff')")
         plot.x_range.js_on_change('start', callback)
 
+    """)
+
+    subscribed_events = p.Set(p.String, help="""
+    Collection of events that are subscribed to by Python callbacks. This is
+    the set of events that will be communicated from BokehJS back to Python
+    for this model.
     """)
 
     syncable: bool = p.Bool(default=True, help="""

--- a/tests/baselines/defaults.yaml
+++ b/tests/baselines/defaults.yaml
@@ -3,11 +3,10 @@ Model:
   tags: []
   js_event_callbacks:
     type: map
-    entries: []
-  subscribed_events: []
   js_property_callbacks:
     type: map
-    entries: []
+  subscribed_events:
+    type: set
   syncable: true
 DataModel:
   __extends__: Model
@@ -39,7 +38,6 @@ HatchProps:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 ScalarHatchProps:
   hatch_color: black
   hatch_alpha: 1.0
@@ -48,7 +46,6 @@ ScalarHatchProps:
   hatch_weight: 1.0
   hatch_extra:
     type: map
-    entries: []
 ImageProps:
   global_alpha:
     type: value
@@ -133,7 +130,6 @@ CustomJS:
   __extends__: Callback
   args:
     type: map
-    entries: []
   code: ''
 SetValue:
   __extends__: Callback
@@ -193,7 +189,6 @@ CustomJSFilter:
   __extends__: Filter
   args:
     type: map
-    entries: []
   code: ''
 Selection:
   __extends__: Model
@@ -201,7 +196,6 @@ Selection:
   line_indices: []
   multiline_indices:
     type: map
-    entries: []
   image_indices: []
 SelectionPolicy:
   __extends__: Model
@@ -227,7 +221,6 @@ ColumnDataSource:
   __extends__: ColumnarDataSource
   data:
     type: map
-    entries: []
 CDSView:
   __extends__: Model
   filter:
@@ -257,14 +250,12 @@ AjaxDataSource:
   content_type: application/json
   http_headers:
     type: map
-    entries: []
 Transform:
   __extends__: Model
 CustomJSTransform:
   __extends__: Transform
   args:
     type: map
-    entries: []
   func: ''
   v_func: ''
 Dodge:
@@ -570,7 +561,6 @@ CustomJSTickFormatter:
   __extends__: TickFormatter
   args:
     type: map
-    entries: []
   code: ''
 DatetimeTickFormatter:
   __extends__: TickFormatter
@@ -676,7 +666,6 @@ Marker:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 AnnularWedge:
   __extends__:
   - XYGlyph
@@ -746,7 +735,6 @@ AnnularWedge:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 Annulus:
   __extends__:
   - XYGlyph
@@ -809,7 +797,6 @@ Annulus:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 Arc:
   __extends__:
   - XYGlyph
@@ -959,7 +946,6 @@ Block:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 Circle:
   __extends__: Marker
   radius:
@@ -1031,7 +1017,6 @@ Ellipse:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 HArea:
   __extends__:
   - LineGlyph
@@ -1065,7 +1050,6 @@ HArea:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 HBar:
   __extends__:
   - LineGlyph
@@ -1127,7 +1111,6 @@ HBar:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 HexTile:
   __extends__:
   - LineGlyph
@@ -1189,7 +1172,6 @@ HexTile:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 ImageBase:
   __extends__: XYGlyph
   x:
@@ -1362,7 +1344,6 @@ MultiPolygons:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 Patch:
   __extends__:
   - ConnectedXYGlyph
@@ -1391,7 +1372,6 @@ Patch:
   hatch_weight: 1.0
   hatch_extra:
     type: map
-    entries: []
 Patches:
   __extends__:
   - LineGlyph
@@ -1447,7 +1427,6 @@ Patches:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 Quad:
   __extends__:
   - LineGlyph
@@ -1509,7 +1488,6 @@ Quad:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 Quadratic:
   __extends__: LineGlyph
   x0:
@@ -1654,7 +1632,6 @@ Rect:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 Scatter:
   __extends__: Marker
   marker:
@@ -1794,7 +1771,6 @@ VArea:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 VBar:
   __extends__:
   - LineGlyph
@@ -1856,7 +1832,6 @@ VBar:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 Wedge:
   __extends__:
   - XYGlyph
@@ -1923,7 +1898,6 @@ Wedge:
     value: 1.0
   hatch_extra:
     type: map
-    entries: []
 LabelingPolicy:
   __extends__: Model
 AllLabels:
@@ -1935,7 +1909,6 @@ CustomLabelingPolicy:
   __extends__: LabelingPolicy
   args:
     type: map
-    entries: []
   code: ''
 Range:
   __extends__: Model
@@ -2069,7 +2042,6 @@ CustomJSExpr:
   __extends__: Expression
   args:
     type: map
-    entries: []
   code: ''
 CumSum:
   __extends__: Expression
@@ -2124,7 +2096,6 @@ StaticLayoutProvider:
   __extends__: LayoutProvider
   graph_layout:
     type: map
-    entries: []
 GraphCoordinates:
   __extends__: CoordinateTransform
   layout:
@@ -2242,7 +2213,6 @@ TileSource:
   max_zoom: 30
   extra_url_vars:
     type: map
-    entries: []
   attribution: ''
   x_origin_offset:
     type: symbol
@@ -2301,7 +2271,6 @@ Axis:
   major_label_orientation: horizontal
   major_label_overrides:
     type: map
-    entries: []
   major_label_policy:
     type: object
     name: AllLabels
@@ -2898,7 +2867,6 @@ UIElement:
   classes: []
   styles:
     type: map
-    entries: []
   stylesheets: []
 bokeh.models.dom.DOMNode:
   __extends__: Model
@@ -3079,7 +3047,6 @@ Grid:
   band_hatch_weight: 1.0
   band_hatch_extra:
     type: map
-    entries: []
 LayoutDOM:
   __extends__: UIElement
   disabled: false
@@ -3173,7 +3140,6 @@ DataAnnotation:
         attributes: {}
       data:
         type: map
-        entries: []
 ArrowHead:
   __extends__: Marking
   size:
@@ -3351,7 +3317,6 @@ BoxAnnotation:
   hatch_weight: 1.0
   hatch_extra:
     type: map
-    entries: []
 Band:
   __extends__: DataAnnotation
   lower:
@@ -3395,7 +3360,6 @@ PolyAnnotation:
   hatch_weight: 1.0
   hatch_extra:
     type: map
-    entries: []
 Slope:
   __extends__: Annotation
   gradient: null
@@ -3750,7 +3714,6 @@ BaseColorBar:
   formatter: auto
   major_label_overrides:
     type: map
-    entries: []
   major_label_policy:
     type: object
     name: NoOverlap
@@ -4075,7 +4038,6 @@ CustomJSHover:
   __extends__: Model
   args:
     type: map
-    entries: []
   code: ''
 HoverTool:
   __extends__: InspectTool
@@ -4090,7 +4052,6 @@ HoverTool:
     - ($sx, $sy)
   formatters:
     type: map
-    entries: []
   mode: mouse
   muted_policy: show
   point_policy: snap_to_data
@@ -4183,16 +4144,12 @@ Plot:
     attributes: {}
   extra_x_ranges:
     type: map
-    entries: []
   extra_y_ranges:
     type: map
-    entries: []
   extra_x_scales:
     type: map
-    entries: []
   extra_y_scales:
     type: map
-    entries: []
   hidpi: true
   title:
     type: object
@@ -4306,7 +4263,6 @@ TeX:
   __extends__: MathText
   macros:
     type: map
-    entries: []
   inline: false
 PlainText:
   __extends__: BaseText
@@ -4672,7 +4628,6 @@ TableWidget:
         attributes: {}
       data:
         type: map
-        entries: []
   view:
     type: object
     name: CDSView

--- a/tests/unit/bokeh/core/property/_util_property.py
+++ b/tests/unit/bokeh/core/property/_util_property.py
@@ -41,21 +41,21 @@ from bokeh.core.properties import Dict, Int, List, Nullable, String # isort:skip
 class _TestHasProps(HasProps):
     x = Int(12)
     y = String("hello")
-    z = List(Int, [1, 2, 3])
+    z = List(Int, default=[1, 2, 3])
     zz = Dict(String, Int)
     s = String(None)
 
 class _TestModel(HasProps):
     x = Int(12)
     y = String("hello")
-    z = List(Int, [1, 2, 3])
+    z = List(Int, default=[1, 2, 3])
     zz = Dict(String, Int)
     s = Nullable(String ,default=None)
 
 class _TestModel2(HasProps):
     x = Int(12)
     y = String("hello")
-    z = List(Int, [1, 2, 3])
+    z = List(Int, default=[1, 2, 3])
     zz = Dict(String, Int)
     s = Nullable(String, default=None)
 

--- a/tests/unit/bokeh/core/property/test_container.py
+++ b/tests/unit/bokeh/core/property/test_container.py
@@ -51,6 +51,7 @@ ALL = (
     'RelativeDelta',
     'RestrictedDict',
     'Seq',
+    'Set',
     'Tuple',
 )
 
@@ -294,6 +295,54 @@ class Test_Seq:
         prop = bcpc.Seq(Int)
         assert str(prop) == "Seq(Int)"
 
+class Test_Set:
+    def test_init(self) -> None:
+        with pytest.raises(TypeError):
+            bcpc.Set() # type: ignore
+
+    def test_valid(self) -> None:
+        prop = bcpc.Set(Int)
+
+        assert prop.is_valid(set())
+        assert prop.is_valid({1, 2, 3})
+
+    def test_invalid(self) -> None:
+        prop = bcpc.Set(Int)
+
+        assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
+        assert not prop.is_valid(0.0)
+        assert not prop.is_valid(1.0)
+        assert not prop.is_valid(1.0+1.0j)
+        assert not prop.is_valid("")
+        assert not prop.is_valid(_TestHasProps())
+        assert not prop.is_valid(_TestModel())
+
+        assert not prop.is_valid(())
+        assert not prop.is_valid([])
+        assert not prop.is_valid({})
+        assert not prop.is_valid(np.array([1, 2]))
+        assert not prop.is_valid((1, 2))
+        assert not prop.is_valid([1, 2])
+        assert not prop.is_valid({1: 2})
+        assert not prop.is_valid(np.array([1, 2]))
+
+        assert not prop.is_valid({"a", "b", "c"})
+        assert not prop.is_valid({1.1, 1.2, 1.3})
+
+    def test_has_ref(self) -> None:
+        prop = bcpc.Set(Int)
+        assert not prop.has_ref
+
+        prop = bcpc.Set(Instance(_TestModel))
+        assert prop.has_ref
+
+    def test_str(self) -> None:
+        prop = bcpc.Set(Int)
+        assert str(prop) == "Set(Int)"
 
 class Test_Tuple:
 

--- a/tests/unit/bokeh/core/property/test_container.py
+++ b/tests/unit/bokeh/core/property/test_container.py
@@ -29,7 +29,7 @@ from bokeh.core.properties import (
     Seq,
     String,
 )
-from bokeh.core.property.wrappers import PropertyValueDict, PropertyValueList
+from bokeh.core.property.wrappers import PropertyValueDict, PropertyValueList, PropertyValueSet
 from bokeh.models import ColumnDataSource
 from tests.support.util.api import verify_all
 
@@ -339,6 +339,12 @@ class Test_Set:
 
         prop = bcpc.Set(Instance(_TestModel))
         assert prop.has_ref
+
+    def test_wrap(self) -> None:
+        prop = bcpc.Set(Int)
+        wrapped = prop.wrap({10, 20, 30})
+        assert isinstance(wrapped, PropertyValueSet)
+        assert prop.wrap(wrapped) is wrapped
 
     def test_str(self) -> None:
         prop = bcpc.Set(Int)

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -117,7 +117,7 @@ class Test_PropertyDescriptor:
         model_unstable_default_values = dict(
             js_event_callbacks={},
             js_property_callbacks={},
-            subscribed_events=[],
+            subscribed_events=set(),
             tags=[],
         )
 

--- a/tests/unit/bokeh/core/property/test_wrappers__property.py
+++ b/tests/unit/bokeh/core/property/test_wrappers__property.py
@@ -57,11 +57,12 @@ import bokeh.core.property.wrappers as bcpw # isort:skip
 #-----------------------------------------------------------------------------
 
 ALL = (
-    'notify_owner',
-    'PropertyValueContainer',
-    'PropertyValueList',
-    'PropertyValueDict',
     'PropertyValueColumnData',
+    'PropertyValueContainer',
+    'PropertyValueDict',
+    'PropertyValueList',
+    'PropertyValueSet',
+    'notify_owner',
 )
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/property/test_wrappers__property.py
+++ b/tests/unit/bokeh/core/property/test_wrappers__property.py
@@ -428,6 +428,38 @@ def test_PropertyValueList_mutators(mock_notify: MagicMock) -> None:
     except:
         pass
 
+@patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
+def test_PropertyValueSet_mutators(mock_notify: MagicMock) -> None:
+    pvs: set[int] = bcpw.PropertyValueSet([10, 20, 30, 40, 50])
+
+    mock_notify.reset_mock()
+    pvs.add(60)
+    assert mock_notify.called
+
+    mock_notify.reset_mock()
+    pvs.difference_update([20, 30])
+    assert mock_notify.called
+
+    mock_notify.reset_mock()
+    pvs.discard(20)
+    assert mock_notify.called
+
+    mock_notify.reset_mock()
+    pvs.intersection_update([20, 30])
+    assert mock_notify.called
+
+    mock_notify.reset_mock()
+    pvs.remove(10)
+    assert mock_notify.called
+
+    mock_notify.reset_mock()
+    pvs.symmetric_difference_update([10, 40])
+    assert mock_notify.called
+
+    mock_notify.reset_mock()
+    pvs.update([50, 60])
+    assert mock_notify.called
+
 def test_PropertyValueColumnData___copy__() -> None:
     source = ColumnDataSource(data=dict(foo=[10]))
     pvcd = source.data.__copy__()

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -115,6 +115,7 @@ ALL = (
     'Required',
     'RestrictedDict',
     'Seq',
+    'Set',
     'Size',
     'SizeSpec',
     'String',

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -144,7 +144,7 @@ class TestBasic:
         class Foo(HasProps):
             x = Int(12)
             y = String("hello")
-            z = List(Int, [1, 2, 3])
+            z = List(Int, default=[1, 2, 3])
             zz = Dict(String, Int)
             s = Nullable(String(None))
 
@@ -488,12 +488,12 @@ def test_HasProps_equals() -> None:
     class Foo(HasProps):
         x = Int(12)
         y = String("hello")
-        z = List(Int, [1,2,3])
+        z = List(Int, default=[1,2,3])
 
     class FooUnrelated(HasProps):
         x = Int(12)
         y = String("hello")
-        z = List(Int, [1,2,3])
+        z = List(Int, default=[1,2,3])
 
     v = Foo().equals(Foo())
     assert v is True

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -1129,7 +1129,7 @@ def test_transform_series_force_list_default_with_buffers() -> None:
             "tags": [],
             'js_property_callbacks': dict(type="map", entries=[]),
             "js_event_callbacks": dict(type="map", entries=[]),
-            "subscribed_events": [],
+            "subscribed_events": dict(type="set", entries=[]),
             "syncable": True,
             "foo": 42,
             "bar": "world",
@@ -1143,7 +1143,7 @@ def test_transform_series_force_list_default_with_buffers() -> None:
             '"js_property_callbacks":{"entries":[],"type":"map"},' +
             '"name":null,' +
             '"null_child":null,' +
-            '"subscribed_events":[],' +
+            '"subscribed_events":{"entries":[],"type":"set"},' +
             '"syncable":true,' +
             '"tags":[]}'
         ) % (child_obj.id, obj.id) == json_string

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -199,7 +199,7 @@ class TestSerializer:
         encoder = Serializer()
         rep = encoder.encode(val)
 
-        assert rep == MapRep(type="map", entries=[])
+        assert rep == MapRep(type="map")
         assert encoder.buffers == []
 
     def test_dict(self) -> None:
@@ -231,7 +231,7 @@ class TestSerializer:
         encoder = Serializer()
 
         val0: set[int] = set()
-        assert encoder.encode(val0) == SetRep(type="set", entries=[])
+        assert encoder.encode(val0) == SetRep(type="set")
 
         val1 = {1, 2, 3}
         assert encoder.encode(val1) == SetRep(type="set", entries=[1, 2, 3])

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -48,6 +48,7 @@ from bokeh.core.serialization import (
     Ref,
     SerializationError,
     Serializer,
+    SetRep,
     SliceRep,
     TypedArrayRep,
 )
@@ -225,6 +226,15 @@ class TestSerializer:
         encoder = Serializer()
         with pytest.raises(SerializationError):
             encoder.encode(val)
+
+    def test_set(self) -> None:
+        encoder = Serializer()
+
+        val0: set[int] = set()
+        assert encoder.encode(val0) == SetRep(type="set", entries=[])
+
+        val1 = {1, 2, 3}
+        assert encoder.encode(val1) == SetRep(type="set", entries=[1, 2, 3])
 
     def test_slice(self) -> None:
         encoder = Serializer()

--- a/tests/unit/bokeh/embed/test_util__embed.py
+++ b/tests/unit/bokeh/embed/test_util__embed.py
@@ -99,7 +99,7 @@ class _GoodEventCallback:
 class EmbedTestUtilModel(Model):
     a = Int(12)
     b = String("hello")
-    c = List(Int, [1, 2, 3])
+    c = List(Int, default=[1, 2, 3])
 
 #-----------------------------------------------------------------------------
 # General API

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -38,7 +38,7 @@ from bokeh.model import Model # isort:skip
 class SomeModel(Model):
     a = Int(12)
     b = String("hello")
-    c = List(Int, [1, 2, 3])
+    c = List(Int, default=[1, 2, 3])
 
 
 class Test_js_on_change:

--- a/tests/unit/bokeh/test_objects.py
+++ b/tests/unit/bokeh/test_objects.py
@@ -188,7 +188,7 @@ class TestModel:
             tags=[],
             js_property_callbacks={},
             js_event_callbacks={},
-            subscribed_events=[],
+            subscribed_events=set(),
             syncable=True,
             some=0,
         )

--- a/tests/unit/bokeh/util/test_callback_manager.py
+++ b/tests/unit/bokeh/util/test_callback_manager.py
@@ -277,7 +277,7 @@ class TestEventCallbackManager:
 
     def test_on_change_good_method(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         good = _GoodEventCallback()
         m.on_event('foo', good.method)
         assert len(m._event_callbacks) == 1
@@ -286,7 +286,7 @@ class TestEventCallbackManager:
     def test_on_change_good_partial_function(self) -> None:
         m = cbm.EventCallbackManager()
         p = partial(_partially_good_event, 'foo')
-        m.subscribed_events = []
+        m.subscribed_events = set()
         m.on_event('foo', p)
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [p]
@@ -294,13 +294,13 @@ class TestEventCallbackManager:
     def test_on_change_bad_partial_function(self) -> None:
         m = cbm.EventCallbackManager()
         p = partial(_partially_bad_event, 'foo')
-        m.subscribed_events = []
+        m.subscribed_events = set()
         m.on_event('foo', p)
         assert len(m._event_callbacks) == 1
 
     def test_on_change_good_partial_method(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         good = _GoodEventCallback()
         p = partial(good.partially_good, 'foo')
         m.on_event('foo', p)
@@ -308,7 +308,7 @@ class TestEventCallbackManager:
 
     def test_on_change_good_functor(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         good = _GoodEventCallback()
         m.on_event('foo', good)
         assert len(m._event_callbacks) == 1
@@ -316,21 +316,21 @@ class TestEventCallbackManager:
 
     def test_on_change_good_function(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         m.on_event('foo', _good_event)
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [_good_event]
 
     def test_on_change_unicode_event_name(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         m.on_event("foo", _good_event)
         assert len(m._event_callbacks) == 1
         assert m._event_callbacks['foo'] == [_good_event]
 
     def test_on_change_good_lambda(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         good = lambda event: event
         m.on_event('foo', good)
         assert len(m._event_callbacks) == 1
@@ -340,35 +340,35 @@ class TestEventCallbackManager:
         def good(event):
             pass
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         m.on_event('foo', good)
         assert len(m._event_callbacks) == 1
         assert len(m._event_callbacks['foo']) == 1
 
     def test_on_change_bad_method(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         bad = _BadEventCallback()
         m.on_event('foo', bad.method)
         assert len(m._event_callbacks) == 1
 
     def test_on_change_bad_functor(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         bad = _BadEventCallback()
         m.on_event('foo', bad)
         assert len(m._event_callbacks) == 1
 
     def test_on_change_bad_function(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         with pytest.raises(ValueError):
             m.on_event('foo', _bad_event)
         assert len(m._event_callbacks) == 0
 
     def test_on_change_bad_lambda(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         with pytest.raises(ValueError):
             m.on_event('foo', lambda x, y: x)
         assert len(m._event_callbacks) == 0
@@ -377,14 +377,14 @@ class TestEventCallbackManager:
         def bad(event, y):
             pass
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         with pytest.raises(ValueError):
             m.on_event('foo', bad)
         assert len(m._event_callbacks) == 0
 
     def test_on_change_with_two_callbacks(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         good1 = _GoodEventCallback()
         good2 = _GoodEventCallback()
         m.on_event('foo', good1.method)
@@ -392,7 +392,7 @@ class TestEventCallbackManager:
 
     def test_on_change_with_two_callbacks_one_bad(self) -> None:
         m = cbm.EventCallbackManager()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         good = _GoodEventCallback()
         bad = _BadEventCallback()
         m.on_event('foo', good.method, bad.method)
@@ -412,7 +412,7 @@ class TestEventCallbackManager:
             out['curdoc'] = curdoc()
         class Modelish(HasDocumentRef, cbm.EventCallbackManager): pass
         m = Modelish()
-        m.subscribed_events = []
+        m.subscribed_events = set()
         m.on_event('foo', cb)
         m.id = 10
         m._document = d2


### PR DESCRIPTION
This was extracted from PR #12370. This PR:

- changes the type of `Model.subscribed_events` to reflect better the behavior of this property
- adds `Set(T)` property type and `PropertyValueSet` wrapper
- adds/finalizes support for serialization of sets
- prunes some duplicated/unnecessary code from parameterized properties