### PR TITLE
Add interp_palette function

### DIFF
--- a/bokehjs/src/lib/api/palettes.ts
+++ b/bokehjs/src/lib/api/palettes.ts
@@ -1,6 +1,7 @@
 import {Color} from "core/types"
-import {linspace} from "core/util/array"
-import {color2hex, color2rgba} from "core/util/color"
+import {linspace, range} from "core/util/array"
+import {interpolate} from "core/util/arrayable"
+import {color2hex, color2rgba, encode_rgba} from "core/util/color"
 
 export const YlGn3       = [0x31a354ff, 0xaddd8eff, 0xf7fcb9ff]
 export const YlGn4       = [0x238443ff, 0x78c679ff, 0xc2e699ff, 0xffffccff]
@@ -1009,6 +1010,43 @@ export const tol = {
 
 export const colorblind = {
   Colorblind,
+}
+
+export function interp_palette(palette: Color[], n: number): Color[] {
+  const npalette = palette.length
+  if (npalette < 1)
+    throw new Error("palette must contain at least one color")
+  if (n < 0)
+    throw new Error("requested palette length cannot be negative")
+
+  // Arrayable.interpolate operates on whole arrays, not slices, so need separate
+  // arrays for each of the R, G, B and A components.
+  const r = new Uint8Array(n)
+  const g = new Uint8Array(n)
+  const b = new Uint8Array(n)
+  const a = new Uint8Array(n)
+  for (let i = 0; i < npalette; i++) {
+    const rgba = color2rgba(palette[i])
+    r[i] = rgba[0]
+    g[i] = rgba[1]
+    b[i] = rgba[2]
+    a[i] = rgba[3]
+  }
+
+  const integers = range(0, npalette)
+  const fractions = linspace(0, npalette-1, n)
+
+  const r_interp = interpolate(fractions, integers, r)
+  const g_interp = interpolate(fractions, integers, g)
+  const b_interp = interpolate(fractions, integers, b)
+  const a_interp = interpolate(fractions, integers, a)
+
+  const ret = new Array<string>(n)
+  for (let i = 0; i < n; i++) {
+    ret[i] = color2hex(encode_rgba([r_interp[i], g_interp[i], b_interp[i], a_interp[i]]))
+  }
+
+  return ret
 }
 
 export function linear_palette<T>(palette: T[], n: number): T[] {

--- a/bokehjs/src/lib/api/palettes.ts
+++ b/bokehjs/src/lib/api/palettes.ts
@@ -1026,11 +1026,7 @@ export function interp_palette(palette: Color[], n: number): Color[] {
   const b = new Uint8Array(n)
   const a = new Uint8Array(n)
   for (let i = 0; i < npalette; i++) {
-    const rgba = color2rgba(palette[i])
-    r[i] = rgba[0]
-    g[i] = rgba[1]
-    b[i] = rgba[2]
-    a[i] = rgba[3]
+    [r[i], g[i], b[i], a[i]] = color2rgba(palette[i])
   }
 
   const integers = range(0, npalette)

--- a/bokehjs/src/lib/api/palettes.ts
+++ b/bokehjs/src/lib/api/palettes.ts
@@ -1,7 +1,7 @@
 import {Color} from "core/types"
 import {linspace, range} from "core/util/array"
 import {interpolate} from "core/util/arrayable"
-import {color2hex, color2rgba, encode_rgba} from "core/util/color"
+import {byte, color2hex, color2rgba, RGBA} from "core/util/color"
 
 export const YlGn3       = [0x31a354ff, 0xaddd8eff, 0xf7fcb9ff]
 export const YlGn4       = [0x238443ff, 0x78c679ff, 0xc2e699ff, 0xffffccff]
@@ -1012,7 +1012,7 @@ export const colorblind = {
   Colorblind,
 }
 
-export function interp_palette(palette: Color[], n: number): Color[] {
+export function interp_palette(palette: Color[], n: number): RGBA[] {
   const npalette = palette.length
   if (npalette < 1)
     throw new Error("palette must contain at least one color")
@@ -1037,9 +1037,9 @@ export function interp_palette(palette: Color[], n: number): Color[] {
   const b_interp = interpolate(fractions, integers, b)
   const a_interp = interpolate(fractions, integers, a)
 
-  const ret = new Array<string>(n)
+  const ret = new Array<RGBA>(n)
   for (let i = 0; i < n; i++) {
-    ret[i] = color2hex(encode_rgba([r_interp[i], g_interp[i], b_interp[i], a_interp[i]]))
+    ret[i] = [byte(r_interp[i]), byte(g_interp[i]), byte(b_interp[i]), byte(a_interp[i])]
   }
 
   return ret

--- a/bokehjs/src/lib/core/util/array.ts
+++ b/bokehjs/src/lib/core/util/array.ts
@@ -104,7 +104,7 @@ export function range(start: number, stop?: number, step: number = 1): number[] 
 }
 
 export function linspace(start: number, stop: number, num: number = 100): number[] {
-  const step = (stop - start) / (num - 1)
+  const step = num == 1 ? 0 : (stop - start) / (num - 1)
   const array = new Array(num)
 
   for (let i = 0; i < num; i++) {

--- a/bokehjs/test/unit/api/palettes.ts
+++ b/bokehjs/test/unit/api/palettes.ts
@@ -1,8 +1,44 @@
 import {expect} from "assertions"
 
-import {linear_palette, varying_alpha_palette} from "@bokehjs/api/palettes"
+import {interp_palette, linear_palette, varying_alpha_palette} from "@bokehjs/api/palettes"
 
 describe("in api/palettes module", () => {
+  describe("interp_palette", () => {
+    // Equivalent tests to bokeh's python unit tests for this function.
+    // Individual RGBA components can differ from Python due to different rounding.
+    it("should support fixed alpha", () => {
+      const palette = ["black", "red"]
+      expect(interp_palette(palette, 0)).to.be.equal([])
+      expect(interp_palette(palette, 1)).to.be.equal(["#000000"])
+      expect(interp_palette(palette, 2)).to.be.equal(["#000000", "#ff0000"])
+      expect(interp_palette(palette, 3)).to.be.equal(["#000000", "#7f0000", "#ff0000"])
+      expect(interp_palette(palette, 4)).to.be.equal(["#000000", "#550000", "#aa0000", "#ff0000"])
+    })
+
+    it("should support varying alpha", () => {
+      const palette = ["#00ff0080", "#00ffff40"]
+      expect(interp_palette(palette, 1)).to.be.equal(["#00ff0080"])
+      expect(interp_palette(palette, 2)).to.be.equal(["#00ff0080", "#00ffff40"])
+      expect(interp_palette(palette, 3)).to.be.equal(["#00ff0080", "#00ff7f60", "#00ffff40"])
+      expect(interp_palette(palette, 4)).to.be.equal(["#00ff0080", "#00ff556a", "#00ffaa55", "#00ffff40"])
+    })
+
+    it("should support passing single color palette", () => {
+      const palette = ["red"]
+      expect(interp_palette(palette, 0)).to.be.equal([])
+      expect(interp_palette(palette, 1)).to.be.equal(["#ff0000"])
+      expect(interp_palette(palette, 2)).to.be.equal(["#ff0000", "#ff0000"])
+    })
+
+    it("should throw error if pass empty palette", () => {
+      expect(() => interp_palette([], 1)).to.throw(Error)
+    })
+
+    it("should throw error if request negative length", () => {
+      expect(() => interp_palette(["red"], -1)).to.throw(Error)
+    })
+  })
+
   describe("linear_palette", () => {
     const palette = ["red", "green", "blue", "black", "yellow", "magenta"]
 

--- a/bokehjs/test/unit/api/palettes.ts
+++ b/bokehjs/test/unit/api/palettes.ts
@@ -5,29 +5,28 @@ import {interp_palette, linear_palette, varying_alpha_palette} from "@bokehjs/ap
 describe("in api/palettes module", () => {
   describe("interp_palette", () => {
     // Equivalent tests to bokeh's python unit tests for this function.
-    // Individual RGBA components can differ from Python due to different rounding.
     it("should support fixed alpha", () => {
       const palette = ["black", "red"]
       expect(interp_palette(palette, 0)).to.be.equal([])
-      expect(interp_palette(palette, 1)).to.be.equal(["#000000"])
-      expect(interp_palette(palette, 2)).to.be.equal(["#000000", "#ff0000"])
-      expect(interp_palette(palette, 3)).to.be.equal(["#000000", "#7f0000", "#ff0000"])
-      expect(interp_palette(palette, 4)).to.be.equal(["#000000", "#550000", "#aa0000", "#ff0000"])
+      expect(interp_palette(palette, 1)).to.be.equal([[0, 0, 0, 255]])
+      expect(interp_palette(palette, 2)).to.be.equal([[0, 0, 0, 255], [255, 0, 0, 255]])
+      expect(interp_palette(palette, 3)).to.be.equal([[0, 0, 0, 255], [128, 0, 0, 255], [255, 0, 0, 255]])
+      expect(interp_palette(palette, 4)).to.be.equal([[0, 0, 0, 255], [85, 0, 0, 255], [170, 0, 0, 255], [255, 0, 0, 255]])
     })
 
     it("should support varying alpha", () => {
       const palette = ["#00ff0080", "#00ffff40"]
-      expect(interp_palette(palette, 1)).to.be.equal(["#00ff0080"])
-      expect(interp_palette(palette, 2)).to.be.equal(["#00ff0080", "#00ffff40"])
-      expect(interp_palette(palette, 3)).to.be.equal(["#00ff0080", "#00ff7f60", "#00ffff40"])
-      expect(interp_palette(palette, 4)).to.be.equal(["#00ff0080", "#00ff556a", "#00ffaa55", "#00ffff40"])
+      expect(interp_palette(palette, 1)).to.be.equal([[0, 255, 0, 128]])
+      expect(interp_palette(palette, 2)).to.be.equal([[0, 255, 0, 128], [0, 255, 255, 64]])
+      expect(interp_palette(palette, 3)).to.be.equal([[0, 255, 0, 128], [0, 255, 128, 96], [0, 255, 255, 64]])
+      expect(interp_palette(palette, 4)).to.be.equal([[0, 255, 0, 128], [0, 255, 85, 107], [0, 255, 170, 85], [0, 255, 255, 64]])
     })
 
     it("should support passing single color palette", () => {
       const palette = ["red"]
       expect(interp_palette(palette, 0)).to.be.equal([])
-      expect(interp_palette(palette, 1)).to.be.equal(["#ff0000"])
-      expect(interp_palette(palette, 2)).to.be.equal(["#ff0000", "#ff0000"])
+      expect(interp_palette(palette, 1)).to.be.equal([[255, 0, 0, 255]])
+      expect(interp_palette(palette, 2)).to.be.equal([[255, 0, 0, 255], [255, 0, 0, 255]])
     })
 
     it("should throw error if pass empty palette", () => {

--- a/bokehjs/test/unit/core/util/array.ts
+++ b/bokehjs/test/unit/core/util/array.ts
@@ -109,4 +109,9 @@ describe("core/util/array module", () => {
     expect(array.split([1, null, 2], null)).to.be.equal([[1], [2]])
     expect(array.split([0, 1, null, 2, null, 3, 4, 5], null)).to.be.equal([[0, 1], [2], [3, 4, 5]])
   })
+
+  it("linspace() should support num less than 2", () => {
+    expect(array.linspace(0, 1, 0)).to.be.equal([])
+    expect(array.linspace(0, 1, 1)).to.be.equal([0])
+  })
 })

--- a/src/bokeh/palettes.py
+++ b/src/bokeh/palettes.py
@@ -429,11 +429,8 @@ import numpy as np
 from .colors.util import NamedColor, RGB
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-
     import numpy.typing as npt
-
-    from .colors.color import RGB
+    from typing_extensions import TypeAlias
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/palettes.py
+++ b/src/bokeh/palettes.py
@@ -426,7 +426,7 @@ from typing import TYPE_CHECKING, Dict, Tuple
 import numpy as np
 
 # Bokeh imports
-from .colors.util import NamedColor, RGB
+from .colors.util import RGB, NamedColor
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/src/bokeh/palettes.py
+++ b/src/bokeh/palettes.py
@@ -1665,7 +1665,7 @@ def interp_palette(palette: Palette, n: int) -> Palette:
     if n < 0:
         raise ValueError("requested palette length cannot be negative")
 
-    rgba_array = _to_rgba_array(palette)
+    rgba_array = to_rgba_array(palette)
     integers = np.arange(npalette)
     fractions = np.linspace(0, npalette-1, n)
 
@@ -1922,7 +1922,7 @@ def gray(n: int) -> Palette:
 # Dev API
 #-----------------------------------------------------------------------------
 
-def _to_rgba_array(palette: Palette) -> npt.NDArray[np.uint8]:
+def to_rgba_array(palette: Palette) -> npt.NDArray[np.uint8]:
     """ Convert palette to a numpy array of uint8 RGBA components.
     """
     rgba_array = np.empty((len(palette), 4), dtype=np.uint8)

--- a/src/bokeh/palettes.py
+++ b/src/bokeh/palettes.py
@@ -1653,10 +1653,10 @@ def interp_palette(palette: Palette, n: int) -> Palette:
             The size of the palette to generate
 
     Returns:
-        seq[str] : a sequence of hex RGB(A) color strings
+        tuple[str] : a sequence of hex RGB(A) color strings
 
     Raises:
-        ValueError if n is negative
+        ValueError if ``n`` is negative or the supplied ``palette`` is empty.
 
     """
     npalette = len(palette)
@@ -1672,9 +1672,9 @@ def interp_palette(palette: Palette, n: int) -> Palette:
     r = np.interp(fractions, integers, rgba_array[:, 0]).astype(np.uint8)
     g = np.interp(fractions, integers, rgba_array[:, 1]).astype(np.uint8)
     b = np.interp(fractions, integers, rgba_array[:, 2]).astype(np.uint8)
-    a = np.interp(fractions, integers, rgba_array[:, 3]) / 255  # Remains floating-point
+    a = np.interp(fractions, integers, rgba_array[:, 3]) / 255.0  # Remains floating-point
 
-    return tuple(RGB(*args).to_hex() for args in zip(r, g ,b, a))
+    return tuple(RGB(*args).to_hex() for args in zip(r, g, b, a))
 
 def magma(n: int) -> Palette:
     """ Generate a palette of colors from the Magma palette.

--- a/src/bokeh/palettes.py
+++ b/src/bokeh/palettes.py
@@ -384,6 +384,7 @@ to generate palettes of arbitrary size.
 .. autofunction:: bokeh.palettes.gray(n)
 .. autofunction:: bokeh.palettes.grey(n)
 .. autofunction:: bokeh.palettes.inferno(n)
+.. autofunction:: bokeh.palettes.interp_palette(palette, n)
 .. autofunction:: bokeh.palettes.linear_palette(palette, n)
 .. autofunction:: bokeh.palettes.magma(n)
 .. autofunction:: bokeh.palettes.varying_alpha_palette(palette, n, start_alpha, end_alpha)
@@ -425,10 +426,12 @@ from typing import TYPE_CHECKING, Dict, Tuple
 import numpy as np
 
 # Bokeh imports
-from .colors.util import NamedColor
+from .colors.util import NamedColor, RGB
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
+
+    import numpy.typing as npt
 
     from .colors.color import RGB
 
@@ -1639,6 +1642,43 @@ def varying_alpha_palette(color: str, n: int | None = None, start_alpha: int = 0
 
     return palette
 
+def interp_palette(palette: Palette, n: int) -> Palette:
+    """ Generate a new palette by interpolating a given palette.
+
+    Linear interpolation is performed separately on each of the RGBA
+    components.
+
+    Args:
+        palette (seq[str]) :
+            A sequence of hex RGB(A) color strings to create new palette from
+
+        n (int) :
+            The size of the palette to generate
+
+    Returns:
+        seq[str] : a sequence of hex RGB(A) color strings
+
+    Raises:
+        ValueError if n is negative
+
+    """
+    npalette = len(palette)
+    if npalette < 1:
+        raise ValueError("palette must contain at least one color")
+    if n < 0:
+        raise ValueError("requested palette length cannot be negative")
+
+    rgba_array = _to_rgba_array(palette)
+    integers = np.arange(npalette)
+    fractions = np.linspace(0, npalette-1, n)
+
+    r = np.interp(fractions, integers, rgba_array[:, 0]).astype(np.uint8)
+    g = np.interp(fractions, integers, rgba_array[:, 1]).astype(np.uint8)
+    b = np.interp(fractions, integers, rgba_array[:, 2]).astype(np.uint8)
+    a = np.interp(fractions, integers, rgba_array[:, 3]) / 255  # Remains floating-point
+
+    return tuple(RGB(*args).to_hex() for args in zip(r, g ,b, a))
+
 def magma(n: int) -> Palette:
     """ Generate a palette of colors from the Magma palette.
 
@@ -1884,6 +1924,17 @@ def gray(n: int) -> Palette:
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
+
+def _to_rgba_array(palette: Palette) -> npt.NDArray[np.uint8]:
+    """ Convert palette to a numpy array of uint8 RGBA components.
+    """
+    rgba_array = np.empty((len(palette), 4), dtype=np.uint8)
+
+    for i, color in enumerate(palette):
+        rgba = NamedColor.from_string(color)
+        rgba_array[i] = (rgba.r, rgba.g, rgba.b, rgba.a*255)
+
+    return rgba_array
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/test_palettes.py
+++ b/tests/unit/bokeh/test_palettes.py
@@ -48,6 +48,31 @@ def test_palettes_dir() -> None:
     assert 'turbo' in dir(pal)
     assert '__new__' not in dir(pal)
 
+def test_interp_palette() -> None:
+    # Constant alpha
+    assert pal.interp_palette(("black", "red"), 0) == ()
+    assert pal.interp_palette(("black", "red"), 1) == ("#000000",)
+    assert pal.interp_palette(("black", "red"), 2) == ("#000000", "#ff0000")
+    assert pal.interp_palette(("black", "red"), 3) == ("#000000", "#7f0000", "#ff0000")
+    assert pal.interp_palette(("black", "red"), 4) == ("#000000", "#550000", "#aa0000", "#ff0000")
+
+    # Varying alpha
+    assert pal.interp_palette(("#00ff0080", "#00ffff40"), 1) == ("#00ff0080",)
+    assert pal.interp_palette(("#00ff0080", "#00ffff40"), 2) == ("#00ff0080", "#00ffff40")
+    assert pal.interp_palette(("#00ff0080", "#00ffff40"), 3) == ("#00ff0080", "#00ff7f60", "#00ffff40")
+    assert pal.interp_palette(("#00ff0080", "#00ffff40"), 4) == ("#00ff0080", "#00ff556b", "#00ffaa55", "#00ffff40")
+
+    # Passing single color palette
+    assert pal.interp_palette(("red",), 0) == ()
+    assert pal.interp_palette(("red",), 1) == ("#ff0000",)
+    assert pal.interp_palette(("red",), 2) == ("#ff0000", "#ff0000")
+
+    with pytest.raises(ValueError):
+        pal.interp_palette((), 1)
+
+    with pytest.raises(ValueError):
+        pal.interp_palette(("black", "red"), -1)
+
 def test_varying_alpha_palette() -> None:
     assert pal.varying_alpha_palette("blue", 3) == ("#0000ff00", "#0000ff80", "#0000ff")
     assert pal.varying_alpha_palette("red", 3, start_alpha=255, end_alpha=128) == ("#ff0000", "#ff0000c0", "#ff000080")


### PR DESCRIPTION
This adds a new `interp_palette` function to both Python and BokehJS code. There is no specific issue for it but it was described in the contouring roadmap discussion here: https://github.com/bokeh/bokeh/discussions/12234#discussioncomment-4694734.

It allows the creation of a palette of specified length by interpolation of a given palette. Linear interpolation is performed separately on each of the RGBA components. The standard use case will be to start with a relatively short palette (many of the palettes we ship have a maximum length of about 10) and use that to create a new palette that is much longer. It will be particularly useful for contour plots.

Example code to create palettes of length 5, 8 and 11 from a palette of length 3:
```python
from bokeh.models import LinearColorMapper
from bokeh.palettes import interp_palette
from bokeh.plotting import figure, row, show
import numpy as np

original_palette = ("royalblue", "yellow", "crimson")

rng = np.random.default_rng(84241)
data = rng.uniform(size=(40, 20))

ps = []
for n in (5, 8, 11):
    p = figure(width=250, height=300, title=f"{n} colors from {len(original_palette)}")
    ps.append(p)

    palette = interp_palette(original_palette, n)
    color_mapper = LinearColorMapper(palette, low=0, high=1)
    glyph = p.image(image=[data], x=0, y=0, dh=1, dw=1, color_mapper=color_mapper)
    p.add_layout(glyph.construct_color_bar(), place="right")

show(row(ps))
```
Note use of new `construct_color_bar` function!

Output generated:

![ex](https://user-images.githubusercontent.com/580326/217357995-72cf3f08-d1d0-4b3f-887d-475d24533018.png)

Whilst implementing this I came across a bug in the BokehJS implementation of `linspace`, which I have fixed. There are new unit tests for this fix as well as for both Python and BokehJS `interp_palette` functions.