### PR TITLE
Resolve issues with code quality checks

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -72,7 +72,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs
-    - ruff
+    - ruff ==0.0.144
     - types-boto
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -71,7 +71,7 @@ dependencies:
     - sphinx-design
     - sphinxext-opengraph
     # tests
-    - ruff
+    - ruff ==0.0.144
     - pandas-stubs
     - types-boto
     - types-colorama

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -72,7 +72,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs
-    - ruff
+    - ruff ==0.0.144
     - types-boto
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -72,7 +72,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs
-    - ruff
+    - ruff ==0.0.144
     - types-boto
     - types-colorama
     - types-mock

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -61,7 +61,7 @@ dependencies:
     - sphinx-design
     - sphinxext-opengraph
     # tests
-    - ruff
+    - ruff ==0.0.144
     - types-boto
     - types-colorama
     - types-mock

--- a/src/bokeh/colors/color.py
+++ b/src/bokeh/colors/color.py
@@ -28,7 +28,6 @@ from re import match
 from typing import (
     TYPE_CHECKING,
     Tuple,
-    Type,
     TypeVar,
     Union,
 )
@@ -120,7 +119,7 @@ class Color(Serializable, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def from_hsl(cls: Type[Self], value: HSL) -> Self:
+    def from_hsl(cls: type[Self], value: HSL) -> Self:
         ''' Create a new color by converting from an HSL color.
 
         *Subclasses must implement this method.*
@@ -137,7 +136,7 @@ class Color(Serializable, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def from_rgb(cls: Type[Self], value: RGB) -> Self:
+    def from_rgb(cls: type[Self], value: RGB) -> Self:
         ''' Create a new color by converting from an RGB color.
 
         *Subclasses must implement this method.*

--- a/src/bokeh/command/subcommand.py
+++ b/src/bokeh/command/subcommand.py
@@ -31,7 +31,6 @@ from typing import (
     Literal,
     Sequence,
     Tuple,
-    Type,
     Union,
 )
 
@@ -68,7 +67,7 @@ class Argument:
     nargs: NotRequired[int | Literal["?", "*", "+", "..."]] = Unspecified
     const: NotRequired[Any] = Unspecified
     default: NotRequired[Any] = Unspecified
-    type: NotRequired[Type[Any]] = Unspecified
+    type: NotRequired[type[Any]] = Unspecified
     choices: NotRequired[Sequence[Any]] = Unspecified
     required: NotRequired[bool] = Unspecified
     help: NotRequired[str] = Unspecified

--- a/src/bokeh/command/subcommands/__init__.py
+++ b/src/bokeh/command/subcommands/__init__.py
@@ -20,9 +20,6 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Type
-
 # Bokeh imports
 from ..subcommand import Subcommand
 
@@ -46,7 +43,7 @@ __all__ = (
 # Private API
 #-----------------------------------------------------------------------------
 
-def _collect() -> list[Type[Subcommand]]:
+def _collect() -> list[type[Subcommand]]:
     from importlib import import_module
     from os import listdir
     from os.path import dirname

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -108,7 +108,7 @@ def abstract(cls: C) -> C:
     cls.__doc__ = append_docstring(cls.__doc__, _ABSTRACT_ADMONITION)
     return cls
 
-def is_DataModel(cls: Type[HasProps]) -> bool:
+def is_DataModel(cls: type[HasProps]) -> bool:
     from ..model import DataModel
     return issubclass(cls, HasProps) and getattr(cls, "__data_model__", False) and cls != DataModel
 
@@ -132,12 +132,12 @@ def _generators(class_dict: dict[str, Any]):
 class _ModelResolver:
     """ """
 
-    _known_models: dict[str, Type[HasProps]]
+    _known_models: dict[str, type[HasProps]]
 
     def __init__(self) -> None:
         self._known_models = {}
 
-    def add(self, cls: Type[HasProps]) -> None:
+    def add(self, cls: type[HasProps]) -> None:
         if not (issubclass(cls, Local) or cls.__name__.startswith("_")):
             # update the mapping of view model names to classes, checking for any duplicates
             previous = self._known_models.get(cls.__qualified_model__, None)
@@ -145,15 +145,15 @@ class _ModelResolver:
                 raise Warning(f"Duplicate qualified model declaration of '{cls.__qualified_model__}'. Previous definition: {previous}")
             self._known_models[cls.__qualified_model__] = cls
 
-    def remove(self, cls: Type[HasProps]) -> None:
+    def remove(self, cls: type[HasProps]) -> None:
         del self._known_models[cls.__qualified_model__]
 
     @property
-    def known_models(self) -> dict[str, Type[HasProps]]:
+    def known_models(self) -> dict[str, type[HasProps]]:
         return dict(self._known_models)
 
     def clear_extensions(self) -> None:
-        def is_extension(obj: Type[HasProps]) -> bool:
+        def is_extension(obj: type[HasProps]) -> bool:
             return getattr(obj, "__implementation__", None) is not None or \
                    getattr(obj, "__javascript__", None) is not None or \
                    getattr(obj, "__css__", None) is not None
@@ -223,7 +223,7 @@ class MetaHasProps(type):
             warn(f"Overrides of {unused_overrides} in class {cls.__name__} does not override anything.", RuntimeWarning, stacklevel=2)
 
     @property
-    def model_class_reverse_map(cls) -> dict[str, Type[HasProps]]:
+    def model_class_reverse_map(cls) -> dict[str, type[HasProps]]:
         return _default_resolver.known_models
 
 class Local:
@@ -762,7 +762,7 @@ class ModelDef(_ModelDef, total=False):
     properties: list[PropertyDef]
     overrides: list[OverrideDef]
 
-def _HasProps_to_serializable(cls: Type[HasProps], serializer: Serializer) -> Ref | ModelDef:
+def _HasProps_to_serializable(cls: type[HasProps], serializer: Serializer) -> Ref | ModelDef:
     from ..model import DataModel, Model
 
     ref = Ref(id=ID(cls.__qualified_model__))
@@ -772,7 +772,7 @@ def _HasProps_to_serializable(cls: Type[HasProps], serializer: Serializer) -> Re
         return ref
 
     # TODO: consider supporting mixin models
-    bases: list[Type[HasProps]] = [ base for base in cls.__bases__ if issubclass(base, Model) and base != DataModel ]
+    bases: list[type[HasProps]] = [ base for base in cls.__bases__ if issubclass(base, Model) and base != DataModel ]
     if len(bases) == 0:
         extends = None
     elif len(bases) == 1:

--- a/src/bokeh/core/property/_sphinx.py
+++ b/src/bokeh/core/property/_sphinx.py
@@ -60,7 +60,7 @@ def property_link(obj: Any) -> str:
 
 Fn: TypeAlias = Callable[[Any], str]
 
-def register_type_link(cls: Type[Any]) -> Callable[[Fn], Fn]:
+def register_type_link(cls: type[Any]) -> Callable[[Fn], Fn]:
     def decorator(func: Fn):
         _type_links[cls] = func
         return func

--- a/src/bokeh/core/property/bases.py
+++ b/src/bokeh/core/property/bases.py
@@ -202,7 +202,7 @@ class Property(PropertyDescriptorFactory[T]):
         """
         return self._copy_default(self._default, no_eval=no_eval)
 
-    def themed_default(self, cls: Type[HasProps], name: str, theme_overrides: dict[str, Any] | None, *, no_eval: bool = False) -> T:
+    def themed_default(self, cls: type[HasProps], name: str, theme_overrides: dict[str, Any] | None, *, no_eval: bool = False) -> T:
         """ The default, transformed by prepare_value() and the theme overrides.
 
         """
@@ -339,7 +339,7 @@ class Property(PropertyDescriptorFactory[T]):
     def _hinted_value(self, value: Any, hint: DocumentPatchedEvent | None) -> Any:
         return value
 
-    def prepare_value(self, owner: HasProps | Type[HasProps], name: str, value: Any, *, hint: DocumentPatchedEvent | None = None) -> T:
+    def prepare_value(self, owner: HasProps | type[HasProps], name: str, value: Any, *, hint: DocumentPatchedEvent | None = None) -> T:
         if value is Intrinsic:
             value = self._raw_default()
         if value is Undefined:
@@ -433,7 +433,7 @@ class Property(PropertyDescriptorFactory[T]):
         self.assertions.append((fn, msg_or_fn))
         return self
 
-    def replace(self, old: Type[Property[Any]], new: Property[Any]) -> Property[Any]:
+    def replace(self, old: type[Property[Any]], new: Property[Any]) -> Property[Any]:
         if self.__class__ == old:
             return new
         else:
@@ -499,7 +499,7 @@ class ParameterizedProperty(Property[T]):
         return super()._may_have_unstable_default() or \
             any(type_param._may_have_unstable_default() for type_param in self.type_params)
 
-    def replace(self, old: Type[Property[Any]], new: Property[Any]) -> Property[Any]:
+    def replace(self, old: type[Property[Any]], new: Property[Any]) -> Property[Any]:
         if self.__class__ == old:
             return new
         else:
@@ -543,7 +543,7 @@ class PrimitiveProperty(Property[T]):
 
     """
 
-    _underlying_type: ClassVar[tuple[Type[Any], ...]]
+    _underlying_type: ClassVar[tuple[type[Any], ...]]
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -97,7 +97,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Type,
     TypeVar,
 )
 
@@ -151,7 +150,7 @@ class AliasPropertyDescriptor(Generic[T]):
         self.property = property
         self.__doc__ = f"This is a compatibility alias for the ``{aliased_name}`` property"
 
-    def __get__(self, obj: HasProps | None, owner: Type[HasProps] | None) -> T:
+    def __get__(self, obj: HasProps | None, owner: type[HasProps] | None) -> T:
         if obj is not None:
             return getattr(obj, self.aliased_name)
         elif owner is not None:
@@ -200,7 +199,7 @@ class PropertyDescriptor(Generic[T]):
         """
         return f"{self.property}"
 
-    def __get__(self, obj: HasProps | None, owner: Type[HasProps] | None) -> T:
+    def __get__(self, obj: HasProps | None, owner: type[HasProps] | None) -> T:
         """ Implement the getter for the Python `descriptor protocol`_.
 
         For instance attribute access, we delegate to the |Property|. For
@@ -306,7 +305,7 @@ class PropertyDescriptor(Generic[T]):
         if self.name in obj._unstable_default_values:
             del obj._unstable_default_values[self.name]
 
-    def class_default(self, cls: Type[HasProps], *, no_eval: bool = False):
+    def class_default(self, cls: type[HasProps], *, no_eval: bool = False):
         """ Get the default value for a specific subtype of ``HasProps``,
         which may not be used for an individual instance.
 

--- a/src/bokeh/core/property/either.py
+++ b/src/bokeh/core/property/either.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, Type, TypeVar
+from typing import Any, TypeVar
 
 # Bokeh imports
 from ...util.strings import nice_join
@@ -105,7 +105,7 @@ class Either(ParameterizedProperty[Any]):
             value = tp.wrap(value)
         return value
 
-    def replace(self, old: Type[Property[Any]], new: Property[Any]) -> Property[Any]:
+    def replace(self, old: type[Property[Any]], new: Property[Any]) -> Property[Any]:
         if self.__class__ == old:
             return new
         else:

--- a/src/bokeh/core/property/include.py
+++ b/src/bokeh/core/property/include.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from copy import copy
-from typing import Type, TypeVar
+from typing import TypeVar
 
 # Bokeh imports
 from ..has_props import HasProps
@@ -50,7 +50,7 @@ class Include(PropertyDescriptorFactory[T]):
 
     """
 
-    def __init__(self, delegate: Type[HasProps], *, help: str = "", prefix: str | None = None) -> None:
+    def __init__(self, delegate: type[HasProps], *, help: str = "", prefix: str | None = None) -> None:
         if not (isinstance(delegate, type) and issubclass(delegate, HasProps)):
             raise ValueError(f"expected a subclass of HasProps, got {delegate!r}")
 

--- a/src/bokeh/core/property/instance.py
+++ b/src/bokeh/core/property/instance.py
@@ -30,7 +30,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Type,
     TypeVar,
 )
 
