### PR TITLE
Disable docker from wheel integration tests

### DIFF
--- a/scripts/docker/bokeh_docker_from_wheel.sh
+++ b/scripts/docker/bokeh_docker_from_wheel.sh
@@ -14,6 +14,6 @@ bokeh sampledata
 # Bokeh Python tests.
 pytest tests/test_defaults.py
 pytest tests/unit -k "not firefox"
-pytest tests/integration
+#pytest tests/integration
 
 echo "End of $0"


### PR DESCRIPTION
Now that we have a docker image for `branch-3.1` we can start to improve how it is used in CI. Currently the docker from wheel CI runs have various `integration` test failures and the runs then hang, so I am just going to disable them in CI and investigate locally.