### PR TITLE
Document Rect glyph shouldn't be used on log axes

### DIFF
--- a/src/bokeh/models/glyphs.py
+++ b/src/bokeh/models/glyphs.py
@@ -1208,8 +1208,8 @@ class Ray(XYGlyph, LineGlyph):
     """)
 
 class Rect(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
-    ''' Render rectangles, characterised by x and y position, width, height,
-    and angle of rotation.
+    ''' Render rectangles, characterised by center position (x and y), width,
+    height, and angle of rotation.
 
     .. warning::
         ``Rect`` glyphs are not well defined on logarithmic scales. Use

--- a/src/bokeh/models/glyphs.py
+++ b/src/bokeh/models/glyphs.py
@@ -1208,7 +1208,13 @@ class Ray(XYGlyph, LineGlyph):
     """)
 
 class Rect(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
-    ''' Render rectangles.
+    ''' Render rectangles, characterised by x and y position, width, height,
+    and angle of rotation.
+
+    .. warning::
+        ``Rect`` glyphs are not well defined on logarithmic scales. Use
+        :class:`~bokeh.models.Block` or :class:`~bokeh.models.Quad` glyphs
+        instead.
 
     '''
 

--- a/src/bokeh/plotting/glyph_api.py
+++ b/src/bokeh/plotting/glyph_api.py
@@ -616,6 +616,11 @@ Examples:
 
         show(plot)
 
+    .. warning::
+        ``Rect`` glyphs are not well defined on logarithmic scales. Use
+        :class:`~bokeh.models.Block` or :class:`~bokeh.models.Quad` glyphs
+        instead.
+
 """
 
     @glyph_method(glyphs.Step)


### PR DESCRIPTION
Fixes #12734.

This is an addition to the `Rect` docs to indicate that they are not well-defined on logarithmic axes.