@@ -67,9 +66,9 @@ class Object(Property[T]):
 
     """
 
-    _instance_type: Type[T] | Callable[[], Type[T]] | str
+    _instance_type: type[T] | Callable[[], type[T]] | str
 
-    def __init__(self, instance_type: Type[T] | Callable[[], Type[T]] | str, default: Init[T] = Undefined, help: str | None = None):
+    def __init__(self, instance_type: type[T] | Callable[[], type[T]] | str, default: Init[T] = Undefined, help: str | None = None):
         if not (isinstance(instance_type, (type, str)) or callable(instance_type)):
             raise ValueError(f"expected a type, fn() -> type, or string, got {instance_type}")
 
@@ -81,7 +80,7 @@ class Object(Property[T]):
         super().__init__(default=default, help=help)
 
     @staticmethod
-    def _assert_type(instance_type: Type[Any]) -> None:
+    def _assert_type(instance_type: type[Any]) -> None:
         pass
 
     def __str__(self) -> str:
@@ -94,8 +93,8 @@ class Object(Property[T]):
         return True
 
     @property
-    def instance_type(self) -> Type[T]:
-        instance_type: Type[Serializable]
+    def instance_type(self) -> type[T]:
+        instance_type: type[Serializable]
         if isinstance(self._instance_type, type):
             instance_type = self._instance_type
         elif isinstance(self._instance_type, str):
@@ -129,7 +128,7 @@ class Instance(Object[S]):
     """ Accept values that are instances of serializable types (e.g. |HasProps|). """
 
     @staticmethod
-    def _assert_type(instance_type: Type[Any]) -> None:
+    def _assert_type(instance_type: type[Any]) -> None:
         if not (isinstance(instance_type, type) and issubclass(instance_type, Serializable)):
             raise ValueError(f"expected a subclass of Serializable (e.g. HasProps), got {instance_type}")
 
@@ -143,7 +142,7 @@ class InstanceDefault(Generic[I]):
     will afford better user-facing documentation than a lambda initializer.
 
     """
