### PR TITLE
Promote note to warning in docs

### DIFF
--- a/docs/bokeh/source/docs/user_guide/styling/plots.rst
+++ b/docs/bokeh/source/docs/user_guide/styling/plots.rst
@@ -228,7 +228,7 @@ If you use the |bokeh.models| interface, use the
                 selection_glyph=selected_circle,
                 nonselection_glyph=nonselected_circle)
 
-.. note::
+.. warning::
     When rendering, Bokeh considers only the *visual* properties of
     ``selection_glyph`` and ``nonselection_glyph``. Changing
     positions, sizes, etc., will have no effect.
@@ -251,7 +251,7 @@ This example uses the first method of passing a color parameter with the
 .. bokeh-plot:: __REPO__/examples/styling/plots/glyph_hover.py
     :source-position: above
 
-.. note::
+.. warning::
     When rendering, Bokeh considers only the *visual* properties of
     ``hover_glyph``. Changing positions, sizes, etc. will have no effect.
 


### PR DESCRIPTION
That the glyphs for `nonselection_glyph` and `hover_glyph` is not affected by size, etc. bit me in the back, and apparently has confused many others as well, judging from the issue tracker. I think this behaviour is very unexpected, and deserves a warning level note.

Also, I think it would be great to be more explicit about what *visual* properties are, or link to where to find that. For me, it is for example not obvious that size is not a visual property. I would love to to it myself, but I am not familiar enough with Bokeh to do that.

- [ ] issues: relates to #2367