### PR TITLE
Restore strict docs build

### DIFF
--- a/docs/bokeh/Makefile
+++ b/docs/bokeh/Makefile
@@ -20,7 +20,7 @@ clean:
 
 html:
 	@start=$$(date +%s) \
-	; sphinx-build -b html -d $(BUILDDIR)/doctrees $(SPHINXOPTS) source $(BUILDDIR)/html \
+	; sphinx-build -b html -d $(BUILDDIR)/doctrees $(SPHINXOPTS) source -W $(BUILDDIR)/html \
 	&& cp -r source/_images/examples $(BUILDDIR)/html/_images/ \
 	&& (cp -r ../../src/bokeh/server/static $(BUILDDIR)/html/ || true) \
 	&& echo \

--- a/src/bokeh/sphinxext/bokeh_model.py
+++ b/src/bokeh/sphinxext/bokeh_model.py
@@ -95,7 +95,8 @@ class BokehModelDirective(BokehDirective):
 
     has_content = True
     required_arguments = 1
-    optional_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
     option_spec = {
         "module": unchanged,
         "canonical": unchanged,


### PR DESCRIPTION
The `-W` was removed from the docs build during the extensive re-org, but a problem has crept in in the mean time. THings are more stabilized now, so this PR restores the `-W` strict build option, and fixes the issue that cropped up with Model signatures. 

I am not sure what the root cause of the problem with Model signatures is at this time, I do not have time to chase it down. 

@mattpap FYI Sphinx computes a signature `id`:

<img width="773" alt="Screen Shot 2022-10-29 at 11 46 41" src="https://user-images.githubusercontent.com/1078448/198847896-333500fe-5c59-484f-9ad1-0b5365d28621.png">

I don't think this is quite right given your recent changes? I won't have time today to do anything about it. If you agree it isa problem please open an issues that describes exactly what should/should not appear in the refguide entries. 
