### PR TITLE
Implement varying_alpha_palette in BokehJS

### DIFF
--- a/bokehjs/src/lib/api/palettes.ts
+++ b/bokehjs/src/lib/api/palettes.ts
@@ -1,4 +1,6 @@
+import {Color} from "core/types"
 import {linspace} from "core/util/array"
+import {color2hex, color2rgba} from "core/util/color"
 
 export const YlGn3       = [0x31a354ff, 0xaddd8eff, 0xf7fcb9ff]
 export const YlGn4       = [0x238443ff, 0x78c679ff, 0xc2e699ff, 0xffffccff]
@@ -1014,6 +1016,35 @@ export function linear_palette<T>(palette: T[], n: number): T[] {
     return linspace(0, palette.length - 1, n).map((i) => palette[i|0])
   else
     throw new Error("too many color entries requested")
+}
+
+export function varying_alpha_palette(color: Color, n: number | null = null, start_alpha: number = 0, end_alpha: number = 255): string[] {
+  if (start_alpha < 0 || start_alpha > 255)
+    throw new Error("start_alpha must be in the range 0 to 255")
+
+  if (end_alpha < 0 || end_alpha > 255)
+    throw new Error("end_alpha must be in the range 0 to 255")
+
+  const rgba = color2rgba(color)
+
+  if (rgba[3] < 255) {
+    const factor = rgba[3] / 255
+    start_alpha *= factor
+    end_alpha *= factor
+  }
+
+  // Length of returned palette
+  const npalette = (n != null && n > 0) ? n : Math.round(Math.abs(end_alpha - start_alpha)) + 1
+
+  // Convert alpha to range 0 to 1
+  const diff_alpha = (end_alpha - start_alpha) / 255
+  start_alpha /= 255
+
+  const palette = new Array<string>(npalette)
+  for (let i = 0; i < npalette; i++)
+    palette[i] = color2hex(rgba, start_alpha + diff_alpha*i / (npalette-1))
+
+  return palette
 }
 
 export function magma(n: number) {

--- a/bokehjs/test/unit/api/palettes.ts
+++ b/bokehjs/test/unit/api/palettes.ts
@@ -1,0 +1,62 @@
+import {expect} from "assertions"
+
+import {linear_palette, varying_alpha_palette} from "@bokehjs/api/palettes"
+
+describe("in api/palettes module", () => {
+  describe("linear_palette", () => {
+    const palette = ["red", "green", "blue", "black", "yellow", "magenta"]
+
+    it("should support returning empty palette", () => {
+      expect(linear_palette(palette, 0)).to.be.equal([])
+    })
+
+    it("should support returning subset of palette", () => {
+      expect(linear_palette(palette, 1)).to.be.equal(["red"])
+      expect(linear_palette(palette, 2)).to.be.equal(["red", "magenta"])
+      expect(linear_palette(palette, 3)).to.be.equal(["red", "blue", "magenta"])
+      expect(linear_palette(palette, 4)).to.be.equal(["red", "green", "black", "magenta"])
+      expect(linear_palette(palette, 5)).to.be.equal(["red", "green", "blue", "black", "magenta"])
+      expect(linear_palette(palette, 6)).to.be.equal(palette)
+    })
+
+    it("should throw error if request too many entries", () => {
+      expect(() => linear_palette(palette, 7)).to.throw(Error)
+    })
+  })
+
+  describe("varying_alpha_palette", () => {
+    // Equivalent tests to bokeh's python unit tests for this function.
+    it("should support RGB color", () => {
+      expect(varying_alpha_palette("blue", 3)).to.be.equal(["#0000ff00", "#0000ff80", "#0000ff"])
+      expect(varying_alpha_palette("red", 3, 255, 128)).to.be.equal(["#ff0000", "#ff0000c0", "#ff000080"])
+      expect(varying_alpha_palette("#123456", 3, 205, 205)).to.be.equal(["#123456cd", "#123456cd", "#123456cd"])
+      expect(varying_alpha_palette("#abc", 3)).to.be.equal(["#aabbcc00", "#aabbcc80", "#aabbcc"])
+
+      const palette = varying_alpha_palette("blue")
+      expect(palette.length).to.be.equal(256)
+      expect(palette[0]).to.be.equal("#0000ff00")
+      expect(palette[63]).to.be.equal("#0000ff3f")
+      expect(palette[127]).to.be.equal("#0000ff7f")
+      expect(palette[191]).to.be.equal("#0000ffbf")
+
+      expect(varying_alpha_palette("#654321", null, 100, 103)).to.be.equal(["#65432164", "#65432165", "#65432166", "#65432167"])
+    })
+
+    it("should raise error if bad argument", () => {
+      expect(() => varying_alpha_palette("red", null, -1)).to.throw(Error)
+      expect(() => varying_alpha_palette("red", null, 256)).to.throw(Error)
+      expect(() => varying_alpha_palette("red", null, 0, -1)).to.throw(Error)
+      expect(() => varying_alpha_palette("red", null, 0, 256)).to.throw(Error)
+    })
+
+    it("should support RGBA color", () => {
+      expect(varying_alpha_palette("#FFAA8080", 3)).to.be.equal(["#ffaa8000", "#ffaa8040", "#ffaa8080"])
+      expect(varying_alpha_palette("#80FFAA80", 3, 255, 0)).to.be.equal(["#80ffaa80", "#80ffaa40", "#80ffaa00"])
+      expect(varying_alpha_palette("#AABBCC80", 3, 128)).to.be.equal(["#aabbcc40", "#aabbcc60", "#aabbcc80"])
+      expect(varying_alpha_palette("#12345680", 3, 0, 128)).to.be.equal(["#12345600", "#12345620", "#12345640"])
+
+      expect(varying_alpha_palette("#FFAA8080").length).to.be.equal(129)
+      expect(varying_alpha_palette("#FFAA8080", null, 0, 128).length).to.be.equal(65)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a BokehJS version of the `varying_alpha_palette` function. It includes a set of tests similar to that already implemented for the Python version of the function.

The motivation is that I would like to use such palettes in BokehJS tests for new palette and color mapper functionality, and rather than create these palettes manually for those tests I thought I may as well implement the function itself.

I have also added unit tests for the BokehJS version of the `linear_palette` function at the same time.