### PR TITLE
Disable Selenium integration tests for now

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -146,6 +146,7 @@ jobs:
           path: examples-report
 
   integration-tests:
+    if: ${{ false }}  # disable for now
     needs: build
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR disables the integration tests job. Prior to #12571 there was typically one "expected" failure, but now there are many, and it is not possible to distinguish "normal" failure to "real" failure. Disabling until the test job can be fixed or replaced. 