### PR TITLE
enable filterwarnings=error

### DIFF
--- a/examples/server/app/clustering/main.py
+++ b/examples/server/app/clustering/main.py
@@ -38,7 +38,7 @@ def clustering(X, algorithm, n_clusters):
 
     # Generate the new colors:
     if algorithm=='MiniBatchKMeans':
-        model = cluster.MiniBatchKMeans(n_clusters=n_clusters)
+        model = cluster.MiniBatchKMeans(n_clusters=n_clusters, n_init=3)
 
     elif algorithm=='Birch':
         model = cluster.Birch(n_clusters=n_clusters)

--- a/examples/server/app/export_csv/main.py
+++ b/examples/server/app/export_csv/main.py
@@ -3,6 +3,7 @@ This example shows the capability of exporting a csv file from ColumnDataSource.
 
 '''
 from os.path import dirname, join
+from pathlib import Path
 
 import pandas as pd
 
@@ -27,8 +28,13 @@ slider = RangeSlider(title="Max Salary", start=10000, end=110000, value=(10000, 
 slider.on_change('value', lambda attr, old, new: update())
 
 button = Button(label="Download", button_type="success")
-button.js_on_event("button_click", CustomJS(args=dict(source=source),
-                            code=open(join(dirname(__file__), "download.js")).read()))
+button.js_on_event(
+    "button_click",
+    CustomJS(
+        args=dict(source=source),
+        code=(Path(__file__).parent / "download.js").read_text(encoding="utf8")
+    )
+)
 
 columns = [
     TableColumn(field="name", title="Employee Name"),

--- a/examples/server/app/export_csv/main.py
+++ b/examples/server/app/export_csv/main.py
@@ -32,7 +32,7 @@ button.js_on_event(
     "button_click",
     CustomJS(
         args=dict(source=source),
-        code=(Path(__file__).parent / "download.js").read_text(encoding="utf8")
+        code=(Path(__file__).parent / "download.js").read_text("utf8")
     )
 )
 

--- a/examples/server/app/image_blur.py
+++ b/examples/server/app/image_blur.py
@@ -6,7 +6,7 @@ of Bokeh to transform images to have certain effects.
 
 '''
 import numpy as np
-import scipy.misc
+import scipy.datasets
 
 try:
     from numba import njit
@@ -21,7 +21,7 @@ from bokeh.models import ColumnDataSource, Slider
 from bokeh.palettes import gray
 from bokeh.plotting import figure
 
-image = scipy.misc.ascent().astype(np.int32)[::-1, :]
+image = scipy.datasets.ascent().astype(np.int32)[::-1, :]
 w, h = image.shape
 
 source = ColumnDataSource(data=dict(image=[image]))

