### PR TITLE
Remove legacy `CanvasRenderingContext2D` polyfills

### DIFF
--- a/bokehjs/src/lib/core/visuals/line.ts
+++ b/bokehjs/src/lib/core/visuals/line.ts
@@ -63,7 +63,7 @@ export class Line extends VisualProperties {
     ctx.lineWidth      = this.line_width.get_value()
     ctx.lineJoin       = this.line_join.get_value()
     ctx.lineCap        = this.line_cap.get_value()
-    ctx.lineDash       = resolve_line_dash(this.line_dash.get_value())
+    ctx.setLineDash(resolve_line_dash(this.line_dash.get_value()))
     ctx.lineDashOffset = this.line_dash_offset.get_value()
   }
 }
@@ -115,7 +115,7 @@ export class LineScalar extends VisualUniforms {
     ctx.lineWidth      = this.line_width.value
     ctx.lineJoin       = this.line_join.value
     ctx.lineCap        = this.line_cap.value
-    ctx.lineDash       = resolve_line_dash(this.line_dash.value)
+    ctx.setLineDash(resolve_line_dash(this.line_dash.value))
     ctx.lineDashOffset = this.line_dash_offset.value
   }
 }
@@ -187,7 +187,7 @@ export class LineVector extends VisualUniforms {
     ctx.lineWidth = width
     ctx.lineJoin = join
     ctx.lineCap = cap
-    ctx.lineDash = resolve_line_dash(dash)
+    ctx.setLineDash(resolve_line_dash(dash))
     ctx.lineDashOffset = offset
   }
 }

