### PR TITLE
Upgrade to mypy 0.990

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -62,7 +62,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.981
+    - mypy >=0.990
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -62,7 +62,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.981
+    - mypy >=0.990
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -62,7 +62,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.981
+    - mypy >=0.990
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -62,7 +62,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.981
+    - mypy >=0.990
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -52,7 +52,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=0.981
+    - mypy >=0.990
     # docs
     - autoclasstoc
     - pydata_sphinx_theme ==0.9

--- a/src/bokeh/core/templates.py
+++ b/src/bokeh/core/templates.py
@@ -75,8 +75,7 @@ def get_env() -> Environment:
     '''
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
         # PyInstaller uses _MEIPASS and only works with jinja2.FileSystemLoader
-        meipass: str = sys._MEIPASS # type: ignore[attr-defined]
-        templates_path = join(meipass, 'bokeh', 'core', '_templates')
+        templates_path = join(sys._MEIPASS, 'bokeh', 'core', '_templates')
     else:
         # Non-frozen Python and cx_Freeze can use __file__ directly
         templates_path = join(dirname(__file__), '_templates')


### PR DESCRIPTION
Fixes:
```
mypy 0.990 (compiled: yes)
src/bokeh/core/templates.py:78: error: Unused "type: ignore" comment
            meipass: str = sys._MEIPASS # type: ignore[attr-defined]
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 719 source files)
```