--- a/examples/server/app/movies/main.py
+++ b/examples/server/app/movies/main.py
@@ -5,6 +5,7 @@ sorting options based on a given dataset.
 '''
 import sqlite3 as sql
 from os.path import dirname, join
+from pathlib import Path
 
 import numpy as np
 import pandas.io.sql as psql
@@ -16,7 +17,7 @@ from bokeh.plotting import figure
 from bokeh.sampledata.movies_data import movie_path
 
 conn = sql.connect(movie_path)
-query = open(join(dirname(__file__), 'query.sql')).read()
+query = (Path(__file__).parent / 'query.sql').read_text(encoding="utf8")
 movies = psql.read_sql(query, conn)
 
 movies["color"] = np.where(movies["Oscars"] > 0, "orange", "grey")
@@ -38,7 +39,7 @@ axis_map = {
     "Year": "Year",
 }
 
-desc = Div(text=open(join(dirname(__file__), "description.html")).read(), sizing_mode="stretch_width")
+desc = Div(text=(Path(__file__).parent / "description.html").read_text(encoding="utf8"), sizing_mode="stretch_width")
 
 # Create Input controls
 reviews = Slider(title="Minimum number of reviews", value=80, start=10, end=300, step=10)
@@ -47,7 +48,7 @@ max_year = Slider(title="End Year released", start=1940, end=2014, value=2014, s
 oscars = Slider(title="Minimum number of Oscar wins", start=0, end=4, value=0, step=1)
 boxoffice = Slider(title="Dollars at Box Office (millions)", start=0, end=800, value=0, step=1)
 genre = Select(title="Genre", value="All",
-               options=open(join(dirname(__file__), 'genres.txt')).read().split())
+               options=(Path(__file__).parent / 'genres.txt').read_text(encoding="utf8").split())
 director = TextInput(title="Director name contains")
 cast = TextInput(title="Cast names contains")
 x_axis = Select(title="X Axis", options=sorted(axis_map.keys()), value="Tomato Meter")

--- a/examples/server/app/movies/main.py
+++ b/examples/server/app/movies/main.py
@@ -17,7 +17,7 @@ from bokeh.plotting import figure
 from bokeh.sampledata.movies_data import movie_path
 
 conn = sql.connect(movie_path)
-query = (Path(__file__).parent / 'query.sql').read_text(encoding="utf8")
+query = (Path(__file__).parent / 'query.sql').read_text("utf8")
 movies = psql.read_sql(query, conn)
 
 movies["color"] = np.where(movies["Oscars"] > 0, "orange", "grey")
@@ -39,7 +39,7 @@ axis_map = {
     "Year": "Year",
 }
 
-desc = Div(text=(Path(__file__).parent / "description.html").read_text(encoding="utf8"), sizing_mode="stretch_width")
+desc = Div(text=(Path(__file__).parent / "description.html").read_text("utf8"), sizing_mode="stretch_width")
 
 # Create Input controls
 reviews = Slider(title="Minimum number of reviews", value=80, start=10, end=300, step=10)
@@ -48,7 +48,7 @@ max_year = Slider(title="End Year released", start=1940, end=2014, value=2014, s
 oscars = Slider(title="Minimum number of Oscar wins", start=0, end=4, value=0, step=1)
 boxoffice = Slider(title="Dollars at Box Office (millions)", start=0, end=800, value=0, step=1)
 genre = Select(title="Genre", value="All",
-               options=(Path(__file__).parent / 'genres.txt').read_text(encoding="utf8").split())
+               options=(Path(__file__).parent / 'genres.txt').read_text("utf8").split())
 director = TextInput(title="Director name contains")
 cast = TextInput(title="Cast names contains")
 x_axis = Select(title="X Axis", options=sorted(axis_map.keys()), value="Tomato Meter")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ filterwarnings = [
     '''ignore:numpy\.ufunc size changed, may indicate binary incompatibility\. Expected 216 from C header, got 232 from PyObject:RuntimeWarning''',
     '''ignore:elementwise comparison failed; this will raise an error in the future\.:DeprecationWarning''',
     '''ignore:numba is not installed\. This example will be painfully slow\.:UserWarning''',
+    '''ignore:Could not infer format, so each element will be parsed individually, falling back to `dateutil`\. To ensure parsing is consistent and as-expected, please specify a format\.:UserWarning''',
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,11 @@ filterwarnings = [
     '''ignore:unclosed <socket.socket .*>:ResourceWarning''',
     '''ignore:unclosed event loop <.*>:ResourceWarning''',
     '''ignore:move_to_element_with_offset\(\) currently tries to use the top left corner of the element as the origin; in Selenium 4\.3 it will use the in-view center point of the element as the origin\.:DeprecationWarning''',
+    '''ignore:Using or importing the ABCs from 'collections' instead of from 'collections\.abc' is deprecated since Python 3\.3, and in 3\.10 it will stop working:DeprecationWarning:tornado''',
+    '''ignore:Unknown config option. asyncio_mode:pytest.PytestConfigWarning''',
+    '''ignore:zmq\.eventloop\.ioloop is deprecated in pyzmq 17\. pyzmq now works with default tornado and asyncio eventloops\.:DeprecationWarning:jupyter_client''',
+    '''ignore:the `interpolation=` argument to percentile was renamed to `method=`.*:DeprecationWarning:pandas''',
+    '''ignore:numpy\.ufunc size changed, may indicate binary incompatibility\. Expected 216 from C header, got 232 from PyObject:RuntimeWarning''',
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ filterwarnings = [
     '''ignore:zmq\.eventloop\.ioloop is deprecated in pyzmq 17\. pyzmq now works with default tornado and asyncio eventloops\.:DeprecationWarning:jupyter_client''',
     '''ignore:the `interpolation=` argument to percentile was renamed to `method=`.*:DeprecationWarning:pandas''',
     '''ignore:numpy\.ufunc size changed, may indicate binary incompatibility\. Expected 216 from C header, got 232 from PyObject:RuntimeWarning''',
+    '''ignore:elementwise comparison failed; this will raise an error in the future\.:DeprecationWarning''',
+    '''ignore:numba is not installed\. This example will be painfully slow\.:UserWarning''',
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,25 @@ markers = [
     "sampledata: a test for bokeh.sampledata",
     "selenium: a test as requiring selenium",
 ]
+filterwarnings = [
+    "error",
+    '''ignore:Module already imported so cannot be rewritten. tests\.support\.plugins\.project:pytest.PytestAssertRewriteWarning''',
+    '''ignore:Properties {'name'} in class ModelThatOverridesName were previously declared on a parent class\. .*:RuntimeWarning''',
+    '''ignore:Jupyter is migrating its paths to use standard platformdirs.*:DeprecationWarning''',
+    '''ignore:'tile_providers module' was deprecated in Bokeh 3\.0\.0 and will be removed, use 'add_tile directly' instead:bokeh.util.warnings.BokehDeprecationWarning''',
+    '''ignore:There is no current event loop:DeprecationWarning''',
+    '''ignore:coroutine 'HTTPServer.close_all_connections' was never awaited:RuntimeWarning''',
+    '''ignore:coroutine 'WebSocketProtocol13\.write_message\.<locals>\.wrapper' was never awaited:RuntimeWarning''',
+    '''ignore:coroutine 'PeriodicCallback._run' was never awaited:RuntimeWarning''',
+    '''ignore:make_current is deprecated; start the event loop first:DeprecationWarning''',
+    '''ignore:'get_provider' was deprecated in Bokeh 3\.0\.0 and will be removed, use 'add_tile directly' instead:bokeh.util.warnings.BokehDeprecationWarning''',
+    '''ignore:'HSL\(\)' was deprecated in Bokeh 2\.3\.1 and will be removed, use 'RGB\(\) or named colors:bokeh.util.warnings.BokehDeprecationWarning''',
+    '''ignore:elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison:FutureWarning''',
+    '''ignore:HTTPResponse\.getheader\(\) is deprecated and will be removed in urllib3 v2\.1\.0\. .*:DeprecationWarning:selenium''',
+    '''ignore:unclosed <socket.socket .*>:ResourceWarning''',
+    '''ignore:unclosed event loop <.*>:ResourceWarning''',
+    '''ignore:move_to_element_with_offset\(\) currently tries to use the top left corner of the element as the origin; in Selenium 4\.3 it will use the in-view center point of the element as the origin\.:DeprecationWarning''',
+]
 
 [tool.coverage.run]
 source = ["src/bokeh"]

