### PR TITLE
Handle line_color=None and fill_color=None in from_contour

### DIFF
--- a/src/bokeh/plotting/contour.py
+++ b/src/bokeh/plotting/contour.py
@@ -201,7 +201,7 @@ def from_contour(
 
     nlevels = len(levels)
 
-    want_line = "line_color" in visuals
+    want_line = visuals.get("line_color", None) is not None
     if want_line:
         # Handle possible callback or interpolation for line_color.
         visuals["line_color"] = _color(visuals["line_color"], nlevels)
@@ -215,14 +215,18 @@ def from_contour(
             prop = visuals.pop(name, None)
             if prop is not None:
                 line_visuals[name] = prop
+    else:
+        visuals.pop("line_color", None)
 
-    want_fill = "fill_color" in visuals
+    want_fill = visuals.get("fill_color", None) is not None
     if want_fill:
         # Handle possible callback or interpolation for fill_color.
         visuals["fill_color"] = _color(visuals["fill_color"], nlevels-1)
 
         fill_cds = ColumnDataSource()
         _process_sequence_literals(MultiPolygons, visuals, fill_cds, False)
+    else:
+        visuals.pop("fill_color", None)
 
     # Check for extra unknown kwargs.
     unknown = visuals.keys() - FillProps.properties() - HatchProps.properties()

--- a/tests/unit/bokeh/plotting/test_contour.py
+++ b/tests/unit/bokeh/plotting/test_contour.py
@@ -208,6 +208,28 @@ class Test_from_contour:
         assert line.line_dash == "dotdash"
         assert line.line_dash_offset == 3
 
+    @pytest.mark.parametrize("kwarg_none", ["line_color", "fill_color"])
+    def test_ignore_kwarg_None(self, xyz_levels, kwarg_none):
+        x, y, z, levels = xyz_levels
+        kwargs = dict(line_color="red", fill_color="blue")
+        kwargs[kwarg_none] = None
+        cr = from_contour(x, y, z, levels, **kwargs)
+
+        # Identify empty CDS by checking length of levels for line contours and lower_levels or
+        # upper_levels for filled contours, as xs and ys can be empty for other reasons (if there
+        # are no contours at all).
+        fill_len = len(cr.fill_renderer.data_source.data["lower_levels"])
+        if kwarg_none == "fill_color":
+            assert fill_len == 0
+        else:
+            assert fill_len > 0
+
+        line_len = len(cr.line_renderer.data_source.data["levels"])
+        if kwarg_none == "line_color":
+            assert line_len == 0
+        else:
+            assert line_len > 0
+
 def test_contour_colorbar(xyz_levels):
     x, y, z, levels = xyz_levels
     cr = from_contour(x, y, z, levels, fill_color="red", line_color="black")


### PR DESCRIPTION
Fixes issue #12506.

`from_contour` uses the presence of `line_color` and `fill_color` in its kwargs to identify if it should calculate and render contour lines and filled polygons respectively. Previously the code just checked if the keys were in the kwargs dictionary but this meant that `line_color=None` would pass the check when it should not have done. So this PR also checks if they are specified but `None`.

I am setting the milestone to 3.1 but I would be happy for it to be squeezed into 3.0 if that is acceptable.