### PR TITLE
Remove runtime dependency on typing_extensions

### DIFF
--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -14,7 +14,6 @@ dependencies:
   - nodejs 16.*
   - ripgrep=0.10.0
   - setuptools
-  - typing_extensions >=3.10.0
   - yaml
 
   # docs

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -14,7 +14,6 @@ dependencies:
   - python-dateutil >=2.1
   - pyyaml >=3.10
   - tornado >=5
-  - typing_extensions >=3.10.0
   - xyzservices>=2021.09.1
 
   # tests
@@ -48,6 +47,7 @@ dependencies:
   - scipy
   - selenium 4.2
   - toml
+  - typing_extensions >=4.0.0
 
   # examples
   - flask >=1.0

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -14,7 +14,6 @@ dependencies:
   - python-dateutil >=2.1
   - pyyaml >=3.10
   - tornado >=5
-  - typing_extensions >=3.10.0
   - xyzservices>=2021.09.1
 
   # tests
@@ -48,6 +47,7 @@ dependencies:
   - scipy
   - selenium 4.2
   - toml
+  - typing_extensions >=4.0.0
 
   # examples
   - flask >=1.0

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -14,7 +14,6 @@ dependencies:
   - python-dateutil >=2.1
   - pyyaml >=3.10
   - tornado >=5
-  - typing_extensions >=3.10.0
   - xyzservices>=2021.09.1
 
   # tests
@@ -48,6 +47,7 @@ dependencies:
   - scipy
   - selenium 4.2
   - toml
+  - typing_extensions >=4.0.0
 
   # examples
   - flask >=1.0

--- a/conda/environment-test-downstream.yml
+++ b/conda/environment-test-downstream.yml
@@ -13,7 +13,6 @@ dependencies:
   - python-dateutil >=2.1
   - pyyaml >=3.10
   - tornado >=5
-  - typing_extensions >=3.10.0
   - xyzservices>=2021.09.1
 
   # tests

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -14,7 +14,6 @@ dependencies:
   - python-dateutil >=2.1
   - pyyaml >=3.10
   - tornado 5.1.*
-  - typing_extensions >=3.10.0
   - xyzservices>=2021.09.1
 
   # tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "pillow >=7.1.0",
     "PyYAML >=3.10",
     "tornado >=5.1",
-    "typing_extensions >=4.0.0",
     "xyzservices >=2021.09.1",
 ]
 authors = [

--- a/tests/codebase/test_no_typing_extensions_common.py
+++ b/tests/codebase/test_no_typing_extensions_common.py
@@ -1,0 +1,50 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2022, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from subprocess import run
+from sys import executable as python
+
+# Bokeh imports
+from tests.support.util.project import ls_modules, verify_clean_imports
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+# There should not be unprotected typing_extensions imports /anywhere/
+TYPING_EXTENIONS = ()
+
+MODULES = ls_modules(skip_prefixes=TYPING_EXTENIONS)
+
+# This test takes a long time to run, but if the combined test fails then
+# uncommenting it will locate exactly what module(s) are the problem
+# @pytest.mark.parametrize('module', MODULES)
+# def test_no_typing_extensions_common_individual(module) -> None:
+#     proc = run([python, "-c", verify_clean_imports('typing_extensions', [module])])
+#     assert proc.returncode == 0, f"typing_extensions imported in common module {module}"
+
+def test_no_typing_extensions_common_combined() -> None:
+    ''' Basic usage of Bokeh should not result in typing_extensions being
+    imported. This test ensures that importing basic modules does not bring in
+    typing_extensions.
+
+    '''
+    proc = run([python, "-c", verify_clean_imports('typing_extensions', MODULES)])
+    assert proc.returncode == 0, "typing_extensions imported in common modules"


### PR DESCRIPTION
This PR continues from #12538 and removes `typing_extensions` as a runtime dependency altogether. 
