### PR TITLE
Bv/deprecated apis in tests

### DIFF
--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -24,8 +24,8 @@ dependencies:
   - icalendar
   - ipython
   - networkx
-  - pydot
   - pygments
+  - pygraphviz
   - pyshp
   - scikit-learn
   - scipy

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -33,8 +33,8 @@ dependencies:
   - nodejs 16.*
   - pre-commit
   - psutil
-  - pydot
   - pygments
+  - pygraphviz
   - pytest >=7.0
   - pytest-asyncio >=0.18.1
   - pytest-cov >=1.8.1

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -33,8 +33,8 @@ dependencies:
   - nodejs 16.*
   - pre-commit
   - psutil
-  - pydot
   - pygments
+  - pygraphviz
   - pytest >=7.0
   - pytest-asyncio >=0.18.1
   - pytest-cov >=1.8.1

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -33,8 +33,8 @@ dependencies:
   - nodejs 16.*
   - pre-commit
   - psutil
-  - pydot
   - pygments
+  - pygraphviz
   - pytest >=7.0
   - pytest-asyncio >=0.18.1
   - pytest-cov >=1.8.1

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -33,8 +33,8 @@ dependencies:
   - nodejs 16.*
   - pre-commit
   - psutil
-  - pydot
   - pygments
+  - pygraphviz
   - pytest >=7.0
   - pytest-asyncio
   - pytest-cov >=1.8.1

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -32,8 +32,8 @@ dependencies:
   - nodejs 16.*
   - pre-commit
   - psutil
-  - pydot
   - pygments
+  - pygraphviz
   - pytest >=7.0
   - pytest-asyncio=0.12.0
   - pytest-cov >=1.8.1

--- a/src/bokeh/io/notebook.py
+++ b/src/bokeh/io/notebook.py
@@ -487,14 +487,13 @@ def load_notebook(resources: Resources | None = None, verbose: bool = False,
         LOAD_MIME_TYPE : jl_js,
     })
 
-def publish_display_data(data: dict[str, Any], metadata: dict[Any, Any] | None = None,
-        source: str | None = None, *, transient: dict[str, Any] | None = None, **kwargs: Any) -> None:
+def publish_display_data(data: dict[str, Any], metadata: dict[Any, Any] | None = None, *, transient: dict[str, Any] | None = None, **kwargs: Any) -> None:
     '''
 
     '''
     # This import MUST be deferred or it will introduce a hard dependency on IPython
     from IPython.display import publish_display_data
-    publish_display_data(data, metadata, source, transient=transient, **kwargs)
+    publish_display_data(data, metadata, transient=transient, **kwargs)
 
 def show_app(app: Application, state: State, notebook_url: str | Callable[[int | None], str], port: int = 0, **kw: Any) -> None:
     ''' Embed a Bokeh server application in a Jupyter Notebook output cell.

--- a/src/bokeh/models/util/structure.py
+++ b/src/bokeh/models/util/structure.py
@@ -228,7 +228,7 @@ class _BokehStructureGraph:
         """
         import networkx as nx
 
-        nodes = nx.nx_pydot.graphviz_layout(self._graph, prog="dot")
+        nodes = nx.nx_agraph.graphviz_layout(self._graph, prog="dot")
         node_x, node_y = zip(*nodes.values())
         models = [self._graph.nodes[x]["model"] for x in nodes]
         node_id = list(nodes.keys())


### PR DESCRIPTION
- [x] issues: fixes #12607 
- [x] issues: fixes #12608

Note that the "Structure Graph Plot" feature seems to be broken, but that is unrelated to this PR since the old vs new networkx code generates identically structured output. I will make a separate issue regarding what to do with `bokeh.models.util.structure` 