### PR TITLE
Robustify maintenance of models' registry

### DIFF
--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -130,6 +130,36 @@ def _generators(class_dict: dict[str, Any]):
             generators[name] = generator
     return generators
 
+class _ModelResolver:
+    """ """
+
+    _known_models: dict[str, Type[HasProps]]
+
+    def __init__(self) -> None:
+        self._known_models = {}
+
+    def add(self, cls: Type[HasProps]) -> None:
+        if not (issubclass(cls, Local) or cls.__name__.startswith("_")):
+            # update the mapping of view model names to classes, checking for any duplicates
+            previous = self._known_models.get(cls.__qualified_model__, None)
+            if previous is not None and not hasattr(cls, "__implementation__"):
+                raise Warning(f"Duplicate qualified model declaration of '{cls.__qualified_model__}'. Previous definition: {previous}")
+            self._known_models[cls.__qualified_model__] = cls
+
+    @property
+    def known_models(self) -> dict[str, Type[HasProps]]:
+        return dict(self._known_models)
+
+    def clear_extensions(self) -> None:
+        def is_extension(obj: Type[HasProps]) -> bool:
+            return getattr(obj, "__implementation__", None) is not None or \
+                   getattr(obj, "__javascript__", None) is not None or \
+                   getattr(obj, "__css__", None) is not None
+
+        self._known_models = {key: val for key, val in self._known_models.items() if not is_extension(val)}
+
+_default_resolver = _ModelResolver()
+
 class MetaHasProps(type):
     ''' Specialize the construction of |HasProps| classes.
 
@@ -190,6 +220,10 @@ class MetaHasProps(type):
         if unused_overrides:
             warn(f"Overrides of {unused_overrides} in class {cls.__name__} does not override anything.", RuntimeWarning, stacklevel=2)
 
+    @property
+    def model_class_reverse_map(cls) -> dict[str, Type[HasProps]]:
+        return _default_resolver.known_models
+
 class Local:
     """Don't register this class in model registry. """
 
@@ -216,8 +250,6 @@ class HasProps(Serializable, metaclass=MetaHasProps):
     __qualified_model__: ClassVar[str]
     __implementation__: ClassVar[Any] # TODO: specific type
     __data_model__: ClassVar[bool]
-
-    model_class_reverse_map: ClassVar[dict[str, Type[HasProps]]] = {}
 
     @classmethod
     def __init_subclass__(cls):
@@ -246,12 +278,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
             cls.__qualified_model__ = qualified()
 
-        if not (issubclass(cls, Local) or cls.__name__.startswith("_")):
-            # update the mapping of view model names to classes, checking for any duplicates
-            previous = cls.model_class_reverse_map.get(cls.__qualified_model__, None)
-            if previous is not None and not hasattr(cls, "__implementation__"):
-                raise Warning(f"Duplicate qualified model declaration of '{cls.__qualified_model__}'. Previous definition: {previous}")
-            cls.model_class_reverse_map[cls.__qualified_model__] = cls
+        _default_resolver.add(cls)
 
     def __init__(self, **properties: Any) -> None:
         '''

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -146,6 +146,9 @@ class _ModelResolver:
                 raise Warning(f"Duplicate qualified model declaration of '{cls.__qualified_model__}'. Previous definition: {previous}")
             self._known_models[cls.__qualified_model__] = cls
 
+    def remove(self, cls: Type[HasProps]) -> None:
+        del self._known_models[cls.__qualified_model__]
+
     @property
     def known_models(self) -> dict[str, Type[HasProps]]:
         return dict(self._known_models)

--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -31,7 +31,7 @@ from typing import (
 
 # Bokeh imports
 from ..core import properties as p
-from ..core.has_props import HasProps, abstract
+from ..core.has_props import HasProps, _default_resolver, abstract
 from ..core.property._sphinx import type_link
 from ..core.property.validation import without_property_validation
 from ..core.serialization import ObjectRefRep, Ref, Serializer
@@ -585,12 +585,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     @classmethod
     def _clear_extensions(cls) -> None:
-        cls.model_class_reverse_map = {
-            k: v for k, v in cls.model_class_reverse_map.items()
-            if getattr(v, "__implementation__", None) is None
-                and getattr(v, "__javascript__", None) is None
-                and getattr(v, "__css__", None) is None
-        }
+        _default_resolver.clear_extensions()
 
     def _detach_document(self) -> None:
         ''' Detach a model from a Bokeh |Document|.

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -20,10 +20,10 @@ import pytest ; pytest
 from os.path import dirname, join
 
 # Bokeh imports
+from bokeh.core.has_props import _default_resolver
 from bokeh.document import Document
 from bokeh.embed.bundle import extension_dirs
 from bokeh.ext import build
-from bokeh.model import Model
 from bokeh.models import Plot
 from bokeh.resources import INLINE
 from tests.support.util.env import envset
@@ -131,7 +131,8 @@ class Test_bundle_custom_extensions:
 
     @classmethod
     def teardown_class(cls):
-        del Model.model_class_reverse_map["latex_label.LatexLabel"]
+        from latex_label import LatexLabel
+        _default_resolver.remove(LatexLabel)
         extension_dirs.clear()
 
     def test_with_INLINE_resources(self) -> None:
@@ -178,7 +179,8 @@ class Test_bundle_ext_package_no_main:
 
     @classmethod
     def teardown_class(cls):
-        del Model.model_class_reverse_map["ext_package_no_main.AModel"]
+        from ext_package_no_main import AModel
+        _default_resolver.remove(AModel)
         extension_dirs.clear()
 
     def test_with_INLINE_resources(self) -> None:

--- a/tests/unit/bokeh/test_objects.py
+++ b/tests/unit/bokeh/test_objects.py
@@ -105,12 +105,6 @@ def large_plot(n: int) -> tuple[Model, set[Model]]:
 
 
 class TestModelCls:
-    def setup_method(self):
-        self.old_map = dict(Model.model_class_reverse_map)
-
-    def teardown_method(self):
-        Model.model_class_reverse_map = self.old_map
-
     def mkclass(self):
         class Test_Class(Model):
             foo = 1
@@ -124,7 +118,6 @@ class TestModelCls:
 
     def test_get_class(self) -> None:
         from bokeh.model import get_class
-        self.mkclass()
         tclass = get_class('test_objects.TestModelCls.mkclass.Test_Class')
         assert hasattr(tclass, 'foo')
         with pytest.raises(KeyError):

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -49,7 +49,7 @@ LOG_LEVELS: list[LogLevel] = ["trace", "debug", "info", "warn", "error", "fatal"
 
 DEFAULT_LOG_JS_RAW = 'Bokeh.set_log_level("info");'
 
-def teardown_module() -> None :
+def teardown_module() -> None:
     Model._clear_extensions()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This prevents sharing mutable class state, which can lead to inconsistencies at runtime. I kept `model_class_reverse_map` for now, but I will deprecate it and remove its usage in near future. `_ModelResolver` and `_default_resolver` are private for now (as `_` indicates).

fixes #12416
