### PR TITLE
Resolve interference between `regl` and `source-map-support`

### DIFF
--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -376,6 +376,9 @@ export class Linker {
       const fix_esexports = transforms.fix_esexports()
       transformers.push(fix_esexports)
 
+      const fix_regl = transforms.fix_regl()
+      transformers.push(fix_regl)
+
       const rewrite_deps = transforms.rewrite_deps((dep) => {
         const module_dep = module.dependencies.get(dep)
         return module_dep != null ? module_dep.id : undefined


### PR DESCRIPTION
I was going to submit change request to regl repository, but looks like regl isn't actively maintained anymore, so I'm fixing this here. With this PR, regl initialization in tests doesn't negatively affect performance anymore.

fixes #12700 
