### PR TITLE
Fixes to mixed array and ndarray streaming

### DIFF
--- a/bokehjs/src/lib/core/util/ndarray.ts
+++ b/bokehjs/src/lib/core/util/ndarray.ts
@@ -218,8 +218,16 @@ export class Float64NDArray extends Float64Array implements NDArrayType {
 export class ObjectNDArray extends Array implements NDArrayType {
   readonly [__ndarray__] = true
   readonly dtype: "object" = "object"
-  readonly shape: number[]
-  readonly dimension: number
+
+  private _shape?: number[]
+
+  get shape(): number[] {
+    return this._shape ?? [this.length]
+  }
+
+  get dimension(): number {
+    return this.shape.length
+  }
 
   constructor(init_: Init<unknown>, shape?: number[]) {
     const init = init_ instanceof ArrayBuffer ? new Float64Array(init_) : init_
@@ -233,8 +241,7 @@ export class ObjectNDArray extends Array implements NDArrayType {
       }
     }
 
-    this.shape = shape ?? (is_NDArray(init) ? init.shape : [this.length])
-    this.dimension = this.shape.length
+    this._shape = shape ?? (is_NDArray(init) ? init.shape : undefined)
   }
 
   [equals](that: this, cmp: Comparator): boolean {

--- a/bokehjs/src/lib/core/util/typed_array.ts
+++ b/bokehjs/src/lib/core/util/typed_array.ts
@@ -1,6 +1,6 @@
 import {TypedArray} from "../types"
 
-export function concat<T extends TypedArray>(array0: T, ...arrays: T[]): T {
+export function concat<T extends TypedArray>(array0: T, ...arrays: ArrayLike<number>[]): T {
   let n = array0.length
   for (const array of arrays)
     n += array.length

--- a/bokehjs/test/unit/core/patching.ts
+++ b/bokehjs/test/unit/core/patching.ts
@@ -374,5 +374,17 @@ describe("core/patching module", () => {
       const r2 = stream_to_column(a2, [100, 200, 300], 10)
       expect(r2).to.be.equal(new Int32NDArray([1, 2, 3, 4, 5, 100, 200, 300]))
     })
+
+    it("should stream Float64 to Array", () => {
+      const a = new Float64NDArray([1, 2, 3, 4, 5])
+      const r = stream_to_column(a, [100, 200])
+      expect(r).to.be.equal(new Float64NDArray([1, 2, 3, 4, 5, 100, 200]))
+    })
+
+    it("should stream Array to Float64", () => {
+      const a = [1, 2, 3, 4, 5]
+      const r = stream_to_column(a, new Float64NDArray([100, 200]))
+      expect(r).to.be.equal(new Float64NDArray([1, 2, 3, 4, 5, 100, 200]))
+    })
   })
 })

--- a/bokehjs/test/unit/core/util/ndarray.ts
+++ b/bokehjs/test/unit/core/util/ndarray.ts
@@ -6,6 +6,7 @@ import {
   Uint16NDArray, Int16NDArray,
   Uint32NDArray, Int32NDArray,
   Float32NDArray, Float64NDArray,
+  ObjectNDArray,
 } from "@bokehjs/core/util/ndarray"
 
 describe("core/util/ndarray module", () => {
@@ -318,6 +319,22 @@ describe("core/util/ndarray module", () => {
     expect(nd4.dtype).to.be.equal("float64")
     expect(nd4.shape).to.be.equal([2, 3])
     expect(nd4.length).to.be.equal(6)
+  })
+
+  it("should support ObjectNDArray", () => {
+    const nd0 = new ObjectNDArray([null, 1, "a", true, [1, 2, 3], {foo: 1}])
+    expect(is_NDArray(nd0)).to.be.true
+    expect(nd0.dtype).to.be.equal("object")
+    expect(nd0.shape).to.be.equal([6])
+    expect(nd0.length).to.be.equal(6)
+    expect(nd0.dimension).to.be.equal(1)
+
+    const nd1 = nd0.concat(new ObjectNDArray([false, 2, "b"])) as ObjectNDArray
+    expect(is_NDArray(nd1)).to.be.true
+    expect(nd1.dtype).to.be.equal("object")
+    expect(nd1.shape).to.be.equal([9])
+    expect(nd1.length).to.be.equal(9)
+    expect(nd0.dimension).to.be.equal(1)
   })
 
   it("should support ndarray() function widthout dtype", () => {


### PR DESCRIPTION
This PR is more of a collection of workarounds than proper fixes, but that's what I can afford to do now. In general, ndarrays in bokehjs need be redesigned, so that they don't extend built-in types, but instead they encapsulate them. Also, more generic coercion rules for data arrays need to be implemented.

fixes #12788