### PR TITLE
Fix coverage config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ markers = [
 
 [tool.coverage.run]
 source = ["src/bokeh"]
-omit = ["*sphinxext/*", "*/tmp/tmp*.py"]
+omit = ["*/sphinxext/*", "*/tmp/tmp*.py"]
 
 [tool.mypy]
 python_version = "3.8"


### PR DESCRIPTION
* [x] fixes #12716

Not 100% sure but I think coverage version 7.0 released in Dec slightly changed how the `omit` value was handled.