-    def __init__(self, model: Type[I], **kwargs: Any) -> None:
+    def __init__(self, model: type[I], **kwargs: Any) -> None:
         self._model = model
         self._kwargs = kwargs
 

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -34,7 +34,6 @@ from typing import (
     Literal,
     NoReturn,
     Sequence,
-    Type,
     TypedDict,
     TypeVar,
     Union,
@@ -201,10 +200,10 @@ ObjID = int
 class Serializer:
     """ Convert built-in and custom types into serializable representations. """
 
-    _encoders: ClassVar[dict[Type[Any], Encoder]] = {}
+    _encoders: ClassVar[dict[type[Any], Encoder]] = {}
 
     @classmethod
-    def register(cls, type: Type[Any], encoder: Encoder) -> None:
+    def register(cls, type: type[Any], encoder: Encoder) -> None:
         assert type not in cls._encoders, f"'{type} is already registered"
         cls._encoders[type] = encoder
 
@@ -687,7 +686,7 @@ class Deserializer:
 
         return instance
 
-    def _resolve_type(self, type: str) -> Type[Model]:
+    def _resolve_type(self, type: str) -> type[Model]:
         from ..model import Model
         cls = Model.model_class_reverse_map.get(type)
         if cls is not None:

--- a/src/bokeh/core/validation/decorators.py
+++ b/src/bokeh/core/validation/decorators.py
@@ -25,7 +25,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Type,
     Union,
     cast,
 )
