### PR TITLE
Reuse object traversal result when bundling

### DIFF
--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -122,6 +122,13 @@ class Test_bundle_for_objs_and_resources:
         # this is a cheap test that a BokehJS file is NOT inline
         assert all(len(x) < 5000 for x in b.js_raw)
 
+    def test_no_objs_all_resources_bundled(self) -> None:
+        b = beb.bundle_for_objs_and_resources([], 'relative')
+        assert any('bokeh-widgets' in f for f in b.js_files)
+        assert any('bokeh-gl' in f for f in b.js_files)
+        assert any('bokeh-tables' in f for f in b.js_files)
+        assert any('bokeh-mathjax' in f for f in b.js_files)
+
 class Test_bundle_custom_extensions:
 
     @classmethod

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -123,7 +123,7 @@ class Test_bundle_for_objs_and_resources:
         assert all(len(x) < 5000 for x in b.js_raw)
 
     def test_no_objs_all_resources_bundled(self) -> None:
-        b = beb.bundle_for_objs_and_resources([], 'relative')
+        b = beb.bundle_for_objs_and_resources(None, 'absolute')
         assert any('bokeh-widgets' in f for f in b.js_files)
         assert any('bokeh-gl' in f for f in b.js_files)
         assert any('bokeh-tables' in f for f in b.js_files)
@@ -233,130 +233,130 @@ class Test__any:
 
 class Test__use_gl:
     def test_without_gl(self, test_plot, test_glplot, test_table, test_widget) -> None:
-        assert beb._use_gl([test_plot]) is False
-        assert beb._use_gl([test_plot, test_table]) is False
-        assert beb._use_gl([test_plot, test_widget]) is False
+        assert beb._use_gl(beb._all_objs([test_plot])) is False
+        assert beb._use_gl(beb._all_objs([test_plot, test_table])) is False
+        assert beb._use_gl(beb._all_objs([test_plot, test_widget])) is False
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
         d.add_root(test_widget)
-        assert beb._use_gl([d]) is False
+        assert beb._use_gl(beb._all_objs([d])) is False
 
     def test_with_gl(self, test_plot, test_glplot, test_table, test_widget) -> None:
-        assert beb._use_gl([test_glplot]) is True
-        assert beb._use_gl([test_plot, test_glplot]) is True
-        assert beb._use_gl([test_plot, test_widget, test_glplot]) is True
-        assert beb._use_gl([test_plot, test_widget, test_table, test_glplot]) is True
+        assert beb._use_gl(beb._all_objs([test_glplot])) is True
+        assert beb._use_gl(beb._all_objs([test_plot, test_glplot])) is True
+        assert beb._use_gl(beb._all_objs([test_plot, test_widget, test_glplot])) is True
+        assert beb._use_gl(beb._all_objs([test_plot, test_widget, test_table, test_glplot])) is True
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
         d.add_root(test_widget)
         d.add_root(test_glplot)
-        assert beb._use_gl([d]) is True
+        assert beb._use_gl(beb._all_objs([d])) is True
 
 
 class Test__use_tables:
     def test_without_tables(self, test_plot, test_glplot, test_table, test_widget) -> None:
-        assert beb._use_tables([test_plot]) is False
-        assert beb._use_tables([test_plot, test_glplot]) is False
-        assert beb._use_tables([test_plot, test_widget]) is False
+        assert beb._use_tables(beb._all_objs([test_plot])) is False
+        assert beb._use_tables(beb._all_objs([test_plot, test_glplot])) is False
+        assert beb._use_tables(beb._all_objs([test_plot, test_widget])) is False
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_glplot)
         d.add_root(test_widget)
-        assert beb._use_tables([d]) is False
+        assert beb._use_tables(beb._all_objs([d])) is False
 
     def test_with_tables(self, test_plot, test_glplot, test_table, test_widget) -> None:
-        assert beb._use_tables([test_table]) is True
-        assert beb._use_tables([test_table, test_plot]) is True
-        assert beb._use_tables([test_table, test_plot, test_glplot]) is True
-        assert beb._use_tables([test_table, test_widget, test_table, test_glplot]) is True
+        assert beb._use_tables(beb._all_objs([test_table])) is True
+        assert beb._use_tables(beb._all_objs([test_table, test_plot])) is True
+        assert beb._use_tables(beb._all_objs([test_table, test_plot, test_glplot])) is True
+        assert beb._use_tables(beb._all_objs([test_table, test_widget, test_table, test_glplot])) is True
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
         d.add_root(test_widget)
         d.add_root(test_glplot)
-        assert beb._use_tables([d]) is True
+        assert beb._use_tables(beb._all_objs([d])) is True
 
 
 class Test__use_widgets:
     def test_without_widgets(self, test_plot, test_glplot, test_table, test_widget) -> None:
-        assert beb._use_widgets([test_plot]) is False
-        assert beb._use_widgets([test_plot, test_glplot]) is False
+        assert beb._use_widgets(beb._all_objs([test_plot])) is False
+        assert beb._use_widgets(beb._all_objs([test_plot, test_glplot])) is False
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_glplot)
-        assert beb._use_widgets([d]) is False
+        assert beb._use_widgets(beb._all_objs([d])) is False
 
     def test_with_widgets(self, test_plot, test_glplot, test_table, test_widget) -> None:
