### PR TITLE
Update ruff / f-string cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_stages: [push]
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.114
+    rev: v0.0.234
     hooks:
       - id: ruff
         stages: [commit]

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -72,7 +72,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs ==1.5.2.221213
-    - ruff ==0.0.144
+    - ruff ==0.0.234
     - types-boto
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -72,7 +72,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs ==1.5.2.221213
-    - ruff ==0.0.144
+    - ruff ==0.0.234
     - types-boto
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -72,7 +72,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs ==1.5.2.221213
-    - ruff ==0.0.144
+    - ruff ==0.0.234
     - types-boto
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -72,7 +72,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs ==1.5.2.221213
-    - ruff ==0.0.144
+    - ruff ==0.0.234
     - types-boto
     - types-colorama
     - types-mock

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -61,7 +61,7 @@ dependencies:
     - sphinx-design
     - sphinxext-opengraph
     # tests
-    - ruff ==0.0.144
+    - ruff ==0.0.234
     - types-boto
     - types-colorama
     - types-mock

--- a/docs/bokeh/source/docs/first_steps/examples/first_steps_5_vectorize_color.py
+++ b/docs/bokeh/source/docs/first_steps/examples/first_steps_5_vectorize_color.py
@@ -7,7 +7,7 @@ x = list(range(0, 26))
 y = random.sample(range(0, 100), 26)
 
 # generate list of rgb hex colors in relation to y
-colors = ["#%02x%02x%02x" % (255, int(round(value * 255 / 100)), 255) for value in y]
+colors = [f"#{255:02x}{int((value * 255) / 100):02x}{255:02x}" for value in y]
 
 # create new plot
 p = figure(

--- a/docs/bokeh/source/docs/first_steps/examples/first_steps_5_vectorize_color_and_size.py
+++ b/docs/bokeh/source/docs/first_steps/examples/first_steps_5_vectorize_color_and_size.py
@@ -9,7 +9,7 @@ y = np.random.random(size=N) * 100
 
 # generate radii and colors based on data
 radii = y / 100 * 2
-colors = ["#%02x%02x%02x" % (255, int(round(value * 255 / 100)), 255) for value in y]
+colors = [f"#{255:02x}{int((value * 255) / 100):02x}{255:02x}" for value in y]
 
 # create a new plot with a specific size
 p = figure(

--- a/examples/basic/axes/bounds.py
+++ b/examples/basic/axes/bounds.py
@@ -12,7 +12,7 @@ N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = ["#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50 + 2 * x, 30 + 2 * y)]
+colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50 + 2 * x, 30 + 2 * y)]
 plot_default = figure(tools='pan, box_zoom, wheel_zoom, reset',
                       title="Cannot pan outside data (bounds='auto')",
                       lod_threshold=None)

--- a/examples/basic/bars/stacked_split.py
+++ b/examples/basic/bars/stacked_split.py
@@ -26,10 +26,10 @@ p = figure(y_range=fruits, height=350, x_range=(-16, 16), title="Fruit import/ex
            toolbar_location=None)
 
 p.hbar_stack(years, y='fruits', height=0.9, color=GnBu3, source=ColumnDataSource(exports),
-             legend_label=["%s exports" % x for x in years])
+             legend_label=[f"{year} exports" for year in years])
 
 p.hbar_stack(years, y='fruits', height=0.9, color=OrRd3, source=ColumnDataSource(imports),
-             legend_label=["%s imports" % x for x in years])
+             legend_label=[f"{year} imports" for year in years])
 
 p.y_range.range_padding = 0.1
 p.ygrid.grid_line_color = None

--- a/examples/integration/glyphs/frame_clipping_multi_backend.py
+++ b/examples/integration/glyphs/frame_clipping_multi_backend.py
@@ -7,7 +7,7 @@ def make_figure(output_backend):
     p = figure(width=400,
                height=400,
                output_backend=output_backend,
-               title="Backend: %s" % output_backend)
+               title=f"Backend: {output_backend}")
 
     p.circle(x=[1, 2, 3], y=[1, 2, 3], radius=0.25, color="blue", alpha=0.5)
     p.annulus(x=[1, 2, 3], y=[1, 2, 3], inner_radius=0.1, outer_radius=0.20, color="orange")

--- a/examples/integration/glyphs/log_scale_multi_backend.py
+++ b/examples/integration/glyphs/log_scale_multi_backend.py
@@ -14,7 +14,7 @@ def make_figure(output_backend):
                height=400,
                toolbar_location=None,
                output_backend=output_backend,
-               title="Backend: %s" % output_backend)
+               title=f"Backend: {output_backend}")
 
     p.xaxis.axis_label = 'Domain'
     p.yaxis.axis_label = 'Values (log scale)'

--- a/examples/integration/layout/multi_plot_layout.py
+++ b/examples/integration/layout/multi_plot_layout.py
@@ -23,7 +23,7 @@ for col in range(0, ncols):
         x = 100.0/ncols*col
         y = 100.0/nrows*row
         r, g, b = int(50+2*x), int(30+2*y), 150
-        color = "#%02x%02x%02x" % (r, g, b)
+        color = f"#{r:02x}{g:02x}{b:02x}"
         figures.append(fig(color, row, col))
 
 save(gridplot(figures, ncols=ncols, toolbar_location=None))