--- a/src/bokeh/application/handlers/directory.py
+++ b/src/bokeh/application/handlers/directory.py
@@ -123,7 +123,8 @@ class DirectoryHandler(Handler):
 
         init_py = join(src_path, '__init__.py')
         if exists(init_py):
-            self._package_runner = CodeRunner(open(init_py).read(), init_py, argv)
+            with open(init_py, encoding="utf8") as init_py_f:
+                self._package_runner = CodeRunner(init_py_f.read(), init_py, argv)
             self._package = self._package_runner.new_module()
             assert self._package is not None
             sys.modules[self._package.__name__] = self._package

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -213,7 +213,7 @@ class MetaHasProps(type):
         redeclared = own_properties.keys() & base_properties.keys()
         if redeclared:
             warn(f"Properties {redeclared!r} in class {cls.__name__} were previously declared on a parent "
-                 "class. It never makes sense to do this. Redundant properties should be deleted here, or on"
+                 "class. It never makes sense to do this. Redundant properties should be deleted here, or on "
                  "the parent class. Override() can be used to change a default value of a base class property.",
                  RuntimeWarning)
 

--- a/src/bokeh/io/util.py
+++ b/src/bokeh/io/util.py
@@ -107,7 +107,10 @@ def temp_filename(ext: str) -> str:
     ''' Generate a temporary, writable filename with the given extension
 
     '''
