### PR TITLE
AutocompleteInput: add parameter to limit the number of completions displayed

### DIFF
--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -426,6 +426,20 @@ export namespace Kinds {
     }
   }
 
+  export class Positive<BaseType extends number> extends Kind<BaseType> {
+    constructor(readonly base_type: Kind<BaseType>) {
+      super()
+    }
+
+    valid(value: unknown): value is BaseType {
+      return this.base_type.valid(value) && value > 0
+    }
+
+    override toString(): string {
+      return `Positive(${this.base_type.toString()})`
+    }
+  }
+
   export class DOMNode extends Kind<Node> {
     valid(value: unknown): value is Node {
       return value instanceof Node
@@ -463,6 +477,7 @@ export const Function = <Args extends unknown[], Ret>() => new Kinds.Function<Ar
 export const DOMNode = new Kinds.DOMNode()
 
 export const NonNegative = <BaseType extends number>(base_type: Kind<BaseType>) => new Kinds.NonNegative(base_type)
+export const Positive = <BaseType extends number>(base_type: Kind<BaseType>) => new Kinds.Positive(base_type)
 
 export const Percent = new Kinds.Percent()
 export const Alpha = Percent

--- a/bokehjs/src/lib/core/util/iterator.ts
+++ b/bokehjs/src/lib/core/util/iterator.ts
@@ -34,6 +34,17 @@ export function* enumerate<T>(seq: Iterable<T>): Iterable<[T, number]> {
   }
 }
 
+export function* take<T>(seq: Iterable<T>, n: number): Iterable<T> {
+  assert(n >= 0)
+  let i = 0
+  for (const item of seq) {
+    if (i++ < n)
+      yield item
+    else
+      break
+  }
+}
+
 export function* skip<T>(seq: Iterable<T>, n: number): Iterable<T> {
   assert(n >= 0)
 

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -48,9 +48,11 @@ export class AutocompleteInputView extends TextInputView {
   protected _update_completions(completions: string[]): void {
     empty(this.menu)
 
-    for (const text of completions) {
+    for (const [index, text] of completions.entries()) {
       const item = div(text)
       this.menu.appendChild(item)
+      if (this.model.max_completions === index + 1)
+        break
     }
 
     if (completions.length > 0)
@@ -169,6 +171,7 @@ export namespace AutocompleteInput {
   export type Props = TextInput.Props & {
     completions: p.Property<string[]>
     min_characters: p.Property<number>
+    max_completions: p.Property<number| null>
     case_sensitive: p.Property<boolean>
     restrict: p.Property<boolean>
   }
@@ -187,9 +190,10 @@ export class AutocompleteInput extends TextInput {
   static {
     this.prototype.default_view = AutocompleteInputView
 
-    this.define<AutocompleteInput.Props>(({Boolean, Int, String, Array, NonNegative}) => ({
+    this.define<AutocompleteInput.Props>(({Boolean, Int, String, Array, NonNegative, Nullable}) => ({
       completions:    [ Array(String), [] ],
       min_characters: [ NonNegative(Int), 2 ],
+      max_completions: [ Nullable(Int),  null ],
       case_sensitive: [ Boolean, true ],
       restrict: [ Boolean, true ],
     }))

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -2,6 +2,7 @@ import {TextInput, TextInputView} from "./text_input"
 
 import {empty, display, undisplay, div, StyleSheetLike} from "core/dom"
 import * as p from "core/properties"
+import {take} from "core/util/iterator"
 import {clamp} from "core/util/math"
 
 import dropdown_css, * as dropdown from "styles/dropdown.css"
@@ -48,15 +49,15 @@ export class AutocompleteInputView extends TextInputView {
   protected _update_completions(completions: string[]): void {
     empty(this.menu)
 
-    for (const [index, text] of completions.entries()) {
+    const {max_completions} = this.model
+    const selected_completions = max_completions != null ? take(completions, max_completions) : completions
+
+    for (const text of selected_completions) {
       const item = div(text)
-      this.menu.appendChild(item)
-      if (this.model.max_completions === index + 1)
-        break
+      this.menu.append(item)
     }
 
-    if (completions.length > 0)
-      this.menu.children[0].classList.add(dropdown.active)
+    this.menu.firstElementChild?.classList.add(dropdown.active)
   }
 
   protected _toggle_menu(): void {
@@ -171,7 +172,7 @@ export namespace AutocompleteInput {
   export type Props = TextInput.Props & {
     completions: p.Property<string[]>
     min_characters: p.Property<number>
-    max_completions: p.Property<number| null>
+    max_completions: p.Property<number | null>
     case_sensitive: p.Property<boolean>
     restrict: p.Property<boolean>
   }
@@ -190,10 +191,10 @@ export class AutocompleteInput extends TextInput {
   static {
     this.prototype.default_view = AutocompleteInputView
 
-    this.define<AutocompleteInput.Props>(({Boolean, Int, String, Array, NonNegative, Nullable}) => ({
+    this.define<AutocompleteInput.Props>(({Boolean, Int, String, Array, NonNegative, Positive, Nullable}) => ({
       completions:    [ Array(String), [] ],
       min_characters: [ NonNegative(Int), 2 ],
-      max_completions: [ Nullable(Int),  null ],
+      max_completions: [ Nullable(Positive(Int)), null ],
       case_sensitive: [ Boolean, true ],
       restrict: [ Boolean, true ],
     }))

--- a/bokehjs/test/unit/core/kinds.ts
+++ b/bokehjs/test/unit/core/kinds.ts
@@ -233,4 +233,48 @@ describe("core/kinds module", () => {
     expect(tp.valid("a")).to.be.false
     expect(tp.valid(1)).to.be.false
   })
+
+  it("should support NonNegative(T) kind", () => {
+    const tp0 = k.NonNegative(k.Int)
+    expect(`${tp0}`).to.be.equal("NonNegative(Int)")
+    expect(tp0.valid(-1)).to.be.false
+    expect(tp0.valid(0)).to.be.true
+    expect(tp0.valid(1)).to.be.true
+
+    expect(tp0.valid(-1.1)).to.be.false
+    expect(tp0.valid(0.0)).to.be.true
+    expect(tp0.valid(1.1)).to.be.false
+
+    const tp1 = k.NonNegative(k.Number)
+    expect(`${tp1}`).to.be.equal("NonNegative(Number)")
+    expect(tp1.valid(-1)).to.be.false
+    expect(tp1.valid(0)).to.be.true
+    expect(tp1.valid(1)).to.be.true
+
+    expect(tp1.valid(-1.1)).to.be.false
+    expect(tp1.valid(0.0)).to.be.true
+    expect(tp1.valid(1.1)).to.be.true
+  })
+
+  it("should support Positive(T) kind", () => {
+    const tp0 = k.Positive(k.Int)
+    expect(`${tp0}`).to.be.equal("Positive(Int)")
+    expect(tp0.valid(-1)).to.be.false
+    expect(tp0.valid(0)).to.be.false
+    expect(tp0.valid(1)).to.be.true
+
+    expect(tp0.valid(-1.1)).to.be.false
+    expect(tp0.valid(0.0)).to.be.false
+    expect(tp0.valid(1.1)).to.be.false
+
+    const tp1 = k.Positive(k.Number)
+    expect(`${tp1}`).to.be.equal("Positive(Number)")
+    expect(tp1.valid(-1)).to.be.false
+    expect(tp1.valid(0)).to.be.false
+    expect(tp1.valid(1)).to.be.true
+
+    expect(tp1.valid(-1.1)).to.be.false
+    expect(tp1.valid(0.0)).to.be.false
+    expect(tp1.valid(1.1)).to.be.true
+  })
 })

--- a/bokehjs/test/unit/core/util/iterator.ts
+++ b/bokehjs/test/unit/core/util/iterator.ts
@@ -1,9 +1,11 @@
 import {expect} from "assertions"
 
 import {
-  range, reverse, enumerate, skip, tail, join, interleave,
+  range, reverse, enumerate, take, skip, tail, join, interleave,
   map, flat_map, every, some, combinations, subsets,
 } from "@bokehjs/core/util/iterator"
+
+import {AssertionError} from "@bokehjs/core/util/assert"
 
 describe("core/util/iterator module", () => {
   it("implements range() function", () => {
@@ -25,6 +27,26 @@ describe("core/util/iterator module", () => {
     expect([...enumerate(["a"])]).to.be.equal([["a", 0]])
     expect([...enumerate(["a", "b"])]).to.be.equal([["a", 0], ["b", 1]])
     expect([...enumerate(["a", "b", "c"])]).to.be.equal([["a", 0], ["b", 1], ["c", 2]])
+  })
+
+  it("implements take() function", () => {
+    expect([...take(range(0, 0), 0)]).to.be.equal([])
+    expect([...take(range(0, 0), 1)]).to.be.equal([])
+    expect([...take(range(0, 0), 9)]).to.be.equal([])
+
+    expect([...take(range(0, 1000), 0)]).to.be.equal([])
+    expect([...take(range(0, 1000), 1)]).to.be.equal([0])
+    expect([...take(range(0, 1000), 9)]).to.be.equal([0, 1, 2, 3, 4, 5, 6, 7, 8])
+
+    expect([...take([], 0)]).to.be.equal([])
+    expect([...take([], 1)]).to.be.equal([])
+    expect([...take([], 9)]).to.be.equal([])
+
+    expect([...take([...range(0, 1000)], 0)]).to.be.equal([])
+    expect([...take([...range(0, 1000)], 1)]).to.be.equal([0])
+    expect([...take([...range(0, 1000)], 9)]).to.be.equal([0, 1, 2, 3, 4, 5, 6, 7, 8])
+
+    expect(() => [...take(range(0, 10), -1)]).to.throw(AssertionError)
   })
 
   it("implements skip() function", () => {

--- a/src/bokeh/models/widgets/inputs.py
+++ b/src/bokeh/models/widgets/inputs.py
@@ -394,6 +394,8 @@ class AutocompleteInput(TextInput):
     user upon typing the beginning of a desired value.
     """)
 
+    max_completions = Nullable(Int, help="""Optional maximum number of completions displayed.""")
+
     min_characters = NonNegative(Int, default=2, help="""
     The number of characters a user must type before completions are presented.
     """)

--- a/src/bokeh/models/widgets/inputs.py
+++ b/src/bokeh/models/widgets/inputs.py
@@ -39,6 +39,7 @@ from ...core.properties import (
     Null,
     Nullable,
     Override,
+    Positive,
     Readonly,
     String,
     Tuple,
@@ -394,13 +395,17 @@ class AutocompleteInput(TextInput):
     user upon typing the beginning of a desired value.
     """)
 
-    max_completions = Nullable(Int, help="""Optional maximum number of completions displayed.""")
+    max_completions = Nullable(Positive(Int), help="""
+    Optional maximum number of completions displayed.
+    """)
 
     min_characters = NonNegative(Int, default=2, help="""
     The number of characters a user must type before completions are presented.
     """)
 
-    case_sensitive = Bool(default=True, help="""Enable or disable case sensitivity""")
+    case_sensitive = Bool(default=True, help="""
+    Enable or disable case sensitivity.
+    """)
 
     restrict = Bool(default=True, help="""
     Set to False in order to allow users to enter text that is not present in the list of completion strings.

--- a/tests/baselines/defaults.yaml
+++ b/tests/baselines/defaults.yaml
@@ -11918,6 +11918,7 @@ AutocompleteInput:
   prefix: null
   suffix: null
   completions: []
+  max_completions: null
   min_characters: 2
   case_sensitive: true
   restrict: true


### PR DESCRIPTION
- [x] issues: fixes https://github.com/bokeh/bokeh/issues/12438
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

This implementation is the most basic one. An alternative (slightly more complicated, at least for me today!) would be to show X completion strings together with a scroll bar to explore the remaining ones (in that case, I don't know if the parameter as defined in this PR would be appropriate or if a parameter limiting the height in pixels of the completions should be preferred). This is my suggestion for now, happy to discuss about it more here or in the issue!