--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -193,7 +193,7 @@ export class ColorBarView extends BaseColorBarView {
     ctx.save()
     ctx.globalAlpha = this.model.scale_alpha
     if (this._image != null) {
-      ctx.setImageSmoothingEnabled(false)
+      ctx.imageSmoothingEnabled = false
       ctx.drawImage(this._image, x, y, width, height)
     }
     if (this.visuals.bar_line.doit) {

--- a/bokehjs/src/lib/models/annotations/html/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/html/label_set.ts
@@ -146,7 +146,7 @@ export class HTMLLabelSetView extends DataAnnotationView {
       this.visuals.border_line.set_vectorize(ctx, i)
 
       // attempt to support vector-style ("8 4 8") line dashing for css mode
-      el.style.borderStyle = ctx.lineDash.length < 2 ? "solid" : "dashed"
+      el.style.borderStyle = ctx.getLineDash().length < 2 ? "solid" : "dashed"
       el.style.borderWidth = `${ctx.lineWidth}px`
       el.style.borderColor = ctx.strokeStyle as string
     }

--- a/bokehjs/src/lib/models/annotations/html/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/html/text_annotation.ts
@@ -97,7 +97,7 @@ export abstract class TextAnnotationView extends AnnotationView {
       this.visuals.border_line.set_value(ctx)
 
       // attempt to support vector-style ("8 4 8") line dashing for css mode
-      el.style.borderStyle = ctx.lineDash.length < 2 ? "solid" : "dashed"
+      el.style.borderStyle = ctx.getLineDash().length < 2 ? "solid" : "dashed"
       el.style.borderWidth = `${ctx.lineWidth}px`
       el.style.borderColor = ctx.strokeStyle as string
     }

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -116,8 +116,8 @@ export abstract class ImageBaseView extends XYGlyphView {
   protected _render(ctx: Context2d, indices: number[], data?: ImageDataBase): void {
     const {image_data, sx, sy, sw, sh} = data ?? this
 
-    const old_smoothing = ctx.getImageSmoothingEnabled()
-    ctx.setImageSmoothingEnabled(false)
+    ctx.save()
+    ctx.imageSmoothingEnabled = false
 
     const [x_sign, y_sign] = this.xy_sign
     const [x_scale, y_scale] = this.xy_scale
@@ -147,7 +147,7 @@ export abstract class ImageBaseView extends XYGlyphView {
       }
     }
 
-    ctx.setImageSmoothingEnabled(old_smoothing)
+    ctx.restore()
   }
 
   protected abstract _flat_img_to_buf8(img: Arrayable<number>): Uint8ClampedArray

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -242,10 +242,10 @@ export class TileRendererView extends RendererView {
       const sh = symax - symin
       const sx = sxmin
       const sy = symin
-      const old_smoothing = this.map_canvas.getImageSmoothingEnabled()
-      this.map_canvas.setImageSmoothingEnabled(this.model.smoothing)
+      const old_smoothing = this.map_canvas.imageSmoothingEnabled
+      this.map_canvas.imageSmoothingEnabled = this.model.smoothing
       this.map_canvas.drawImage(tile_data.img, sx, sy, sw, sh)
-      this.map_canvas.setImageSmoothingEnabled(old_smoothing)
+      this.map_canvas.imageSmoothingEnabled = old_smoothing
       tile_data.finished = true
     }
   }

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -69,7 +69,8 @@ describe("core/visuals", () => {
         const model = new SomeModel(attrs)
         const view = await build_view(model)
 
-        const ctx = {} as Context2d
+        const canvas = document.createElement("canvas")
+        const ctx = canvas.getContext("2d")! as Context2d
         view.visuals.fill.set_value(ctx)
 
         expect(ctx.fillStyle).to.be.equal("rgba(255, 0, 0, 0.6)") // #ff000099
@@ -120,14 +121,15 @@ describe("core/visuals", () => {
         const view = await build_view(model)
         const {line} = view.visuals
 
-        const ctx = {} as Context2d
+        const canvas = document.createElement("canvas")
+        const ctx = canvas.getContext("2d")! as Context2d
         line.set_value(ctx)
 
         expect(ctx.strokeStyle).to.be.equal("rgba(255, 0, 0, 0.6)") // #ff000099
         expect(ctx.lineWidth).to.be.equal(2)
         expect(ctx.lineJoin).to.be.equal("miter")
         expect(ctx.lineCap).to.be.equal("butt")
-        expect(ctx.lineDash).to.be.equal([1, 2])
+        expect(ctx.getLineDash()).to.be.equal([1, 2])
         expect(ctx.lineDashOffset).to.be.equal(2)
       })
     })
@@ -184,7 +186,8 @@ describe("core/visuals", () => {
         const view = await build_view(model)
         const {text} = view.visuals
 
-        const ctx = {} as Context2d
+        const canvas = document.createElement("canvas")
+        const ctx = canvas.getContext("2d")! as Context2d
         text.set_value(ctx)
 
         expect(ctx.fillStyle).to.be.equal("rgba(255, 0, 0, 0.6)") // #ff000099
@@ -227,7 +230,7 @@ describe("core/visuals", () => {
 
       it("should get initialized with appropriate indices", async () => {
         const circle = new Circle({fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}})
-        const data = {fill_color: ["red", "green", "blue"], fill_alpha: [0, 0.6, 1]}
+        const data = {fill_color: ["red", "green", "blue"], fill_alpha: [0, 0.6, 0.8]}
         const renderer_view = await create_glyph_renderer_view(circle, data)
 
         const filter = new IndexFilter({indices: [1, 2]})
@@ -235,11 +238,13 @@ describe("core/visuals", () => {
         // XXX: need to manually set_data because signals for renderer aren't connected by create_glyph_view util
         renderer_view.set_data()
 
-        const ctx = {} as Context2d
+        const canvas = document.createElement("canvas")
+        const ctx = canvas.getContext("2d")! as Context2d
+
         const glyph_view = renderer_view.glyph as CircleView
         glyph_view.visuals.fill.set_vectorize(ctx, 1)
 
-        expect(ctx.fillStyle).to.be.equal("rgba(0, 0, 255, 1)") // #ff000099
+        expect(ctx.fillStyle).to.be.equal("rgba(0, 0, 255, 0.8)")
       })
     })
   })

--- a/examples/server/app/spectrogram/waterfall.ts
+++ b/examples/server/app/spectrogram/waterfall.ts
@@ -51,9 +51,7 @@ export class WaterfallRendererView extends RendererView {
   protected _render(): void {
     const {ctx} = this.layer
     ctx.save()
-
-    const smoothing = ctx.getImageSmoothingEnabled()
-    ctx.setImageSmoothingEnabled(false)
+    ctx.imageSmoothingEnabled = false
 
     this._update_tiles()
 
@@ -66,14 +64,13 @@ export class WaterfallRendererView extends RendererView {
     ctx.scale(1, -1)
     ctx.translate(0, -sy)
 
-    for (let i = 0; i < sx.length; i++)
+    for (let i = 0; i < sx.length; i++) {
       ctx.drawImage(this.canvases[i], sx[i], sy, sw, sh)
+    }
 
     ctx.translate(0, sy)
     ctx.scale(1, -1)
     ctx.translate(0, -sy)
-
-    ctx.setImageSmoothingEnabled(smoothing)
 
     ctx.restore()
   }


### PR DESCRIPTION
Removes legacy cruft that was supposed to be removed in 3.0 and limits changes to built-in objects (which usually is a bad idea).