### PR TITLE
Emit `RangesUpdate` event for all linked plots

### DIFF
--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -69,8 +69,6 @@ export class DataRange1d extends DataRange {
     }))
   }
 
-  readonly plots = new Set<PlotView>()
-
   protected _initial_start: number | null
   protected _initial_end: number | null
   protected _initial_range_padding: number

--- a/bokehjs/src/lib/models/ranges/range.ts
+++ b/bokehjs/src/lib/models/ranges/range.ts
@@ -1,4 +1,5 @@
 import {Model} from "../../model"
+import type {PlotView} from "../plots/plot"
 import * as p from "core/properties"
 
 export namespace Range {
@@ -49,4 +50,7 @@ export abstract class Range extends Model {
   get span(): number {
     return Math.abs(this.end - this.start)
   }
+
+  /** internal */
+  readonly plots = new Set<PlotView>()
 }

--- a/docs/bokeh/source/docs/releases/3.1.0.rst
+++ b/docs/bokeh/source/docs/releases/3.1.0.rst
@@ -3,7 +3,7 @@
 3.1.0
 =====
 
-Bokeh Version ``3.1.0`` (?? Jan 2023) is a minor milestone of Bokeh project.
+Bokeh Version ``3.1.0`` (?? Feb 2023) is a minor milestone of Bokeh project.
 
 Changes
 -------
@@ -20,3 +20,5 @@ Changes
   now required to fill-in all property values before serialization.
 * `RangeTool` is not a multi `GestureTool` anymore, thus it can't be activated
   with `Toolbar.active_multi`. The tool is now active by default.
+* ``RangesUpdate`` event now triggers on all linked plots instead of on the
+  one that user interaction resulted in changed ranges.

--- a/examples/basic/layouts/dashboard.py
+++ b/examples/basic/layouts/dashboard.py
@@ -48,7 +48,7 @@ def slider():
 
         const x = source.data.x
         const y = Array.from(x, (x) => B + A*Math.sin(k*x+phi))
-        source.data = { x, y }
+        source.data = {x, y}
     """)
 
     amp.js_on_change('value', callback)

--- a/src/bokeh/events.py
+++ b/src/bokeh/events.py
@@ -143,6 +143,14 @@ class Event:
     '''
     event_name: ClassVar[str]
 
+    @staticmethod
+    def cls_for(event_name: str) -> type[Event]:
+        event_cls = _CONCRETE_EVENT_CLASSES.get(event_name)
+        if event_cls is not None:
+            return event_cls
+        else:
+            raise ValueError(f"unknown event name '{event_name}'")
+
     @classmethod
     def __init_subclass__(cls):
         super().__init_subclass__()

--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -302,19 +302,19 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     def js_on_event(self, event: str | type[Event], *callbacks: JSEventCallback) -> None:
         if isinstance(event, str):
-            pass
+            event_name = Event.cls_for(event).event_name
         elif isinstance(event, type) and issubclass(event, Event):
-            event = event.event_name
+            event_name = event.event_name
         else:
             raise ValueError(f"expected string event name or event class, got {event}")
 
-        all_callbacks = list(self.js_event_callbacks.get(event, []))
+        all_callbacks = list(self.js_event_callbacks.get(event_name, []))
 
         for callback in callbacks:
             if callback not in all_callbacks:
                 all_callbacks.append(callback)
 
-        self.js_event_callbacks[event] = all_callbacks
+        self.js_event_callbacks[event_name] = all_callbacks
 
     def js_link(self, attr: str, other: Model, other_attr: str, attr_selector: int | str | None = None) -> None:
         ''' Link two Bokeh model properties using JavaScript.

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -101,35 +101,41 @@ class Test_js_on_change:
 
 class Test_js_on_event:
 
+    def test_fails_with_unknown_event_name(self) -> None:
+        cb = CustomJS(code="foo")
+        m = SomeModel()
+        with pytest.raises(ValueError):
+            m.js_on_event("foo", cb)
+
     def test_with_multple_callbacks(self) -> None:
         cb1 = CustomJS(code="foo")
         cb2 = CustomJS(code="bar")
         m = SomeModel()
-        m.js_on_event("some", cb1, cb2)
-        assert m.js_event_callbacks == {"some": [cb1, cb2]}
+        m.js_on_event("document_ready", cb1, cb2)
+        assert m.js_event_callbacks == {"document_ready": [cb1, cb2]}
 
     def test_with_multple_callbacks_separately(self) -> None:
         cb1 = CustomJS(code="foo")
         cb2 = CustomJS(code="bar")
         m = SomeModel()
-        m.js_on_event("some", cb1)
-        assert m.js_event_callbacks == {"some": [cb1]}
-        m.js_on_event("some", cb2)
-        assert m.js_event_callbacks == {"some": [cb1, cb2]}
+        m.js_on_event("document_ready", cb1)
+        assert m.js_event_callbacks == {"document_ready": [cb1]}
+        m.js_on_event("document_ready", cb2)
+        assert m.js_event_callbacks == {"document_ready": [cb1, cb2]}
 
     def test_ignores_dupe_callbacks(self) -> None:
         cb = CustomJS(code="foo")
         m = SomeModel()
-        m.js_on_event("some", cb, cb)
-        assert m.js_event_callbacks == {"some": [cb]}
+        m.js_on_event("document_ready", cb, cb)
+        assert m.js_event_callbacks == {"document_ready": [cb]}
 
     def test_ignores_dupe_callbacks_separately(self) -> None:
         cb = CustomJS(code="foo")
         m = SomeModel()
-        m.js_on_event("some", cb)
-        assert m.js_event_callbacks == {"some": [cb]}
-        m.js_on_event("some", cb)
-        assert m.js_event_callbacks == {"some": [cb]}
+        m.js_on_event("document_ready", cb)
+        assert m.js_event_callbacks == {"document_ready": [cb]}
+        m.js_on_event("document_ready", cb)
+        assert m.js_event_callbacks == {"document_ready": [cb]}
 
 class Test_js_link:
     def test_value_error_on_bad_attr(self) -> None:


### PR DESCRIPTION
Previously it was emitted only for the interactive plot. This PR also makes `js_on_event()` fail for invalid event names.

fixes #12778