--- a/examples/integration/widgets/layout_multiple_widgets.py
+++ b/examples/integration/widgets/layout_multiple_widgets.py
@@ -63,7 +63,7 @@ layout = column(
     #RadioGroup(labels=["Radio Option 7", "Radio Option 8", "Radio Option 9"], active=2, inline=True),
 
     #Select(options=["Select Option 1", "Select Option 2", "Select Option 3"]),
-    #MultiSelect(options=["MultiSelect Option %d" % (i+1) for i in range(16)], size=6),
+    #MultiSelect(options=[f"MultiSelect Option {i+1}" for i in range(16)], size=6),
 
     #Paragraph(text="Paragraph 1"),
     #Paragraph(text="Paragraph 2"),

--- a/examples/interaction/js_callbacks/color_sliders.py
+++ b/examples/interaction/js_callbacks/color_sliders.py
@@ -14,10 +14,10 @@ from bokeh.themes import Theme
 
 R, G, B = (75, 125, 125)
 
-def rgb_to_hex(rgb):
-    return '#%02x%02x%02x' % rgb
+def rgb_to_hex(r, g, b):
+    return f"#{r:02x}{g:02x}{b:02x}"
 
-color = rgb_to_hex((R, G, B))
+color = rgb_to_hex(R, G, B)
 text_color = '#ffffff'
 
 # create a data source to enable refreshing of fill & text color

--- a/examples/interaction/js_callbacks/customjs_for_range_update.py
+++ b/examples/interaction/js_callbacks/customjs_for_range_update.py
@@ -10,7 +10,7 @@ x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
 colors = [
-    "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
+    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
 ]
 
 box = BoxAnnotation(left=0, right=0, bottom=0, top=0,

--- a/examples/interaction/js_callbacks/js_on_event.py
+++ b/examples/interaction/js_callbacks/js_on_event.py
@@ -16,22 +16,22 @@ def display_event(div, attributes=[]):
     in the div model.
     """
     style = 'float: left; clear: left; font-size: 13px'
-    return CustomJS(args=dict(div=div), code="""
-        const attrs = %s;
+    return CustomJS(args=dict(div=div), code=f"""
+        const attrs = {attributes};
         const args = [];
-        for (let i = 0; i < attrs.length; i++) {
-            const val = JSON.stringify(cb_obj[attrs[i]], function(key, val) {
+        for (let i = 0; i < attrs.length; i++) {{
+            const val = JSON.stringify(cb_obj[attrs[i]], function(key, val) {{
                 return val.toFixed ? Number(val.toFixed(2)) : val;
-            })
+            }})
             args.push(attrs[i] + '=' + val)
-        }
-        const line = "<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
+        }}
+        const line = "<span style={style!r}><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
         const text = div.text.concat(line);
         const lines = text.split("\\n")
         if (lines.length > 35)
             lines.shift();
         div.text = lines.join("\\n");
-    """ % (attributes, style))
+    """)
 
 # Follows the color_scatter gallery example
 
@@ -40,7 +40,7 @@ x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
 colors = [
-    "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
+    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
 ]
 
 p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset,tap,lasso_select,box_select,box_zoom,undo,redo")

--- a/examples/models/basic_plot.py
+++ b/examples/models/basic_plot.py
@@ -42,5 +42,5 @@ if __name__ == "__main__":
     filename = "basic_plot.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Basic Glyph Plot"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/buttons.py
+++ b/examples/models/buttons.py
@@ -75,5 +75,5 @@ if __name__ == "__main__":
     filename = "buttons.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Button widgets"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/calendars.py
+++ b/examples/models/calendars.py
@@ -104,5 +104,5 @@ if __name__ == "__main__":
     filename = "calendars.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Calendar 2014"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/colors.py
+++ b/examples/models/colors.py
@@ -42,7 +42,7 @@ plot.add_layout(xaxis_below, 'below')
 plot.add_layout(CategoricalAxis(), 'left')
 
 url = "http://www.colors.commutercreative.com/@names/"
-tooltips = """Click the color to go to:<br /><a href="{url}">{url}</a>""".format(url=url)
+tooltips = f"Click the color to go to:<br /><a href='{url}'>{url}</a>"
 
 tap = TapTool(renderers=[rect_renderer], callback=OpenURL(url=url))
 hover = HoverTool(renderers=[rect_renderer], tooltips=tooltips)
@@ -56,5 +56,5 @@ if __name__ == "__main__":
     filename = "colors.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "CSS3 Color Names"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/custom.py
+++ b/examples/models/custom.py
@@ -117,5 +117,5 @@ if __name__ == "__main__":
     filename = "custom.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Demonstration of user-defined models"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/customjs.py
+++ b/examples/models/customjs.py
@@ -38,5 +38,5 @@ if __name__ == "__main__":
     filename = "customjs.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Demonstration of custom callback written in TypeScript"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/dateaxis.py
+++ b/examples/models/dateaxis.py
@@ -36,5 +36,5 @@ if __name__ == "__main__":
     filename = "dateaxis.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Date Axis Example"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/daylight.py
+++ b/examples/models/daylight.py
@@ -107,5 +107,5 @@ if __name__ == "__main__":
     filename = "daylight.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Daylight Plot"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/gauges.py
+++ b/examples/models/gauges.py
@@ -110,5 +110,5 @@ if __name__ == "__main__":
     filename = "gauges.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Gauges"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/glyphs.py
+++ b/examples/models/glyphs.py
@@ -115,5 +115,5 @@ if __name__ == "__main__":
     filename = "glyphs.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Glyphs"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/maps.py
+++ b/examples/models/maps.py
@@ -59,5 +59,5 @@ if __name__ == "__main__":
     filename = "maps.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Google Maps Example"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/maps_cities.py
+++ b/examples/models/maps_cities.py
@@ -36,5 +36,5 @@ if __name__ == "__main__":
     filename = "maps_cities.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Google Maps - World cities Example"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/sliders.py
+++ b/examples/models/sliders.py
@@ -74,5 +74,5 @@ if __name__ == "__main__":
     filename = "sliders.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "sliders"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/tile_source.py
+++ b/examples/models/tile_source.py
@@ -29,5 +29,5 @@ if __name__ == "__main__":
     filename = "tile_source.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Tile Source Example"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/toolbars.py
+++ b/examples/models/toolbars.py
@@ -7,7 +7,7 @@ N = 1000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = ["#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)]
+colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)]
 
 TOOLS="hover,crosshair,pan,reset,box_select"
 

--- a/examples/models/toolbars2.py
+++ b/examples/models/toolbars2.py
@@ -7,7 +7,7 @@ N = 1000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = ["#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)]
+colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)]
 
 TOOLS="hover,crosshair,pan,wheel_zoom,zoom_in,zoom_out,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select"
 

--- a/examples/models/trail.py
+++ b/examples/models/trail.py
@@ -137,5 +137,5 @@ if __name__ == "__main__":
     filename = "trail.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Trail map and altitude profile"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/twin_axis.py
+++ b/examples/models/twin_axis.py
@@ -48,5 +48,5 @@ if __name__ == "__main__":
     filename = "twin_axis.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Twin Axis Plot"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/widgets.py
+++ b/examples/models/widgets.py
@@ -225,5 +225,5 @@ if __name__ == "__main__":
     filename = "widgets.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, "Widgets"))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/output/apis/autoload_static_flask.py
+++ b/examples/output/apis/autoload_static_flask.py
@@ -15,7 +15,7 @@ def render_plot():
     y = np.random.random(size=N) * 100
     radii = np.random.random(size=N) * 1.5
     colors = [
-        "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
+        f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
     ]
 
     TOOLS="crosshair,pan,wheel_zoom,box_zoom,reset,tap,save,box_select,poly_select,lasso_select"

--- a/examples/output/apis/file_html.py
+++ b/examples/output/apis/file_html.py
@@ -122,5 +122,5 @@ if __name__ == "__main__":
     filename = "file_html.html"
     with open(filename, "w") as f:
         f.write(file_html(doc, INLINE, plot.title.text))
-    print("Wrote %s" % filename)
+    print(f"Wrote {filename}")
     view(filename)

--- a/examples/output/apis/server_session/bokeh_app.py
+++ b/examples/output/apis/server_session/bokeh_app.py
@@ -8,7 +8,7 @@ x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
 colors = [
-    "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
+    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
 ]
 
 p = figure(tools="", toolbar_location=None)

--- a/examples/plotting/custom_tooltip.py
+++ b/examples/plotting/custom_tooltip.py
@@ -28,16 +28,14 @@ data=dict(
     type_color=[colormap[x] for x in elements["metal"]]
 )
 
-mass_format = '{0.00}'
-
 TOOLTIPS = """
     <div style="width: 62px; height: 62px; opacity: .8; padding: 5px; background-color: @type_color;>
     <h1 style="margin: 0; font-size: 12px;"> @atomic_number </h1>
     <h1 style="margin: 0; font-size: 24px;"><strong> @sym </strong></h1>
     <p style=" margin: 0; font-size: 8px;"><strong> @name </strong></p>
-    <p style="margin: 0; font-size: 8px;"> @atomic_mass{mass_format} </p>
+    <p style="margin: 0; font-size: 8px;"> @atomic_mass{0.00} </p>
     </div>
-""".format(mass_format=mass_format)
+"""
 
 p = figure(width=900, height=450, tooltips=TOOLTIPS, title='Densities by Atomic Mass')
 p.background_fill_color = "#fafafa"

--- a/examples/plotting/hover.py
+++ b/examples/plotting/hover.py
@@ -22,7 +22,7 @@ N = len(x)
 inds = [str(i) for i in np.arange(N)]
 radii = np.random.random(size=N)*0.4 + 1.7
 colors = [
-    "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
+    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
 ]
 
 data=dict(

--- a/examples/plotting/tap.py
+++ b/examples/plotting/tap.py
@@ -10,7 +10,7 @@ N = len(x)
 inds = [str(i) for i in np.arange(N)]
 radii = np.random.random(size=N)*0.4 + 1.7
 colors = [
-    "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
+    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
 ]
 
 TOOLS="crosshair,pan,wheel_zoom,box_zoom,reset,tap,save"

--- a/examples/plotting/toolbar_autohide.py
+++ b/examples/plotting/toolbar_autohide.py
@@ -16,7 +16,7 @@ N = 1000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = ["#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)]
+colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)]
 
 def make_plot(autohide=None):
     p = figure(width=300, height=300, title='Autohiding toolbar' if autohide else 'Not autohiding toolbar')

--- a/examples/server/api/flask_gunicorn_embed.py
+++ b/examples/server/api/flask_gunicorn_embed.py
@@ -60,7 +60,7 @@ sockets, port = bind_sockets("localhost", 0)
 
 @app.route('/', methods=['GET'])
 def bkapp_page():
-    script = server_document('http://localhost:%d/bkapp' % port)
+    script = server_document(f"http://localhost:{port}/bkapp")
     return render_template("embed.html", script=script, template="Flask")
 
 def bk_worker():

--- a/examples/server/app/crossfilter/main.py
+++ b/examples/server/app/crossfilter/main.py
@@ -43,7 +43,7 @@ def create_figure():
         kw['x_range'] = sorted(set(xs))
     if y.value in discrete:
         kw['y_range'] = sorted(set(ys))
-    kw['title'] = "%s vs %s" % (x_title, y_title)
+    kw['title'] = f"{x_title} vs {y_title}"
 
     p = figure(height=600, width=800, tools='pan,box_zoom,hover,reset', **kw)
     p.xaxis.axis_label = x_title

--- a/examples/server/app/events_app.py
+++ b/examples/server/app/events_app.py
@@ -19,21 +19,21 @@ def display_event(div, attributes=[]):
     in the div model.
     """
     style = 'float: left; clear: left; font-size: 13px'
-    return CustomJS(args=dict(div=div), code="""
-        const {to_string} = Bokeh.require("core/util/pretty")
-        const attrs = %s;
+    return CustomJS(args=dict(div=div), code=f"""
+        const {{to_string}} = Bokeh.require("core/util/pretty")
+        const attrs = {attributes};
         const args = [];
-        for (let i = 0; i<attrs.length; i++ ) {
-            const val = to_string(cb_obj[attrs[i]], {precision: 2})
+        for (let i = 0; i<attrs.length; i++ ) {{
+            const val = to_string(cb_obj[attrs[i]], {{precision: 2}})
             args.push(attrs[i] + '=' + val)
-        }
-        const line = "<span style=%r><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
+        }}
+        const line = "<span style={style!r}><b>" + cb_obj.event_name + "</b>(" + args.join(", ") + ")</span>\\n";
         const text = div.text.concat(line);
         const lines = text.split("\\n")
         if (lines.length > 35)
             lines.shift();
         div.text = lines.join("\\n");
-    """ % (attributes, style))
+    """)
 
 def print_event(attributes=[]):
     """
@@ -41,8 +41,7 @@ def print_event(attributes=[]):
     """
     def python_callback(event):
         cls_name = event.__class__.__name__
-        attrs = ', '.join(['{attr}={val}'.format(attr=attr, val=event.__dict__[attr])
-                       for attr in attributes])
+        attrs = ', '.join([f"{attr}={event.__dict__[attr]}" for attr in attributes])
         print(f"{cls_name}({attrs})")
 
     return python_callback
@@ -53,9 +52,7 @@ N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [
-    "#%02x%02x%02x" % (int(r), int(g), 150) for r, g in zip(50+2*x, 30+2*y)
-]
+colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)]
 
 p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset,tap,lasso_select,box_select,box_zoom,undo,redo")
 

--- a/examples/server/app/movies/main.py
+++ b/examples/server/app/movies/main.py
@@ -22,7 +22,7 @@ movies = psql.read_sql(query, conn)
 movies["color"] = np.where(movies["Oscars"] > 0, "orange", "grey")
 movies["alpha"] = np.where(movies["Oscars"] > 0, 0.9, 0.25)
 movies.fillna(0, inplace=True)  # just replace missing values with zero
-movies["revenue"] = movies.BoxOffice.apply(lambda x: '{:,d}'.format(int(x)))
+movies["revenue"] = movies.BoxOffice.apply(lambda x: f"{int(x)}")
 
 with open(join(dirname(__file__), "razzies-clean.csv")) as f:
     razzies = f.read().splitlines()

--- a/examples/server/app/taylor.py
+++ b/examples/server/app/taylor.py
@@ -54,7 +54,7 @@ def update():
         errbox.text = ""
     x, fy, ty = taylor(expr, xs, slider.value, (-2*sy.pi, 2*sy.pi), 200)
 
-    p.title.text = "Taylor (n=%d) expansion comparison for: %s" % (slider.value, expr)
+    p.title.text = f"Taylor (n={slider.value}) expansion comparison for: {expr}"
     legend.items[0].label = value(f"{expr}")
     legend.items[1].label = value(f"taylor({expr})")
     source.data = dict(x=x, fy=fy, ty=ty)

--- a/examples/topics/categorical/heatmap_unemployment.py
+++ b/examples/topics/categorical/heatmap_unemployment.py
@@ -33,7 +33,7 @@ mapper = LinearColorMapper(palette=colors, low=df.rate.min(), high=df.rate.max()
 
 TOOLS = "hover,save,pan,box_zoom,reset,wheel_zoom"
 
-p = figure(title="US Unemployment ({0} - {1})".format(years[0], years[-1]),
+p = figure(title=f"US Unemployment ({years[0]} - {years[-1]})",
            x_range=years, y_range=list(reversed(months)),
            x_axis_location="above", width=900, height=400,
            tools=TOOLS, toolbar_location='below',

--- a/examples/topics/hex/hex_coords.py
+++ b/examples/topics/hex/hex_coords.py
@@ -14,7 +14,7 @@ p.hex_tile(q, r, size=1, fill_color=["firebrick"]*3 + ["navy"]*4,
 
 x, y = axial_to_cartesian(q, r, 1, "pointytop")
 
-p.text(x, y, text=["(%d, %d)" % (q,r) for (q, r) in zip(q, r)],
+p.text(x, y, text=[f"({q}, {r})" for (q, r) in zip(q, r)],
        text_baseline="middle", text_align="center")
 
 show(p)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,14 +114,20 @@ exclude = [
     'node_modules',
 ]
 per-file-ignores = {"__init__.py" = ["F403"]}
-select = ["E", "F", "M", "U", "W"]
+select = ["E", "F", "RUF", "UP", "W"]
 ignore = [
+    'E401', # Multiple imports on one line
     'E402', # Module level import not at top of file
     'E731', # Do not assign a lambda expression, use a def
     'E741', # Ambiguous variable name: I
+    'RUF001',
+    'RUF005',
 ]
 line-length = 165
 target-version = "py38"
+
+[tool.ruff.pyupgrade]
+keep-runtime-typing = true
 
 # For now enable each typed module individually.
 [[tool.mypy.overrides]]

--- a/src/bokeh/__init__.py
+++ b/src/bokeh/__init__.py
@@ -103,7 +103,7 @@ def _formatwarning(message, category, filename, lineno, line=None):
     from .util.warnings import BokehDeprecationWarning, BokehUserWarning
     if category not in (BokehDeprecationWarning, BokehUserWarning):
         return original_formatwarning(message, category, filename, lineno, line)
-    return "%s: %s\n" % (category.__name__, message)
+    return f"{category.__name__}: {message}\n"
 warnings.formatwarning = _formatwarning
 
 del _formatwarning

--- a/src/bokeh/colors/color.py
+++ b/src/bokeh/colors/color.py
@@ -342,9 +342,9 @@ class RGB(Color):
 
         '''
         if self.a < 1.0:
-            return "#%02X%02X%02X%02X" % (self.r, self.g, self.b, round(self.a*255))
+            return f"#{self.r:02x}{self.g:02x}{self.b:02x}{int(round(self.a*255)):02x}"
         else:
-            return "#%02X%02X%02X" % (self.r, self.g, self.b)
+            return f"#{self.r:02x}{self.g:02x}{self.b:02x}"
 
     def to_hsl(self) -> HSL:
         ''' Return a corresponding HSL color for this RGB color.

--- a/src/bokeh/command/subcommands/file_output.py
+++ b/src/bokeh/command/subcommands/file_output.py
@@ -136,7 +136,7 @@ class FileOutputSubcommand(Subcommand):
         else:
             base = route[1:]
 
-        return "%s.%s" % (base, ext)
+        return f"{base}.{ext}"
 
     def invoke(self, args: argparse.Namespace) -> None:
         '''

--- a/src/bokeh/command/util.py
+++ b/src/bokeh/command/util.py
@@ -135,7 +135,7 @@ def build_single_handler_application(path: str, argv: list[str] | None = None) -
         raise ValueError("Path for Bokeh server application does not exist: %s" % path)
 
     if handler.failed:
-        raise RuntimeError("Error loading %s:\n\n%s\n%s " % (path, handler.error, handler.error_detail))
+        raise RuntimeError(f"Error loading {path}:\n\n{handler.error}\n{handler.error_detail} ")
 
     application = Application(handler)
 

--- a/src/bokeh/core/property_mixins.py
+++ b/src/bokeh/core/property_mixins.py
@@ -228,15 +228,15 @@ A rough measure of the 'size' of the hatching pattern. Generally speaking, the
 higher the number, the more spread out the pattern will be.
 """
 
-_hatch_pattern_help = """
+_hatch_pattern_help = f"""
 Built-in patterns are can either be specified as long names:
 
-%s
+{', '. join(HatchPattern)}
 
 or as one-letter abbreviations:
 
-%s
-""" % (", ". join(HatchPattern), ", ". join(repr(x) for x in HatchPatternAbbreviation))
+{', '. join(repr(x) for x in HatchPatternAbbreviation)}
+"""
 
 _hatch_weight_help = """
 A width value for line-strokes used in hatching.

--- a/src/bokeh/core/types.py
+++ b/src/bokeh/core/types.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import os  # noqa: F401 # lgtm [py/unused-import]
+import os
 from typing import (
     TYPE_CHECKING,
     Literal,

--- a/src/bokeh/embed/server.py
+++ b/src/bokeh/embed/server.py
@@ -310,7 +310,7 @@ def _process_arguments(arguments: dict[str, str] | None) -> str:
     result = ""
     for key, value in arguments.items():
         if not key.startswith("bokeh-"):
-            result += "&{}={}".format(quote_plus(str(key)), quote_plus(str(value)))
+            result += f"&{quote_plus(str(key))}={quote_plus(str(value))}"
     return result
 
 def _process_app_path(app_path: str) -> str:

--- a/src/bokeh/embed/util.py
+++ b/src/bokeh/embed/util.py
@@ -140,7 +140,7 @@ def OutputDocumentFor(objs: Sequence[Model], apply_theme: Theme | type[FromCurdo
     docs = {obj.document for obj in objs if obj.document is not None}
 
     if always_new:
-        def finish() -> None:
+        def finish() -> None:  # noqa
             _dispose_temp_doc(objs)
         doc = _create_temp_doc(objs)
     else:
@@ -268,7 +268,7 @@ class RenderRoots:
                 if root.name == key:
                     break
             else:
-                raise ValueError("root with '%s' name not found" % key)
+                raise ValueError(f"root with {key!r} name not found")
 
         return RenderRoot(elementid, root.id, root.name, root.tags)
 

--- a/src/bokeh/io/export.py
+++ b/src/bokeh/io/export.py
@@ -498,7 +498,7 @@ class _TempFile:
         # default tmp directory.
         try:
             self.fd, self.path = mkstemp(prefix=prefix, suffix=suffix, dir=os.getcwd())
-        except (OSError, IOError):
+        except OSError:
             self.fd, self.path = mkstemp(prefix=prefix, suffix=suffix)
 
     def __enter__(self) -> _TempFile:

--- a/src/bokeh/io/notebook.py
+++ b/src/bokeh/io/notebook.py
@@ -377,7 +377,7 @@ def destroy_server(server_id: ID) -> None:
     '''
     server = curstate().uuid_to_server.get(server_id, None)
     if server is None:
-        log.debug("No server instance found for uuid: %r" % server_id)
+        log.debug(f"No server instance found for uuid: {server_id!r}")
         return
 
     try:
@@ -553,8 +553,8 @@ def show_app(app: Application, state: State, notebook_url: str | Callable[[int |
     else:
         url = _server_url(notebook_url, server.port)
 
-    logging.debug("Server URL is %s" % url)
-    logging.debug("Origin URL is %s" % origin)
+    logging.debug(f"Server URL is {url}")
+    logging.debug(f"Origin URL is {origin}")
 
     from ..embed import server_document
     script = server_document(url, resources=None)

--- a/src/bokeh/layouts.py
+++ b/src/bokeh/layouts.py
@@ -594,8 +594,8 @@ def _create_grid(iterable: Iterable[UIElement | list[UIElement]], sizing_mode: S
             return_list.append(item)
         else:
             raise ValueError(
-                """Only LayoutDOM items can be inserted into a layout.
-                Tried to insert: %s of type %s""" % (item, type(item))
+                f"""Only LayoutDOM items can be inserted into a layout.
+                Tried to insert: {item} of type {type(item)}"""
             )
     if layer % 2 == 0:
         return column(children=return_list, sizing_mode=sizing_mode, **kwargs)

--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -382,14 +382,14 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
         '''
         descriptor = self.lookup(attr, raises=False)
         if descriptor is None:
-            raise ValueError("%r is not a property of self (%r)" % (attr, self))
+            raise ValueError(f"{attr!r} is not a property of self ({self!r})")
 
         if not isinstance(other, Model):
             raise ValueError("'other' is not a Bokeh model: %r" % other)
 
         other_descriptor = other.lookup(other_attr, raises=False)
         if other_descriptor is None:
-            raise ValueError("%r is not a property of other (%r)" % (other_attr, other))
+            raise ValueError(f"{other_attr!r} is not a property of other ({other!r})")
 
         from bokeh.models import CustomJS
 
@@ -496,7 +496,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
         '''
         result = list(self.select(selector))
         if len(result) > 1:
-            raise ValueError("Found more than one object matching %s: %r" % (selector, result))
+            raise ValueError(f"Found more than one object matching {selector}: {result!r}")
         if len(result) == 0:
             return None
         return result[0]

--- a/src/bokeh/models/plots.py
+++ b/src/bokeh/models/plots.py
@@ -467,22 +467,16 @@ class Plot(LayoutDOM):
         if self.x_scale is not None:
             for rng in x_ranges:
                 if isinstance(rng, (DataRange1d, Range1d)) and not isinstance(self.x_scale, (LinearScale, LogScale)):
-                    incompatible.append("incompatibility on x-dimension: %s, %s" %(rng, self.x_scale))
+                    incompatible.append(f"incompatibility on x-dimension: {rng}, {self.x_scale}")
                 elif isinstance(rng, FactorRange) and not isinstance(self.x_scale, CategoricalScale):
-                    incompatible.append("incompatibility on x-dimension: %s/%s" %(rng, self.x_scale))
-                # special case because CategoricalScale is a subclass of LinearScale, should be removed in future
-                if isinstance(rng, (DataRange1d, Range1d)) and isinstance(self.x_scale, CategoricalScale):
-                    incompatible.append("incompatibility on x-dimension: %s, %s" %(rng, self.x_scale))
+                    incompatible.append(f"incompatibility on x-dimension: {rng}, {self.x_scale}")
 
         if self.y_scale is not None:
             for rng in y_ranges:
                 if isinstance(rng, (DataRange1d, Range1d)) and not isinstance(self.y_scale, (LinearScale, LogScale)):
-                    incompatible.append("incompatibility on y-dimension: %s/%s" %(rng, self.y_scale))
+                    incompatible.append(f"incompatibility on y-dimension: {rng}, {self.y_scale}")
                 elif isinstance(rng, FactorRange) and not isinstance(self.y_scale, CategoricalScale):
-                    incompatible.append("incompatibility on y-dimension: %s/%s" %(rng, self.y_scale))
-                # special case because CategoricalScale is a subclass of LinearScale, should be removed in future
-                if isinstance(rng, (DataRange1d, Range1d)) and isinstance(self.y_scale, CategoricalScale):
-                    incompatible.append("incompatibility on y-dimension: %s, %s" %(rng, self.y_scale))
+                    incompatible.append(f"incompatibility on y-dimension: {rng}, {self.y_scale}")
 
         if incompatible:
             return ", ".join(incompatible) + " [%s]" % self
@@ -918,7 +912,7 @@ class GridPlot(LayoutDOM):
 
 def _check_conflicting_kwargs(a1, a2, kwargs):
     if a1 in kwargs and a2 in kwargs:
-        raise ValueError("Conflicting properties set on plot: %r and %r" % (a1, a2))
+        raise ValueError(f"Conflicting properties set on plot: {a1!r} and {a2!r}")
 
 class _list_attr_splat(list):
     def __setattr__(self, attr, value):
@@ -934,7 +928,7 @@ class _list_attr_splat(list):
         try:
             return _list_attr_splat([getattr(x, attr) for x in self])
         except Exception:
-            raise AttributeError("Trying to access %r attribute on a 'splattable' list, but list items have no %r attribute" % (attr, attr))
+            raise AttributeError(f"Trying to access {attr!r} attribute on a 'splattable' list, but list items have no {attr!r} attribute")
 
     def __dir__(self):
         if len({type(x) for x in self}) == 1:

--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -88,8 +88,8 @@ class GlyphRenderer(DataRenderer):
             suggestions = ['" (closest match: "%s")' % s[0] if s else '"' for s in [
                 get_close_matches(term[0], self.data_source.column_names, n=1) for term in missing_values]]
             missing_values = [("".join([m[0], s]), m[1]) for m, s in zip(missing_values, suggestions)]
-            missing = ['key "%s" value "%s' % (k, v) for v, k in missing_values]
-            return "%s [renderer: %s]" % (", ".join(sorted(missing)), self)
+            missing = [f'key "{k}" value "{v}' for v, k in missing_values]
+            return "{} [renderer: {}]".format(", ".join(sorted(missing)), self)
 
     data_source = Required(Instance(DataSource), help="""
     Local data source to use when rendering glyphs on the plot.

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -529,16 +529,14 @@ class ColumnDataSource(ColumnarDataSource):
         oldkeys = set(self.data.keys())
 
         if newkeys != oldkeys:
-            missing = oldkeys - newkeys
-            extra = newkeys - oldkeys
+            missing = sorted(oldkeys - newkeys)
+            extra = sorted(newkeys - oldkeys)
             if missing and extra:
-                raise ValueError(
-                    "Must stream updates to all existing columns (missing: %s, extra: %s)" % (", ".join(sorted(missing)), ", ".join(sorted(extra)))
-                )
+                raise ValueError(f"Must stream updates to all existing columns (missing: {', '.join(missing)}, extra: {', '.join(extra)})")
             elif missing:
-                raise ValueError("Must stream updates to all existing columns (missing: %s)" % ", ".join(sorted(missing)))
+                raise ValueError(f"Must stream updates to all existing columns (missing: {', '.join(missing)})")
             else:
-                raise ValueError("Must stream updates to all existing columns (extra: %s)" % ", ".join(sorted(extra)))
+                raise ValueError(f"Must stream updates to all existing columns (extra: {', '.join(extra)})")
 
         if needs_length_check:
             lengths: set[int] = set()
@@ -546,7 +544,7 @@ class ColumnDataSource(ColumnarDataSource):
             for _, x in new_data.items():
                 if isinstance(x, arr_types):
                     if len(x.shape) != 1:
-                        raise ValueError("stream(...) only supports 1d sequences, got ndarray with size %r" % (x.shape,))
+                        raise ValueError(f"stream(...) only supports 1d sequences, got ndarray with size {x.shape!r}")
                     lengths.add(x.shape[0])
                 else:
                     lengths.add(len(x))

--- a/src/bokeh/plotting/_graph.py
+++ b/src/bokeh/plotting/_graph.py
@@ -58,10 +58,7 @@ def get_graph_kwargs(node_source, edge_source, **kwargs):
             # try converting the source to ColumnDataSource
             node_source = ColumnDataSource(node_source)
         except ValueError as err:
-            msg = "Failed to auto-convert {curr_type} to ColumnDataSource.\n Original error: {err}".format(
-                curr_type=str(type(node_source)),
-                err=err.message
-            )
+            msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err.message}"
             raise ValueError(msg).with_traceback(sys.exc_info()[2])
 
     if not isinstance(edge_source, ColumnarDataSource):
@@ -69,10 +66,7 @@ def get_graph_kwargs(node_source, edge_source, **kwargs):
             # try converting the source to ColumnDataSource
             edge_source = ColumnDataSource(edge_source)
         except ValueError as err:
-            msg = "Failed to auto-convert {curr_type} to ColumnDataSource.\n Original error: {err}".format(
-                curr_type=str(type(edge_source)),
-                err=err.message
-            )
+            msg = f"Failed to auto-convert {type(edge_source)} to ColumnDataSource.\n Original error: {err.message}"
             raise ValueError(msg).with_traceback(sys.exc_info()[2])
 
     marker = kwargs.pop('node_marker', None)

--- a/src/bokeh/plotting/_legends.py
+++ b/src/bokeh/plotting/_legends.py
@@ -47,7 +47,7 @@ LEGEND_ARGS = ['legend', 'legend_label', 'legend_field', 'legend_group']
 def pop_legend_kwarg(kwargs):
     result = {attr: kwargs.pop(attr) for attr in LEGEND_ARGS if attr in kwargs}
     if len(result) > 1:
-        raise ValueError("Only one of %s may be provided, got: %s" % (nice_join(LEGEND_ARGS), nice_join(result.keys())))
+        raise ValueError(f"Only one of {nice_join(LEGEND_ARGS)} may be provided, got: {nice_join(result.keys())}")
     return result
 
 def update_legend(plot, legend_kwarg, glyph_renderer):

--- a/src/bokeh/protocol/receiver.py
+++ b/src/bokeh/protocol/receiver.py
@@ -151,7 +151,7 @@ class Receiver:
         content = self._assume_text(fragment)
         self._fragments.append(content)
 
-        header_json, metadata_json, content_json = [self._assume_text(x) for x in self._fragments[:3]]
+        header_json, metadata_json, content_json = (self._assume_text(x) for x in self._fragments[:3])
 
         self._partial = self._protocol.assemble(header_json, metadata_json, content_json)
 

--- a/src/bokeh/server/protocol_handler.py
+++ b/src/bokeh/server/protocol_handler.py
@@ -91,7 +91,7 @@ class ProtocolHandler:
             handler = self._handlers.get(message.msgtype)
 
         if handler is None:
-            raise ProtocolError("%s not expected on server" % message)
+            raise ProtocolError(f"{message} not expected on server")
 
         try:
             work = await handler(message, connection)

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -394,7 +394,7 @@ class Server(BaseServer):
         ``BokehTornado``.
 
         '''
-        log.info("Starting Bokeh server version %s (running on Tornado %s)" % (__version__, tornado_version))
+        log.info(f"Starting Bokeh server version {__version__} (running on Tornado {tornado_version})")
 
         opts = _ServerOpts(kwargs)
 

--- a/src/bokeh/server/views/autoload_js_handler.py
+++ b/src/bokeh/server/views/autoload_js_handler.py
@@ -70,7 +70,8 @@ class AutoloadJsHandler(SessionHandler):
         absolute_url = self.get_argument("bokeh-absolute-url", default=None)
 
         if absolute_url:
-            server_url = '{uri.scheme}://{uri.netloc}'.format(uri=urlparse(absolute_url))
+            uri = urlparse(absolute_url)
+            server_url = f"{uri.scheme}://{uri.netloc}"
         else:
             server_url = None
 

--- a/src/bokeh/sphinxext/bokeh_sitemap.py
+++ b/src/bokeh/sphinxext/bokeh_sitemap.py
@@ -76,7 +76,8 @@ def build_finished(app, exception):
         with open(filename, "w") as f:
             f.write(_header)
             for link in links_iter:
-                f.write(_item % escape(link.strip().replace("https://", "http://")))  # TODO (bev) get rid of old style string subsitution
+                http_link = escape(link.strip().replace("https://", "http://"))
+                f.write(_item.format(link=http_link))
             f.write(_footer)
     except OSError as e:
         raise SphinxError(f"cannot write sitemap.txt, reason: {e}")
@@ -103,7 +104,7 @@ _header = """\
 
 _item = """\
    <url>
-      <loc>%s</loc>
+      <loc>{link}</loc>
    </url>
 
 """

--- a/src/bokeh/util/compiler.py
+++ b/src/bokeh/util/compiler.py
@@ -260,7 +260,7 @@ class CustomModel:
                 impl = TypeScript(impl)
 
         if isinstance(impl, Inline) and impl.file is None:
-            file = "%s%s.ts" % (self.file + ":" if self.file else "", self.name)
+            file = f"{self.file + ':' if self.file else ''}{self.name}.ts"
             impl = impl.__class__(impl.code, file)
 
         return impl

--- a/src/bokeh/util/strings.py
+++ b/src/bokeh/util/strings.py
@@ -88,8 +88,8 @@ def nice_join(seq: Iterable[str], sep: str = ", ", conjuction: str = "or") -> st
 
 def snakify(name: str, sep: str = "_") -> str:
     ''' Convert CamelCase to snake_case. '''
-    name = re.sub("([A-Z]+)([A-Z][a-z])", r"\1%s\2" % sep, name)
-    name = re.sub("([a-z\\d])([A-Z])", r"\1%s\2" % sep, name)
+    name = re.sub("([A-Z]+)([A-Z][a-z])", rf"\1{sep}\2", name)
+    name = re.sub("([a-z\\d])([A-Z])", rf"\1{sep}\2", name)
     return name.lower()
 
 def append_docstring(docstring: str | None, extra: str) -> str | None:

--- a/src/bokeh/util/terminal.py
+++ b/src/bokeh/util/terminal.py
@@ -51,12 +51,12 @@ try:
     import colorama
     from colorama import Fore, Style
 
-    def bright(text: str) -> str: return "%s%s%s" % (Style.BRIGHT, text, Style.RESET_ALL)
-    def dim(text: str) -> str:    return "%s%s%s" % (Style.DIM, text, Style.RESET_ALL)
-    def red(text: str) -> str:    return "%s%s%s" % (Fore.RED, text, Style.RESET_ALL)
-    def green(text: str) -> str:  return "%s%s%s" % (Fore.GREEN, text, Style.RESET_ALL)
-    def white(text: str) -> str:  return "%s%s%s%s" % (Fore.WHITE, Style.BRIGHT, text, Style.RESET_ALL)
-    def yellow(text: str) -> str: return "%s%s%s" % (Fore.YELLOW, text, Style.RESET_ALL)
+    def bright(text: str) -> str: return f"{Style.BRIGHT}{text}{Style.RESET_ALL}"
+    def dim(text: str) -> str:    return f"{Style.DIM}{text}{Style.RESET_ALL}"
+    def red(text: str) -> str:    return f"{Fore.RED}{text}{Style.RESET_ALL}"
+    def green(text: str) -> str:  return f"{Fore.GREEN}{text}{Style.RESET_ALL}"
+    def white(text: str) -> str:  return f"{Fore.WHITE}{Style.BRIGHT}{text}{Style.RESET_ALL}"
+    def yellow(text: str) -> str: return f"{Fore.YELLOW}{text}{Style.RESET_ALL}"
 
     if sys.platform == "win32":
         colorama.init()
@@ -80,22 +80,22 @@ def write(*values: str, **kwargs: str) -> None:
 
 def fail(msg: str | None = None, label: str = "FAIL") -> None:
     text = " " + msg if msg is not None else ""
-    write("%s%s" % (red("[%s]" % label), text))
+    write(red(f"[{label}]") + text)
 
 
 def info(msg: str | None = None, label: str = "INFO") -> None:
     text = " " + msg if msg is not None else ""
-    write("%s%s" % (white("[%s]" % label), text))
+    write(white(f"[{label}]") + text)
 
 
 def ok(msg: str | None = None, label: str = "OK") -> None:
     text = " " + msg if msg is not None else ""
-    write("%s%s" % (green("[%s]" % label), text))
+    write(green(f"[{label}]") + text)
 
 
 def warn(msg: str | None = None, label: str = "WARN") -> None:
     text = " " + msg if msg is not None else ""
-    write("%s%s" % (yellow("[%s]" % label), text))
+    write(yellow(f"[{label}]") + text)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/util/token.py
+++ b/src/bokeh/util/token.py
@@ -239,7 +239,7 @@ class _BytesEncoder(json.JSONEncoder):
 
 class _BytesDecoder(json.JSONDecoder):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(object_hook=self.bytes_object_hook, *args, **kwargs)
+        super().__init__(*args, object_hook=self.bytes_object_hook, **kwargs)
 
     def bytes_object_hook(self, obj: dict[Any, Any]) -> Any:
         if set(obj.keys()) == {"bytes"}:

--- a/src/bokeh/util/warnings.py
+++ b/src/bokeh/util/warnings.py
@@ -27,11 +27,7 @@ log = logging.getLogger(__name__)
 import inspect
 import os
 import warnings  # lgtm [py/import-and-import-from]
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing_extensions import Type
-
+from typing import Type
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/tests/integration/widgets/test_select.py
+++ b/tests/integration/widgets/test_select.py
@@ -66,8 +66,8 @@ class Test_Select:
         assert len(opts) == 3
 
         for i, opt in enumerate(opts, 1):
-            assert opt.text == "Option %d" % i
-            assert opt.get_attribute('value') == "Option %d" % i
+            assert opt.text == f"Option {i}"
+            assert opt.get_attribute('value') == f"Option {i}"
 
         assert page.has_no_console_errors()
 
@@ -84,8 +84,8 @@ class Test_Select:
         assert len(opts) == 3
 
         for i, opt in enumerate(opts, 1):
-            assert opt.text == "Option %d" % i
-            assert opt.get_attribute('value') == "Option %d" % i
+            assert opt.text == f"Option {i}"
+            assert opt.get_attribute('value') == f"Option {i}"
 
         assert page.has_no_console_errors()
 
@@ -103,8 +103,8 @@ class Test_Select:
         assert len(opts) == 3
 
         for i, opt in enumerate(opts, 1):
-            assert opt.text == "Option %d" % i
-            assert opt.get_attribute('value') == "%d" % i
+            assert opt.text == f"Option {i}"
+            assert opt.get_attribute('value') == str(i)
 
         assert page.has_no_console_errors()
 
@@ -121,8 +121,8 @@ class Test_Select:
         assert len(opts) == 3
 
         for i, opt in enumerate(opts, 1):
-            assert opt.text == "Option %d" % i
-            assert opt.get_attribute('value') == "%d" % i
+            assert opt.text == f"Option {i}"
+            assert opt.get_attribute('value') == str(i)
 
         assert page.has_no_console_errors()
 
@@ -139,12 +139,12 @@ class Test_Select:
         assert len(grps) == 2
 
         for i, grp in enumerate(grps, 1):
-            assert grp.get_attribute('label') == "g%d" %i
+            assert grp.get_attribute('label') == f"g{i}"
             opts = grp.find_elements(By.TAG_NAME, 'option')
             assert len(opts) == i
             for j, opt in enumerate(opts, 1):
-                assert opt.text == "Option %d" % (i*10 + j)
-                assert opt.get_attribute('value') == "Option %d" % (i*10 + j)
+                assert opt.text == f"Option {i*10 + j}"
+                assert opt.get_attribute('value') == f"Option {i*10 + j}"
 
         assert page.has_no_console_errors()
 
@@ -163,11 +163,11 @@ class Test_Select:
         assert len(grps) == 2
 
         for i, grp in enumerate(grps, 1):
-            assert grp.get_attribute('label') == "g%d" %i
+            assert grp.get_attribute('label') == f"g{i}"
             opts = grp.find_elements(By.TAG_NAME, 'option')
             assert len(opts) == i
             for j, opt in enumerate(opts, 1):
-                assert opt.text == "Option %d" % (i*10 + j)
+                assert opt.text == f"Option {i*10 + j}"
                 assert opt.get_attribute('value') == f"Option {i*10 + j}"
 
         assert page.has_no_console_errors()
@@ -185,12 +185,12 @@ class Test_Select:
         assert len(grps) == 2
 
         for i, grp in enumerate(grps, 1):
-            assert grp.get_attribute('label') == "g%d" %i
+            assert grp.get_attribute('label') == f"g{i}"
             opts = grp.find_elements(By.TAG_NAME, 'option')
             assert len(opts) == i
             for j, opt in enumerate(opts, 1):
-                assert opt.text == "Option %d" % (i*10 + j)
-                assert opt.get_attribute('value') == "%d" % (i*10 + j)
+                assert opt.text == f"Option {i*10 + j}"
+                assert opt.get_attribute('value') == f"{i*10 + j}"
 
         assert page.has_no_console_errors()
 
@@ -213,7 +213,7 @@ class Test_Select:
             opts = grp.find_elements(By.TAG_NAME, 'option')
             assert len(opts) == i
             for j, opt in enumerate(opts, 1):
-                assert opt.text == "Option %d" % (i*10 + j)
+                assert opt.text == f"Option {i*10 + j}"
                 assert opt.get_attribute('value') == f"{i*10 + j}"
 
         assert page.has_no_console_errors()

--- a/tests/support/util/examples.py
+++ b/tests/support/util/examples.py
@@ -94,7 +94,7 @@ class Example:
             "no_js"    if self.no_js       else "",
         ]
 
-        return "Example(%r, %s)" % (self.relpath, "|".join(f for f in flags if f))
+        return f"Example({self.relpath!r}, {'|'.join(f for f in flags if f)})"
 
     __repr__ = __str__
 

--- a/tests/support/util/screenshot.py
+++ b/tests/support/util/screenshot.py
@@ -92,7 +92,7 @@ def _run_in_browser(engine: list[str], url: str, local_wait: int | None = None, 
         cmd += [str(local_wait)]
     if global_wait is not None:
         cmd += [str(global_wait)]
-    trace("Running command: %s" % " ".join(cmd))
+    trace(f"Running command: {' '.join(cmd)}")
 
     env = os.environ.copy()
     env["NODE_PATH"] = join(TOP_PATH, 'bokehjs', 'node_modules')
@@ -100,7 +100,7 @@ def _run_in_browser(engine: list[str], url: str, local_wait: int | None = None, 
     try:
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     except OSError as e:
-        fail("Failed to run: %s" % " ".join(cmd))
+        fail(f"Failed to run: {' '.join(cmd)}")
         fail(str(e))
         sys.exit(1)
 

--- a/tests/support/util/selenium.py
+++ b/tests/support/util/selenium.py
@@ -212,9 +212,9 @@ INIT = 'Bokeh._testing.init();'
 
 def RECORD(key: str, value: Any, *, final: bool = True) -> str:
     if final:
-        return 'Bokeh._testing.record(%r, %s);' % (key, value)
+        return f"Bokeh._testing.record({key!r}, {value});"
     else:
-        return 'Bokeh._testing.record0(%r, %s);' % (key, value)
+        return f"Bokeh._testing.record0({key!r}, {value});"
 
 RESULTS = 'return Bokeh._testing.results'
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -162,14 +162,14 @@ def test_file_examples(file_example: Example, example: Example, report: list[Exa
             continue
         warn(line, label="PY")
 
-    assert status != "timeout", "%s timed out" % example.relpath
-    assert status == 0, "%s failed to run (exit code %s)" % (example.relpath, status)
+    assert status != "timeout", f"{example.relpath} timed out"
+    assert status == 0, f"{example.relpath} failed to run (exit code {status})"
 
     if example.no_js:
         if not config.option.no_js:
-            warn("skipping bokehjs for %s" % example.relpath)
+            warn(f"skipping bokehjs for {example.relpath}")
     else:
-        _run_in_browser(example, "file://%s.html" % example.path_no_ext, report, config.option.verbose)
+        _run_in_browser(example, f"file://{example.path_no_ext}.html", report, config.option.verbose)
 
 def test_server_examples(server_example: Example, example: Example, report: list[Example], config: _pytest.config.Config, bokeh_server: str) -> None:
     if config.option.verbose:
@@ -208,7 +208,7 @@ def _print_webengine_output(result: JSResult) -> None:
         line = message['line']
         col = message['col']
 
-        msg = "{%s} %s:%s:%s %s" % (level, url, line, col, text)
+        msg = f"{{{level}}} {url}:{line}:{col} {text}"
         info(msg, label="JS")
 
     for error in errors:
@@ -223,7 +223,7 @@ def _run_in_browser(example: Example, url: str, report: list[Example], verbose: 
     result = run_in_chrome(url)
     end = time.time()
 
-    info("Example rendered in %s" % white("%.3fs" % (end - start)))
+    info(f"Example rendered in {(end-start):.3f} seconds")
 
     success = result["success"]
     timeout = result["timeout"]
@@ -236,7 +236,7 @@ def _run_in_browser(example: Example, url: str, report: list[Example], verbose: 
     no_errors = len(errors) == 0
 
     if timeout:
-        warn("%s %s" % (red("TIMEOUT:"), "bokehjs did not finish"))
+        warn(f"{red('TIMEOUT:')} bokehjs did not finish")
 
     if verbose:
         _print_webengine_output(result)

--- a/tests/unit/bokeh/colors/test_color__colors.py
+++ b/tests/unit/bokeh/colors/test_color__colors.py
@@ -318,11 +318,11 @@ class Test_RGB:
 
     def test_to_hex(self) -> None:
         c = bcc.RGB(10, 20, 30)
-        assert c.to_hex(), "#%02X%02X%02X" % (c.r, c.g, c.b)
-        assert bcc.RGB(10, 20, 30, 0.0).to_hex() == "#0A141E00"
-        assert bcc.RGB(10, 20, 30, 0.5).to_hex() == "#0A141E80"
-        assert bcc.RGB(10, 20, 30, 0.996).to_hex() == "#0A141EFE"
-        assert bcc.RGB(10, 20, 30, 1.0).to_hex() == "#0A141E"
+        assert c.to_hex(), f"#{c.r:02x}{c.g:02x}{c.b:02x}"
+        assert bcc.RGB(10, 20, 30, 0.0).to_hex() == "#0a141e00"
+        assert bcc.RGB(10, 20, 30, 0.5).to_hex() == "#0a141e80"
+        assert bcc.RGB(10, 20, 30, 0.996).to_hex() == "#0a141efe"
+        assert bcc.RGB(10, 20, 30, 1.0).to_hex() == "#0a141e"
 
     def test_to_hsl(self) -> None:
         c = bcc.RGB(255, 100, 0)

--- a/tests/unit/bokeh/command/test_bootstrap.py
+++ b/tests/unit/bokeh/command/test_bootstrap.py
@@ -34,7 +34,7 @@ from bokeh.command.bootstrap import main # isort:skip
 def _assert_version_output(capsys: Capture):
     out, err = capsys.readouterr()
     err_expected = ""
-    out_expected = ("%s\n" % __version__)
+    out_expected = (f"{__version__}\n")
     assert err == err_expected
     assert out == out_expected
 

--- a/tests/unit/bokeh/core/property/test_bases.py
+++ b/tests/unit/bokeh/core/property/test_bases.py
@@ -110,7 +110,7 @@ class TestProperty:
         def raise_(ex):
                 raise ex
 
-        p.asserts(False, lambda obj, name, value: raise_(ValueError("bad %s %s %s" % (hp==obj, name, value))))
+        p.asserts(False, lambda obj, name, value: raise_(ValueError(f"bad {hp==obj} {name} {value}")))
 
         with pytest.raises(ValueError) as e:
                 p.prepare_value(hp, "foo", 10)

--- a/tests/unit/bokeh/core/property/test_dataspec.py
+++ b/tests/unit/bokeh/core/property/test_dataspec.py
@@ -314,43 +314,43 @@ class Test_FontSizeSpec:
 
         for unit in css_units.split("|"):
 
-            v = '10%s' % unit
+            v = f"10{unit}"
             a.x = v
             assert a.x == v
             assert a.lookup('x').get_value(a) == Value(v)
 
-            v = '10.2%s' % unit
+            v = f"10.2{unit}"
             a.x = v
             assert a.x == v
             assert a.lookup('x').get_value(a) == Value(v)
 
-            f = '_10%s' % unit
+            f = f"_10{unit}"
             a.x = f
             assert a.x == f
             assert a.lookup('x').get_value(a) == Field(f)
 
-            f = '_10.2%s' % unit
+            f = f"_10.2{unit}"
             a.x = f
             assert a.x == f
             assert a.lookup('x').get_value(a) == Field(f)
 
         for unit in css_units.upper().split("|"):
-            v = '10%s' % unit
+            v = f"10{unit}"
             a.x = v
             assert a.x == v
             assert a.lookup('x').get_value(a) == Value(v)
 
-            v = '10.2%s' % unit
+            v = f"10.2{unit}"
             a.x = v
             assert a.x == v
             assert a.lookup('x').get_value(a) == Value(v)
 
-            f = '_10%s' % unit
+            f = f"_10{unit}"
             a.x = f
             assert a.x == f
             assert a.lookup('x').get_value(a) == Field(f)
 
-            f = '_10.2%s' % unit
+            f = f"_10.2{unit}"
             a.x = f
             assert a.x == f
             assert a.lookup('x').get_value(a) == Field(f)

--- a/tests/unit/bokeh/core/property/test_visual.py
+++ b/tests/unit/bokeh/core/property/test_visual.py
@@ -159,34 +159,34 @@ class Test_FontSize:
         prop = bcpv.FontSize()
 
         for unit in css_units.split("|"):
-            v = '10%s' % unit
+            v = f"10{unit}"
             assert prop.is_valid(v)
 
-            v = '10.2%s' % unit
+            v = f"10.2{unit}"
             assert prop.is_valid(v)
 
         for unit in css_units.upper().split("|"):
-            v = '10%s' % unit
+            v = f"10{unit}"
             assert prop.is_valid(v)
 
-            v = '10.2%s' % unit
+            v = f"10.2{unit}"
             assert prop.is_valid(v)
 
     def test_invalid(self) -> None:
         prop = bcpv.FontSize()
 
         for unit in css_units.split("|"):
-            v = '_10%s' % unit
+            v = f"_10{unit}"
             assert not prop.is_valid(v)
 
-            v = '_10.2%s' % unit
+            v = f"_10.2{unit}"
             assert not prop.is_valid(v)
 
         for unit in css_units.upper().split("|"):
-            v = '_10%s' % unit
+            v = f"_10{unit}"
             assert not prop.is_valid(v)
 
-            v = '_10.2%s' % unit
+            v = f"_10.2{unit}"
             assert not prop.is_valid(v)
 
         assert not prop.is_valid(None)

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -325,7 +325,7 @@ class Test_file_html:
         js_resources = JSResources(mode="absolute", components=["bokeh"])
         template = Template("<head>{{ bokeh_js }}</head><body></body>")
         output = bes.file_html(test_plot, (js_resources, None), "title", template=template)
-        html = "<head>%s</head><body></body>" % js_resources.render_js()
+        html = f"<head>{js_resources.render_js()}</head><body></body>"
         assert output == html
 
     @patch('bokeh.embed.bundle.warn')
@@ -341,7 +341,7 @@ class Test_file_html:
         css_resources = CSSResources(mode="relative", components=["bokeh"])
         template = Template("<head>{{ bokeh_css }}</head><body></body>")
         output = bes.file_html(test_plot, (None, css_resources), "title", template=template)
-        html = "<head>%s</head><body></body>" % css_resources.render_css()
+        html = f"<head>{css_resources.render_css()}</head><body></body>"
         assert output == html
 
     @patch('bokeh.embed.bundle.warn')

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -137,20 +137,20 @@ class Test_js_link:
         m2 = SomeModel()
         with pytest.raises(ValueError) as e:
             m1.js_link('junk', m2, 'b')
-        assert str(e.value).endswith("%r is not a property of self (%r)" % ("junk", m1))
+        assert str(e.value).endswith(f"'junk' is not a property of self ({m1!r})")
 
     def test_value_error_on_bad_other(self) -> None:
         m1 = SomeModel()
         with pytest.raises(ValueError) as e:
             m1.js_link('a', 'junk', 'b')
-        assert str(e.value).endswith("'other' is not a Bokeh model: %r" % "junk")
+        assert str(e.value).endswith("'other' is not a Bokeh model: 'junk'")
 
     def test_value_error_on_bad_other_attr(self) -> None:
         m1 = SomeModel()
         m2 = SomeModel()
         with pytest.raises(ValueError) as e:
             m1.js_link('a', m2, 'junk')
-        assert str(e.value).endswith("%r is not a property of other (%r)" % ("junk", m2))
+        assert str(e.value).endswith(f"'junk' is not a property of other ({m2!r})")
 
     def test_creates_customjs(self) -> None:
         m1 = SomeModel()

--- a/tests/unit/bokeh/models/_util_models.py
+++ b/tests/unit/bokeh/models/_util_models.py
@@ -71,8 +71,8 @@ def check_properties_existence(model: HasProps, *props: list[str]) -> None:
     found = set(model.properties())
     missing = expected.difference(found)
     extra = found.difference(expected)
-    assert len(missing) == 0, "Properties missing: {0}".format(", ".join(sorted(missing)))
-    assert len(extra) == 0, "Extra properties: {0}".format(", ".join(sorted(extra)))
+    assert len(missing) == 0, f"Properties missing: {', '.join(sorted(missing))}"
+    assert len(extra) == 0, f"Extra properties: {', '.join(sorted(extra))}"
 
 def check_fill_properties(model: HasProps, prefix: str = "", fill_color: str | None = Color.gray, fill_alpha: float = 1.0) -> None:
     assert getattr(model, prefix + "fill_color") == fill_color

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -152,7 +152,7 @@ def test_websocket_compression_level() -> None:
 def test_websocket_origins(ManagedServerLoop, unused_tcp_port) -> None:
     application = Application()
     with ManagedServerLoop(application, port=unused_tcp_port) as server:
-        assert server._tornado.websocket_origins == {"localhost:%s" % unused_tcp_port}
+        assert server._tornado.websocket_origins == {f"localhost:{unused_tcp_port}"}
 
     # OK this is a bit of a confusing mess. The user-facing arg for server is
     # "allow_websocket_origin" which gets converted to "extra_websocket_origins"

--- a/tests/unit/bokeh/test___init__.py
+++ b/tests/unit/bokeh/test___init__.py
@@ -92,7 +92,7 @@ class TestWarnings:
     @pytest.mark.parametrize('cat', (BokehDeprecationWarning, BokehUserWarning))
     def test_bokeh_custom(self, cat) -> None:
         r = warnings.formatwarning("message", cat, "line", "lineno")
-        assert r == "%s: %s\n" %(cat.__name__, "message")
+        assert r == f"{cat.__name__}: message\n"
 
     def test_general_default(self) -> None:
         r = warnings.formatwarning("message", RuntimeWarning, "line", "lineno")

--- a/tests/unit/bokeh/test_palettes.py
+++ b/tests/unit/bokeh/test_palettes.py
@@ -49,21 +49,21 @@ def test_palettes_dir() -> None:
     assert '__new__' not in dir(pal)
 
 def test_varying_alpha_palette() -> None:
-    assert pal.varying_alpha_palette("blue", 3) == ("#0000FF00", "#0000FF80", "#0000FF")
-    assert pal.varying_alpha_palette("red", 3, start_alpha=255, end_alpha=128) == ("#FF0000", "#FF0000C0", "#FF000080")
-    assert pal.varying_alpha_palette("#123456", 3, start_alpha=205, end_alpha=205) == ("#123456CD", "#123456CD", "#123456CD")
-    assert pal.varying_alpha_palette("#abc", 3) == ("#AABBCC00", "#AABBCC80", "#AABBCC")
+    assert pal.varying_alpha_palette("blue", 3) == ("#0000ff00", "#0000ff80", "#0000ff")
+    assert pal.varying_alpha_palette("red", 3, start_alpha=255, end_alpha=128) == ("#ff0000", "#ff0000c0", "#ff000080")
+    assert pal.varying_alpha_palette("#123456", 3, start_alpha=205, end_alpha=205) == ("#123456cd", "#123456cd", "#123456cd")
+    assert pal.varying_alpha_palette("#abc", 3) == ("#aabbcc00", "#aabbcc80", "#aabbcc")
 
     palette = pal.varying_alpha_palette("blue")
     assert len(palette) == 256
-    assert palette[::64] == ("#0000FF00", "#0000FF40", "#0000FF80", "#0000FFC0")
+    assert palette[::64] == ("#0000ff00", "#0000ff40", "#0000ff80", "#0000ffc0")
 
     assert pal.varying_alpha_palette("#654321", start_alpha=100, end_alpha=103) == ("#65432164", "#65432165", "#65432166", "#65432167")
 
     with pytest.raises(ValueError):
         pal.varying_alpha_palette("bluey")
     with pytest.raises(ValueError):
-        pal.varying_alpha_palette("#8F")
+        pal.varying_alpha_palette("#8f")
     with pytest.raises(ValueError):
         pal.varying_alpha_palette("red", start_alpha=-1)
     with pytest.raises(ValueError):
@@ -74,13 +74,13 @@ def test_varying_alpha_palette() -> None:
         pal.varying_alpha_palette("red", end_alpha=256)
 
     # Combining with alpha from color argument.
-    assert pal.varying_alpha_palette("#FFAA8080", 3) == ("#FFAA8000", "#FFAA8040", "#FFAA8080")
-    assert pal.varying_alpha_palette("#80FFAA80", 3, start_alpha=255, end_alpha=0) == ("#80FFAA80", "#80FFAA40", "#80FFAA00")
-    assert pal.varying_alpha_palette("#AABBCC80", 3, start_alpha=128) == ("#AABBCC40", "#AABBCC60", "#AABBCC80")
+    assert pal.varying_alpha_palette("#ffaa8080", 3) == ("#ffaa8000", "#ffaa8040", "#ffaa8080")
+    assert pal.varying_alpha_palette("#80ffaa80", 3, start_alpha=255, end_alpha=0) == ("#80ffaa80", "#80ffaa40", "#80ffaa00")
+    assert pal.varying_alpha_palette("#aabbcc80", 3, start_alpha=128) == ("#aabbcc40", "#aabbcc60", "#aabbcc80")
     assert pal.varying_alpha_palette("#12345680", 3, start_alpha=0, end_alpha=128) == ("#12345600", "#12345620", "#12345640")
 
-    assert len(pal.varying_alpha_palette("#FFAA8080")) == 129
-    assert len(pal.varying_alpha_palette("#FFAA8080", end_alpha=128)) == 65
+    assert len(pal.varying_alpha_palette("#ffaa8080")) == 129
+    assert len(pal.varying_alpha_palette("#ffaa8080", end_alpha=128)) == 65
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -163,7 +163,7 @@ class TestResources:
             r.log_level = level
             assert r.log_level == level
             if not r.dev:
-                assert r.js_raw[-1] == 'Bokeh.set_log_level("%s");' % level
+                assert r.js_raw[-1] == f'Bokeh.set_log_level("{level}");'
         with pytest.raises(ValueError):
             setattr(r, "log_level", "foo")
 

--- a/tests/unit/bokeh/test_themes.py
+++ b/tests/unit/bokeh/test_themes.py
@@ -240,12 +240,12 @@ class TestThemes:
         for name, value in props.items():
             property = model.lookup(name)
             if property is None:
-                raise RuntimeError("Model %r has no property %s" % (model, name))
+                raise RuntimeError(f"Model {model!r} has no property {name!r}")
             default = property.class_default(model_class)
             if default != value:
-                print("%s.%s differs default %r theme %r" % (model_class.__name__, name, default, value))
+                print(f"{model_class.__name__}.{name} differs default {default!r} theme {value!r}")
             else:
-                print("%s.%s default %r is identical in the theme" % (model_class.__name__, name, default))
+                print(f"{model_class.__name__}.{name} default {default!r} is identical in the theme")
 
     def _compare_dict_to_model_defaults(self, props, model_name):
         import bokeh.models as models


### PR DESCRIPTION
This PR updates the repo to use the latest version of `ruff`. Incidentally, this version calls out many (but not all) instances of old-style string formatting. So this PR also updates many instance of old-style formatting to use f-strings. I would guess this brings the codebase to about 85% in terms of getting rid of old-style formatting. 
