### PR TITLE
Add text_outline_color to documentation

### DIFF
--- a/docs/bokeh/source/docs/includes/text_props.txt
+++ b/docs/bokeh/source/docs/includes/text_props.txt
@@ -13,7 +13,7 @@
 
 ``text_color``
     color to use to render text with
-    
+
 ``text_outline_color``
     color to use to provide a stroked outline to text
 

--- a/docs/bokeh/source/docs/includes/text_props.txt
+++ b/docs/bokeh/source/docs/includes/text_props.txt
@@ -13,6 +13,9 @@
 
 ``text_color``
     color to use to render text with
+    
+``text_outline_color``
+    color to use to provide a stroked outline to text
 
 ``text_alpha``
     floating point between 0 (transparent) and 1 (opaque)
@@ -30,5 +33,5 @@
     - ``'hanging'``
 
 .. note::
-    There is currently only support for filling text. An interface to stroke
-    the outlines of text has not yet been exposed.
+    There is currently only support for providing an outline color for text. An interface for more advanced control of stroked
+    outlines of text has not yet been exposed.


### PR DESCRIPTION
Support for ``text_outline_color`` was added in #12287 but this was not yet added to the documentation. This resolves issue #12642 

- [x] issues: fixes #12642 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