@@ -65,7 +64,7 @@ def _validator(code_or_name: int | str | Issue, validator_type: ValidatorType) -
         validation decorator
 
     """
-    issues: Type[Error] | Type[Warning] = \
+    issues: type[Error] | type[Warning] = \
         Error if validator_type == "error" else Warning
 
     def decorator(func: ValidationFunction) -> Validator:

--- a/src/bokeh/document/callbacks.py
+++ b/src/bokeh/document/callbacks.py
@@ -25,12 +25,7 @@ log = logging.getLogger(__name__)
 import weakref
 from collections import defaultdict
 from functools import wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Type,
-)
+from typing import TYPE_CHECKING, Any, Callable
 
 # Bokeh imports
 from ..core.enums import HoldPolicy, HoldPolicyType
@@ -274,7 +269,7 @@ class DocumentCallbackManager:
         if receiver not in self._change_callbacks:
             self._change_callbacks[receiver] = lambda event: event.dispatch(receiver)
 
-    def on_event(self, event: str | Type[Event], *callbacks: EventCallback) -> None:
+    def on_event(self, event: str | type[Event], *callbacks: EventCallback) -> None:
         ''' Provide callbacks to invoke if a bokeh event is received.
 
         '''

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -37,12 +37,7 @@ log = logging.getLogger(__name__)
 import gc
 import weakref
 from json import loads
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    Type,
-)
+from typing import TYPE_CHECKING, Any, Iterable
 
 # External imports
 from jinja2 import Template
@@ -529,7 +524,7 @@ class Document:
         '''
         self.callbacks.on_change_dispatch_to(receiver)
 
-    def on_event(self, event: str | Type[Event], *callbacks: EventCallback) -> None:
+    def on_event(self, event: str | type[Event], *callbacks: EventCallback) -> None:
         ''' Provide callbacks to invoke if a bokeh event is received.
 
         '''
@@ -690,7 +685,7 @@ class Document:
             return None
         return result[0]
 
-    def set_select(self, selector: SelectorType | Type[Model], updates: dict[str, Any]) -> None:
+    def set_select(self, selector: SelectorType | type[Model], updates: dict[str, Any]) -> None:
         ''' Update objects that match a given selector with the specified
         attribute/value updates.
 

--- a/src/bokeh/document/events.py
+++ b/src/bokeh/document/events.py
@@ -62,7 +62,6 @@ from typing import (
     Callable,
     ClassVar,
     List,
-    Type,
     Union,
     cast,
 )
@@ -205,7 +204,7 @@ class DocumentPatchedEvent(DocumentChangedEvent, Serializable):
 
     kind: ClassVar[str]
 
-    _handlers: ClassVar[dict[str, Type[DocumentPatchedEvent]]] = {}
+    _handlers: ClassVar[dict[str, type[DocumentPatchedEvent]]] = {}
 
     def __init_subclass__(cls):
         cls._handlers[cls.kind] = cls

--- a/src/bokeh/embed/bundle.py
+++ b/src/bokeh/embed/bundle.py
@@ -37,7 +37,6 @@ from typing import (
     Callable,
     Iterator,
     Sequence,
-    Type,
     TypedDict,
 )
 from warnings import warn
@@ -237,7 +236,7 @@ def bundle_for_objs_and_resources(objs: Sequence[Model | Document] | None,
 # Private API
 #-----------------------------------------------------------------------------
 
-def _query_extensions(objs: Sequence[Model | Document], query: Callable[[Type[Model]], bool]) -> bool:
+def _query_extensions(objs: Sequence[Model | Document], query: Callable[[type[Model]], bool]) -> bool:
     names: set[str] = set()
 
     for obj in _all_objs(objs):

--- a/src/bokeh/embed/standalone.py
+++ b/src/bokeh/embed/standalone.py
@@ -258,7 +258,7 @@ def components(models: Model | Sequence[Model] | dict[str, Model], wrap_script: 
 
     # now convert dict to list, saving keys in the same order
     model_keys = None
-    dict_type: Type[dict[Any, Any]] = dict
+    dict_type: type[dict[Any, Any]] = dict
     if isinstance(models, dict):
         dict_type = models.__class__
         model_keys = models.keys()

--- a/src/bokeh/embed/util.py
+++ b/src/bokeh/embed/util.py
@@ -28,7 +28,6 @@ from typing import (
     Any,
     Iterator,
     Sequence,
-    Type,
 )
 from weakref import WeakKeyDictionary
 
@@ -77,7 +76,7 @@ class FromCurdoc:
     pass
 
 @contextmanager
-def OutputDocumentFor(objs: Sequence[Model], apply_theme: Theme | Type[FromCurdoc] | None = None,
+def OutputDocumentFor(objs: Sequence[Model], apply_theme: Theme | type[FromCurdoc] | None = None,
         always_new: bool = False) -> Iterator[Document]:
     ''' Find or create a (possibly temporary) Document to use for serializing
     Bokeh content.
@@ -417,7 +416,7 @@ def _dispose_temp_doc(models: Sequence[Model]) -> None:
 
 _themes: WeakKeyDictionary[Document, Theme] = WeakKeyDictionary()
 
-def _set_temp_theme(doc: Document, apply_theme: Theme | Type[FromCurdoc] | None) -> None:
+def _set_temp_theme(doc: Document, apply_theme: Theme | type[FromCurdoc] | None) -> None:
     _themes[doc] = doc.theme
     if apply_theme is FromCurdoc:
         from ..io import curdoc

--- a/src/bokeh/events.py
+++ b/src/bokeh/events.py
@@ -71,7 +71,6 @@ from typing import (
     Any,
     ClassVar,
     Literal,
-    Type,
     TypedDict,
 )
 
@@ -125,7 +124,7 @@ __all__ = (
 # Private API
 #-----------------------------------------------------------------------------
 
-_CONCRETE_EVENT_CLASSES: dict[str, Type[Event]] = {}
+_CONCRETE_EVENT_CLASSES: dict[str, type[Event]] = {}
 
 #-----------------------------------------------------------------------------
 # General API

--- a/src/bokeh/layouts.py
+++ b/src/bokeh/layouts.py
@@ -293,7 +293,7 @@ def gridplot(
             else:
                 raise ValueError("Only UIElement and LayoutDOM items can be inserted into a grid")
 
-    def merge(cls: Type[Tool], group: list[Tool]):
+    def merge(cls: type[Tool], group: list[Tool]):
         if issubclass(cls, (SaveTool, CopyTool, ExamineTool, FullscreenTool)):
             return cls()
         else:
@@ -511,7 +511,7 @@ def group_tools(tools: list[Tool | ToolProxy], *, merge: MergeFn[Tool] | None = 
         tool: Tool
         props: Any
 
-    by_type: defaultdict[Type[Tool], list[ToolEntry]] = defaultdict(list)
+    by_type: defaultdict[type[Tool], list[ToolEntry]] = defaultdict(list)
     computed: list[Tool | ToolProxy] = []
 
     for tool in tools:

--- a/src/bokeh/model/docs.py
+++ b/src/bokeh/model/docs.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Type
+from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from ..util.serialization import make_id
@@ -85,7 +85,7 @@ def html_repr(obj: Model):
 
     return html
 
-def process_example(cls: Type[Any]) -> None:
+def process_example(cls: type[Any]) -> None:
     ''' A decorator to mark abstract base classes derived from |HasProps|.
 
     '''

--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -22,12 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from inspect import Parameter, Signature, isclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    Type,
-)
+from typing import TYPE_CHECKING, Any, Iterable
 
 # Bokeh imports
 from ..core import properties as p
@@ -231,7 +226,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     @classmethod
     @without_property_validation
-    def parameters(cls: Type[Model]) -> list[Parameter]:
+    def parameters(cls: type[Model]) -> list[Parameter]:
         ''' Generate Python ``Parameter`` values suitable for functions that are
         derived from the glyph.
 
@@ -305,7 +300,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
         return arg_params + kwarg_params
 
-    def js_on_event(self, event: str | Type[Event], *callbacks: JSEventCallback) -> None:
+    def js_on_event(self, event: str | type[Event], *callbacks: JSEventCallback) -> None:
         if isinstance(event, str):
             pass
         elif isinstance(event, type) and issubclass(event, Event):
@@ -506,7 +501,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
             return None
         return result[0]
 
-    def set_select(self, selector: Type[Model] | SelectorType, updates: dict[str, Any]) -> None:
+    def set_select(self, selector: type[Model] | SelectorType, updates: dict[str, Any]) -> None:
         ''' Update objects that match a given selector with the specified
         attribute/value updates.
 

--- a/src/bokeh/model/util.py
+++ b/src/bokeh/model/util.py
@@ -21,12 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Type,
-)
+from typing import TYPE_CHECKING, Any, Callable
 
 # Bokeh imports
 from ..core.has_props import HasProps, Qualified
@@ -142,7 +137,7 @@ def collect_models(*input_values: Any) -> list[Model]:
     '''
     return collect_filtered_models(None, *input_values)
 
-def get_class(view_model_name: str) -> Type[Model]:
+def get_class(view_model_name: str) -> type[Model]:
     ''' Look up a Bokeh model class, given its view model name.
 
     Args:

--- a/src/bokeh/plotting/_plot.py
+++ b/src/bokeh/plotting/_plot.py
@@ -19,12 +19,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from collections.abc import Sequence
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Type,
-)
+from typing import TYPE_CHECKING, Any, Literal
 
 # External imports
 import numpy as np
@@ -141,7 +136,7 @@ def process_axis_and_grid(plot: Plot, axis_type: AxisType | None, axis_location:
 # Private API
 #-----------------------------------------------------------------------------
 
-def _get_axis_class(axis_type: AxisType | None, range_input: Range, dim: Dim) -> tuple[Type[Axis] | None, Any]:
+def _get_axis_class(axis_type: AxisType | None, range_input: Range, dim: Dim) -> tuple[type[Axis] | None, Any]:
     if axis_type is None:
         return None, {}
     elif axis_type == "linear":
@@ -170,7 +165,7 @@ def _get_axis_class(axis_type: AxisType | None, range_input: Range, dim: Dim) ->
     else:
         raise ValueError(f"Unrecognized axis_type: '{axis_type!r}'")
 
-def _get_num_minor_ticks(axis_class: Type[Axis], num_minor_ticks: int | Literal["auto"] | None) -> int:
+def _get_num_minor_ticks(axis_class: type[Axis], num_minor_ticks: int | Literal["auto"] | None) -> int:
     if isinstance(num_minor_ticks, int):
         if num_minor_ticks <= 1:
             raise ValueError("num_minor_ticks must be > 1")

--- a/src/bokeh/protocol/__init__.py
+++ b/src/bokeh/protocol/__init__.py
@@ -27,7 +27,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Type,
     overload,
 )
 
@@ -69,7 +68,7 @@ MessageType = Literal[
     "SERVER-INFO-REQ",
 ]
 
-SPEC: dict[MessageType, Type[Message[Any]]] = {
+SPEC: dict[MessageType, type[Message[Any]]] = {
     "ACK": ack,
     "ERROR": error,
     "OK": ok,
@@ -93,7 +92,7 @@ class Protocol:
     ''' Provide a message factory for the Bokeh Server message protocol.
 
     '''
-    _messages: dict[MessageType, Type[Message[Any]]]
+    _messages: dict[MessageType, type[Message[Any]]]
 
     def __init__(self) -> None:
         self._messages = SPEC

--- a/src/bokeh/server/auth_provider.py
+++ b/src/bokeh/server/auth_provider.py
@@ -23,7 +23,6 @@ from typing import (
     Awaitable,
     Callable,
     NewType,
-    Type,
 )
 
 # External imports
@@ -73,11 +72,11 @@ class AuthProvider:
         self._validate()
 
     @property
-    def endpoints(self) -> list[tuple[str, Type[RequestHandler]]]:
+    def endpoints(self) -> list[tuple[str, type[RequestHandler]]]:
         ''' URL patterns for login/logout endpoints.
 
         '''
-        endpoints: list[tuple[str, Type[RequestHandler]]] = []
+        endpoints: list[tuple[str, type[RequestHandler]]] = []
         if self.login_handler:
             assert self.login_url is not None
             endpoints.append((self.login_url, self.login_handler))
@@ -127,7 +126,7 @@ class AuthProvider:
         pass
 
     @property
-    def login_handler(self) -> Type[RequestHandler] | None:
+    def login_handler(self) -> type[RequestHandler] | None:
         ''' A request handler class for a login page.
 
         This property may return None, if ``login_url`` is supplied
@@ -150,7 +149,7 @@ class AuthProvider:
         pass
 
     @property
-    def logout_handler(self) -> Type[RequestHandler] | None:
+    def logout_handler(self) -> type[RequestHandler] | None:
         ''' A request handler class for a logout page.
 
         This property may return None.

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -30,7 +30,6 @@ from typing import (
     Any,
     Mapping,
     Sequence,
-    Type,
 )
 from urllib.parse import urljoin
 
@@ -781,7 +780,7 @@ class BokehTornado(TornadoApplication):
 # Dev API
 #-----------------------------------------------------------------------------
 
-def create_static_handler(prefix: str, key: str, app: Application) -> tuple[str, Type[StaticFileHandler | StaticHandler], dict[str, Any]]:
+def create_static_handler(prefix: str, key: str, app: Application) -> tuple[str, type[StaticFileHandler | StaticHandler], dict[str, Any]]:
     route = prefix
     route += "/static/(.*)" if key == "/" else key + "/static/(.*)"
     if app.static_path is not None:

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -433,7 +433,7 @@ class PrioritizedSetting(Generic[T]):
 
         raise RuntimeError(f"No configured value found for setting {self._name!r}")
 
-    def __get__(self, instance: Any, owner: Type[Any]) -> PrioritizedSetting[T]:
+    def __get__(self, instance: Any, owner: type[Any]) -> PrioritizedSetting[T]:
         return self
 
     def __set__(self, instance: Any, value: str | T) -> None:

--- a/src/bokeh/themes/theme.py
+++ b/src/bokeh/themes/theme.py
@@ -21,12 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Type,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, overload
 
 # External imports
 import yaml
@@ -198,7 +193,7 @@ class Theme:
         # class.
         self._by_class_cache = {}
 
-    def _add_glyph_defaults(self, cls: Type[HasProps], props: dict[str, Any]) -> None:
+    def _add_glyph_defaults(self, cls: type[HasProps], props: dict[str, Any]) -> None:
         from ..models.glyphs import Glyph
         if issubclass(cls, Glyph):
             if hasattr(cls, "line_alpha"):
@@ -208,7 +203,7 @@ class Theme:
             if hasattr(cls, "text_alpha"):
                 props.update(self._text_defaults)
 
-    def _for_class(self, cls: Type[Model]) -> dict[str, Any]:
+    def _for_class(self, cls: type[Model]) -> dict[str, Any]:
         if cls.__name__ not in self._by_class_cache:
             attrs = self._json['attrs']
             combined: dict[str, Any] = {}

--- a/src/bokeh/util/callback_manager.py
+++ b/src/bokeh/util/callback_manager.py
@@ -29,7 +29,6 @@ from typing import (
     Any,
     Callable,
     Sequence,
-    Type,
     Union,
     cast,
 )
@@ -83,7 +82,7 @@ class EventCallbackManager:
         super().__init__(*args, **kw)
         self._event_callbacks = defaultdict(list)
 
-    def on_event(self, event: str | Type[Event], *callbacks: EventCallback) -> None:
+    def on_event(self, event: str | type[Event], *callbacks: EventCallback) -> None:
         ''' Run callbacks when the specified event occurs on this Model
 
         Not all Events are supported for all Models.

--- a/src/bokeh/util/compiler.py
+++ b/src/bokeh/util/compiler.py
@@ -39,7 +39,6 @@ from typing import (
     Callable,
     Dict,
     Sequence,
-    Type,
 )
 
 # Bokeh imports
@@ -218,7 +217,7 @@ class CustomModel:
     ''' Represent a custom (user-defined) Bokeh model.
 
     '''
-    def __init__(self, cls: Type[HasProps]) -> None:
+    def __init__(self, cls: type[HasProps]) -> None:
         self.cls = cls
 
     @property
@@ -301,7 +300,7 @@ def calc_cache_key(custom_models: dict[str, CustomModel]) -> str:
 
 _bundle_cache: dict[str, str] = {}
 
-def bundle_models(models: Sequence[Type[HasProps]] | None) -> str | None:
+def bundle_models(models: Sequence[type[HasProps]] | None) -> str | None:
     """Create a bundle of selected `models`. """
     custom_models = _get_custom_models(models)
     if custom_models is None:
@@ -465,7 +464,7 @@ def _model_cache_no_op(model: CustomModel, implementation: Implementation) -> At
 
 _CACHING_IMPLEMENTATION = _model_cache_no_op
 
-def _get_custom_models(models: Sequence[Type[HasProps]] | None) -> dict[str, CustomModel] | None:
+def _get_custom_models(models: Sequence[type[HasProps]] | None) -> dict[str, CustomModel] | None:
     """Returns CustomModels for models with a custom `__implementation__`"""
     custom_models: dict[str, CustomModel] = dict()
 

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -32,7 +32,7 @@ import datetime as dt
 import uuid
 from functools import lru_cache
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Type
+from typing import TYPE_CHECKING, Any
 
 # External imports
 import numpy as np
@@ -318,7 +318,7 @@ def transform_array(array: npt.NDArray[Any]) -> npt.NDArray[Any]:
     # XXX: as long as we can't support 64-bit integers, try to convert
     # to 32-bits. If not possible, let the serializer convert to a less
     # efficient representation and/or deal with any error messaging.
-    def _cast_if_can(array: npt.NDArray[Any], dtype: Type[Any]) -> npt.NDArray[Any]:
+    def _cast_if_can(array: npt.NDArray[Any], dtype: type[Any]) -> npt.NDArray[Any]:
         info = np.iinfo(dtype)
 
         if np.any((array < info.min) | (info.max < array)):

--- a/tests/support/util/filesystem.py
+++ b/tests/support/util/filesystem.py
@@ -33,7 +33,6 @@ from typing import (
     Callable,
     ContextManager,
     Iterator,
-    Type,
 )
 
 # Bokeh imports
@@ -62,7 +61,7 @@ class TmpDir(ContextManager[str]):
     def __init__(self, prefix: str) -> None:
         self._dir = tempfile.mkdtemp(prefix=prefix, dir=_LOCAL_TMP)
 
-    def __exit__(self, type: Type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None) -> None:
+    def __exit__(self, type: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None) -> None:
         try:
             shutil.rmtree(path=self._dir)
         except Exception as e:

--- a/tests/unit/bokeh/models/test_defaults.py
+++ b/tests/unit/bokeh/models/test_defaults.py
@@ -17,7 +17,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, Type
+from typing import Any
 
 # Bokeh imports
 from bokeh.core.property.descriptors import PropertyDescriptor
@@ -46,7 +46,7 @@ def all_descriptors():
             yield (model, name, descriptor)
 
 @pytest.mark.parametrize("model, name, descriptor", list(all_descriptors()))
-def test_default_values(model: Type[Model], name: str, descriptor: PropertyDescriptor[Any]) -> None:
+def test_default_values(model: type[Model], name: str, descriptor: PropertyDescriptor[Any]) -> None:
     p = descriptor.property
     # In a few instances there is a default that needs to be prepared, e.g. by
     # an accepts clause. Use class_default rather than _raw_default.

--- a/tests/unit/bokeh/models/test_layouts__models.py
+++ b/tests/unit/bokeh/models/test_layouts__models.py
@@ -16,9 +16,6 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Type
-
 # Bokeh imports
 from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure
@@ -46,7 +43,7 @@ def check_props_with_sizing_mode(layout: LayoutDOM):
     assert layout.sizing_mode is None
 
 
-def check_children_prop(layout_callable: Type[Row | Column]):
+def check_children_prop(layout_callable: type[Row | Column]):
     ## component subclasses are layouts, widgets and plots
     components = [Row(), Column(), figure()]
 


### PR DESCRIPTION
I replaced `Type[T]` with `type[T]` where it can be used, so that it doesn't conflict with Python 3.8. When we drop 3.8, then the rest can be rewritten. I pinned ruff to version 0.0.144, which is the last one that works correctly.
