### PR TITLE
improve rgb colors in examples

### DIFF
--- a/examples/basic/axes/bounds.py
+++ b/examples/basic/axes/bounds.py
@@ -7,19 +7,19 @@ from bokeh.models import LinearAxis, Range1d
 from bokeh.plotting import figure, show
 from bokeh.sampledata.stocks import AAPL, GOOG
 
-# Plot where bounds are set by auto
 N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50 + 2 * x, 30 + 2 * y)]
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
+
+# Plot where bounds are set by auto
 plot_default = figure(tools='pan, box_zoom, wheel_zoom, reset',
                       title="Cannot pan outside data (bounds='auto')",
                       lod_threshold=None)
 plot_default.scatter(x, y, radius=radii, fill_color=colors, fill_alpha=0.6, line_color=None)
 plot_default.x_range.bounds = 'auto'
 plot_default.y_range.bounds = 'auto'
-
 
 # Plot where ranges are manually set
 x_range = Range1d(0, 3, bounds=(-1, 3.5), min_interval=1.5)
@@ -29,7 +29,6 @@ plot_range = figure(tools='pan, box_zoom, wheel_zoom, reset',
                     title="Manual bounds x:(-1, 3.5) y:(-0.5, 4) min_interval:1.5")
 plot_range.rect(x=[1, 2], y=[1, 1], width=0.9, height=0.9)
 
-
 # Manually set y_max only
 x_range = Range1d(0, 3, max_interval=4)
 y_range = Range1d(0, 3, bounds=(None, 3), max_interval=4)
@@ -38,8 +37,6 @@ plot_range_un = figure(tools='pan, wheel_zoom, reset',
                        title="Unbounded (except for y_max=3 and max_interval=4)")
 plot_range_un.rect(x=[1, 2], y=[1, 1], width=0.9, height=0.9, color='#043A8D')
 
-
-
 # Bounded on reversed ranges (except for y_max)
 x_range = Range1d(3, 0, bounds=(-1, 3.5), min_interval=1.5)
 y_range = Range1d(3, 0, bounds=(-0.5, 4), min_interval=1.5)
@@ -47,8 +44,6 @@ plot_range_rev = figure(tools='pan,wheel_zoom,reset',
                         x_range=x_range, y_range=y_range,
                         title="Manual bounds x:(-1, 3.5) y:(-0.5, 4) min_range:1.5 (reverse ranges)")
 plot_range_rev.rect(x=[1, 2], y=[1, 1], width=0.9, height=0.9, color='#8CBEDB')
-
-
 
 # Chart where limits are set on a categorical range
 fruits = {

--- a/examples/basic/scatters/color_scatter.py
+++ b/examples/basic/scatters/color_scatter.py
@@ -15,7 +15,7 @@ N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = np.array([ [r, g, 150] for r, g in zip(50 + 2*x, 30 + 2*y) ], dtype="uint8")
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
 TOOLS="hover,crosshair,pan,wheel_zoom,zoom_in,zoom_out,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select,examine,help"
 

--- a/examples/interaction/js_callbacks/color_sliders.py
+++ b/examples/interaction/js_callbacks/color_sliders.py
@@ -12,28 +12,23 @@ from bokeh.models import ColumnDataSource, CustomJS, Slider
 from bokeh.plotting import curdoc, figure, show
 from bokeh.themes import Theme
 
-R, G, B = (75, 125, 125)
-
-def rgb_to_hex(r, g, b):
-    return f"#{r:02x}{g:02x}{b:02x}"
-
-color = rgb_to_hex(R, G, B)
-text_color = '#ffffff'
+color = R, G, B = (75, 125, 125)
+text_color = (255, 255, 255)
 
 # create a data source to enable refreshing of fill & text color
 source = ColumnDataSource(data=dict(color=[color], text_color=[text_color]))
 
 # create first plot, as a rect() glyph and centered text label, with fill and text color taken from source
 p = figure(x_range=(-8, 8), y_range=(-4, 4),
-            width=400, height=300,
-            title='move sliders to change', tools='')
+           width=400, height=300,
+           title='move sliders to change', tools='')
 
 p.rect(0, 0, width=18, height=10, fill_color='color',
         line_color = 'black', source=source)
 
 p.text(0, 0, text='color', text_color='text_color',
-        alpha=0.6667, text_font_size='48px', text_baseline='middle',
-        text_align='center', source=source)
+       alpha=0.6667, text_font_size='48px', text_baseline='middle',
+       text_align='center', source=source)
 
 red = Slider(title="R", start=0, end=255, value=R, step=1)
 green = Slider(title="G", start=0, end=255, value=G, step=1)