-    return NamedTemporaryFile(suffix="." + ext).name
+    # todo: not safe - the file is deleted before being written to so another
+    # process can generate the same filename
+    with NamedTemporaryFile(suffix="." + ext) as f:
+        return f.name
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/src/bokeh/sampledata/les_mis.py
+++ b/src/bokeh/sampledata/les_mis.py
@@ -44,11 +44,8 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-import json
-
 # Bokeh imports
-from ..util.sampledata import package_path
+from ..util.sampledata import load_json, package_path
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -74,4 +71,4 @@ __all__ = (
 # Code
 #-----------------------------------------------------------------------------
 
-data = json.load(open(package_path('les_mis.json')))
+data = load_json(package_path('les_mis.json'))

--- a/src/bokeh/sampledata/olympics2014.py
+++ b/src/bokeh/sampledata/olympics2014.py
@@ -36,11 +36,8 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-import json
-
 # Bokeh imports
-from ..util.sampledata import package_path
+from ..util.sampledata import load_json, package_path
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -66,4 +63,4 @@ __all__ = (
 # Code
 #-----------------------------------------------------------------------------
 
-data = json.load(open(package_path('olympics2014.json')))
+data = load_json(package_path('olympics2014.json'))

--- a/src/bokeh/sampledata/us_cities.py
+++ b/src/bokeh/sampledata/us_cities.py
@@ -32,11 +32,8 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-import json
-
 # Bokeh imports
-from ..util.sampledata import external_path
+from ..util.sampledata import external_path, load_json
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -62,4 +59,4 @@ __all__ = (
 # Code
 #-----------------------------------------------------------------------------
 
-data = json.load(open(external_path('us_cities.json')))
+data = load_json(external_path('us_cities.json'))

--- a/src/bokeh/util/sampledata.py
+++ b/src/bokeh/util/sampledata.py
@@ -56,7 +56,9 @@ def download(progress: bool = True) -> None:
 
     # HTTP requests are cheaper for us, and there is nothing private to protect
     s3 = 'http://sampledata.bokeh.org'
-    files = json.load(open(Path(__file__).parent / "sampledata.json"))
+
+    with (Path(__file__).parent / "sampledata.json").open("rb") as f:
+        files = json.load(f)
 
     for filename, md5 in files:
         real_name, ext = splitext(filename)
@@ -145,6 +147,10 @@ def package_path(filename: str | Path) -> Path:
 
     '''
     return package_dir() / filename
+
+def load_json(filename: str | Path) -> Any:
+    with open(filename, "rb") as f:
+        return json.load(f)
 
 def open_csv(filename: str | Path) -> TextIO:
     '''

--- a/tests/codebase/test_json.py
+++ b/tests/codebase/test_json.py
@@ -41,11 +41,11 @@ def test_json() -> None:
     bad: list[str] = []
 
     for path in paths:
-        f = open(TOP_PATH/path)
-        try:
-            json.load(f)
-        except Exception as e:
-            bad.append(f"{path}: {e}" )
+        with (TOP_PATH/path).open() as f:
+            try:
+                json.load(f)
+            except Exception as e:
+                bad.append(f"{path}: {e}" )
 
     assert len(bad) == 0, "Malformed JSON detected:\n" + ",".join(bad)
 

--- a/tests/support/plugins/file_server.py
+++ b/tests/support/plugins/file_server.py
@@ -29,7 +29,7 @@ import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.request import URLopener
+from urllib.request import urlopen
 
 # External imports
 import pytest
@@ -110,7 +110,7 @@ class SimpleWebServer:
         self.stop_serving = True
         try:
             # This is to force stop the server loop
-            URLopener().open(f"http://{self.host}:{self.port}")
+            urlopen(f"http://{self.host}:{self.port}")
         except OSError:
             pass
         log.info("Shutting down the webserver")

--- a/tests/support/util/screenshot.py
+++ b/tests/support/util/screenshot.py
@@ -104,12 +104,13 @@ def _run_in_browser(engine: list[str], url: str, local_wait: int | None = None, 
         fail(str(e))
         sys.exit(1)
 
-    (stdout, stderr) = proc.communicate()
+    with proc:
+        (stdout, stderr) = proc.communicate()
 
-    if proc.returncode != 0:
-        output = stderr.decode("utf-8")
-        fail(output)
-        sys.exit(1)
+        if proc.returncode != 0:
+            output = stderr.decode("utf-8")
+            fail(output)
+            sys.exit(1)
 
     output = stdout.decode("utf-8")
     return json.loads(output)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -289,25 +289,27 @@ with open(filename, 'rb') as example:
         signal.alarm(20 if not example.is_slow else 60)
 
     start = time.time()
-    proc = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    with subprocess.Popen(
+        cmd, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    ) as proc:
 
-    status: ProcStatus
-    try:
-        status = proc.wait()
-    except Timeout:
-        proc.kill()
-        status = 'timeout'
-    finally:
-        if sys.platform != "win32":
-            signal.alarm(0)
+        status: ProcStatus
+        try:
+            status = proc.wait()
+        except Timeout:
+            proc.kill()
+            status = 'timeout'
+        finally:
+            if sys.platform != "win32":
+                signal.alarm(0)
 
-    end = time.time()
+        end = time.time()
 
-    assert proc.stdout is not None
-    assert proc.stderr is not None
+        assert proc.stdout is not None
+        assert proc.stderr is not None
 
-    out = proc.stdout.read().decode("utf-8")
-    err = proc.stderr.read().decode("utf-8")
+        out = proc.stdout.read().decode("utf-8")
+        err = proc.stderr.read().decode("utf-8")
 
     return (status, end - start, out, err)
 

--- a/tests/unit/bokeh/command/test_util__command.py
+++ b/tests/unit/bokeh/command/test_util__command.py
@@ -47,9 +47,9 @@ def test_die(capsys: Capture) -> None:
     assert out == ""
 
 def test_build_single_handler_application_unknown_file() -> None:
-    with pytest.raises(ValueError) as e:
-        f = tempfile.NamedTemporaryFile(suffix=".bad")
-        util.build_single_handler_application(f.name)
+    with tempfile.NamedTemporaryFile(suffix=".bad") as f:
+        with pytest.raises(ValueError) as e:
+            util.build_single_handler_application(f.name)
     assert "Expected a '.py' script or '.ipynb' notebook, got: " in str(e.value)
 
 def test_build_single_handler_application_nonexistent_file() -> None:

--- a/tests/unit/bokeh/io/test_util__io.py
+++ b/tests/unit/bokeh/io/test_util__io.py
@@ -18,12 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 import os
-from unittest.mock import (
-    MagicMock,
-    Mock,
-    PropertyMock,
-    patch,
-)
+from unittest.mock import MagicMock, patch
 
 # Module under test
 import bokeh.io.util as biu # isort:skip
@@ -44,17 +39,15 @@ def test_detect_current_filename() -> None:
     filename = biu.detect_current_filename()
     assert filename and filename.endswith(("py.test", "pytest", "py.test-script.py", "pytest-script.py"))
 
-@patch('bokeh.io.util.NamedTemporaryFile')
-def test_temp_filename(mock_tmp: MagicMock) -> None:
-    fn = Mock()
-    type(fn).name = PropertyMock(return_value="Junk.test")
-    mock_tmp.return_value = fn
-
-    r = biu.temp_filename("test")
-    assert r == "Junk.test"
-    assert mock_tmp.called
-    assert mock_tmp.call_args[0] == ()
-    assert mock_tmp.call_args[1] == {'suffix': '.test'}
+def test_temp_filename() -> None:
+    with patch('bokeh.io.util.NamedTemporaryFile', **{
+        'return_value.__enter__.return_value.name': 'Junk.test',
+    }) as mock_tmp:
+        r = biu.temp_filename("test")
+        assert r == "Junk.test"
+        assert mock_tmp.called
+        assert mock_tmp.call_args[0] == ()
+        assert mock_tmp.call_args[1] == {'suffix': '.test'}
 
 def test_default_filename() -> None:
     old_detect_current_filename = biu.detect_current_filename

--- a/tests/unit/bokeh/models/test_sources.py
+++ b/tests/unit/bokeh/models/test_sources.py
@@ -19,7 +19,6 @@ import pytest ; pytest
 # Standard library imports
 import datetime as dt
 import io
-import warnings
 
 # External imports
 import numpy as np
@@ -281,7 +280,7 @@ class TestColumnDataSource:
         assert ds.column_names == []
 
     def test_remove_exists2(self) -> None:
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(UserWarning, match=r"Unable to find column 'foo' in data source") as w:
             ds = bms.ColumnDataSource()
             ds.remove("foo")
             assert ds.column_names == []
@@ -763,25 +762,25 @@ Lime,Green,99,$0.39
         #with pytest.raises(ValueError):
         #    ds.data.update(dict(a=[10, 11, 12]))
 
-        with warnings.catch_warnings(record=True) as warns:
+        with pytest.warns(UserWarning) as warns:
             bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21, 22]))
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = bms.ColumnDataSource()
-        with warnings.catch_warnings(record=True) as warns:
+        with pytest.warns(UserWarning) as warns:
             ds.data = dict(a=[10, 11], b=[20, 21, 22])
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = bms.ColumnDataSource(data=dict(a=[10, 11]))
-        with warnings.catch_warnings(record=True) as warns:
+        with pytest.warns(UserWarning) as warns:
             ds.data["b"] = [20, 21, 22]
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 2), ('b', 3)"
 
         ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))
-        with warnings.catch_warnings(record=True) as warns:
+        with pytest.warns(UserWarning) as warns:
             ds.data.update(dict(a=[10, 11, 12]))
         assert len(warns) == 1
         assert str(warns[0].message) == "ColumnDataSource's columns must be of the same length. Current lengths: ('a', 3), ('b', 2)"

--- a/tests/unit/bokeh/server/test_util.py
+++ b/tests/unit/bokeh/server/test_util.py
@@ -36,6 +36,7 @@ def test_bind_sockets_with_zero_port() -> None:
     assert len(ss) == 1
     assert isinstance(ss[0], socket.socket)
     assert isinstance(port, int)
+    ss[0].close()
 
 def test_check_allowlist_rejects_port_mismatch() -> None:
     assert util.check_allowlist("foo:100", ["foo:101", "foo:102"]) is False


### PR DESCRIPTION
This configures warnings to be raised as errors rather than being logged at the end of a test run. Currently there are a number of warnings and deprecations in numpy, pandas, tornado and CPython that are being ignored that will become an issue one day. This PR fixes the easy ones (missing `with` statements, or renamed function calls) and ignores the ones that will need their own PR to fix by listing them explicitly in the config file

- [x] issues: fixes #12872
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
