### PR TITLE
Guard numpy.typing.ArrayType with `if TYPE_CHECKING`

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -7,7 +7,7 @@ dependencies:
   # runtime
   - contourpy >=1
   - jinja2 >=2.7
-  - numpy >=1.11.3
+  - numpy >=1.20.0
   - packaging >=16.8
   - pandas >=1.2
   - pillow >=4.0

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -7,7 +7,7 @@ dependencies:
   # runtime
   - contourpy >=1
   - jinja2 >=2.7
-  - numpy >=1.11.3
+  - numpy >=1.20.0
   - packaging >=16.8
   - pandas >=1.2
   - pillow >=4.0

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -7,7 +7,7 @@ dependencies:
   # runtime
   - contourpy >=1
   - jinja2 >=2.7
-  - numpy >=1.11.3
+  - numpy >=1.20.0
   - packaging >=16.8
   - pandas >=1.2
   - pillow >=4.0

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -7,7 +7,7 @@ dependencies:
   # runtime
   - contourpy >=1
   - jinja2 >=2.7
-  - numpy >=1.11.3
+  - numpy >=1.20.0
   - packaging >=16.8
   - pandas >=1.2
   - pillow >=4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8"
 dependencies = [
     "Jinja2 >=2.9",
     "contourpy >=1",
-    "numpy >=1.11.3",
+    "numpy >=1.20.0",
     "packaging >=16.8",
     "pandas >=1.2",
     "pillow >=7.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8"
 dependencies = [
     "Jinja2 >=2.9",
     "contourpy >=1",
-    "numpy >=1.20.0",
+    "numpy >=1.11.3",
     "packaging >=16.8",
     "pandas >=1.2",
     "pillow >=7.1.0",

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -10,7 +10,11 @@
 #-----------------------------------------------------------------------------
 from __future__ import annotations
 
+# Standard library imports
+from typing import TYPE_CHECKING
+
 import logging # isort:skip
+
 log = logging.getLogger(__name__)
 
 #-----------------------------------------------------------------------------
@@ -19,7 +23,6 @@ log = logging.getLogger(__name__)
 
 # External imports
 import numpy as np
-from numpy.typing import ArrayLike
 
 # Bokeh imports
 from ..core.enums import HorizontalLocation, MarkerType, VerticalLocation
@@ -67,6 +70,9 @@ from ._stack import double_stack, single_stack
 from ._tools import process_active_tools, process_tools_arg
 from .contour import ContourRenderer, from_contour
 from .glyph_api import _MARKER_SHORTCUTS, GlyphAPI
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants


### PR DESCRIPTION
Fixes:

    > from numpy.typing import ArrayLike
    ModuleNotFoundError: No module named 'numpy.typing'

See also:
* https://numpy.org/doc/stable/release.html#:~:text=numpy.typing%20is%20accessible%20at%20runtime
* https://github.com/kernc/backtesting.py/issues/805
