### PR TITLE
Activate bugbear checks in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ exclude = [
     'node_modules',
 ]
 per-file-ignores = {"__init__.py" = ["F403"]}
-select = ["E", "F", "RUF", "UP", "W"]
+select = ["B", "E", "F", "RUF", "UP", "W"]
 ignore = [
     'E401', # Multiple imports on one line
     'E402', # Module level import not at top of file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,17 @@ exclude = [
 per-file-ignores = {"__init__.py" = ["F403"]}
 select = ["B", "E", "F", "RUF", "UP", "W"]
 ignore = [
+    'B005', # Using .strip() with multi-character strings is misleading the reader
+    'B006', # Do not use mutable data structures for argument defaults
+    'B007', # Loop control variable not used within the loop body
+    'B008', # Do not perform function calls in argument defaults
+    'B009', # Do not call getattr(x, 'attr'), instead use normal property access: x.attr
+    'B010', # Do not call setattr(x, 'attr', val), instead use normal property access: x.attr = val
+    'B011', # Do not call assert False since python -O removes these calls
+    'B015', # Pointless comparison. This comparison does nothing but waste CPU instructions
+    'B020', # Loop control variable overrides iterable it iterates
+    'B023', # Functions defined inside a loop must not use variables redefined in the loop
+    'B904', # Within an except clause, raise exceptions with raise ... from err or raise ... from None to distinguish them from errors in exception handling
     'E401', # Multiple imports on one line
     'E402', # Module level import not at top of file
     'E731', # Do not assign a lambda expression, use a def


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #12769
- [ ] tests added / passed
Tests for ruff fail (output below).
```
examples/interaction/js_callbacks/js_on_event.py:13:35: B006 Do not use mutable data structures for argument defaults
examples/server/app/duffing_oscillator.py:84:5: B007 Loop control variable `i` not used within loop body
examples/server/app/events_app.py:16:35: B006 Do not use mutable data structures for argument defaults
examples/server/app/events_app.py:38:28: B006 Do not use mutable data structures for argument defaults
examples/topics/geo/tile_demo.py:45:5: B007 Loop control variable `i` not used within loop body
examples/topics/hierarchical/treemap.py:38:5: B007 Loop control variable `index` not used within loop body
examples/topics/hierarchical/treemap.py:38:21: B007 Loop control variable `Sales` not used within loop body
src/bokeh/application/handlers/code.py:84:78: B006 Do not use mutable data structures for argument defaults
src/bokeh/application/handlers/directory.py:113:65: B006 Do not use mutable data structures for argument defaults
src/bokeh/application/handlers/notebook.py:68:65: B006 Do not use mutable data structures for argument defaults
src/bokeh/application/handlers/script.py:82:65: B006 Do not use mutable data structures for argument defaults
src/bokeh/application/handlers/server_lifecycle.py:57:65: B006 Do not use mutable data structures for argument defaults
src/bokeh/application/handlers/server_request_handler.py:59:65: B006 Do not use mutable data structures for argument defaults
src/bokeh/colors/util.py:163:17: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/command/subcommands/serve.py:923:17: B020 Loop control variable `path` overrides iterable it iterates
src/bokeh/core/has_props.py:714:13: B010 Do not call `setattr` with a constant attribute value. It is not any safer than normal property access.
src/bokeh/core/has_props.py:720:16: B007 Loop control variable `v` not used within loop body
src/bokeh/core/json_encoder.py:157:51: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/container.py:123:82: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/container.py:150:82: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/container.py:189:32: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/container.py:297:32: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/container.py:310:66: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/datetime.py:74:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/core/property/datetime.py:127:60: B008 Do not perform function call `datetime.timedelta` in argument defaults
src/bokeh/core/property/json.py:68:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/core/property/visual.py:92:32: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/visual.py:133:32: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/wrappers.py:406:37: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/property/wrappers.py:472:16: B007 Loop control variable `v` not used within loop body
src/bokeh/core/serialization.py:215:52: B006 Do not use mutable data structures for argument defaults
src/bokeh/core/validation/decorators.py:85:21: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/document/callbacks.py:337:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/document/document.py:219:17: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/embed/bundle.py:106:46: B006 Do not use mutable data structures for argument defaults
src/bokeh/embed/bundle.py:106:70: B006 Do not use mutable data structures for argument defaults
src/bokeh/embed/bundle.py:107:36: B006 Do not use mutable data structures for argument defaults
src/bokeh/embed/bundle.py:107:61: B006 Do not use mutable data structures for argument defaults
src/bokeh/embed/bundle.py:107:82: B006 Do not use mutable data structures for argument defaults
src/bokeh/embed/elements.py:84:46: B006 Do not use mutable data structures for argument defaults
src/bokeh/embed/server.py:130:114: B006 Do not use mutable data structures for argument defaults
src/bokeh/embed/standalone.py:300:52: B006 Do not use mutable data structures for argument defaults
src/bokeh/embed/util.py:267:23: B007 Loop control variable `elementid` not used within loop body
src/bokeh/layouts.py:319:26: B006 Do not use mutable data structures for argument defaults
src/bokeh/models/plots.py:931:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/models/sources.py:269:17: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/plotting/_figure.py:382:13: B020 Loop control variable `kw` overrides iterable it iterates
src/bokeh/plotting/_figure.py:423:13: B020 Loop control variable `kw` overrides iterable it iterates
src/bokeh/plotting/_figure.py:473:17: B020 Loop control variable `kw` overrides iterable it iterates
src/bokeh/plotting/_figure.py:479:17: B020 Loop control variable `kw` overrides iterable it iterates
src/bokeh/plotting/_figure.py:562:13: B020 Loop control variable `kw` overrides iterable it iterates
src/bokeh/plotting/_figure.py:604:13: B020 Loop control variable `kw` overrides iterable it iterates
src/bokeh/plotting/_graph.py:62:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/plotting/_graph.py:70:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/plotting/_graph.py:138:20: B005 Using `.strip()` with multi-character strings is misleading the reader
src/bokeh/plotting/_graph.py:138:78: B005 Using `.strip()` with multi-character strings is misleading the reader
src/bokeh/plotting/_renderer.py:144:56: B006 Do not use mutable data structures for argument defaults
src/bokeh/plotting/_renderer.py:144:78: B006 Do not use mutable data structures for argument defaults
src/bokeh/plotting/_renderer.py:241:17: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/protocol/message.py:190:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/protocol/message.py:195:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/protocol/message.py:200:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/server/tornado.py:259:45: B008 Do not perform function call `settings.secret_key_bytes` in argument defaults
src/bokeh/server/tornado.py:260:40: B008 Do not perform function call `settings.sign_sessions` in argument defaults
src/bokeh/server/tornado.py:272:34: B008 Do not perform function call `settings.ico_path` in argument defaults
src/bokeh/server/tornado.py:274:48: B008 Do not perform function call `NullAuth` in argument defaults
src/bokeh/server/util.py:158:17: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/server/views/multi_root_static_handler.py:56:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/server/views/multi_root_static_handler.py:65:13: B007 Loop control variable `name` not used within loop body
src/bokeh/settings.py:218:9: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/settings.py:777:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_dataframe.py:82:9: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_enum.py:104:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_model.py:124:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_options.py:108:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_palette.py:109:9: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_plot.py:173:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_plot.py:229:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_plot.py:299:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_prop.py:108:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_prop.py:124:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_releases.py:84:21: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_settings.py:88:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/sphinxext/bokeh_sitemap.py:83:9: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/util/browser.py:118:9: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/util/compiler.py:115:9: B007 Loop control variable `i` not used within loop body
src/bokeh/util/compiler.py:254:16: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
src/bokeh/util/compiler.py:584:9: B007 Loop control variable `i` not used within loop body
src/bokeh/util/sampledata.py:98:9: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/util/sampledata.py:116:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/util/sampledata.py:167:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
src/bokeh/util/token.py:77:52: B008 Do not perform function call `settings.secret_key_bytes` in argument defaults
src/bokeh/util/token.py:78:40: B008 Do not perform function call `settings.sign_sessions` in argument defaults
src/bokeh/util/token.py:92:51: B008 Do not perform function call `settings.secret_key_bytes` in argument defaults
src/bokeh/util/token.py:93:39: B008 Do not perform function call `settings.sign_sessions` in argument defaults
src/bokeh/util/token.py:164:54: B008 Do not perform function call `settings.secret_key_bytes` in argument defaults
src/bokeh/util/token.py:165:42: B008 Do not perform function call `settings.sign_sessions` in argument defaults
src/bokeh/util/token.py:206:59: B008 Do not perform function call `settings.secret_key_bytes` in argument defaults
src/bokeh/util/token.py:207:54: B008 Do not perform function call `settings.sign_sessions` in argument defaults
src/bokeh/util/token.py:322:36: B008 Do not perform function call `settings.secret_key_bytes` in argument defaults
src/bokeh/util/tornado.py:225:13: B904 Within an except clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
tests/support/defaults.py:98:31: B023 Function definition does not bind loop variable `obj`
tests/support/defaults.py:98:76: B023 Function definition does not bind loop variable `obj`
tests/support/util/examples.py:77:90: B006 Do not use mutable data structures for argument defaults
tests/test_bokehjs.py:40:20: B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
tests/test_defaults.py:44:20: B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
tests/unit/bokeh/command/subcommands/test_serve.py:450:9: B007 Loop control variable `i` not used within loop body
tests/unit/bokeh/command/subcommands/test_serve.py:462:9: B007 Loop control variable `i` not used within loop body
tests/unit/bokeh/command/subcommands/test_serve.py:526:32: B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
tests/unit/bokeh/core/test_has_props.py:97:12: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:100:12: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:103:23: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:106:12: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:109:12: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:112:23: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:115:12: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:119:9: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:124:9: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:129:9: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:134:9: B009 Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
tests/unit/bokeh/core/test_has_props.py:534:16: B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
tests/unit/bokeh/document/test_callbacks__document.py:282:9: B015 Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
tests/unit/bokeh/document/test_callbacks__document.py:285:9: B015 Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
tests/unit/bokeh/models/_util_models.py:87:127: B006 Do not use mutable data structures for argument defaults
tests/unit/bokeh/models/test_plots.py:485:13: B015 Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
tests/unit/bokeh/server/_util_server.py:66:35: B006 Do not use mutable data structures for argument defaults
tests/unit/bokeh/test_driving.py:61:9: B007 Loop control variable `i` not used within loop body
tests/unit/bokeh/test_driving.py:68:9: B007 Loop control variable `i` not used within loop body
tests/unit/bokeh/test_driving.py:78:9: B007 Loop control variable `i` not used within loop body
tests/unit/bokeh/test_driving.py:96:9: B007 Loop control variable `i` not used within loop body
tests/unit/bokeh/test_driving.py:103:9: B007 Loop control variable `i` not used within loop body
tests/unit/bokeh/test_driving.py:110:9: B007 Loop control variable `i` not used within loop body
tests/unit/bokeh/test_events.py:43:35: B006 Do not use mutable data structures for argument defaults
tests/unit/bokeh/test_resources.py:168:13: B010 Do not call `setattr` with a constant attribute value. It is not any safer than normal property access.
Found 134 errors.
36 potentially fixable with the --fix option.
```
- [ ] release document entry (if new feature or API change)
