### PR TITLE
add construct_color_bar for glyphs

### DIFF
--- a/docs/bokeh/source/docs/user_guide/basic/annotations.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/annotations.rst
@@ -215,8 +215,20 @@ See |interactive legends| in the user guide for more information and examples.
 Color bars
 ----------
 
-To create a |ColorBar|, use an instance of |ColorMapper| containing a color
-palette.
+To create a |ColorBar|, you can pass an instance of |ColorMapper| containing
+a color palette, for example:
+
+.. code:: python
+
+    color_bar = ColorBar(color_mapper=color_mapper, padding=5)
+
+However, for many glyphs, you can call ``construct_color_bar`` on the renderer
+returned by the glyph method to create a color bar automatically, if the glyph
+already has a color mapping configured:
+
+.. code:: python
+
+    color_bar = r.construct_color_bar(padding=5)
 
 Color bars can be located inside as well as left, right, below, or above the
 plot. Specify the location of a color bar when adding the |ColorBar| object to

--- a/examples/basic/annotations/colorbar_log.py
+++ b/examples/basic/annotations/colorbar_log.py
@@ -8,7 +8,7 @@
 '''
 import numpy as np
 
-from bokeh.models import ColorBar, LogColorMapper
+from bokeh.models import LogColorMapper
 from bokeh.plotting import figure, show
 
 
@@ -23,10 +23,10 @@ image = Z * 1e6
 color_mapper = LogColorMapper(palette="Viridis256", low=1, high=1e7)
 
 plot = figure(x_range=(0,1), y_range=(0,1), toolbar_location=None)
-plot.image(image=[image], color_mapper=color_mapper,
-           dh=1.0, dw=1.0, x=0, y=0)
+r = plot.image(image=[image], color_mapper=color_mapper,
+               dh=1.0, dw=1.0, x=0, y=0)
 
-color_bar = ColorBar(color_mapper=color_mapper)
+color_bar = r.construct_color_bar(padding=1)
 
 plot.add_layout(color_bar, "right")
 

--- a/examples/basic/data/color_mappers.py
+++ b/examples/basic/data/color_mappers.py
@@ -10,21 +10,22 @@ log mapping and linear mapping with different color palette.
 import numpy as np
 
 from bokeh.layouts import column, gridplot
-from bokeh.models import ColumnDataSource, LinearColorMapper, LogColorMapper
+from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure, show
-from bokeh.transform import transform
+from bokeh.transform import linear_cmap, log_cmap
 
 x = np.random.random(size=2000) * 1000
 y = np.random.normal(size=2000) * 2 + 5
 source = ColumnDataSource(dict(x=x, y=y))
 
-def make_plot(mapper_type, palette):
-    cls = LogColorMapper if mapper_type == "log" else LinearColorMapper
-    mapper = cls(palette=palette, low=1, high=1000)
+def make_plot(mapper, palette):
+    cmap = mapper("x", palette=palette, low=1, high=1000)
+    axis_type = mapper.__name__.split("_")[0] # linear or log
 
-    p = figure(x_range=(1, 1000), title=f"{palette} with {mapper_type} mapping",
-               toolbar_location=None, tools="", x_axis_type=mapper_type)
-    r = p.scatter('x', 'y', alpha=0.8, source=source, color=transform('x', mapper))
+    p = figure(x_range=(1, 1000), title=f"{palette} with {mapper.__name__}",
+               toolbar_location=None, tools="", x_axis_type=axis_type)
+
+    r = p.scatter('x', 'y', alpha=0.8, source=source, color=cmap)
 
     color_bar = r.construct_color_bar(padding=0,
                                       ticker=p.xaxis.ticker,
@@ -33,16 +34,16 @@ def make_plot(mapper_type, palette):
 
     return p
 
-p1 = make_plot("linear", "Viridis256")
-p2 = make_plot("log", "Viridis256")
-p3 = make_plot("linear", "Viridis6")
-p4 = make_plot("log", "Viridis6")
+p1 = make_plot(linear_cmap, "Viridis256")
+p2 = make_plot(log_cmap, "Viridis256")
+p3 = make_plot(linear_cmap, "Viridis6")
+p4 = make_plot(log_cmap, "Viridis6")
 
 p5 = figure(x_range=(1, 1000), width=800, height=300, toolbar_location=None, tools="",
-            title="Viridis256 with linear mapping, low/high = 200/800 = pink/grey")
-mapper = LinearColorMapper(palette="Viridis256", low=200, high=800,
-                           low_color="pink", high_color="darkgrey")
-p5.scatter(x='x', y='y', alpha=0.8, source=source, color=transform('x', mapper))
+            title="Viridis256 with linear_cmap, low/high = 200/800 = pink/grey")
+cmap = linear_cmap("x", palette="Viridis256", low=200, high=800,
+                   low_color="pink", high_color="darkgrey")
+p5.scatter(x='x', y='y', alpha=0.8, source=source, color=cmap)
 
 grid =  gridplot([[p1, p2], [p3, p4]], width=400, height=300, toolbar_location=None)
 show(column(grid, p5))

--- a/examples/basic/data/color_mappers.py
+++ b/examples/basic/data/color_mappers.py
@@ -10,7 +10,7 @@ log mapping and linear mapping with different color palette.
 import numpy as np
 
 from bokeh.layouts import column, gridplot
-from bokeh.models import ColorBar, ColumnDataSource, LinearColorMapper, LogColorMapper
+from bokeh.models import ColumnDataSource, LinearColorMapper, LogColorMapper
 from bokeh.plotting import figure, show
 from bokeh.transform import transform
 
@@ -24,10 +24,11 @@ def make_plot(mapper_type, palette):
 
     p = figure(x_range=(1, 1000), title=f"{palette} with {mapper_type} mapping",
                toolbar_location=None, tools="", x_axis_type=mapper_type)
-    p.scatter('x', 'y', alpha=0.8, source=source, color=transform('x', mapper))
+    r = p.scatter('x', 'y', alpha=0.8, source=source, color=transform('x', mapper))
 
-    color_bar = ColorBar(color_mapper=mapper, padding=0,
-                         ticker=p.xaxis.ticker, formatter=p.xaxis.formatter)
+    color_bar = r.construct_color_bar(padding=0,
+                                      ticker=p.xaxis.ticker,
+                                      formatter=p.xaxis.formatter)
     p.add_layout(color_bar, 'below')
 
     return p

--- a/examples/basic/data/linear_cmap_colorbar.py
+++ b/examples/basic/data/linear_cmap_colorbar.py
@@ -1,4 +1,4 @@
-from bokeh.models import ColorBar, ColumnDataSource
+from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure, show
 from bokeh.transform import linear_cmap
 
@@ -12,10 +12,10 @@ p = figure(width=300, height=300, title="Linear color map based on Y")
 # use the field name of the column source
 cmap = linear_cmap(field_name='y', palette="Spectral6", low=min(y), high=max(y))
 
-p.scatter(x='x', y='y', color=cmap, size=15, source=source)
+r = p.scatter(x='x', y='y', color=cmap, size=15, source=source)
 
-# pass the mapper's transform to the colorbar
-color_bar = ColorBar(color_mapper=cmap['transform'], width=10)
+# create a color bar from the scatter glyph renderer
+color_bar = r.construct_color_bar(width=10)
 
 p.add_layout(color_bar, 'right')
 

--- a/examples/plotting/dynamic_color_mapping.py
+++ b/examples/plotting/dynamic_color_mapping.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 from bokeh.layouts import gridplot
-from bokeh.models import ColorBar, LinearColorMapper
-from bokeh.palettes import Plasma256
+from bokeh.models import LinearColorMapper
 from bokeh.plotting import figure, show
+from bokeh.transform import transform
 
 tooltips = [("x", "$x"), ("y", "$y"), ("r", "@radius")]
 tools = "pan,box_select,box_zoom,reset"
@@ -22,30 +22,37 @@ def data_sloped():
     r = 2*(x + y)*np.linspace(0, 1, N)
     return x*100, y*100, r
 
-mapper = LinearColorMapper(palette=Plasma256, low_color="white", high_color="black")
+mapper = LinearColorMapper(palette="Plasma256", low_color="white", high_color="black")
 
 p0 = figure(width=500, height=500, tooltips=tooltips, tools=tools)
 x0, y0, r0 = data_flat(0.8)
-g0 = p0.scatter(x0, y0, radius=r0, fill_color=dict(field="radius", transform=mapper), fill_alpha=0.6, line_color=None)
+g0 = p0.scatter(x0, y0, radius=r0,
+               fill_color=transform("radius", mapper),
+               fill_alpha=0.6, line_color=None)
 mapper.domain.append((g0, "radius"))
 
 p1 = figure(width=500, height=500, tooltips=tooltips, tools=tools)
 x1, y1, r1 = data_flat(1.0)
-g1 = p1.scatter(x1, y1, radius=r1, fill_color=dict(field="radius", transform=mapper), fill_alpha=0.6, line_color=None)
+g1 = p1.scatter(x1, y1, radius=r1,
+               fill_color=transform("radius", mapper),
+               fill_alpha=0.6, line_color=None)
 mapper.domain.append((g1, "radius"))
 
 p2 = figure(width=500, height=500, tooltips=tooltips, tools=tools)
 x2, y2, r2 = data_flat(1.2)
-g2 = p2.scatter(x2, y2, radius=r2, fill_color=dict(field="radius", transform=mapper), fill_alpha=0.6, line_color=None)
+g2 = p2.scatter(x2, y2, radius=r2,
+               fill_color=transform("radius", mapper),
+               fill_alpha=0.6, line_color=None)
 mapper.domain.append((g2, "radius"))
 
 p3 = figure(width=500, height=500, tooltips=tooltips, tools=tools)
 x3, y3, r3 = data_sloped()
-g3 = p3.scatter(x3, y3, radius=r3, fill_color=dict(field="radius", transform=mapper), fill_alpha=0.6, line_color=None)
+g3 = p3.scatter(x3, y3, radius=r3,
+               fill_color=transform("radius", mapper),
+               fill_alpha=0.6, line_color=None)
 mapper.domain.append((g3, "radius"))
 
-color_bar = ColorBar(color_mapper=mapper, padding=0)
+color_bar = g3.construct_color_bar(padding=0)
 p3.add_layout(color_bar, "below")
 
-grid = gridplot([[p0, p1], [p2, p3]])
-show(grid)
+show(gridplot([[p0, p1], [p2, p3]]))

--- a/examples/topics/categorical/heatmap_unemployment.py
+++ b/examples/topics/categorical/heatmap_unemployment.py
@@ -12,9 +12,10 @@ from math import pi
 
 import pandas as pd
 
-from bokeh.models import BasicTicker, ColorBar, LinearColorMapper, PrintfTickFormatter
+from bokeh.models import BasicTicker, PrintfTickFormatter
 from bokeh.plotting import figure, show
 from bokeh.sampledata.unemployment1948 import data
+from bokeh.transform import linear_cmap
 
 data['Year'] = data['Year'].astype(str)
 data = data.set_index('Year')
@@ -22,19 +23,18 @@ data.drop('Annual', axis=1, inplace=True)
 data.columns.name = 'Month'
 
 years = list(data.index)
-months = list(data.columns)
+months = list(reversed(data.columns))
 
 # reshape to 1D array or rates with a month and year for each row.
 df = pd.DataFrame(data.stack(), columns=['rate']).reset_index()
 
 # this is the colormap from the original NYTimes plot
 colors = ["#75968f", "#a5bab7", "#c9d9d3", "#e2e2e2", "#dfccce", "#ddb7b1", "#cc7878", "#933b41", "#550b1d"]
-mapper = LinearColorMapper(palette=colors, low=df.rate.min(), high=df.rate.max())
 
 TOOLS = "hover,save,pan,box_zoom,reset,wheel_zoom"
 
 p = figure(title=f"US Unemployment ({years[0]} - {years[-1]})",
-           x_range=years, y_range=list(reversed(months)),
+           x_range=years, y_range=months,
            x_axis_location="above", width=900, height=400,
            tools=TOOLS, toolbar_location='below',
            tooltips=[('date', '@Month @Year'), ('rate', '@rate%')])
@@ -46,15 +46,17 @@ p.axis.major_label_text_font_size = "7px"
 p.axis.major_label_standoff = 0
 p.xaxis.major_label_orientation = pi / 3
 
-p.rect(x="Year", y="Month", width=1, height=1,
-       source=df,
-       fill_color={'field': 'rate', 'transform': mapper},
-       line_color=None)
+r = p.rect(x="Year", y="Month", width=1, height=1, source=df,
+           fill_color=linear_cmap("rate", colors, low=df.rate.min(), high=df.rate.max()),
+           line_color=None)
 
-color_bar = ColorBar(color_mapper=mapper, major_label_text_font_size="7px",
-                     ticker=BasicTicker(desired_num_ticks=len(colors)),
-                     formatter=PrintfTickFormatter(format="%d%%"),
-                     label_standoff=6, border_line_color=None)
-p.add_layout(color_bar, 'right')
+p.add_layout(r.construct_color_bar(
+    major_label_text_font_size="7px",
+    ticker=BasicTicker(desired_num_ticks=len(colors)),
+    formatter=PrintfTickFormatter(format="%d%%"),
+    label_standoff=6,
+    border_line_color=None,
+    padding=5
+), 'right')
 
 show(p)

--- a/examples/topics/geo/eclipse.py
+++ b/examples/topics/geo/eclipse.py
@@ -16,28 +16,24 @@ from os.path import dirname, join, realpath
 import pandas as pd
 import shapefile as shp
 
-from bokeh.models import ColorBar, ColumnDataSource, Label, LinearColorMapper
-from bokeh.palettes import TolYlOrBr5
+from bokeh.models import ColumnDataSource, Label
 from bokeh.plotting import figure, show
 from bokeh.sampledata.us_states import data
+from bokeh.transform import linear_cmap
 
 ROOT = dirname(realpath(__file__))
 
-states = pd.DataFrame.from_dict(data.copy(), orient="index")
+states = pd.DataFrame.from_dict(data, orient="index")
 states.drop(["AK", "HI"], inplace=True)
 
 trends = pd.read_csv(join(ROOT, "eclipse_data/trends.csv"))
 
-states.set_index("name", inplace=True)
-trends.set_index("Region", inplace=True)
+totality_path = shp.Reader(join(ROOT, "eclipse_data/upath17")).shapes()[0]
 
-states["trend"] = trends["solar eclipse"]
-
-upath17 = shp.Reader(join(ROOT, "eclipse_data/upath17"))
-(totality_path,) = upath17.shapes()
-
-p = figure(width=1000, height=600, background_fill_color="#333344",
-           tools="", toolbar_location=None, x_axis_location=None, y_axis_location=None)
+p = figure(
+    width=1000, height=600, background_fill_color="#333344",
+    tools="", toolbar_location=None, x_axis_location=None, y_axis_location=None
+)
 
 p.grid.grid_line_color = None
 
@@ -46,48 +42,44 @@ p.title.align = "center"
 p.title.text_font_size = "21px"
 p.title.text_color = "#333344"
 
-mapper = LinearColorMapper(palette=list(TolYlOrBr5), low=0, high=100)
-
 source = ColumnDataSource(data=dict(
-    state_xs=list(states.lons),
-    state_ys=list(states.lats),
-    trend=states.trend,
+    state_xs=states.lons,
+    state_ys=states.lats,
+    trend=trends["solar eclipse"],
 ))
-us = p.patches("state_xs", "state_ys",
-    fill_color=dict(field="trend", transform=mapper),
-    source=source,
-    line_color="#333344", line_width=1)
 
-p.x_range.renderers = [us]
-p.y_range.renderers = [us]
+us = p.patches(
+    "state_xs", "state_ys", source=source,
+    fill_color=linear_cmap("trend", palette="TolYlOrBr5", low=0, high=100),
+    line_color="#333344", line_width=1
+)
+
+p.x_range.renderers = p.y_range.renderers = [us]
 
 totality_x, totality_y = zip(*totality_path.points)
-p.patch(totality_x, totality_y,
-    fill_color="black", fill_alpha=0.7,
-    line_color=None)
+p.patch(
+    totality_x, totality_y,
+    fill_color="black", fill_alpha=0.7, line_color=None
+)
 
-path = Label(
-    x=-76.3, y=31.4,
-    angle=-36.5, angle_units="deg",
+p.add_layout(Label(
     text="Solar eclipse path of totality",
-    text_baseline="middle", text_font_size="11px", text_color="silver")
-p.add_layout(path)
+    x=-76.3, y=31.4, angle=-36.5, angle_units="deg",
+    text_baseline="middle", text_font_size="11px", text_color="silver"
+))
 
-color_bar = ColorBar(
-    color_mapper=mapper,
+p.add_layout(us.construct_color_bar(
+    title='Popularity of "solar eclipse" search term',
     location="bottom_left", orientation="horizontal",
-    title="Popularity of \"solar eclipse\" search term",
     title_text_font_size="16px", title_text_font_style="bold",
     title_text_color="lightgrey", major_label_text_color="lightgrey",
-    background_fill_alpha=0.0)
-p.add_layout(color_bar)
+    background_fill_alpha=0.0
+))
 
-notes = Label(
-    x=0, y=0, x_units="screen", y_units="screen",
-    x_offset=40, y_offset=20,
+p.add_layout(Label(
     text="Source: Google Trends, NASA Scientific Visualization Studio",
-    level="overlay",
-    text_font_size="11px", text_color="gray")
-p.add_layout(notes)
+    x=0, y=0, x_units="screen", y_units="screen", x_offset=40, y_offset=20,
+    text_font_size="11px", text_color="gray", level="overlay",
+))
 
 show(p)

--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -171,7 +171,7 @@ class GlyphRenderer(DataRenderer):
         * ``text_color.transform`` for TextGlyph
         * ``color_mapper`` for Image
 
-        In general, the function will "do th right thing" based on glyph type.
+        In general, the function will "do the right thing" based on glyph type.
         If different behavior is needed, ColorBars can be consructed by hand.
 
         Extra keyword arguments may be passed in to control ``ColorBar``

--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -172,7 +172,7 @@ class GlyphRenderer(DataRenderer):
         * ``color_mapper`` for Image
 
         In general, the function will "do the right thing" based on glyph type.
-        If different behavior is needed, ColorBars can be consructed by hand.
+        If different behavior is needed, ColorBars can be constructed by hand.
 
         Extra keyword arguments may be passed in to control ``ColorBar``
         properties such as `title`.

--- a/tests/unit/bokeh/models/test_glyph_renderer.py
+++ b/tests/unit/bokeh/models/test_glyph_renderer.py
@@ -1,0 +1,124 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2023, Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Bokeh imports
+from bokeh.models import (
+    Circle,
+    ColorBar,
+    ColumnDataSource,
+    IndexFilter,
+    Line,
+    Patch,
+)
+from bokeh.transform import linear_cmap, log_cmap
+
+# Module under test
+import bokeh.models.renderers as bmr # isort:skip
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+
+class TestGlyphRenderer:
+
+    def test_construct_color_bar_bad_visual(self):
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+
+        msg = "construct_color_bar expects 'fill' or 'line' for visual, got 'junk'"
+        with pytest.raises(ValueError, match=msg):
+            renderer.construct_color_bar("junk")
+
+    @pytest.mark.parametrize("mapper", (linear_cmap, log_cmap))
+    def test_construct_color_bar_default_good(self, mapper):
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+        renderer.glyph = Circle(fill_color=linear_cmap("foo", "Viridis256", 0, 100))
+        cb = renderer.construct_color_bar(title="Title")
+        assert isinstance(cb, ColorBar)
+        assert cb.color_mapper is renderer.glyph.fill_color.transform
+        assert cb.title == "Title"
+
+    def test_construct_color_bar_default_bad(self):
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+        renderer.glyph = Circle()
+
+        msg = "construct_color_bar expects fill_color to be a field with a colormapper transform"
+        with pytest.raises(ValueError, match=msg):
+            renderer.construct_color_bar()
+
+    @pytest.mark.parametrize("mapper", (linear_cmap, log_cmap))
+    def test_construct_color_bar_fill_good(self, mapper):
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+        renderer.glyph = Circle(fill_color=linear_cmap("foo", "Viridis256", 0, 100))
+        cb = renderer.construct_color_bar("fill", title="Title")
+        assert isinstance(cb, ColorBar)
+        assert cb.color_mapper is renderer.glyph.fill_color.transform
+        assert cb.title == "Title"
+
+    def test_construct_color_bar_fill_bad(self):
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+        renderer.glyph = Circle()
+
+        msg = "construct_color_bar expects fill_color to be a field with a colormapper transform"
+        with pytest.raises(ValueError, match=msg):
+            renderer.construct_color_bar("fill")
+
+    @pytest.mark.parametrize("mapper", (linear_cmap, log_cmap))
+    def test_construct_color_bar_line_good(self, mapper):
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+        renderer.glyph = Circle(line_color=linear_cmap("foo", "Viridis256", 0, 100))
+        cb = renderer.construct_color_bar("line", title="Title")
+        assert isinstance(cb, ColorBar)
+        assert cb.color_mapper is renderer.glyph.line_color.transform
+        assert cb.title == "Title"
+
+    def test_construct_color_bar_line_bad(self):
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+        renderer.glyph = Circle()
+
+        msg = "construct_color_bar expects line_color to be a field with a colormapper transform"
+        with pytest.raises(ValueError, match=msg):
+            renderer.construct_color_bar("line")
+
+    @pytest.mark.parametrize('glyph', (Line, Patch))
+    def test_check_cdsview_filters_with_connected_error(self, glyph) -> None:
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+        renderer.glyph = glyph()
+
+        check = renderer._check_cdsview_filters_with_connected()
+        assert check == []
+
+        renderer.view.filter = IndexFilter()
+        check = renderer._check_cdsview_filters_with_connected()
+        assert check != []
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/models/test_graph_renderer.py
+++ b/tests/unit/bokeh/models/test_graph_renderer.py
@@ -20,10 +20,7 @@ import pytest ; pytest
 from bokeh.models import (
     Circle,
     ColumnDataSource,
-    IndexFilter,
-    Line,
     MultiLine,
-    Patch,
     StaticLayoutProvider,
 )
 
@@ -37,20 +34,6 @@ import bokeh.models.renderers as bmr # isort:skip
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
-
-
-class TestGlyphRenderer:
-    @pytest.mark.parametrize('glyph', [Line, Patch])
-    def test_check_cdsview_filters_with_connected_error(self, glyph) -> None:
-        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
-        renderer.glyph = glyph()
-
-        check = renderer._check_cdsview_filters_with_connected()
-        assert check == []
-
-        renderer.view.filter = IndexFilter()
-        check = renderer._check_cdsview_filters_with_connected()
-        assert check != []
 
 
 class TestGraphRenderer:


### PR DESCRIPTION
This PR adds a `construct_color_bar` method to `GlyphRenderer` to mirror and be consistent with the one added to the contour renderer. 

@bokeh/core please have a quick glance. If there are no concerns with the proposed API, I will go on to add tests and update relevant examples and documentation. We could potentially add a little more error checking as well (currently will see bare AttributeErrors if asking for "fill" colorbar on a glyph like`Text` with no `fill_color`, but that also seems like a fairly rare corner case)

EDIT: This PR also fixes the "bad column name" validation on glyph renderers. The old code was not straightforward, had no tests, and AFAICT it has actually been completely broken for some time. I added tests for it as well. 

- [x] issues: fixes #12736
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
