### PR TITLE
Upgrade `actions/{checkout,cache,...}` to `v3`

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # full history to get proper build version
       - uses: conda-incubator/setup-miniconda@v2
@@ -76,7 +76,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -184,7 +184,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -223,7 +223,7 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -292,11 +292,11 @@ jobs:
       IMAGE_TAG: bokeh/bokeh-dev:branch-3.1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download wheel package
         id: download
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: wheel-package
           path: dist/

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -22,7 +22,7 @@ jobs:
           echo "branch_name=$(echo ${{ github.ref_name }} | tr / -)" >> $GITHUB_ENV
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload artifact
         if: ${{ inputs.push_to_docker_hub }} == "Save as artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: artifact
           path: bokeh-dev.tar

--- a/.github/workflows/bokeh-docker-test.yml
+++ b/.github/workflows/bokeh-docker-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # full history to get proper build version
 
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Upload report
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: bokeh-report-docker
           path: bokeh-report-docker

--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -36,7 +36,7 @@ jobs:
           echo "Please contact @bokeh/core about conducting releases."
           exit 1
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Please contact @bokeh/core about conducting releases."
           exit 1
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload report
         if: runner.os == 'Linux' && (success() || failure())
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: bokehjs-report
           path: bokehjs-report

--- a/.github/workflows/composite/test-setup/action.yml
+++ b/.github/workflows/composite/test-setup/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Download wheel package
       id: download
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name: wheel-package
         path: dist/
@@ -39,7 +39,7 @@ runs:
 
     - name: Cache node modules
       if: ${{ inputs.source-tree == 'keep' }}
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
         key: ${{ runner.os }}-node-${{ hashFiles('bokehjs/package-lock.json') }}
@@ -51,7 +51,7 @@ runs:
 
     - name: Cache sampledata
       if: ${{ inputs.sampledata == 'cache' }}
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.bokeh/data
         key: ${{ runner.os }}-sampledata-${{ hashFiles('bokeh/util/sampledata.json') }}


### PR DESCRIPTION
This will hopefully silence all 59 warnings in CI (e.g. https://github.com/bokeh/bokeh/actions/runs/3867021644) about legacy node.js and legacy CI APIs (like `set-output` or `save-state`).