--- a/examples/interaction/js_callbacks/customjs_for_range_update.py
+++ b/examples/interaction/js_callbacks/customjs_for_range_update.py
@@ -9,9 +9,7 @@ N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [
-    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
-]
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
 box = BoxAnnotation(left=0, right=0, bottom=0, top=0,
     fill_alpha=0.1, line_color='black', fill_color='black')

--- a/examples/interaction/js_callbacks/js_on_event.py
+++ b/examples/interaction/js_callbacks/js_on_event.py
@@ -39,9 +39,7 @@ N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [
-    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
-]
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
 p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset,tap,lasso_select,box_select,box_zoom,undo,redo")
 

--- a/examples/models/toolbars.py
+++ b/examples/models/toolbars.py
@@ -7,7 +7,7 @@ N = 1000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)]
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
 TOOLS="hover,crosshair,pan,reset,box_select"
 

--- a/examples/models/toolbars2.py
+++ b/examples/models/toolbars2.py
@@ -7,7 +7,7 @@ N = 1000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)]
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
 TOOLS="hover,crosshair,pan,wheel_zoom,zoom_in,zoom_out,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select"
 

--- a/examples/output/apis/autoload_static_flask.py
+++ b/examples/output/apis/autoload_static_flask.py
@@ -14,9 +14,7 @@ def render_plot():
     x = np.random.random(size=N) * 100
     y = np.random.random(size=N) * 100
     radii = np.random.random(size=N) * 1.5
-    colors = [
-        f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
-    ]
+    colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
     TOOLS="crosshair,pan,wheel_zoom,box_zoom,reset,tap,save,box_select,poly_select,lasso_select"
 
@@ -26,18 +24,18 @@ def render_plot():
               fill_color=colors, fill_alpha=0.6,
               line_color=None)
 
-    js, tag = autoload_static(p, CDN, "http://localhost:%s/plot.js" % port)
+    js, tag = autoload_static(p, CDN, f"http://localhost:{port}/plot.js")
 
-    html = """
+    html = f"""
     <html>
         <head>
             <title>color_scatter example</title>
         </head>
         <body>
-            %s
+            {tag}
         </body>
     </html>
-    """ % tag
+    """
 
     return html, js
 
@@ -50,11 +48,6 @@ def plot_html():
 @app.route('/plot.js')
 def plot_js():
     return Response(js, mimetype='text/javascript')
-
-    #return app.send_static_file("plot.js")
-    #with open("plot.js") as plot_js:
-    #    js = plot_js.read()
-    #return Response(js, mimetype='text/javascript')
 
 if __name__ == "__main__":
     app.run(port=port)

--- a/examples/output/apis/server_session/bokeh_app.py
+++ b/examples/output/apis/server_session/bokeh_app.py
@@ -7,9 +7,7 @@ N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [
-    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
-]
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
 p = figure(tools="", toolbar_location=None)
 

--- a/examples/plotting/hover.py
+++ b/examples/plotting/hover.py
@@ -2,45 +2,40 @@ import itertools
 
 import numpy as np
 
+from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure, show
 
-TOOLS="crosshair,pan,wheel_zoom,box_zoom,reset,hover,save"
+TOOLS = "crosshair,pan,wheel_zoom,box_zoom,reset,hover,save"
 
 TOOLTIPS = [
     ("index", "$index"),
-    ("(x,y)", "($x, $y)"),
+    ("(x, y)", "($x, $y)"),
     ("radius", "@radius"),
     ("fill color", "$color[hex, swatch]:colors"),
     ("foo", "@foo"),
     ("bar", "@bar"),
 ]
 
