### PR TITLE
Allow `plt.show()` to append after a `<script>`

### DIFF
--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -184,6 +184,26 @@ export function empty(node: Node, attrs: boolean = false): void {
   }
 }
 
+export function contains(element: Element, child: Node) {
+  /**
+   * Like Node.contains(), but traverses Shadow DOM boundaries.
+   */
+  let current = child
+
+  while (current.parentNode != null) {
+    const parent = current.parentNode
+    if (parent == element) {
+      return true
+    } else if (parent instanceof ShadowRoot) {
+      current = parent.host
+    } else {
+      current = parent
+    }
+  }
+
+  return false
+}
+
 export function display(element: HTMLElement, display: boolean = true): void {
   element.style.display = display ? "" : "none"
 }

--- a/bokehjs/src/lib/embed/dom.ts
+++ b/bokehjs/src/lib/embed/dom.ts
@@ -1,18 +1,20 @@
-import {div, replaceWith} from "../core/dom"
+import {div, replaceWith, contains} from "../core/dom"
 import {ID} from "../core/types"
 import {isString} from "../core/util/types"
 import {RenderItem} from "./json"
 
-function _get_element(target: ID | HTMLElement): HTMLElement {
+export type EmbedTarget = HTMLElement | DocumentFragment
+
+function _get_element(target: ID | EmbedTarget): EmbedTarget {
   let element = isString(target) ? document.getElementById(target) : target
 
   if (element == null)
     throw new Error(`Error rendering Bokeh model: could not find ${isString(target) ? `#${target}` : target} HTML tag`)
-  if (!document.body.contains(element))
+  if (!contains(document.body, element))
     throw new Error(`Error rendering Bokeh model: element ${isString(target) ? `#${target}` : target} must be under <body>`)
 
   // If autoload script, replace script tag with div for embedding.
-  if (element.tagName == "SCRIPT") {
+  if (element instanceof HTMLElement && element.tagName == "SCRIPT") {
     const root_el = div()
     replaceWith(element, root_el)
     element = root_el
@@ -21,7 +23,7 @@ function _get_element(target: ID | HTMLElement): HTMLElement {
   return element
 }
 
-export function _resolve_element(item: RenderItem): HTMLElement {
+export function _resolve_element(item: RenderItem): EmbedTarget {
   const {elementid} = item
 
   if (elementid != null)
@@ -30,10 +32,10 @@ export function _resolve_element(item: RenderItem): HTMLElement {
     return document.body
 }
 
-export function _resolve_root_elements(item: RenderItem): HTMLElement[] {
-  const roots: HTMLElement[] = []
+export function _resolve_root_elements(item: RenderItem): EmbedTarget[] {
+  const roots: EmbedTarget[] = []
 
-  if ((item.root_ids != null) && (item.roots != null)) {
+  if (item.root_ids != null && item.roots != null) {
     for (const root_id of item.root_ids)
       roots.push(_get_element(item.roots[root_id]))
   }

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -10,7 +10,7 @@ import {ViewManager} from "core/view"
 import {DocsJson, RenderItem, Roots} from "./json"
 import {add_document_standalone} from "./standalone"
 import {add_document_from_session, _get_ws_url} from "./server"
-import {_resolve_element, _resolve_root_elements} from "./dom"
+import {_resolve_element, _resolve_root_elements, EmbedTarget} from "./dom"
 
 export {DocsJson, RenderItem, Roots} from "./json"
 export {add_document_standalone, index} from "./standalone"
@@ -19,7 +19,7 @@ export {embed_items_notebook, kernels} from "./notebook"
 
 export type JsonItem = {doc: DocJson, root_id: ID, target_id: ID}
 
-export async function embed_item(item: JsonItem, target?: ID | HTMLElement): Promise<ViewManager> {
+export async function embed_item(item: JsonItem, target?: ID | EmbedTarget): Promise<ViewManager> {
   const docs_json: DocsJson = {}
   const doc_id = uuid4()
   docs_json[doc_id] = item.doc

--- a/bokehjs/src/lib/embed/json.ts
+++ b/bokehjs/src/lib/embed/json.ts
@@ -1,9 +1,10 @@
 import {DocJson} from "../document"
 import {ID} from "core/types"
+import {type EmbedTarget} from "./dom"
 
 export type DocsJson = {[key: string]: DocJson}
 
-export type Roots = {[index: string]: ID | HTMLElement}
+export type Roots = {[index: string]: ID | EmbedTarget}
 
 export interface RenderItem {
   docid?: string

--- a/bokehjs/src/lib/embed/notebook.ts
+++ b/bokehjs/src/lib/embed/notebook.ts
@@ -88,6 +88,11 @@ export function embed_items_notebook(docs_json: DocsJson, render_items: RenderIt
     const roots = _resolve_root_elements(item)
 
     add_document_standalone(document, element, roots)
-    roots[0].removeAttribute("id")
+
+    for (const root of roots) {
+      if (root instanceof HTMLElement) {
+        root.removeAttribute("id")
+      }
+    }
   }
 }

--- a/bokehjs/src/lib/embed/server.ts
+++ b/bokehjs/src/lib/embed/server.ts
@@ -4,6 +4,7 @@ import {logger} from "../core/logging"
 import {ViewManager} from "../core/view"
 
 import {add_document_standalone} from "./standalone"
+import {EmbedTarget} from "./dom"
 
 // @internal
 export function _get_ws_url(app_path: string | undefined, absolute_url: string | undefined): string {
@@ -45,8 +46,8 @@ function _get_session(websocket_url: string, token: string, args_string: string)
 }
 
 // Fill element with the roots from token
-export async function add_document_from_session(websocket_url: string, token: string, element: HTMLElement,
-    roots: HTMLElement[] = [], use_for_title: boolean = false): Promise<ViewManager> {
+export async function add_document_from_session(websocket_url: string, token: string, element: EmbedTarget,
+    roots: EmbedTarget[] = [], use_for_title: boolean = false): Promise<ViewManager> {
   const args_string = window.location.search.substring(1)
   let session: ClientSession
   try {

--- a/bokehjs/src/lib/embed/standalone.ts
+++ b/bokehjs/src/lib/embed/standalone.ts
@@ -4,12 +4,13 @@ import {HasProps} from "../core/has_props"
 import {View, ViewManager} from "../core/view"
 import {DOMView} from "../core/dom_view"
 import {build_view} from "../core/build_views"
+import {EmbedTarget} from "./dom"
 
 // A map from the root model IDs to their views.
 export const index: {[key: string]: View} = {}
 
-export async function add_document_standalone(document: Document, element: HTMLElement,
-    roots: (HTMLElement | null)[] = [], use_for_title: boolean = false): Promise<ViewManager> {
+export async function add_document_standalone(document: Document, element: EmbedTarget,
+    roots: (EmbedTarget | null)[] = [], use_for_title: boolean = false): Promise<ViewManager> {
   // this is a LOCAL index of views used only by this particular rendering
   // call, so we can remove the views we create.
   const views = new ViewManager()

--- a/docs/bokeh/docserver.py
+++ b/docs/bokeh/docserver.py
@@ -42,7 +42,9 @@ from tornado.wsgi import WSGIContainer
 from bokeh.util.tornado import fixup_windows_event_loop_policy
 
 IOLOOP = None
+HOST = "localhost"
 PORT = 5009
+VISIT_URL = f"http://{HOST}:{PORT}/en/latest/index.html"
 SPHINX_TOP = Path(__file__).resolve().parent
 
 app = flask.Flask(__name__, static_folder="/unused")
@@ -64,7 +66,7 @@ def docs(filename):
 
 
 def open_browser():
-    webbrowser.open(f"http://localhost:{PORT}/en/latest/index.html", new=2)
+    webbrowser.open(VISIT_URL, new=2)
 
 
 def serve_http():
@@ -79,7 +81,7 @@ if __name__ == "__main__":
     fixup_windows_event_loop_policy()
 
     print(f"\nStarting Bokeh plot server on port {PORT}...")
-    print(f"Visit http://localhost:{PORT}/en/latest/index.html to see plots\n")
+    print(f"Visit {VISIT_URL} to see plots\n")
 
     server = threading.Thread(target=serve_http)
     server.start()

--- a/src/bokeh/models/plots.py
+++ b/src/bokeh/models/plots.py
@@ -585,7 +585,7 @@ class Plot(LayoutDOM):
 
     renderers = List(Instance(Renderer), help="""
     A list of all glyph renderers for this plot.
-    
+
     This property can be manipulated by hand, but the ``add_glyph`` is
     recommended to help make sure all necessary setup is performed.
     """)

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -183,7 +183,7 @@ def convert_datetime_type(obj: Any | pd.Timestamp | pd.Timedelta | dt.datetime |
 
     # Pandas Period
     if isinstance(obj, pd.Period):
-        return obj.to_timestamp().value / 10**6.0  # type: ignore
+        return obj.to_timestamp().value / 10**6.0
 
     # Pandas Timestamp
     if isinstance(obj, pd.Timestamp):


### PR DESCRIPTION
This also allows to embed into document fragments and improves handling of embedding under shadow DOM.

fixes #12101
