### PR TITLE
add missing date slider to widgets page

### DIFF
--- a/docs/bokeh/source/docs/user_guide/interaction/widgets.rst
+++ b/docs/bokeh/source/docs/user_guide/interaction/widgets.rst
@@ -202,6 +202,17 @@ values, a ``step`` size in units of days, an initial ``value``, and a ``title``:
 
 More information can be found in the reference guide entry for |DateRangeSlider|.
 
+DateSlider
+~~~~~~~~~~
+
+The Bokeh date slider can be configured with ``start`` and ``end`` date
+values, a ``step`` size in units of days, an initial ``value``, and a ``title``:
+
+.. bokeh-plot:: __REPO__/examples/interaction/widgets/dateslider.py
+    :source-position: below
+
+More information can be found in the reference guide entry for |DateSlider|.
+
 DatetimeRangeSlider
 ~~~~~~~~~~~~~~~~~~~
 
@@ -486,6 +497,7 @@ More information can be found in the reference guide entry for |Toggle|.
 .. |DataTable|              replace:: :class:`~bokeh.models.widgets.tables.DataTable`
 .. |DatePicker|             replace:: :class:`~bokeh.models.widgets.inputs.DatePicker`
 .. |DateRangeSlider|        replace:: :class:`~bokeh.models.widgets.sliders.DateRangeSlider`
+.. |DateSlider|             replace:: :class:`~bokeh.models.widgets.sliders.DateSlider`
 .. |DatetimeRangeSlider|    replace:: :class:`~bokeh.models.widgets.sliders.DatetimeRangeSlider`
 .. |Div|                    replace:: :class:`~bokeh.models.widgets.markups.Div`
 .. |Dropdown|               replace:: :class:`~bokeh.models.widgets.buttons.Dropdown`

--- a/examples/interaction/widgets/dateslider.py
+++ b/examples/interaction/widgets/dateslider.py
@@ -1,0 +1,13 @@
+from datetime import date
+
+from bokeh.io import show
+from bokeh.models import CustomJS, DateSlider
+
+date_slider = DateSlider(value=date(2016, 1, 1),
+                         start=date(2015, 1, 1),
+                         end=date(2017, 12, 31))
+date_slider.js_on_change("value", CustomJS(code="""
+    console.log('date_slider: value=' + this.value, this.toString())
+"""))
+
+show(date_slider)


### PR DESCRIPTION
- [x] issues: fixes #12744
- [x] release document entry (if new feature or API change)


<img width="784" alt="Screenshot 2023-01-25 at 10 43 29" src="https://user-images.githubusercontent.com/1078448/214654837-1e079977-3d43-4ace-b2e0-7c93a00dca09.png">
