### PR TITLE
Fix bokehjs interpolate to handle length 1 arrays

### DIFF
--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -363,8 +363,8 @@ export function interpolate(points: Arrayable<number>, x_values: Arrayable<numbe
   for (let i = 0; i < n; i++) {
     const point = points[i]
 
-    if (isNaN(point)) {
-      results[i] = point
+    if (isNaN(point) || x_values.length == 0) {
+      results[i] = NaN
       continue
     }
 
@@ -402,6 +402,9 @@ export function left_edge_index(point: number, intervals: Arrayable<number>): nu
     return -1
   if (point > intervals[intervals.length - 1])
     return intervals.length
+  if (intervals.length == 1)
+    // Implies point == intervals[0]
+    return 0
   let leftEdgeIndex = 0
   let rightEdgeIndex = intervals.length - 1
   while (rightEdgeIndex - leftEdgeIndex != 1) {

--- a/bokehjs/test/unit/core/util/arrayable.ts
+++ b/bokehjs/test/unit/core/util/arrayable.ts
@@ -130,4 +130,33 @@ describe("core/util/arrayable module", () => {
     expect(arrayable.minmax([1, 2, NaN, 3])).to.be.equal([1, 3])
     expect(arrayable.minmax([3, 2, NaN, 1])).to.be.equal([1, 3])
   })
+
+  it("should support left_edge_index() function", () => {
+    expect(arrayable.left_edge_index(-100, [1, 2])).to.be.equal(-1)
+    expect(arrayable.left_edge_index(0.999, [1, 2])).to.be.equal(-1)
+    expect(arrayable.left_edge_index(1, [1, 2])).to.be.equal(0)
+    expect(arrayable.left_edge_index(1.5, [1, 2])).to.be.equal(0)
+    expect(arrayable.left_edge_index(2, [1, 2])).to.be.equal(0)
+    expect(arrayable.left_edge_index(2.001, [1, 2])).to.be.equal(2)
+    expect(arrayable.left_edge_index(100, [1, 2])).to.be.equal(2)
+
+    expect(arrayable.left_edge_index(0.999, [1])).to.be.equal(-1)
+    expect(arrayable.left_edge_index(1, [1])).to.be.equal(0)
+    expect(arrayable.left_edge_index(1.001, [1])).to.be.equal(1)
+  })
+
+  it("should support interpolate() function", () => {
+    const x = [1, 2, 4]
+    const y = [-1, 0, 2]
+    expect(arrayable.interpolate([], x, y)).to.be.equal([])
+    expect(arrayable.interpolate([1, 2, 4], x, y)).to.be.equal([-1, 0, 2])
+    expect(arrayable.interpolate([1.5, 2.5, 3, 3.5], x, y)).to.be.equal([-0.5, 0.5, 1, 1.5])
+    expect(arrayable.interpolate([-100, 0.9, 4.1, 100], x, y)).to.be.equal([-1, -1, 2, 2])
+
+    expect(arrayable.interpolate([], [1], [2])).to.be.equal([])
+    expect(arrayable.interpolate([0.999, 1, 1.001], [1], [2])).to.be.equal([2, 2, 2])
+
+    expect(arrayable.interpolate([], [], [])).to.be.equal([])
+    expect(arrayable.interpolate([1], [], [])).to.be.equal([NaN])
+  })
 })


### PR DESCRIPTION
This fixes the BokehJS `interpolate` and `left_edge_index` (which `interpolate` calls) functions to correctly handle arrays with length 1 and 0. There weren't any unit tests for these functions so I have added them to test use cases that I exercise in palette and color mapper functionality.

- [x] issues: fixes #12784
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
