### PR TITLE
Add support for `ValueSubmit` event on `TextInput`

### DIFF
--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -12,6 +12,7 @@ export type BokehEventType =
 export type ModelEventType =
   "button_click" |
   "menu_item_click" |
+  "value_submit" |
   UIEventType
 
 export type UIEventType =
@@ -45,6 +46,7 @@ export type BokehEventMap = {
   document_ready: DocumentReady
   button_click: ButtonClick
   menu_item_click: MenuItemClick
+  value_submit: ValueSubmit
   lodstart: LODStart
   lodend: LODEnd
   rangesupdate: RangesUpdate
@@ -125,6 +127,19 @@ export class MenuItemClick extends ModelEvent {
   protected override get event_values(): Attrs {
     const {item} = this
     return {...super.event_values, item}
+  }
+}
+
+@event("value_submit")
+export class ValueSubmit extends ModelEvent {
+
+  constructor(readonly value: string) {
+    super()
+  }
+
+  protected override get event_values(): Attrs {
+    const {value} = this
+    return {...super.event_values, value}
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -142,7 +142,9 @@ export class AutocompleteInputView extends TextInputView {
 
   _keydown(_event: KeyboardEvent): void {}
 
-  _keyup(event: KeyboardEvent): void {
+  protected override _keyup(event: KeyboardEvent): void {
+    super._keyup(event)
+
     switch (event.key) {
       case "Enter": {
         this.change_input()

--- a/bokehjs/src/lib/models/widgets/text_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_input.ts
@@ -2,6 +2,7 @@ import {TextLikeInput, TextLikeInputView} from "./text_like_input"
 
 import {input, div} from "core/dom"
 import * as p from "core/properties"
+import {ValueSubmit} from "core/bokeh_events"
 
 import * as inputs from "styles/widgets/inputs.css"
 
@@ -23,6 +24,17 @@ export class TextInputView extends TextLikeInputView {
     const suffix_el = suffix != null ? div({class: "bk-input-suffix"}, suffix) : null
     const container_el = div({class: "bk-input-container"}, prefix_el, this.input_el, suffix_el)
     return container_el
+  }
+
+  override render(): void {
+    super.render()
+    this.input_el.addEventListener("keyup", (event) => this._keyup(event))
+  }
+
+  protected _keyup(event: KeyboardEvent): void {
+    if (event.key == "Enter" && !event.shiftKey && !event.ctrlKey && !event.altKey) {
+      this.model.trigger_event(new ValueSubmit(this.input_el.value))
+    }
   }
 }
 

--- a/bokehjs/test/unit/models/widgets/text_input.ts
+++ b/bokehjs/test/unit/models/widgets/text_input.ts
@@ -1,0 +1,36 @@
+import {expect} from "assertions"
+import {display} from "../../_util"
+
+import {TextInput} from "@bokehjs/models/widgets"
+import {ValueSubmit} from "@bokehjs/core/bokeh_events"
+
+describe("TextInput", () => {
+  it("should support ValueSubmit event", async () => {
+    const input = new TextInput({value: ""})
+    const values: string[] = []
+    input.on_event(ValueSubmit, (event) => {
+      values.push(event.value)
+    })
+    const {view} = await display(input, [200, 50])
+    const input_view = view.owner.get_one(input)
+
+    function enter() {
+      const event = new KeyboardEvent("keyup", {key: "Enter", shiftKey: false, ctrlKey: false, altKey: false})
+      input_view.input_el.dispatchEvent(event)
+    }
+
+    expect(values).to.be.equal([])
+    enter()
+    expect(values).to.be.equal([""])
+    enter()
+    expect(values).to.be.equal(["", ""])
+    enter()
+    expect(values).to.be.equal(["", "", ""])
+    input_view.input_el.value = "abc"
+    expect(values).to.be.equal(["", "", ""])
+    enter()
+    expect(values).to.be.equal(["", "", "", "abc"])
+    enter()
+    expect(values).to.be.equal(["", "", "", "abc", "abc"])
+  })
+})

--- a/examples/interaction/js_callbacks/js_on_event.py
+++ b/examples/interaction/js_callbacks/js_on_event.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from bokeh import events
 from bokeh.layouts import column, row
-from bokeh.models import Button, CustomJS, Div
+from bokeh.models import Button, CustomJS, Div, TextInput
 from bokeh.plotting import figure, show
 
 
@@ -51,13 +51,16 @@ p.scatter(x, y, radius=radii,
 
 div = Div(width=1000)
 button = Button(label="Button", button_type="success", width=300)
-layout = column(button, row(p, div))
-
+text_input = TextInput(placeholder="Input a value and press Enter ...", width=300)
+layout = column(button, text_input, row(p, div))
 
 # Register event callbacks
 
-# Button event
+# Button events
 button.js_on_event(events.ButtonClick, display_event(div))
+
+# TextInput events
+text_input.js_on_event(events.ValueSubmit, display_event(div, ["value"]))
 
 # LOD events
 p.js_on_event(events.LODStart, display_event(div))

--- a/src/bokeh/events.py
+++ b/src/bokeh/events.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
     from .model import Model
     from .models.plots import Plot
     from .models.widgets.buttons import AbstractButton
+    from .models.widgets.inputs import TextInput
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -93,8 +94,8 @@ __all__ = (
     'DocumentReady',
     'DoubleTap',
     'Event',
-    'LODStart',
     'LODEnd',
+    'LODStart',
     'MenuItemClick',
     'ModelEvent',
     'MouseEnter',
@@ -107,17 +108,18 @@ __all__ = (
     'Pinch',
     'PinchEnd',
     'PinchStart',
-    'RangesUpdate',
-    'Rotate',
-    'RotateEnd',
-    'RotateStart',
     'PlotEvent',
     'PointEvent',
     'Press',
     'PressUp',
+    'RangesUpdate',
     'Reset',
+    'Rotate',
+    'RotateEnd',
+    'RotateStart',
     'SelectionGeometry',
     'Tap',
+    'ValueSubmit',
 )
 
 #-----------------------------------------------------------------------------
@@ -237,6 +239,22 @@ class MenuItemClick(ModelEvent):
     def __init__(self, model: Model, item: str | None = None) -> None:
         self.item = item
         super().__init__(model=model)
+
+class ValueSubmit(ModelEvent):
+    ''' Announce a value being submitted on a text input widget.
+
+    '''
+    event_name = 'value_submit'
+
+    value: str
+
+    def __init__(self, model: TextInput | None, value: str) -> None:
+        from .models.widgets import TextInput
+        if model is not None and not isinstance(model, TextInput):
+            clsname = self.__class__.__name__
+            raise ValueError(f"{clsname} event only applies to text input models")
+        super().__init__(model=model)
+        self.value = value
 
 class PlotEvent(ModelEvent):
     ''' The base class for all events applicable to Plot models.

--- a/tests/unit/bokeh/test_events.py
+++ b/tests/unit/bokeh/test_events.py
@@ -18,7 +18,12 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh.core.serialization import Deserializer
-from bokeh.models import Button, Div, Plot
+from bokeh.models import (
+    Button,
+    Div,
+    Plot,
+    TextInput,
+)
 
 # Module under test
 from bokeh import events # isort:skip
@@ -55,17 +60,22 @@ def test_common_decode_json() -> None:
 
         if issubclass(event_cls, events.ButtonClick):
             model = Button()
+        elif issubclass(event_cls, events.ValueSubmit):
+            model = TextInput()
         else:
             model = Plot()
+
+        entries = []
+        if issubclass(event_cls, events.ModelEvent):
+            entries.append(["model", dict(id=model.id)])
+        if issubclass(event_cls, events.ValueSubmit):
+            entries.append(["value", ""])
 
         decoder = Deserializer(references=[model])
         event = decoder.decode(dict(
             type="event",
             name=event_cls.event_name,
-            values=dict(
-                type="map",
-                entries=[["model", dict(id=model.id)]] if issubclass(event_cls, events.ModelEvent) else [],
-            ),
+            values=dict(type="map", entries=entries),
         ))
 
         assert isinstance(event, events.Event)


### PR DESCRIPTION
Instead of complicating semantics of change events on `TextInput`, I added a new event `ValueSubmit`, which is triggered on every "Enter" key press . `ValueSubmit` holds input's value, so that we don't have to synchronize this event with model's `value` property changes.

fixes #12772

/cc @jbednar, @sandhujasmine
