### PR TITLE
Add `eqhist_cmap` function to transform.py

### DIFF
--- a/docs/bokeh/source/docs/user_guide/basic/data.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/data.rst
@@ -312,13 +312,14 @@ Client-side color mapping
 With color mapping, you can encode values from a sequence of data into
 specific colors.
 
-Bokeh provides two functions to perform color mapping directly in the
+Bokeh provides three functions to perform color mapping directly in the
 browser:
 
 * The :func:`~bokeh.transform.linear_cmap` function for linear color mapping
 * The :func:`~bokeh.transform.log_cmap` function for logarithmic color mapping
+* The :func:`~bokeh.transform.eqhist_cmap` function for equalized histogram color mapping
 
-Both functions operate similarly and accept the following arguments:
+All three functions operate similarly and accept the following arguments:
 
 * The name of a ``ColumnDataSource`` column containing the data to map colors to
 * A palette (which can be one of :ref:`Bokeh's pre-defined palettes

--- a/src/bokeh/transform.py
+++ b/src/bokeh/transform.py
@@ -36,9 +36,9 @@ from .models.mappers import (
     CategoricalColorMapper,
     CategoricalMarkerMapper,
     CategoricalPatternMapper,
+    EqHistColorMapper,
     LinearColorMapper,
     LogColorMapper,
-    EqHistColorMapper,
 )
 from .models.transforms import Dodge, Jitter
 

--- a/src/bokeh/transform.py
+++ b/src/bokeh/transform.py
@@ -121,8 +121,15 @@ def dodge(field_name: str, value: float, range: Range | None = None) -> Field:
     '''
     return Field(field_name, Dodge(value=value, range=range))
 
-def eqhist_cmap(field_name: str, palette: Sequence[ColorLike], low: float, high: float,
-        low_color: ColorLike | None = None, high_color: ColorLike | None = None, nan_color: ColorLike = "gray") -> Field:
+def eqhist_cmap(
+    field_name: str,
+    palette: Sequence[ColorLike],
+    low: float,
+    high: float,
+    low_color: ColorLike | None = None,
+    high_color: ColorLike | None = None,
+    nan_color: ColorLike = "gray",
+) -> Field:
     ''' Create a ``DataSpec`` dict that applies a client-side
     ``EqHistColorMapper`` transformation to a ``ColumnDataSource`` column.
 
@@ -161,8 +168,14 @@ def eqhist_cmap(field_name: str, palette: Sequence[ColorLike], low: float, high:
         )
     )
 
-def factor_cmap(field_name: str, palette: Sequence[ColorLike], factors: Factors,
-        start: float = 0, end: float | None = None, nan_color: ColorLike = "gray") -> Field:
+def factor_cmap(
+    field_name: str,
+    palette: Sequence[ColorLike],
+    factors: Factors,
+    start: float = 0,
+    end: float | None = None,
+    nan_color: ColorLike = "gray",
+) -> Field:
     ''' Create a ``DataSpec`` dict that applies a client-side
     ``CategoricalColorMapper`` transformation to a ``ColumnDataSource``
     column.
@@ -199,8 +212,13 @@ def factor_cmap(field_name: str, palette: Sequence[ColorLike], factors: Factors,
         )
     )
 
-def factor_hatch(field_name: str, patterns: Sequence[str], factors: Factors,
-        start: float = 0, end: float | None = None) -> Field:
+def factor_hatch(
+    field_name: str,
+    patterns: Sequence[str],
+    factors: Factors,
+    start: float = 0,
+    end: float | None = None,
+) -> Field:
     ''' Create a ``DataSpec`` dict that applies a client-side
     ``CategoricalPatternMapper`` transformation to a ``ColumnDataSource``
     column.
@@ -235,8 +253,13 @@ def factor_hatch(field_name: str, patterns: Sequence[str], factors: Factors,
         )
     )
 
-def factor_mark(field_name: str, markers: Sequence[str], factors: Factors,
-        start: float = 0, end: float | None = None) -> Field:
+def factor_mark(
+    field_name: str,
+    markers: Sequence[str],
+    factors: Factors,
+    start: float = 0,
+    end: float | None = None,
+) -> Field:
     ''' Create a ``DataSpec`` dict that applies a client-side
     ``CategoricalMarkerMapper`` transformation to a ``ColumnDataSource``
     column.
@@ -273,8 +296,13 @@ def factor_mark(field_name: str, markers: Sequence[str], factors: Factors,
         )
     )
 
-def jitter(field_name: str, width: float, mean: float = 0,
-        distribution: JitterRandomDistributionType = "uniform", range: Range | None = None) -> Field:
+def jitter(
+    field_name: str,
+    width: float,
+    mean: float = 0,
+    distribution: JitterRandomDistributionType = "uniform",
+    range: Range | None = None,
+) -> Field:
     ''' Create a ``DataSpec`` dict that applies a client-side ``Jitter``
     transformation to a ``ColumnDataSource`` column.
 
@@ -306,8 +334,15 @@ def jitter(field_name: str, width: float, mean: float = 0,
         )
     )
 
-def linear_cmap(field_name: str, palette: Sequence[ColorLike], low: float, high: float,
-        low_color: ColorLike | None = None, high_color: ColorLike | None = None, nan_color: ColorLike = "gray") -> Field:
+def linear_cmap(
+    field_name: str,
+    palette: Sequence[ColorLike],
+    low: float,
+    high: float,
+    low_color: ColorLike | None = None,
+    high_color: ColorLike | None = None,
+    nan_color: ColorLike = "gray",
+) -> Field:
     ''' Create a ``DataSpec`` dict that applies a client-side
     ``LinearColorMapper`` transformation to a ``ColumnDataSource`` column.
 
@@ -346,8 +381,15 @@ def linear_cmap(field_name: str, palette: Sequence[ColorLike], low: float, high:
         )
     )
 
-def log_cmap(field_name: str, palette: Sequence[ColorLike], low: float, high: float,
-        low_color: ColorLike | None = None, high_color: ColorLike | None = None, nan_color: ColorLike = "gray") -> Field:
+def log_cmap(
+    field_name: str,
+    palette: Sequence[ColorLike],
+    low: float,
+    high: float,
+    low_color: ColorLike | None = None,
+    high_color: ColorLike | None = None,
+    nan_color: ColorLike = "gray",
+) -> Field:
     ''' Create a ``DataSpec`` dict that applies a client-side ``LogColorMapper``
     transformation to a ``ColumnDataSource`` column.
 

--- a/src/bokeh/transform.py
+++ b/src/bokeh/transform.py
@@ -38,6 +38,7 @@ from .models.mappers import (
     CategoricalPatternMapper,
     LinearColorMapper,
     LogColorMapper,
+    EqHistColorMapper,
 )
 from .models.transforms import Dodge, Jitter
 
@@ -56,6 +57,7 @@ if TYPE_CHECKING:
 __all__ = (
     'cumsum',
     'dodge',
+    'eqhist_cmap',
     'factor_cmap',
     'factor_hatch',
     'factor_mark',
@@ -118,6 +120,46 @@ def dodge(field_name: str, value: float, range: Range | None = None) -> Field:
 
     '''
     return Field(field_name, Dodge(value=value, range=range))
+
+def eqhist_cmap(field_name: str, palette: Sequence[ColorLike], low: float, high: float,
+        low_color: ColorLike | None = None, high_color: ColorLike | None = None, nan_color: ColorLike = "gray") -> Field:
+    ''' Create a ``DataSpec`` dict that applies a client-side
+    ``EqHistColorMapper`` transformation to a ``ColumnDataSource`` column.
+
+    Args:
+        field_name (str) : a field name to configure ``DataSpec`` with
+
+        palette (seq[color]) : a list of colors to use for colormapping
+
+        low (float) : a minimum value of the range to map into the palette.
+            Values below this are clamped to ``low``.
+
+        high (float) : a maximum value of the range to map into the palette.
+            Values above this are clamped to ``high``.
+
+        low_color (color, optional) : color to be used if data is lower than
+            ``low`` value. If None, values lower than ``low`` are mapped to the
+            first color in the palette. (default: None)
+
+        high_color (color, optional) : color to be used if data is higher than
+            ``high`` value. If None, values higher than ``high`` are mapped to
+            the last color in the palette. (default: None)
+
+        nan_color (color, optional) : a default color to use when mapping data
+            from a column does not succeed (default: "gray")
+
+    '''
+    return Field(
+        field_name,
+        EqHistColorMapper(
+            palette=palette,
+            low=low,
+            high=high,
+            nan_color=nan_color,
+            low_color=low_color,
+            high_color=high_color,
+        )
+    )
 
 def factor_cmap(field_name: str, palette: Sequence[ColorLike], factors: Factors,
         start: float = 0, end: float | None = None, nan_color: ColorLike = "gray") -> Field:

--- a/tests/unit/bokeh/test_transform.py
+++ b/tests/unit/bokeh/test_transform.py
@@ -24,6 +24,7 @@ from bokeh.models import (
     CategoricalPatternMapper,
     CumSum,
     Dodge,
+    EqHistColorMapper,
     FactorRange,
     Jitter,
     LinearColorMapper,
@@ -42,6 +43,7 @@ import bokeh.transform as bt # isort:skip
 ALL = (
     'cumsum',
     'dodge',
+    'eqhist_cmap',
     'factor_cmap',
     'factor_hatch',
     'factor_mark',
@@ -93,6 +95,32 @@ class Test_dodge:
         assert t.transform.value == 0.5
         assert t.transform.range is r
         assert t.transform.range.factors == ["a"]
+
+
+class Test_eqhist_cmap:
+    def test_basic(self) -> None:
+        t = bt.eqhist_cmap("foo", ["red", "green"], 0, 10, low_color="orange", high_color="blue", nan_color="pink")
+        assert isinstance(t, Field)
+        assert t.field == "foo"
+        assert isinstance(t.transform, EqHistColorMapper)
+        assert t.transform.palette == ["red", "green"]
+        assert t.transform.low == 0
+        assert t.transform.high == 10
+        assert t.transform.low_color == "orange"
+        assert t.transform.high_color == "blue"
+        assert t.transform.nan_color == "pink"
+
+    def test_defaults(self) -> None:
+        t = bt.eqhist_cmap("foo", ["red", "green"], 0, 10)
+        assert isinstance(t, Field)
+        assert t.field == "foo"
+        assert isinstance(t.transform, EqHistColorMapper)
+        assert t.transform.palette == ["red", "green"]
+        assert t.transform.low == 0
+        assert t.transform.high == 10
+        assert t.transform.low_color is None
+        assert t.transform.high_color is None
+        assert t.transform.nan_color == "gray"
 
 
 class Test_factor_cmap:


### PR DESCRIPTION
Hi everyone, thank you for the great package!

This PR will add a corresponding function (`eqhist_cmap`) for the `EqHistColorMapper` in `bokeh.transform`. Unit tests have also been added and are passing. 

- [x] issues: fixes #12752 
- [x] tests added / passed
- [x] release document entry (if new feature or API change) 
