### PR TITLE
Add 'p' prefix to simple IDs in Python

### DIFF
--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -261,7 +261,7 @@ def make_id() -> ID:
     if settings.simple_ids():
         with _simple_id_lock:
             _simple_id += 1
-            return ID(str(_simple_id))
+            return ID(f"p{_simple_id}")
     else:
         return make_globally_unique_id()
 

--- a/tests/unit/bokeh/util/test_util__serialization.py
+++ b/tests/unit/bokeh/util/test_util__serialization.py
@@ -42,16 +42,16 @@ import bokeh.util.serialization as bus # isort:skip
 class Test_make_id:
     def test_default(self) -> None:
         bus._simple_id = 999
-        assert bus.make_id() == "1000"
-        assert bus.make_id() == "1001"
-        assert bus.make_id() == "1002"
+        assert bus.make_id() == "p1000"
+        assert bus.make_id() == "p1001"
+        assert bus.make_id() == "p1002"
 
     def test_simple_ids_yes(self) -> None:
         bus._simple_id = 999
         with envset(BOKEH_SIMPLE_IDS="yes"):
-            assert bus.make_id() == "1000"
-            assert bus.make_id() == "1001"
-            assert bus.make_id() == "1002"
+            assert bus.make_id() == "p1000"
+            assert bus.make_id() == "p1001"
+            assert bus.make_id() == "p1002"
 
     def test_simple_ids_no(self) -> None:
         with envset(BOKEH_SIMPLE_IDS="no"):


### PR DESCRIPTION
In bokehjs we already add `j` prefix. Having prefixed IDs for development makes development and debugging easier, especially in browsers (e.g. auto-completion in plain objects is more useful). It also helps to assert that IDs are actually strings, especially in the context of plain JS objects, where the string vs. numeric keys situation is confusing and error prone.
