### PR TITLE
Move intro paragraph

### DIFF
--- a/docs/bokeh/source/docs/user_guide/topics/hierarchical.rst
+++ b/docs/bokeh/source/docs/user_guide/topics/hierarchical.rst
@@ -1,11 +1,11 @@
 .. _ug_topics_hierarchical:
 
+Hierarchical data
+=================
+
 Bokeh does not have any built-in APIs specifically for handling hierarchical
 data, but it is possible to use Bokeh's basic components together with other
 libraries handle many cases. Some examples are described below.
-
-Hierarchical data
-=================
 
 .. _ug_topics_hierarchical_treemap:
 

--- a/docs/bokeh/source/docs/user_guide/topics/hierarchical.rst
+++ b/docs/bokeh/source/docs/user_guide/topics/hierarchical.rst
@@ -5,7 +5,7 @@ Hierarchical data
 
 Bokeh does not have any built-in APIs specifically for handling hierarchical
 data, but it is possible to use Bokeh's basic components together with other
-libraries handle many cases. Some examples are described below.
+libraries to handle many cases. Some examples are described below.
 
 .. _ug_topics_hierarchical_treemap:
 


### PR DESCRIPTION
@bryevdv did you mean for the intro paragraph of the "Hierarchical data" section to be above the main headline?
![image](https://user-images.githubusercontent.com/39711796/198812796-c3f7e23a-2a4c-44e9-aa4a-86007c354191.png)

If not, this PR moves the section underneath the main headline. Otherwise, feel free to simply close this PR!