### PR TITLE
Rename `select_every_mousemove` to `continuous`

### DIFF
--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -45,7 +45,7 @@ export class BoxSelectToolView extends SelectToolView {
     const [[left, right], [top, bottom]] = [sxlim, sylim]
     this.model.overlay.update({left, right, top, bottom})
 
-    if (this.model.select_every_mousemove) {
+    if (this.model.continuous) {
       this._do_select(sxlim, sylim, false, this._select_mode(ev))
     }
   }
@@ -94,7 +94,7 @@ export namespace BoxSelectTool {
 
   export type Props = SelectTool.Props & {
     dimensions: p.Property<Dimensions>
-    select_every_mousemove: p.Property<boolean>
+    continuous: p.Property<boolean>
     overlay: p.Property<BoxAnnotation>
     origin: p.Property<BoxOrigin>
   }
@@ -114,10 +114,10 @@ export class BoxSelectTool extends SelectTool {
     this.prototype.default_view = BoxSelectToolView
 
     this.define<BoxSelectTool.Props>(({Boolean, Ref}) => ({
-      dimensions:             [ Dimensions, "both" ],
-      select_every_mousemove: [ Boolean, false ],
-      overlay:                [ Ref(BoxAnnotation), DEFAULT_BOX_OVERLAY ],
-      origin:                 [ BoxOrigin, "corner" ],
+      dimensions: [ Dimensions, "both" ],
+      continuous: [ Boolean, false ],
+      overlay:    [ Ref(BoxAnnotation), DEFAULT_BOX_OVERLAY ],
+      origin:     [ BoxOrigin, "corner" ],
     }))
 
     this.register_alias("box_select", () => new BoxSelectTool())

--- a/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
@@ -43,7 +43,7 @@ export class LassoSelectToolView extends SelectToolView {
     const [sx, sy] = this.plot_view.frame.bbox.clip(ev.sx, ev.sy)
     this._append_overlay(sx, sy)
 
-    if (this.model.select_every_mousemove) {
+    if (this.model.continuous) {
       this._do_select(this.sxs, this.sys, false, this._select_mode(ev))
     }
   }
@@ -78,7 +78,7 @@ export namespace LassoSelectTool {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = SelectTool.Props & {
-    select_every_mousemove: p.Property<boolean>
+    continuous: p.Property<boolean>
     overlay: p.Property<PolyAnnotation>
     /** internal */
     persistent: p.Property<boolean>
@@ -99,8 +99,8 @@ export class LassoSelectTool extends SelectTool {
     this.prototype.default_view = LassoSelectToolView
 
     this.define<LassoSelectTool.Props>(({Boolean, Ref}) => ({
-      select_every_mousemove: [ Boolean, true ],
-      overlay:                [ Ref(PolyAnnotation), DEFAULT_POLY_OVERLAY ],
+      continuous: [ Boolean, true ],
+      overlay: [ Ref(PolyAnnotation), DEFAULT_POLY_OVERLAY ],
     }))
 
     this.internal<LassoSelectTool.Props>(({Boolean}) => ({

--- a/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
@@ -55,7 +55,7 @@ export class PolySelectToolView extends SelectToolView {
 
     this.model.overlay.update({xs: this.sxs, ys: this.sys})
 
-    if (this.model.select_every_mousemove) {
+    if (this.model.continuous) {
       this._do_select(this.sxs, this.sys, true, this._select_mode(ev))
     }
   }
@@ -86,7 +86,7 @@ export namespace PolySelectTool {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = SelectTool.Props & {
-    select_every_mousemove: p.Property<boolean>
+    continuous: p.Property<boolean>
     overlay: p.Property<PolyAnnotation>
   }
 }
@@ -105,7 +105,7 @@ export class PolySelectTool extends SelectTool {
     this.prototype.default_view = PolySelectToolView
 
     this.define<PolySelectTool.Props>(({Boolean, Ref}) => ({
-      select_every_mousemove: [ Boolean, false ],
+      continuous: [ Boolean, false ],
       overlay: [ Ref(PolyAnnotation), DEFAULT_POLY_OVERLAY ],
     }))
 

--- a/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
@@ -54,6 +54,10 @@ export class PolySelectToolView extends SelectToolView {
     this.sys.push(sy)
 
     this.model.overlay.update({xs: this.sxs, ys: this.sys})
+
+    if (this.model.select_every_mousemove) {
+      this._do_select(this.sxs, this.sys, true, this._select_mode(ev))
+    }
   }
 
   _do_select(sx: number[], sy: number[], final: boolean, mode: SelectionMode): void {
@@ -82,6 +86,7 @@ export namespace PolySelectTool {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = SelectTool.Props & {
+    select_every_mousemove: p.Property<boolean>
     overlay: p.Property<PolyAnnotation>
   }
 }
@@ -99,7 +104,8 @@ export class PolySelectTool extends SelectTool {
   static {
     this.prototype.default_view = PolySelectToolView
 
-    this.define<PolySelectTool.Props>(({Ref}) => ({
+    this.define<PolySelectTool.Props>(({Boolean, Ref}) => ({
+      select_every_mousemove: [ Boolean, false ],
       overlay: [ Ref(PolyAnnotation), DEFAULT_POLY_OVERLAY ],
     }))
 

--- a/docs/bokeh/source/docs/releases/3.1.0.rst
+++ b/docs/bokeh/source/docs/releases/3.1.0.rst
@@ -3,9 +3,10 @@
 3.1.0
 =====
 
-Bokeh Version ``3.1.0`` () is a minor milestone of Bokeh project.
+Bokeh Version ``3.1.0`` (?? Jan 2023) is a minor milestone of Bokeh project.
 
 Changes
 -------
 
 * Official support for Python 3.11 was added
+* ``select_every_mousemove`` was deprecated and renamed to ``continuous``

--- a/examples/plotting/scatter_selection.py
+++ b/examples/plotting/scatter_selection.py
@@ -34,7 +34,7 @@ p1.circle(x, y, color="navy", size=6, alpha=0.6)
 
 p2 = figure(title="selection on mousemove", **opts)
 p2.square(x, y, color="olive", size=6, alpha=0.6)
-p2.select_one(BoxSelectTool).select_every_mousemove = True
+p2.select_one(BoxSelectTool).continuous = True
 
 p3 = figure(title="default highlight", **opts)
 p3.circle(x, y, color="firebrick", alpha=0.5, size=6)

--- a/examples/server/app/selection_histogram.py
+++ b/examples/server/app/selection_histogram.py
@@ -37,8 +37,8 @@ p = figure(tools=TOOLS, width=600, height=600, min_border=10, min_border_left=50
            toolbar_location="above", x_axis_location=None, y_axis_location=None,
            title="Linked Histograms")
 p.background_fill_color = "#fafafa"
-p.select(BoxSelectTool).select_every_mousemove = False
-p.select(LassoSelectTool).select_every_mousemove = False
+p.select(BoxSelectTool).continuous = False
+p.select(LassoSelectTool).continuous = False
 
 r = p.scatter(x, y, size=3, color="#3A5785", alpha=0.6)
 

--- a/src/bokeh/core/properties.py
+++ b/src/bokeh/core/properties.py
@@ -220,6 +220,7 @@ __all__ = (
     'DataSpec',
     'Date',
     'Datetime',
+    'DeprecatedAlias',
     'Dict',
     'DistanceSpec',
     'Either',
@@ -296,7 +297,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-from .property.alias import Alias
+from .property.alias import Alias, DeprecatedAlias
 
 from .property.aliases import CoordinateLike
 

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -169,6 +169,9 @@ class AliasPropertyDescriptor(Generic[T]):
     def has_unstable_default(self, obj: HasProps) -> bool:
         return obj.lookup(self.aliased_name).has_unstable_default(obj)
 
+    def class_default(self, cls: Type[HasProps], *, no_eval: bool = False):
+        return cls.lookup(self.aliased_name).class_default(cls, no_eval=no_eval)
+
 class PropertyDescriptor(Generic[T]):
     """ A base class for Bokeh properties with simple get/set and serialization
     behavior.

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -155,7 +155,7 @@ class AliasPropertyDescriptor(Generic[T]):
         self.name = name
         self.alias = alias
         self.property = alias
-        self.__doc__ = f"This is a compatibility alias for the '{self.aliased_name}' property."
+        self.__doc__ = f"This is a compatibility alias for the {self.aliased_name!r} property."
 
     def __get__(self, obj: HasProps | None, owner: type[HasProps] | None) -> T:
         if obj is not None:
@@ -192,11 +192,11 @@ class DeprecatedAliasPropertyDescriptor(AliasPropertyDescriptor[T]):
         major, minor, patch = self.alias.since
         since = f"{major}.{minor}.{patch}"
         self.__doc__ = f"""\
-This is a backwards compatibility alias for the '{self.aliased_name}' property.
+This is a backwards compatibility alias for the {self.aliased_name!r} property.
 
 .. note::
-    Property '{self.name}' was deprecated in bokeh {since} and will be removed
-    at some point. Update your code to use '{self.aliased_name}' instead.
+    Property {self.name!r} was deprecated in Bokeh {since} and will be removed
+    in the future. Update your code to use {self.aliased_name!r} instead.
 """
 
     def _warn(self) -> None:

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -101,6 +101,7 @@ from typing import (
 )
 
 # Bokeh imports
+from ...util.deprecation import deprecated
 from .singletons import Undefined
 from .wrappers import PropertyValueColumnData, PropertyValueContainer
 
@@ -109,6 +110,7 @@ if TYPE_CHECKING:
 
     from ...document.events import DocumentPatchedEvent
     from ..has_props import HasProps, Setter
+    from .alias import Alias, DeprecatedAlias
     from .bases import Property
 
 #-----------------------------------------------------------------------------
@@ -119,6 +121,7 @@ __all__ = (
     'AliasPropertyDescriptor',
     'ColumnDataPropertyDescriptor',
     'DataSpecPropertyDescriptor',
+    'DeprecatedAliasPropertyDescriptor',
     'PropertyDescriptor',
     'UnitsSpecPropertyDescriptor',
     'UnsetValueError',
@@ -144,11 +147,15 @@ class AliasPropertyDescriptor(Generic[T]):
 
     serialized: bool = False
 
-    def __init__(self, name: str, aliased_name: str, property: Property[T]) -> None:
+    @property
+    def aliased_name(self) -> str:
+        return self.alias.aliased_name
+
+    def __init__(self, name: str, alias: Alias[T]) -> None:
         self.name = name
-        self.aliased_name = aliased_name
-        self.property = property
-        self.__doc__ = f"This is a compatibility alias for the ``{aliased_name}`` property"
+        self.alias = alias
+        self.property = alias
+        self.__doc__ = f"This is a compatibility alias for the '{self.aliased_name}' property."
 
     def __get__(self, obj: HasProps | None, owner: type[HasProps] | None) -> T:
         if obj is not None:
@@ -164,13 +171,47 @@ class AliasPropertyDescriptor(Generic[T]):
 
     @property
     def readonly(self) -> bool:
-        return self.property.readonly
+        return self.alias.readonly
 
     def has_unstable_default(self, obj: HasProps) -> bool:
         return obj.lookup(self.aliased_name).has_unstable_default(obj)
 
-    def class_default(self, cls: Type[HasProps], *, no_eval: bool = False):
+    def class_default(self, cls: type[HasProps], *, no_eval: bool = False):
         return cls.lookup(self.aliased_name).class_default(cls, no_eval=no_eval)
+
+class DeprecatedAliasPropertyDescriptor(AliasPropertyDescriptor[T]):
+    """
+
+    """
+
+    alias: DeprecatedAlias[T]
+
+    def __init__(self, name: str, alias: DeprecatedAlias[T]) -> None:
+        super().__init__(name, alias)
+
+        major, minor, patch = self.alias.since
+        since = f"{major}.{minor}.{patch}"
+        self.__doc__ = f"""\
+This is a backwards compatibility alias for the '{self.aliased_name}' property.
+
+.. note::
+    Property '{self.name}' was deprecated in bokeh {since} and will be removed
+    at some point. Update your code to use '{self.aliased_name}' instead.
+"""
+
+    def _warn(self) -> None:
+        deprecated(self.alias.since, self.name, self.aliased_name, self.alias.extra)
+
+    def __get__(self, obj: HasProps | None, owner: type[HasProps] | None) -> T:
+        if obj is not None:
+            # Warn only when accesing descriptor's value, otherwise there would
+            # be a lot of spurious warnings from parameter resolution, etc.
+            self._warn()
+        return super().__get__(obj, owner)
+
+    def __set__(self, obj: HasProps | None, value: T) -> None:
+        self._warn()
+        super().__set__(obj, value)
 
 class PropertyDescriptor(Generic[T]):
     """ A base class for Bokeh properties with simple get/set and serialization

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -296,6 +296,21 @@ class SelectTool(GestureTool):
     """)
 
 @abstract
+class RegionSelectTool(SelectTool):
+    ''' Base class for region selection tools (e.g. box, polygon, lasso).
+
+    '''
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    select_every_mousemove = Bool(False, help="""
+    Whether a selection computation should happen continuously during selection
+    gestures, or only once when the selection region is completed.
+    """)
+
+@abstract
 class InspectTool(GestureTool):
     ''' A base class for tools that perform "inspections", e.g. ``HoverTool``.
 
@@ -870,7 +885,7 @@ class ZoomOutTool(PlotActionTool):
     that causes overall focus or aspect ratio to change.
     """)
 
-class BoxSelectTool(Drag, SelectTool):
+class BoxSelectTool(Drag, RegionSelectTool):
     ''' *toolbar icon*: |box_select_icon|
 
     The box selection tool allows users to make selections on a Plot by showing
@@ -890,11 +905,6 @@ class BoxSelectTool(Drag, SelectTool):
     # explicit __init__ to support Init signatures
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-
-    select_every_mousemove = Bool(False, help="""
-    Whether a selection computation should happen on every mouse event, or only
-    once, when the selection region is completed. Default: False
-    """)
 
     dimensions = Enum(Dimensions, default="both", help="""
     Which dimensions the box selection is to be free in. By default, users may
@@ -928,7 +938,7 @@ DEFAULT_POLY_OVERLAY = InstanceDefault(PolyAnnotation,
     line_dash=[4, 4]
 )
 
-class LassoSelectTool(Drag, SelectTool):
+class LassoSelectTool(Drag, RegionSelectTool):
     ''' *toolbar icon*: |lasso_select_icon|
 
     The lasso selection tool allows users to make selections on a Plot by
@@ -955,16 +965,13 @@ class LassoSelectTool(Drag, SelectTool):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    select_every_mousemove = Bool(True, help="""
-    Whether a selection computation should happen on every mouse event, or only
-    once, when the selection region is completed.
-    """)
-
     overlay = Instance(PolyAnnotation, default=DEFAULT_POLY_OVERLAY, help="""
     A shaded annotation drawn to indicate the selection region.
     """)
 
-class PolySelectTool(Tap, SelectTool):
+    select_every_mousemove = Override(default=True)
+
+class PolySelectTool(Tap, RegionSelectTool):
     ''' *toolbar icon*: |poly_select_icon|
 
     The polygon selection tool allows users to make selections on a

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -56,7 +56,6 @@ from ..core.enums import (
 )
 from ..core.has_props import abstract
 from ..core.properties import (
-    Alias,
     Alpha,
     AnyRef,
     Auto,
@@ -64,6 +63,7 @@ from ..core.properties import (
     Color,
     Date,
     Datetime,
+    DeprecatedAlias,
     Dict,
     Either,
     Enum,
@@ -311,7 +311,7 @@ class RegionSelectTool(SelectTool):
     gestures, or only once when the selection region is completed.
     """)
 
-    select_every_mousemove = Alias("continuous")
+    select_every_mousemove = DeprecatedAlias("continuous", since=(3, 1, 0))
 
 @abstract
 class InspectTool(GestureTool):

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -56,6 +56,7 @@ from ..core.enums import (
 )
 from ..core.has_props import abstract
 from ..core.properties import (
+    Alias,
     Alpha,
     AnyRef,
     Auto,
@@ -305,10 +306,12 @@ class RegionSelectTool(SelectTool):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    select_every_mousemove = Bool(False, help="""
+    continuous = Bool(False, help="""
     Whether a selection computation should happen continuously during selection
     gestures, or only once when the selection region is completed.
     """)
+
+    select_every_mousemove = Alias("continuous")
 
 @abstract
 class InspectTool(GestureTool):
@@ -969,7 +972,7 @@ class LassoSelectTool(Drag, RegionSelectTool):
     A shaded annotation drawn to indicate the selection region.
     """)
 
-    select_every_mousemove = Override(default=True)
+    continuous = Override(default=True)
 
 class PolySelectTool(Tap, RegionSelectTool):
     ''' *toolbar icon*: |poly_select_icon|

--- a/src/bokeh/util/deprecation.py
+++ b/src/bokeh/util/deprecation.py
@@ -61,7 +61,7 @@ def deprecated(since_or_msg: Version | str,
 
         major, minor, patch = since_or_msg
         since = f"{major}.{minor}.{patch}"
-        message = f"{old} was deprecated in Bokeh {since} and will be removed, use {new} instead."
+        message = f"{old!r} was deprecated in Bokeh {since} and will be removed, use {new!r} instead."
         if extra is not None:
             message += " " + extra.strip()
     else:

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -5024,6 +5024,10 @@
     renderers: "auto",
     mode: "replace",
   },
+  RegionSelectTool: {
+    __extends__: "SelectTool",
+    select_every_mousemove: false,
+  },
   InspectTool: {
     __extends__: "GestureTool",
     toggleable: true,
@@ -5152,9 +5156,8 @@
   BoxSelectTool: {
     __extends__: [
       "Drag",
-      "SelectTool",
+      "RegionSelectTool",
     ],
-    select_every_mousemove: false,
     dimensions: "both",
     overlay: {
       type: "object",
@@ -5183,7 +5186,7 @@
   LassoSelectTool: {
     __extends__: [
       "Drag",
-      "SelectTool",
+      "RegionSelectTool",
     ],
     select_every_mousemove: true,
     overlay: {
@@ -5212,7 +5215,7 @@
   PolySelectTool: {
     __extends__: [
       "Tap",
-      "SelectTool",
+      "RegionSelectTool",
     ],
     overlay: {
       type: "object",

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -5026,7 +5026,7 @@
   },
   RegionSelectTool: {
     __extends__: "SelectTool",
-    select_every_mousemove: false,
+    continuous: false,
   },
   InspectTool: {
     __extends__: "GestureTool",
@@ -5188,7 +5188,7 @@
       "Drag",
       "RegionSelectTool",
     ],
-    select_every_mousemove: true,
+    continuous: true,
     overlay: {
       type: "object",
       name: "PolyAnnotation",

--- a/tests/unit/bokeh/core/property/test_alias.py
+++ b/tests/unit/bokeh/core/property/test_alias.py
@@ -28,6 +28,7 @@ import bokeh.core.property.alias as bcpa # isort:skip
 
 ALL = (
     "Alias",
+    "DeprecatedAlias",
 )
 
 #-----------------------------------------------------------------------------
@@ -38,6 +39,13 @@ class Test_Alias:
     def test_create_default(self) -> None:
         alias = bcpa.Alias("width", help="Object's width")
         assert alias.aliased_name == "width"
+        assert alias.help == "Object's width"
+
+class Test_DeprecatedAlias:
+    def test_create_default(self) -> None:
+        alias = bcpa.DeprecatedAlias("width", since=(3, 1, 0), help="Object's width")
+        assert alias.aliased_name == "width"
+        assert alias.since == (3, 1, 0)
         assert alias.help == "Object's width"
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -21,8 +21,15 @@ import typing as tp
 from unittest.mock import MagicMock, patch
 
 # Bokeh imports
-from bokeh.core.properties import Int, List, Nullable
+from bokeh.core.properties import (
+    Alias,
+    DeprecatedAlias,
+    Int,
+    List,
+    Nullable,
+)
 from bokeh.model import Model
+from bokeh.util.warnings import BokehDeprecationWarning
 from tests.support.util.api import verify_all
 
 # Module under test
@@ -36,6 +43,7 @@ ALL = (
     'AliasPropertyDescriptor',
     'ColumnDataPropertyDescriptor',
     'DataSpecPropertyDescriptor',
+    'DeprecatedAliasPropertyDescriptor',
     'PropertyDescriptor',
     'UnitsSpecPropertyDescriptor',
     'UnsetValueError',
@@ -259,17 +267,71 @@ class Test_UnitSpecDescriptor:
         assert d.__doc__ == f.__doc__
         assert d.units_prop == g
 
-class Test_AliasSpecDescriptor:
+class Test_AliasDescriptor:
     def test___init__(self) -> None:
-        class Foo:
-            '''doc'''
-            pass
-        f = Foo()
-        d = bcpd.AliasPropertyDescriptor("foo", "bar", f)
+        f = Alias("bar")
+        d = bcpd.AliasPropertyDescriptor("foo", f)
         assert d.name == "foo"
         assert d.aliased_name == "bar"
         assert d.property == f
-        assert d.__doc__ == "This is a compatibility alias for the ``bar`` property"
+        assert d.__doc__ == "This is a compatibility alias for the 'bar' property."
+
+    def test_values(self) -> None:
+        class Some(Model):
+            p0 = Int(default=17)
+            p1 = Alias("p0")
+
+        obj = Some()
+
+        assert obj.p0 == 17
+        assert obj.p1 == 17
+
+        obj.p0 = 18
+        assert obj.p0 == 18
+        assert obj.p1 == 18
+
+        obj.p1 = 19
+        assert obj.p0 == 19
+        assert obj.p1 == 19
+
+class Test_DeprecatedAliasDescriptor:
+    def test___init__(self) -> None:
+        f = DeprecatedAlias("bar", since=(3, 1, 0))
+        d = bcpd.DeprecatedAliasPropertyDescriptor("foo", f)
+        assert d.name == "foo"
+        assert d.aliased_name == "bar"
+        assert d.property == f
+        assert d.__doc__ == """\
+This is a backwards compatibility alias for the 'bar' property.
+
+.. note::
+    Property 'foo' was deprecated in bokeh 3.1.0 and will be removed
+    at some point. Update your code to use 'bar' instead.
+"""
+
+    @patch("warnings.warn")
+    def test_warns(self, mock_warn: MagicMock) -> None:
+        class Some(Model):
+            p0 = Int(default=17)
+            p1 = DeprecatedAlias("p0", since=(3, 1, 0))
+
+        obj = Some()
+
+        assert obj.p0 == 17
+        assert not mock_warn.called
+
+        assert obj.p1 == 17
+        assert mock_warn.called
+        assert mock_warn.call_args[0] == ("p1 was deprecated in Bokeh 3.1.0 and will be removed, use p0 instead.", BokehDeprecationWarning)
+        mock_warn.reset_mock()
+
+        obj.p0 = 18
+        assert not mock_warn.called
+
+        obj.p1 = 19
+        assert mock_warn.called
+        assert mock_warn.call_args[0] == ("p1 was deprecated in Bokeh 3.1.0 and will be removed, use p0 instead.", BokehDeprecationWarning)
+        mock_warn.reset_mock()
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/core/property/test_descriptors.py
+++ b/tests/unit/bokeh/core/property/test_descriptors.py
@@ -18,7 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 import typing as tp
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 # Bokeh imports
 from bokeh.core.properties import (
@@ -305,8 +305,8 @@ class Test_DeprecatedAliasDescriptor:
 This is a backwards compatibility alias for the 'bar' property.
 
 .. note::
-    Property 'foo' was deprecated in bokeh 3.1.0 and will be removed
-    at some point. Update your code to use 'bar' instead.
+    Property 'foo' was deprecated in Bokeh 3.1.0 and will be removed
+    in the future. Update your code to use 'bar' instead.
 """
 
     @patch("warnings.warn")
@@ -321,16 +321,22 @@ This is a backwards compatibility alias for the 'bar' property.
         assert not mock_warn.called
 
         assert obj.p1 == 17
-        assert mock_warn.called
-        assert mock_warn.call_args[0] == ("p1 was deprecated in Bokeh 3.1.0 and will be removed, use p0 instead.", BokehDeprecationWarning)
+        mock_warn.assert_called_once_with(
+            "'p1' was deprecated in Bokeh 3.1.0 and will be removed, use 'p0' instead.",
+            BokehDeprecationWarning,
+            stacklevel=ANY,
+        )
         mock_warn.reset_mock()
 
         obj.p0 = 18
         assert not mock_warn.called
 
         obj.p1 = 19
-        assert mock_warn.called
-        assert mock_warn.call_args[0] == ("p1 was deprecated in Bokeh 3.1.0 and will be removed, use p0 instead.", BokehDeprecationWarning)
+        mock_warn.assert_called_once_with(
+            "'p1' was deprecated in Bokeh 3.1.0 and will be removed, use 'p0' instead.",
+            BokehDeprecationWarning,
+            stacklevel=ANY,
+        )
         mock_warn.reset_mock()
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -70,6 +70,7 @@ ALL = (
     'DataSpec',
     'Date',
     'Datetime',
+    'DeprecatedAlias',
     'Dict',
     'DistanceSpec',
     'Either',

--- a/tests/unit/bokeh/util/test_deprecation.py
+++ b/tests/unit/bokeh/util/test_deprecation.py
@@ -35,9 +35,7 @@ def foo(): pass
 @patch('warnings.warn')
 def test_message(mock_warn: MagicMock) -> None:
     dep.deprecated('test')
-    assert mock_warn.called
-    assert mock_warn.call_args[0] == ("test", dep.BokehDeprecationWarning)
-    assert mock_warn.call_args[1] == {'stacklevel': 3}
+    mock_warn.assert_called_once_with("test", dep.BokehDeprecationWarning, stacklevel=3)
 
 def test_message_no_extra_args() -> None:
     with pytest.raises(ValueError):
@@ -71,17 +69,21 @@ def test_since_bad_tuple() -> None:
 
 @patch('warnings.warn')
 def test_since(mock_warn: MagicMock) -> None:
-    dep.deprecated((1,2,3), old="foo", new="bar")
-    assert mock_warn.called
-    assert mock_warn.call_args[0] == ("foo was deprecated in Bokeh 1.2.3 and will be removed, use bar instead.", dep.BokehDeprecationWarning)
-    assert mock_warn.call_args[1] == {'stacklevel': 3}
+    dep.deprecated((1, 2, 3), old="foo", new="bar")
+    mock_warn.assert_called_once_with(
+        "'foo' was deprecated in Bokeh 1.2.3 and will be removed, use 'bar' instead.",
+        dep.BokehDeprecationWarning,
+        stacklevel=3,
+    )
 
 @patch('warnings.warn')
 def test_since_with_extra(mock_warn: MagicMock) -> None:
-    dep.deprecated((1,2,3), old="foo", new="bar", extra="baz")
-    assert mock_warn.called
-    assert mock_warn.call_args[0] == ("foo was deprecated in Bokeh 1.2.3 and will be removed, use bar instead. baz", dep.BokehDeprecationWarning)
-    assert mock_warn.call_args[1] == {'stacklevel': 3}
+    dep.deprecated((1, 2, 3), old="foo", new="bar", extra="baz")
+    mock_warn.assert_called_once_with(
+        "'foo' was deprecated in Bokeh 1.2.3 and will be removed, use 'bar' instead. baz",
+        dep.BokehDeprecationWarning,
+        stacklevel=3,
+    )
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
Renames the property, deprecates the old one and adds support for `DeprecatedAlias()` to make such deprecations easier.

fixes #12590