### PR TITLE
Fix Either to run transform on the first param that pass validation

### DIFF
--- a/src/bokeh/core/property/bases.py
+++ b/src/bokeh/core/property/bases.py
@@ -354,6 +354,7 @@ class Property(PropertyDescriptorFactory[T]):
             for tp, converter in self.alternatives:
                 if tp.is_valid(value):
                     value = converter(value)
+                    self.validate(value)
                     break
             else:
                 error = e

--- a/src/bokeh/core/property/either.py
+++ b/src/bokeh/core/property/either.py
@@ -81,11 +81,15 @@ class Either(ParameterizedProperty[Any]):
         super().__init__(type_param0, *type_params, default=default, help=help)
         for tp in self.type_params:
             self.alternatives.extend(tp.alternatives)
+        self.valids)
 
     def transform(self, value: Any) -> Any:
         for param in self.type_params:
             try:
-                return param.transform(value)
+                # if valid was not executed, or all valids failed - transform one by one
+                # else: run transform on the first param that pass validation
+                if len(self.valids)==0 or not any(self.valids) or self.valids[i]: 
+                    return param.transform(value)
             except ValueError:
                 pass
 
@@ -93,8 +97,8 @@ class Either(ParameterizedProperty[Any]):
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
-
-        if any(param.is_valid(value) for param in self.type_params):
+        self.valids = [param.is_valid(value) for param in self.type_params]
+        if any(self.valids):
             return
 
         msg = "" if not detail else f"expected an element of either {nice_join([ str(param) for param in self.type_params ])}, got {value!r}"

--- a/src/bokeh/core/property/either.py
+++ b/src/bokeh/core/property/either.py
@@ -81,7 +81,7 @@ class Either(ParameterizedProperty[Any]):
         super().__init__(type_param0, *type_params, default=default, help=help)
         for tp in self.type_params:
             self.alternatives.extend(tp.alternatives)
-        self.valids)
+        self.valids = []
 
     def transform(self, value: Any) -> Any:
         for param in self.type_params:

--- a/src/bokeh/core/property/either.py
+++ b/src/bokeh/core/property/either.py
@@ -84,7 +84,7 @@ class Either(ParameterizedProperty[Any]):
         self.valids = []
 
     def transform(self, value: Any) -> Any:
-        for param in self.type_params:
+        for i, param in enumerate(self.type_params):
             try:
                 # if valid was not executed, or all valids failed - transform one by one
                 # else: run transform on the first param that pass validation


### PR DESCRIPTION
See https://github.com/bokeh/bokeh/pull/12775#issuecomment-1435162651
Basically to fix this I had to do the following:
Create a list that keeps which values pass validation and run transform on the first param that pass the validation, but there are some edge cases:
- if all params fail validation, just run transform 1-by-1
- validation can be disabled by the user, in the case again just run transform 1-by-1
- sometimes when all params fail validation, convertors are executed here: https://github.com/bokeh/bokeh/blob/226fb6aff189458dd5e5616c8fc375494b05ec2b/src/bokeh/core/property/bases.py#L356, but this is via is_valid which does not update the valids list in Either, so once we find a valid converter and value, we need to re-run the validation function to update the valids list.

- [x] issues: fixes #11830 

