### PR TITLE
Don't allow `Model(id="some", **properties)`

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -314,7 +314,7 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
     // when loading a bunch of models, we want to do initialization as a second pass
     // because other objects that this one depends on might not be loaded yet
     if (deferred) {
-      assert(keys(attrs).length == 1)
+      assert(keys(attrs).length == 1, "'id' cannot be used together with property initializers")
     } else {
       const vals = attrs instanceof Map ? attrs : new Dict(attrs)
       this.initialize_props(vals)

--- a/tests/unit/bokeh/document/test_models.py
+++ b/tests/unit/bokeh/document/test_models.py
@@ -23,6 +23,7 @@ import gc
 from mock import MagicMock, patch
 
 # Bokeh imports
+from bokeh.core.types import ID
 from bokeh.document import Document
 from bokeh.models import Div, Row
 
@@ -72,12 +73,12 @@ class TestDocumentModelManager:
         dm = bdm.DocumentModelManager(d)
         assert len(dm) == 0
 
-        m = Div(id="foo")
+        m = Div()
 
-        dm["foo"] = m
+        dm[m.id] = m
         assert len(dm) == 1
 
-        assert dm["foo"] is m
+        assert dm[m.id] is m
 
         with pytest.raises(KeyError):
             dm["junk"]
@@ -87,11 +88,11 @@ class TestDocumentModelManager:
         dm = bdm.DocumentModelManager(d)
         assert len(dm) == 0
 
-        m = Div(id="foo")
+        m = Div()
 
-        dm["foo"] = m
+        dm[m.id] = m
 
-        assert "foo" in dm
+        assert m.id in dm
         assert "junk" not in dm
 
     def test_iter(self) -> None:
@@ -179,15 +180,15 @@ class TestDocumentModelManager:
         dm = d.models
         assert len(dm) == 0
 
-        m1 = Div(id="m1")
-        m2 = Div(id="m2")
+        m1 = Div()
+        m2 = Div()
 
         d.add_root(m1)
         d.add_root(m2)
 
-        assert dm.get_by_id("m1") is m1
-        assert dm.get_by_id("m2") is m2
-        assert dm.get_by_id("junk") is None
+        assert dm.get_by_id(m1.id) is m1
+        assert dm.get_by_id(m2.id) is m2
+        assert dm.get_by_id(ID("junk")) is None
 
     def test_get_one_by_name(self) -> None:
         d = Document()
@@ -227,8 +228,8 @@ class TestDocumentModelManager:
         dm = d.models
         assert len(dm) == 0
 
-        r1 = Row(children=[Div(id="d1", name="dr1")])
-        r2 = Row(children=[Div(id="d2", name="dr2"), Div(id="d3", name="dr2")])
+        r1 = Row(children=[Div(name="dr1")])
+        r2 = Row(children=[Div(name="dr2"), Div(name="dr2")])
 
         d.add_root(r1)
         d.add_root(r2)
@@ -254,24 +255,24 @@ class TestDocumentModelManager:
         dm = d.models
         assert len(dm) == 0
 
-        m1 = Div(id="m1")
-        m2 = Div(id="m2")
+        m1 = Div()
+        m2 = Div()
 
         d.add_root(m1)
         d.add_root(m2)
 
-        assert not dm.seen("m1")
-        assert not dm.seen("m2")
+        assert not dm.seen(m1.id)
+        assert not dm.seen(m2.id)
 
         d.remove_root(m2)
 
-        assert not dm.seen("m1")
-        assert dm.seen("m2")
+        assert not dm.seen(m1.id)
+        assert dm.seen(m2.id)
 
         d.remove_root(m1)
 
-        assert dm.seen("m1")
-        assert dm.seen("m2")
+        assert dm.seen(m1.id)
+        assert dm.seen(m2.id)
 
     def test_update_name(self) -> None:
         d = Document()

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -18,6 +18,7 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh.core.properties import Int, List, String
+from bokeh.core.types import ID
 from bokeh.models import *  # NOQA
 from bokeh.models import CustomJS
 from bokeh.plotting import *  # NOQA
@@ -40,6 +41,11 @@ class SomeModel(Model):
     b = String("hello")
     c = List(Int, default=[1, 2, 3])
 
+class Test_Model___init__:
+
+    def test_id_not_permitted(self) -> None:
+        with pytest.raises(ValueError):
+            SomeModel(id=ID("foo"))
 
 class Test_js_on_change:
     def test_exception_for_no_callbacks(self) -> None:

--- a/tests/unit/bokeh/test_objects.py
+++ b/tests/unit/bokeh/test_objects.py
@@ -27,6 +27,7 @@ from bokeh.core.properties import (
     String,
 )
 from bokeh.core.property.wrappers import PropertyValueDict, PropertyValueList
+from bokeh.core.types import ID
 from bokeh.model import Model
 
 # Module under test
@@ -168,13 +169,14 @@ class TestModel:
         self.maxDiff = None
 
     def test_init(self) -> None:
-        testObject = SomeModel(id='test_id')
-        assert testObject.id == 'test_id'
+        obj = SomeModel.__new__(SomeModel, id=ID("test_id"))
+        Model.__init__(obj)
+        assert obj.id == "test_id"
 
         testObject2 = SomeModel()
         assert testObject2.id is not None
 
-        assert set(testObject.properties()) == {
+        assert set(obj.properties()) == {
             "name",
             "tags",
             "js_property_callbacks",
@@ -183,7 +185,7 @@ class TestModel:
             "syncable",
             "some",
         }
-        assert testObject.properties_with_values(include_defaults=True) == dict(
+        assert obj.properties_with_values(include_defaults=True) == dict(
             name=None,
             tags=[],
             js_property_callbacks={},
@@ -192,7 +194,7 @@ class TestModel:
             syncable=True,
             some=0,
         )
-        assert testObject.properties_with_values(include_defaults=False) == {}
+        assert obj.properties_with_values(include_defaults=False) == {}
 
     def test_references_by_ref_by_value(self) -> None:
         from bokeh.core.has_props import HasProps


### PR DESCRIPTION
This brings bokeh up to speed with bokehjs' handling initialization of models with explicit `id`. Using `Model(id="some", **properties)` is now disallowed, only `Model(**properties)` is permitted. Setting an explicit `id` is only permitted by using `Model.__new__(Model, id="some")`. Properties can be later initialized by using `Model.set_from_json(...)` (as `Deserializer._decode_object_ref()` does).

TODO:

- [x] unit tests