-        assert beb._use_widgets([test_widget]) is True
-        assert beb._use_widgets([test_widget, test_plot]) is True
-        assert beb._use_widgets([test_widget, test_plot, test_glplot]) is True
-        assert beb._use_widgets([test_widget, test_plot, test_glplot, test_table]) is True
-        assert beb._use_widgets([test_table, test_table, test_glplot]) is True
+        assert beb._use_widgets(beb._all_objs([test_widget])) is True
+        assert beb._use_widgets(beb._all_objs([test_widget, test_plot])) is True
+        assert beb._use_widgets(beb._all_objs([test_widget, test_plot, test_glplot])) is True
+        assert beb._use_widgets(beb._all_objs([test_widget, test_plot, test_glplot, test_table])) is True
+        assert beb._use_widgets(beb._all_objs([test_table, test_table, test_glplot])) is True
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
         d.add_root(test_widget)
         d.add_root(test_glplot)
-        assert beb._use_widgets([d]) is True
+        assert beb._use_widgets(beb._all_objs([d])) is True
 
 
 class Test__use_mathjax:
     def test_without_mathjax(self, test_plot, test_glplot, test_table, test_widget, test_mathtext) -> None:
-        assert beb._use_mathjax([test_plot]) is False
-        assert beb._use_mathjax([test_plot, test_glplot]) is False
-        assert beb._use_mathjax([test_plot, test_table]) is False
-        assert beb._use_mathjax([test_plot, test_widget]) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot])) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_glplot])) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_table])) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_widget])) is False
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
         d.add_root(test_widget)
-        assert beb._use_mathjax([d]) is False
+        assert beb._use_mathjax(beb._all_objs([d])) is False
 
     def test_with_mathjax(self, test_plot, test_glplot, test_table, test_widget, test_mathtext, test_plaintext) -> None:
-        assert beb._use_mathjax([test_mathtext]) is True
-        assert beb._use_mathjax([test_plot, test_mathtext]) is True
-        assert beb._use_mathjax([test_plot, test_glplot, test_mathtext]) is True
-        assert beb._use_mathjax([test_plot, test_widget, test_mathtext]) is True
-        assert beb._use_mathjax([test_plot, test_widget, test_table, test_mathtext]) is True
-        assert beb._use_mathjax([test_plot, test_plaintext, test_mathtext]) is True
+        assert beb._use_mathjax(beb._all_objs([test_mathtext])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_mathtext])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_glplot, test_mathtext])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_widget, test_mathtext])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_widget, test_table, test_mathtext])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_plaintext, test_mathtext])) is True
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
         d.add_root(test_widget)
         d.add_root(test_mathtext)
-        assert beb._use_mathjax([d]) is True
+        assert beb._use_mathjax(beb._all_objs([d])) is True
 
     def test_with_mathstring(self, test_plot, test_glplot, test_table, test_widget, test_mathtext,
             test_mathstring_axis_label, test_mathstring_major_label_overrides) -> None:
-        assert beb._use_mathjax([test_mathstring_axis_label]) is True
-        assert beb._use_mathjax([test_plot, test_mathstring_axis_label]) is True
-        assert beb._use_mathjax([test_plot, test_glplot, test_mathstring_axis_label]) is True
-        assert beb._use_mathjax([test_plot, test_widget, test_mathstring_axis_label]) is True
-        assert beb._use_mathjax([test_plot, test_widget, test_table, test_mathstring_axis_label]) is True
-        assert beb._use_mathjax([test_plot, test_mathtext, test_mathstring_axis_label]) is True
-        assert beb._use_mathjax([test_plot, test_mathstring_major_label_overrides]) is True
+        assert beb._use_mathjax(beb._all_objs([test_mathstring_axis_label])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_mathstring_axis_label])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_glplot, test_mathstring_axis_label])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_widget, test_mathstring_axis_label])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_widget, test_table, test_mathstring_axis_label])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_mathtext, test_mathstring_axis_label])) is True
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_mathstring_major_label_overrides])) is True
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
         d.add_root(test_widget)
         d.add_root(test_mathstring_axis_label)
-        assert beb._use_mathjax([d]) is True
+        assert beb._use_mathjax(beb._all_objs([d])) is True
 
     def test_with_plaintext(self, test_plot, test_glplot, test_table, test_widget, test_mathtext, test_plaintext) -> None:
-        assert beb._use_mathjax([test_plaintext]) is False
-        assert beb._use_mathjax([test_plot, test_plaintext]) is False
-        assert beb._use_mathjax([test_plot, test_glplot, test_plaintext]) is False
-        assert beb._use_mathjax([test_plot, test_widget, test_plaintext]) is False
-        assert beb._use_mathjax([test_plot, test_widget, test_table, test_plaintext]) is False
-        assert beb._use_mathjax([test_plot, test_mathtext, test_plaintext]) is True
+        assert beb._use_mathjax(beb._all_objs([test_plaintext])) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_plaintext])) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_glplot, test_plaintext])) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_widget, test_plaintext])) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_widget, test_table, test_plaintext])) is False
+        assert beb._use_mathjax(beb._all_objs([test_plot, test_mathtext, test_plaintext])) is True
         d = Document()
         d.add_root(test_plot)
         d.add_root(test_table)
         d.add_root(test_widget)
         d.add_root(test_plaintext)
-        assert beb._use_mathjax([d]) is False
+        assert beb._use_mathjax(beb._all_objs([d])) is False
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This replaces 9 calls to Model.references() with a single one, reducing
the time it takes to create a plot and write out the HTML by about 46%.