### PR TITLE
Ensure change callback manipulation is threadsafe

### DIFF
--- a/src/bokeh/document/callbacks.py
+++ b/src/bokeh/document/callbacks.py
@@ -356,7 +356,8 @@ class DocumentCallbackManager:
                 if model:
                     model._trigger_event(event)
 
-        for cb in self._event_callbacks.get(event.event_name, []):
+        callbacks = self._event_callbacks.get(event.event_name, []).copy()
+        for cb in callbacks:
             cb(event)
 
     def trigger_on_change(self, event: DocumentChangedEvent) -> None:

--- a/src/bokeh/document/callbacks.py
+++ b/src/bokeh/document/callbacks.py
@@ -375,7 +375,8 @@ class DocumentCallbackManager:
             invoke_with_curdoc(doc, event.callback_invoker)
 
         def invoke_callbacks() -> None:
-            for cb in self._change_callbacks.values():
+            callbacks = self._change_callbacks.copy()
+            for cb in callbacks.values():
                 cb(event)
         invoke_with_curdoc(doc, invoke_callbacks)
 

--- a/tests/unit/bokeh/document/test_callbacks__document.py
+++ b/tests/unit/bokeh/document/test_callbacks__document.py
@@ -191,6 +191,28 @@ class TestDocumentCallbackManager:
         cm._change_callbacks[recv](evt)
         assert called == evt
 
+    def test_event_callbacks_for_event_name(self) -> None:
+        d = Document()
+        cm = bdc.DocumentCallbackManager(d)
+        def cb1(event: Any) -> None:
+            pass
+        def cb2(event: Any) -> None:
+            pass
+
+        assert cm.event_callbacks_for_event_name("document_ready") == ()
+        cm.on_event("document_ready", cb1)
+
+        assert cm.event_callbacks_for_event_name("junk") == ()
+
+        assert cm.event_callbacks_for_event_name("document_ready") == (cb1,)
+
+        cm.on_event("document_ready", cb2)
+        cbs = cm.event_callbacks_for_event_name("document_ready")
+        assert isinstance(cbs, tuple)
+        assert len(cbs) == 2
+        assert cb1 in cbs
+        assert cb2 in cbs
+
     def test_on_event_good_string(self) -> None:
         d = Document()
         cm = bdc.DocumentCallbackManager(d)
@@ -248,6 +270,26 @@ class TestDocumentCallbackManager:
 
         with pytest.raises(ValueError):
             cm.on_session_destroyed(bad) # type: ignore  [arg-type]  # want to test bad param
+
+    def test_change_callbacks(self) -> None:
+        d = Document()
+        cm = bdc.DocumentCallbackManager(d)
+        def cb1(x: Any) -> None:
+            pass
+        def cb2(x: Any) -> None:
+            pass
+
+        cm.change_callbacks() == ()
+
+        cm.on_change(cb1)
+        cm.change_callbacks() == (cb1,)
+
+        cm.on_change(cb2)
+        cbs = cm.change_callbacks()
+        assert isinstance(cbs, tuple)
+        assert len(cbs) == 2
+        assert cb1 in cbs
+        assert cb2 in cbs
 
     def test_remove_on_change(self) -> None:
         d = Document()


### PR DESCRIPTION
The `_change_callbacks` dictionary is being iterated over directly which means that when another thread removes or adds a callback we get `RuntimeError: dictionary changed size during iteration`.

Due to the nature of threading issues I don't have a good reproducer.

- [x] issues: fixes https://github.com/holoviz/panel/issues/4086
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