-xx, yy = np.meshgrid(range(0,101,4), range(0,101,4))
-x = xx.flatten()
-y = yy.flatten()
-N = len(x)
-inds = [str(i) for i in np.arange(N)]
-radii = np.random.random(size=N)*0.4 + 1.7
-colors = [
-    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
-]
+N = 26 * 26
+x, y = np.mgrid[0:101:4, 0:101:4].reshape((2, N))
 
-data=dict(
+source = ColumnDataSource(data=dict(
     x=x,
     y=y,
-    radius=radii,
-    colors=colors,
+    radius=np.random.random(N) * 0.4 + 1.7,
+    colors=np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8"),
     foo=list(itertools.permutations("abcdef"))[:N],
     bar=np.random.normal(size=N),
-)
+    text=[str(i) for i in np.arange(N)],
+))
 
 p = figure(title="Hoverful Scatter", tools=TOOLS, tooltips=TOOLTIPS)
 
-r = p.circle(x='x', y='y', radius='radius', source=data,
-             fill_color='colors', fill_alpha=0.6, line_color=None)
+r = p.circle("x", "y", radius="radius", source=source,
+             fill_color="colors", fill_alpha=0.6, line_color=None)
 p.hover.renderers = [r] # hover only for circles
 
-p.text(x, y, text=inds, alpha=0.5, text_font_size="7px",
-       text_baseline="middle", text_align="center")
+p.text("x", "y", text="text", source=source, alpha=0.5,
+       text_font_size="7px", text_baseline="middle", text_align="center")
 
-show(p)  # open a browser
+show(p)

--- a/examples/plotting/tap.py
+++ b/examples/plotting/tap.py
@@ -3,27 +3,22 @@ import numpy as np
 from bokeh.models import TapTool
 from bokeh.plotting import figure, show
 
-xx, yy = np.meshgrid(range(0,101,4), range(0,101,4))
-x = xx.flatten()
-y = yy.flatten()
-N = len(x)
-inds = [str(i) for i in np.arange(N)]
-radii = np.random.random(size=N)*0.4 + 1.7
-colors = [
-    f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)
-]
+N = 26 * 26
+x, y = np.mgrid[0:101:4, 0:101:4].reshape((2, N))
+text = [str(i) for i in np.arange(N)]
+radii = np.random.random(N) * 0.4 + 1.7
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
-TOOLS="crosshair,pan,wheel_zoom,box_zoom,reset,tap,save"
+TOOLS = "crosshair,pan,wheel_zoom,box_zoom,reset,tap,save"
 
 p = figure(title="Tappy Scatter", tools=TOOLS)
 
 cr = p.circle(x, y, radius=radii,
               fill_color=colors, fill_alpha=0.6, line_color=None)
 
-tr = p.text(x, y, text=inds, alpha=0.5, text_font_size="7px",
+tr = p.text(x, y, text=text, alpha=0.5, text_font_size="7px",
             text_baseline="middle", text_align="center")
 
-# in the browser console, you will see messages when circles are clicked
 tool = p.select_one(TapTool).renderers = [cr]
 
-show(p)  # open a browser
+show(p)

--- a/examples/plotting/toolbar_autohide.py
+++ b/examples/plotting/toolbar_autohide.py
@@ -16,7 +16,7 @@ N = 1000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)]
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
 def make_plot(autohide=None):
     p = figure(width=300, height=300, title='Autohiding toolbar' if autohide else 'Not autohiding toolbar')

--- a/examples/server/app/events_app.py
+++ b/examples/server/app/events_app.py
@@ -52,7 +52,7 @@ N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = [f"#{int(r):02x}{int(g):02x}{150:02x}" for r, g in zip(50+2*x, 30+2*y)]
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
 
 p = figure(tools="pan,wheel_zoom,zoom_in,zoom_out,reset,tap,lasso_select,box_select,box_zoom,undo,redo")
 


### PR DESCRIPTION
* [x] issues: fixes #12760 

Opted for just using np arrays everywhere since all the examples were already using numpy anyway. 

Also cleaned up a few other aspects of the same examples.