### PR TITLE
Bv/use runner cores

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -86,7 +86,7 @@ jobs:
           sampledata: 'cache'
 
       - name: Run codebase checks
-        run: pytest --color=yes tests/codebase
+        run: pytest --color=yes tests/codebase -n 2 -v
 
       - name: MyPy
         if: success() || failure()
@@ -201,7 +201,7 @@ jobs:
 
       - name: Run tests
         if: success() || failure()
-        run: pytest --cov=bokeh --cov-report=xml --color=yes tests/unit
+        run: pytest --cov=bokeh --cov-report=xml --color=yes -v tests/unit
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
@@ -233,7 +233,7 @@ jobs:
           sampledata: 'none' # no sampledata for minimal tests
 
       - name: Run tests
-        run: pytest -m "not sampledata" --cov=bokeh --cov-report=xml --color=yes tests/unit
+        run: pytest -m "not sampledata" --cov=bokeh --cov-report=xml --color=yes -v tests/unit
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3

--- a/scripts/ci/build_docs.sh
+++ b/scripts/ci/build_docs.sh
@@ -4,7 +4,7 @@ set -x #echo on
 
 cd docs/bokeh
 export GOOGLE_API_KEY=${GOOGLE_API_KEY:-"unset"}
-make SPHINXOPTS=-v all
+make SPHINXOPTS="-v -j 2" all
 
 { set +x ;} 2> /dev/null #echo off
 


### PR DESCRIPTION
GH runners have at least 2 cores Experiment to see if these can be used effectively in CI.

Currently locally one unit test fails with `-n > 1` and examples tests do not function at all. 
