### PR TITLE
Switch to isolated modules in TypeScript

### DIFF
--- a/bokehjs/examples/tsconfig.json
+++ b/bokehjs/examples/tsconfig.json
@@ -23,6 +23,7 @@
     "experimentalDecorators": true,
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/bokehjs/make/tsconfig.json
+++ b/bokehjs/make/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -199,7 +199,7 @@ export async function init(base_dir: Path, _bokehjs_dir: Path, base_setup: InitO
     write_json(paths.tsconfig, tsconfig_json)
   }
 
-  write(paths.index, "")
+  write(paths.index, "export {}")
   print(`Created empty ${cyan("index.ts")}. This is the entry point of your extension.`)
 
   const rel = relative(process.cwd(), base_dir)

--- a/bokehjs/src/compiler/tsconfig.ext.json
+++ b/bokehjs/src/compiler/tsconfig.ext.json
@@ -22,6 +22,7 @@
     "experimentalDecorators": true,
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/bokehjs/src/compiler/tsconfig.json
+++ b/bokehjs/src/compiler/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -3,7 +3,7 @@ import {entries} from "./util/object"
 import {BBox} from "./util/bbox"
 import {Size, Box, Extents} from "./types"
 
-export {CSSStyles, CSSStylesNative, CSSOurStyles} from "./css"
+export type {CSSStyles, CSSStylesNative, CSSOurStyles} from "./css"
 
 export type HTMLAttrs = {[name: string]: unknown}
 export type HTMLItem = string | Node | NodeList | HTMLCollection | null | undefined

--- a/bokehjs/src/lib/core/layout/index.ts
+++ b/bokehjs/src/lib/core/layout/index.ts
@@ -1,4 +1,5 @@
-export {Size, Sizeable, Margin, SizingPolicy, Sizing, BoxSizing, SizeHint, Percent} from "./types"
+export type {Size, Margin, Sizing, BoxSizing, SizeHint, Percent} from "./types"
+export {Sizeable, SizingPolicy} from "./types"
 export {Layoutable, ContentLayoutable} from "./layoutable"
 export {HStack, VStack} from "./alignments"
 export {Grid, Row, Column} from "./grid"

--- a/bokehjs/src/lib/core/layout/types.ts
+++ b/bokehjs/src/lib/core/layout/types.ts
@@ -2,7 +2,7 @@ import {Align} from "../enums"
 import {Enum} from "../kinds"
 
 import {Size, Extents} from "../types"
-export {Size}
+export {type Size}
 
 import {LRTB} from "../util/bbox"
 

--- a/bokehjs/src/lib/core/serialization/index.ts
+++ b/bokehjs/src/lib/core/serialization/index.ts
@@ -1,3 +1,3 @@
-export {Serializer, SerializationError, Serializable, serialize} from "./serializer"
+export {Serializer, SerializationError, type Serializable, serialize} from "./serializer"
 export {Buffer, Base64Buffer} from "./buffer"
 export * from "./reps"

--- a/bokehjs/src/lib/core/visuals/index.ts
+++ b/bokehjs/src/lib/core/visuals/index.ts
@@ -14,7 +14,7 @@ import {View} from "../view"
 import * as mixins from "../property_mixins"
 
 import {VisualProperties, VisualUniforms, Renderable} from "./visual"
-export {VisualProperties, VisualUniforms, Renderable}
+export {VisualProperties, VisualUniforms, type Renderable}
 
 export class Visuals {
   *[Symbol.iterator](): Generator<VisualProperties | VisualUniforms, void, undefined> {

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -12,7 +12,7 @@ import {add_document_standalone} from "./standalone"
 import {add_document_from_session, _get_ws_url} from "./server"
 import {_resolve_element, _resolve_root_elements, EmbedTarget} from "./dom"
 
-export {DocsJson, RenderItem, Roots} from "./json"
+export type {DocsJson, RenderItem, Roots} from "./json"
 export {add_document_standalone, index} from "./standalone"
 export {add_document_from_session} from "./server"
 export {embed_items_notebook, kernels} from "./notebook"

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -15,7 +15,7 @@ import {CanvasLayer} from "core/util/canvas"
 import {unreachable} from "core/util/assert"
 import {SerializableState} from "core/view"
 
-export {DOMBoxSizing}
+export {type DOMBoxSizing}
 
 export type CSSSizeKeyword = "auto" | "min-content" | "fit-content" | "max-content"
 

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -8,7 +8,7 @@ import * as p from "core/properties"
 import {GestureTool, GestureToolView} from "./gesture_tool"
 import {tool_icon_range} from "styles/icons.css"
 
-export const enum Side { None, Left, Right, LeftRight, Bottom, Top, BottomTop, LeftRightBottomTop }
+export enum Side { None, Left, Right, LeftRight, Bottom, Top, BottomTop, LeftRightBottomTop }
 
 export function flip_side(side: Side): Side {
   switch (side) {

--- a/bokehjs/src/lib/tsconfig.json
+++ b/bokehjs/src/lib/tsconfig.json
@@ -22,6 +22,7 @@
     "experimentalDecorators": true,
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bokehjs/src/server/tsconfig.json
+++ b/bokehjs/src/server/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bokehjs/test/codebase/tsconfig.json
+++ b/bokehjs/test/codebase/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bokehjs/test/defaults/tsconfig.json
+++ b/bokehjs/test/defaults/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bokehjs/test/devtools/tsconfig.json
+++ b/bokehjs/test/devtools/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bokehjs/test/integration/tsconfig.json
+++ b/bokehjs/test/integration/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/bokehjs/test/unit/core/property_mixins.ts
+++ b/bokehjs/test/unit/core/property_mixins.ts
@@ -1,2 +1,0 @@
-describe("property_mixins module", () => {
-})

--- a/bokehjs/test/unit/tsconfig.json
+++ b/bokehjs/test/unit/tsconfig.json
@@ -23,6 +23,7 @@
     "jsxFactory": "DOM.createSVGElement",
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/examples/advanced/extensions/gears/tsconfig.json
+++ b/examples/advanced/extensions/gears/tsconfig.json
@@ -22,6 +22,7 @@
     "experimentalDecorators": true,
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/tests/unit/bokeh/embed/ext_package_no_main/tsconfig.json
+++ b/tests/unit/bokeh/embed/ext_package_no_main/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "target": "ES2017",

--- a/tests/unit/bokeh/embed/latex_label/tsconfig.json
+++ b/tests/unit/bokeh/embed/latex_label/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true,
     "module": "ES2020",
     "moduleResolution": "node",
+    "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "target": "ES2017",

--- a/tests/unit/bokeh/test_ext.py
+++ b/tests/unit/bokeh/test_ext.py
@@ -35,7 +35,7 @@ def test_ext_commands(tmpdir) -> None:
 
     assert _names(tmp) == []
 
-    assert ext.init(tmp, bokehjs_version="2.4.0") is True
+    assert ext.init(tmp, bokehjs_version="3.0.0") is True
     assert _names(tmp) == [
         "bokeh.ext.json",
         "index.ts",


### PR DESCRIPTION
This is usually a requirement in modern JS bundlers like parcel, to have `isolatedModules` option enabled in `tsconfig` files. It doesn't change much otherwise, except that type re-exports have to by explicitly marked (trivial fix) and that one cannot use `const enums` anymore (we use them in one place, but it can be replaced with regular enums, and will be removed in PR #12468 anyway). This PR is first step out of many to simplify, modernize and speed up bokehjs' build. I don't have a concrete plan yet on exactly what tools I would like to use and what specific direction to follow.