### PR TITLE
Enable strict boolean expressions lint rule

### DIFF
--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -40,7 +40,15 @@
     "@typescript-eslint/semi": ["error", "never"],
     "@typescript-eslint/type-annotation-spacing": ["error"],
     "@typescript-eslint/no-unnecessary-condition": ["warn", {"allowConstantLoopConditions": true}],
-    "@typescript-eslint/strict-boolean-expressions": ["error", {"allowAny": true}],
+    "@typescript-eslint/strict-boolean-expressions": ["error", {
+      "allowAny": true,
+      "allowString": false,
+      "allowNumber": false,
+      "allowNullableObject": false,
+      "allowNullableBoolean": false,
+      "allowNullableString": false,
+      "allowNullableNumber": false
+    }],
     "@typescript-eslint/no-unnecessary-type-assertion": ["error"],
     "@typescript-eslint/no-unnecessary-type-constraint": ["error"],
     "no-self-assign": ["error", {"props": false}],

--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -118,7 +118,7 @@ async function headless(devtools_port: number): Promise<ChildProcess> {
         const [line] = result
         console.log(line.trim())
         resolve(proc)
-      } else if (buffer.match(/bind\(\)/)) {
+      } else if (buffer.match(/bind\(\)/) != null) {
         proc.stderr.removeAllListeners()
         clearTimeout(timer)
         reject(new BuildError("headless", `can't start headless browser on port ${devtools_port}`))

--- a/bokehjs/src/compiler/compiler.ts
+++ b/bokehjs/src/compiler/compiler.ts
@@ -23,7 +23,7 @@ export type Failed = {
 }
 
 export function is_failed<T>(obj: T | Partial<Failed>): obj is Failed {
-  return typeof obj == "object" && !!obj && "diagnostics" in obj && obj.diagnostics != null
+  return typeof obj == "object" && obj != null && "diagnostics" in obj && obj.diagnostics != null
 }
 
 export type TSConfig = {

--- a/bokehjs/src/compiler/transforms.ts
+++ b/bokehjs/src/compiler/transforms.ts
@@ -169,14 +169,14 @@ export function collect_exports(exported: Exports[]) {
         exported.push({type: "named", name: "default"})
       } else if (ts.isClassDeclaration(statement) || ts.isFunctionDeclaration(statement)) {
         const flags = ts.getCombinedModifierFlags(statement)
-        if (flags & ts.ModifierFlags.Export) {
+        if ((flags & ts.ModifierFlags.Export) != 0) {
           // export class X {}
           // export function f() {}
           if (statement.name != null) {
             const name = statement.name.text
             exported.push({type: "named", name})
           }
-        } else if (flags & ts.ModifierFlags.ExportDefault) {
+        } else if ((flags & ts.ModifierFlags.ExportDefault) != 0) {
           // export default class X {}
           // export function f() {}
           exported.push({type: "named", name: "default"})

--- a/bokehjs/src/lib/api/parser.ts
+++ b/bokehjs/src/lib/api/parser.ts
@@ -159,7 +159,7 @@ function is_decimal_digit(ch: number): boolean {
 function is_identifier_start(ch: number): boolean {
   return (ch >= 65 && ch <= 90) || // A...Z
     (ch >= 97 && ch <= 122) || // a...z
-    (ch >= 128 && !binary_ops[String.fromCharCode(ch)]) || // any non-ASCII that is not an operator
+    (ch >= 128 && !(String.fromCharCode(ch) in binary_ops)) || // any non-ASCII that is not an operator
     (additional_identifier_chars.has(String.fromCharCode(ch))) // additional characters
 }
 
@@ -636,7 +636,7 @@ export class Parser {
         closed = true
         this.index++
 
-        if (termination == CPAREN_CODE && separator_count && separator_count >= args.length) {
+        if (termination == CPAREN_CODE && separator_count != 0 && separator_count >= args.length) {
           this.error(`Unexpected token '${String.fromCharCode(termination)}'`)
         }
 
@@ -690,7 +690,7 @@ export class Parser {
       this.index++
       if (nodes.length == 1) {
         return nodes[0]
-      } else if (!nodes.length) {
+      } else if (nodes.length == 0) {
         return false
       } else {
         return {

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -143,7 +143,7 @@ export class ClientConnection {
   }
 
   protected async _repull_session_doc(resolve: SessionResolver, reject: Rejecter): Promise<void> {
-    logger.debug(this.session ? "Repulling session" : "Pulling session for first time")
+    logger.debug(this.session != null ? "Repulling session" : "Pulling session for first time")
     try {
       const doc_json = await this._pull_doc_json()
       if (this.session == null) {
@@ -247,10 +247,10 @@ export class ClientConnection {
   protected _steady_state_handler(message: Message<unknown>): void {
     const reqid = message.reqid()
     const pr = this._pending_replies.get(reqid)
-    if (pr) {
+    if (pr != null) {
       this._pending_replies.delete(reqid)
       pr.resolve(message)
-    } else if (this.session) {
+    } else if (this.session != null) {
       this.session.handle(message)
     } else if (message.msgtype() != "PATCH-DOC") {
       // This branch can be executed only before we get the document.

--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -174,7 +174,7 @@ export function prepend(element: Node, ...nodes: Node[]): void {
 
 export function empty(node: Node, attrs: boolean = false): void {
   let child: ChildNode | null
-  while (child = node.firstChild) {
+  while ((child = node.firstChild) != null) {
     node.removeChild(child)
   }
   if (attrs && node instanceof Element) {
@@ -233,7 +233,7 @@ export function offset_bbox(element: Element): BBox {
 export function parent(el: HTMLElement, selector: string): HTMLElement | null {
   let node: HTMLElement | null = el
 
-  while (node = node.parentElement) {
+  while ((node = node.parentElement) != null) {
     if (node.matches(selector))
       return node
   }
@@ -242,7 +242,8 @@ export function parent(el: HTMLElement, selector: string): HTMLElement | null {
 }
 
 function num(value: string | null): number {
-  return parseFloat(value!) || 0
+  const num = parseFloat(value!)
+  return isFinite(num) ? num : 0
 }
 
 export type ElementExtents = {

--- a/bokehjs/src/lib/core/graphics.ts
+++ b/bokehjs/src/lib/core/graphics.ts
@@ -174,7 +174,7 @@ export class TextBox extends GraphicsBox {
     if (res != null) {
       let {value, unit} = res
       value *= font_size_scale
-      if (unit == "em" && base_font_size) {
+      if (unit == "em" && base_font_size != 0) {
         value *= base_font_size
         unit = "px"
       }

--- a/bokehjs/src/lib/core/util/algorithms.ts
+++ b/bokehjs/src/lib/core/util/algorithms.ts
@@ -96,7 +96,7 @@ export function cbb(
   const x_bounds: number[] = Array(n + 2)
   const y_bounds: number[] = Array(n + 2)
 
-  while (j--) {
+  while (j-- > 0) {
     const t = tvalues[j]
     const mt = 1 - t
 

--- a/bokehjs/src/lib/core/util/bitset.ts
+++ b/bokehjs/src/lib/core/util/bitset.ts
@@ -78,7 +78,7 @@ export class BitSet implements Equatable {
     this._check_bounds(k)
     const i = k >>> 5  // Math.floor(k/32)
     const j = k & 0x1f // k % 32
-    return !!((this._array[i] >> j) & 0x1)
+    return ((this._array[i] >> j) & 0b1) == 0b1
   }
 
   set(k: number, v: boolean = true): void {
@@ -87,9 +87,9 @@ export class BitSet implements Equatable {
     const i = k >>> 5  // Math.floor(k/32)
     const j = k & 0x1f // k % 32
     if (v)
-      this._array[i] |= 0x1 << j
+      this._array[i] |= 0b1 << j
     else
-      this._array[i] &= ~(0x1 << j)
+      this._array[i] &= ~(0b1 << j)
   }
 
   unset(k: number): void {
@@ -117,7 +117,7 @@ export class BitSet implements Equatable {
         k += 32
       } else {
         for (let j = 0; j < 32 && k < size; j++, k++) {
-          if ((word >>> j) & 0x1)
+          if (((word >>> j) & 0b1) == 0b1)
             c += 1
         }
       }
@@ -134,7 +134,7 @@ export class BitSet implements Equatable {
         continue
       }
       for (let j = 0; j < 32 && k < size; j++, k++) {
-        if ((word >>> j) & 0x1)
+        if (((word >>> j) & 0b1) == 0b1)
           yield k
       }
     }
@@ -149,7 +149,7 @@ export class BitSet implements Equatable {
         continue
       }
       for (let j = 0; j < 32 && k < size; j++, k++) {
-        if (!((word >>> j) & 0x1))
+        if (((word >>> j) & 0b1) == 0b0)
           yield k
       }
     }

--- a/bokehjs/src/lib/core/util/color.ts
+++ b/bokehjs/src/lib/core/util/color.ts
@@ -124,7 +124,7 @@ export function css4_parse(color: string): RGBA | null {
   */
   color = color.trim().toLowerCase()
 
-  if (!color)
+  if (color == "")
     return null
   else if (color == "transparent")
     return transparent()

--- a/bokehjs/src/lib/core/util/eq.ts
+++ b/bokehjs/src/lib/core/util/eq.ts
@@ -63,7 +63,7 @@ export class Comparator {
     // It's done here since we only need them for objects and arrays comparison.
     const {a_stack, b_stack} = this
     let length = a_stack.length
-    while (length--) {
+    while (length-- > 0) {
       // Linear search. Performance is inversely proportional to the number of
       // unique nested structures.
       if (a_stack[length] === a)

--- a/bokehjs/src/lib/core/util/svg.ts
+++ b/bokehjs/src/lib/core/util/svg.ts
@@ -355,7 +355,7 @@ export class SVGRenderingContext2D implements BaseCanvasRenderingContext2D {
 
     // allow passing in an existing context to wrap around
     // if a context is passed in, we know a canvas already exist
-    if (options?.ctx) {
+    if (options?.ctx != null) {
       this.__ctx = options.ctx
     } else {
       this.__canvas = this.__document.createElement("canvas")
@@ -635,13 +635,13 @@ export class SVGRenderingContext2D implements BaseCanvasRenderingContext2D {
     * Helper function to add path command
     */
   __addPathCommand(x: number, y: number, path: string): void {
-    const separator = !this.__currentDefaultPath ? "" : " "
+    const separator = this.__currentDefaultPath == "" ? "" : " "
     this.__currentDefaultPath += separator + path
     this.__currentPosition = {x, y}
   }
 
   get _hasCurrentDefaultPath(): boolean {
-    return !!this.__currentDefaultPath
+    return this.__currentDefaultPath != ""
   }
 
   /**
@@ -1218,7 +1218,7 @@ export class SVGRenderingContext2D implements BaseCanvasRenderingContext2D {
       if (this.globalAlpha != 1.0)
         svgImage.setAttribute("opacity", `${this.globalAlpha}`)
 
-      if (sx || sy || sw !== image.width || sh !== image.height) {
+      if (sx != 0 || sy != 0 || sw !== image.width || sh !== image.height) {
         // crop the image using a temporary canvas
         const canvas = this.__document.createElement("canvas")
         canvas.width = dw
@@ -1343,7 +1343,7 @@ export class SVGRenderingContext2D implements BaseCanvasRenderingContext2D {
     else if (args[0] instanceof DOMMatrix)
       matrix = args[0]
     else
-      matrix = new DOMMatrix(Object.values(!args[0]))
+      matrix = new DOMMatrix(Object.values(args[0] == null))
 
     this._transform = AffineTransform.from_DOMMatrix(matrix)
   }

--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -142,7 +142,7 @@ export function replace_placeholders(content: string | {html: string}, data_sour
 
     // missing value, return ???
     if (value == null)
-      return encode ? encode("???") : "???"
+      return encode != null ? encode("???") : "???"
 
     // 'safe' format, return the value as-is
     if (format == "safe") {
@@ -153,7 +153,7 @@ export function replace_placeholders(content: string | {html: string}, data_sour
     // format and escape everything else
     const formatter = get_formatter(spec, format, formatters)
     const result = `${formatter(value, format, special_vars)}`
-    return encode ? encode(result) : result
+    return encode != null ? encode(result) : result
   })
 
   if (!has_html)

--- a/bokehjs/src/lib/models/annotations/html/label_set.ts
+++ b/bokehjs/src/lib/models/annotations/html/label_set.ts
@@ -124,7 +124,7 @@ export class HTMLLabelSetView extends DataAnnotationView {
     })()
 
     let transform = `translate(${x_t}, ${y_t})`
-    if (angle) {
+    if (angle != 0) {
       transform += `rotate(${angle}rad)`
     }
 

--- a/bokehjs/src/lib/models/annotations/html/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/html/text_annotation.ts
@@ -75,7 +75,7 @@ export abstract class TextAnnotationView extends AnnotationView {
     })()
 
     let transform = `translate(${x_t}, ${y_t})`
-    if (angle) {
+    if (angle != 0) {
       transform += `rotate(${angle}rad)`
     }
 

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -30,7 +30,7 @@ export class CategoricalAxisView extends AxisView {
     const [range] = this.ranges as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
-    if (!range.tops || range.tops.length < 2 || !this.visuals.separator_line.doit)
+    if (range.tops == null || range.tops.length < 2 || !this.visuals.separator_line.doit)
       return
 
     const dim = this.dimension

--- a/bokehjs/src/lib/models/dom/html.ts
+++ b/bokehjs/src/lib/models/dom/html.ts
@@ -43,7 +43,7 @@ export class HTMLView extends DOMNodeView {
         })
 
         let node: Node | null
-        while (node = iter.nextNode()) {
+        while ((node = iter.nextNode()) != null) {
           assert(node instanceof Element)
 
           const id = node.getAttribute("id")

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -226,14 +226,12 @@ export class DatetimeTickFormatter extends TickFormatter {
       if (context == "")
         return label
 
-      if (loc == "above")
-        return `${context}\n${label}`
-      if (loc == "below")
-        return `${label}\n${context}`
-      if (loc == "left")
-        return `${context} ${label}`
-      if (loc == "right")
-        return `${label} ${context}`
+      switch (loc) {
+        case "above": return `${context}\n${label}`
+        case "below": return `${label}\n${context}`
+        case "left":  return `${context} ${label}`
+        case "right": return `${label} ${context}`
+      }
     }
     return label
   }

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -69,7 +69,7 @@ export class ImageURLView extends XYGlyphView {
 
     for (let i = 0; i < n_urls; i++) {
       const url = this.url.get(i)
-      if (!url)
+      if (url == "")
         continue
 
       const loader = new ImageLoader(url, {
@@ -205,7 +205,7 @@ export class ImageURLView extends XYGlyphView {
     const sw2 = sw_i/2
     const sh2 = sh_i/2
 
-    if (angle_i) {
+    if (angle_i != 0) {
       ctx.translate(sx_i, sy_i)
 
       //rotation about center of image

--- a/bokehjs/src/lib/models/glyphs/marker.ts
+++ b/bokehjs/src/lib/models/glyphs/marker.ts
@@ -42,13 +42,15 @@ export abstract class MarkerView extends XYGlyphView {
       ctx.beginPath()
       ctx.translate(sx_i, sy_i)
 
-      if (angle_i)
+      if (angle_i != 0) {
         ctx.rotate(angle_i)
+      }
 
       this._render_one(ctx, i, r, this.visuals)
 
-      if (angle_i)
+      if (angle_i != 0) {
         ctx.rotate(-angle_i)
+      }
 
       ctx.translate(-sx_i, -sy_i)
     }

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -114,7 +114,7 @@ export class RectView extends CenterRotatableView {
         continue
 
       ctx.beginPath()
-      if (angle_i) {
+      if (angle_i != 0) {
         ctx.translate(sx_i, sy_i)
         ctx.rotate(angle_i)
         const box = new BBox({x: -sw_i/2, y: -sh_i/2, width: sw_i, height: sh_i})

--- a/bokehjs/src/lib/models/glyphs/scatter.ts
+++ b/bokehjs/src/lib/models/glyphs/scatter.ts
@@ -45,13 +45,15 @@ export class ScatterView extends MarkerView {
       ctx.beginPath()
       ctx.translate(sx_i, sy_i)
 
-      if (angle_i)
+      if (angle_i != 0) {
         ctx.rotate(angle_i)
+      }
 
       marker_funcs[marker_i](ctx, i, r, this.visuals)
 
-      if (angle_i)
+      if (angle_i != 0) {
         ctx.rotate(-angle_i)
+      }
 
       ctx.translate(-sx_i, -sy_i)
     }

--- a/bokehjs/src/lib/models/glyphs/webgl/utils/math.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/utils/math.ts
@@ -11,7 +11,7 @@ function gcd2(a: number, b: number): number {
     lower = a
   }
 
-  let divisor: number = higher % lower
+  let divisor = higher % lower
 
   while (divisor != 0) {
     higher = lower
@@ -23,7 +23,7 @@ function gcd2(a: number, b: number): number {
 }
 
 export function gcd(values: number[]): number {
-  let ret: number = values[0]
+  let ret = values[0]
 
   for (let i = 1; i < values.length; i++)
     ret = gcd2(ret, values[i])
@@ -33,5 +33,5 @@ export function gcd(values: number[]): number {
 
 // From regl
 export function is_pow_2(v: number): boolean {
-  return !(v & (v - 1)) && (!!v)
+  return (v & (v - 1)) == 0 && v != 0
 }

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -65,7 +65,7 @@ export class GMapPlotView extends PlotView {
     const decoder = new TextDecoder("utf-8")
     this._api_key = decoder.decode(this.model.api_key)
 
-    if (!this._api_key) {
+    if (this._api_key == "") {
       const url = "https://developers.google.com/maps/documentation/javascript/get-api-key"
       logger.error(`api_key is required. See ${url} for more information on how to obtain your own.`)
     }

--- a/bokehjs/src/lib/models/plots/range_manager.ts
+++ b/bokehjs/src/lib/models/plots/range_manager.ts
@@ -95,7 +95,7 @@ export class RangeManager {
       if (xr instanceof DataRange1d) {
         const bounds_to_use = xr.scale_hint == "log" ? log_bounds : bounds
         xr.update(bounds_to_use, 0, this.parent, r)
-        if (xr.follow) {
+        if (xr.follow != null) {
           follow_enabled = true
         }
       }
@@ -107,7 +107,7 @@ export class RangeManager {
       if (yr instanceof DataRange1d) {
         const bounds_to_use = yr.scale_hint == "log" ? log_bounds : bounds
         yr.update(bounds_to_use, 1, this.parent, r)
-        if (yr.follow) {
+        if (yr.follow != null) {
           follow_enabled = true
         }
       }

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -316,7 +316,7 @@ export class GlyphRendererView extends DataRendererView {
       if (inspected.is_empty())
         return []
       else {
-        if (inspected.selected_glyph)
+        if (inspected.selected_glyph != null)
           return this.model.view.convert_indices_from_subset(indices)
         else if (inspected.indices.length > 0)
           return inspected.indices
@@ -347,7 +347,7 @@ export class GlyphRendererView extends DataRendererView {
       selection_glyph = this.selection_glyph
     }
 
-    if (this.hover_glyph != null && inspected_subset_indices.length) {
+    if (this.hover_glyph != null && inspected_subset_indices.length != 0) {
       // TODO: keep working on Indices instead of converting back and forth
       const set = new Set(indices)
       for (const i of inspected_subset_indices) {
@@ -357,9 +357,9 @@ export class GlyphRendererView extends DataRendererView {
     }
 
     // Render with no selection
-    if (!selected_full_indices.length) {
+    if (selected_full_indices.length == 0) {
       if (this.glyph instanceof LineView) {
-        if (this.hover_glyph != null && inspected_subset_indices.length)
+        if (this.hover_glyph != null && inspected_subset_indices.length != 0)
           this.hover_glyph.render(ctx, this.model.view.convert_indices_from_subset(inspected_subset_indices))
         else
           glyph.render(ctx, all_indices)
@@ -374,7 +374,7 @@ export class GlyphRendererView extends DataRendererView {
         }
       } else {
         glyph.render(ctx, indices)
-        if (this.hover_glyph != null && inspected_subset_indices.length)
+        if (this.hover_glyph != null && inspected_subset_indices.length != 0)
           this.hover_glyph.render(ctx, inspected_subset_indices)
       }
     // Render with selection

--- a/bokehjs/src/lib/models/text/math_text.ts
+++ b/bokehjs/src/lib/models/text/math_text.ts
@@ -109,7 +109,7 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
     if (res != null) {
       let {value, unit} = res
       value *= font_size_scale
-      if (unit == "em" && _base_font_size) {
+      if (unit == "em" && _base_font_size != 0) {
         value *= _base_font_size
         unit = "px"
       }
@@ -206,11 +206,13 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
 
     // XXX: perhaps use getComputedStyle()?
     const svg_styles = this.svg_element.getAttribute("style")?.split(";")
-    if (svg_styles) {
+    if (svg_styles != null) {
       const rules_map = new Map()
       svg_styles.forEach(property => {
         const [rule, value] = property.split(":")
-        if (rule) rules_map.set(rule.trim(), value.trim())
+        if (rule.trim() != "") {
+          rules_map.set(rule.trim(), value.trim())
+        }
       })
       const v_align = parse_css_length(rules_map.get("vertical-align"))
 
@@ -247,7 +249,7 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
   height?: {value: number, unit: "%"}
 
   _size(): Size {
-    if (!this.svg_image) {
+    if (this.svg_image == null) {
       if (this.provider.status == "failed" || this.provider.status == "not_started") {
         return {
           width: text_width(this.truncated_text, this.font),
@@ -357,7 +359,7 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
    * been loaded draws the image in it otherwise draws the model's text.
   */
   paint(ctx: Context2d): void {
-    if (!this.svg_image) {
+    if (this.svg_image == null) {
       if (this.provider.status == "not_started" || this.provider.status == "loading")
         this.provider.ready.connect(() => this.load_image())
 
@@ -377,7 +379,7 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
 
     const {x, y} = this._computed_position()
 
-    if (this.svg_image) {
+    if (this.svg_image != null) {
       const {width, height} = this.get_image_dimensions()
       ctx.drawImage(this.svg_image, x, y, width, height)
     } else if (this.provider.status == "failed" || this.provider.status == "not_started") {
@@ -390,7 +392,7 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
 
     ctx.restore()
 
-    if (!this._has_finished && (this.provider.status == "failed" || this.svg_image)) {
+    if (!this._has_finished && (this.provider.status == "failed" || this.svg_image != null)) {
       this._has_finished = true
       this.parent.notify_finished_after_paint()
     }
@@ -485,7 +487,7 @@ export class MathMLView extends MathTextView {
   override get styled_text(): string {
     let styled = this.text.trim()
     let matchs = styled.match(/<math(.*?[^?])?>/s)
-    if (!matchs)
+    if (matchs == null)
       return this.text.trim()
 
     styled = insert_text_on_position(
@@ -495,7 +497,7 @@ export class MathMLView extends MathTextView {
     )
 
     matchs = styled.match(/<\/[^>]*?math.*?>/s)
-    if (!matchs)
+    if (matchs == null)
       return this.text.trim()
 
     return insert_text_on_position(styled, styled.indexOf(matchs[0]), "</mstyle>")

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -76,7 +76,7 @@ export abstract class EditToolView extends GestureToolView {
   _pop_glyphs(cds: ColumnarDataSource, num_objects: number): void {
     // Pops rows in the CDS until only num_objects are left
     const columns = cds.columns()
-    if (!num_objects || !columns.length)
+    if (num_objects == 0 || columns.length == 0)
       return
     for (const column of columns) {
       let array = cds.get_array(column)

--- a/bokehjs/src/lib/models/tools/edit/line_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/line_edit_tool.ts
@@ -39,7 +39,7 @@ export class LineEditToolView extends LineToolView {
       return
 
     const renderers = this.model.renderers
-    if (!renderers.length) {
+    if (renderers.length == 0) {
       this._set_intersection([], [])
       this._selected_renderer = null
       this._drawing = false
@@ -62,7 +62,7 @@ export class LineEditToolView extends LineToolView {
     const point = this._map_drag(ev.sx, ev.sy, renderer)
     if (point == null)
       return
-    else if (this._drawing && this._selected_renderer) {
+    else if (this._drawing && this._selected_renderer != null) {
       const mode = this._select_mode(ev)
       const selected_points = this._select_event(ev, mode, [renderer])
       if (selected_points.length == 0) {
@@ -98,7 +98,7 @@ export class LineEditToolView extends LineToolView {
     if (this._basepoint == null)
       return
     this._drag_points(ev, [this.model.intersection_renderer], this.model.dimensions)
-    if (this._selected_renderer)
+    if (this._selected_renderer != null)
       this._selected_renderer.data_source.change.emit()
   }
 
@@ -107,7 +107,7 @@ export class LineEditToolView extends LineToolView {
       return
     this._drag_points(ev, [this.model.intersection_renderer])
     this._emit_cds_changes(this.model.intersection_renderer.data_source, false, true, true)
-    if (this._selected_renderer) {
+    if (this._selected_renderer != null) {
       this._emit_cds_changes(this._selected_renderer.data_source)
     }
     this._basepoint = null
@@ -118,7 +118,7 @@ export class LineEditToolView extends LineToolView {
   }
 
   override deactivate(): void {
-    if (!this._selected_renderer) {
+    if (this._selected_renderer == null) {
       return
     } else if (this._drawing) {
       this._drawing = false

--- a/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/point_draw_tool.ts
@@ -9,7 +9,7 @@ export class PointDrawToolView extends EditToolView {
 
   override _tap(ev: TapEvent): void {
     const renderers = this._select_event(ev, this._select_mode(ev), this.model.renderers)
-    if (renderers.length || !this.model.add) {
+    if (renderers.length != 0 || !this.model.add) {
       return
     }
 

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -232,7 +232,7 @@ export class PolyDrawToolView extends PolyToolView {
       this._remove()
       this._drawing = false
     }
-    if (this.model.vertex_renderer)
+    if (this.model.vertex_renderer != null)
       this._hide_vertices()
   }
 }

--- a/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
@@ -32,7 +32,7 @@ export class PolyEditToolView extends PolyToolView {
     // Type once dataspecs are typed
     const point_glyph: any = this.model.vertex_renderer.glyph
     const [pxkey, pykey] = [point_glyph.x.field, point_glyph.y.field]
-    if (vertex_selected.length && this._selected_renderer != null) {
+    if (vertex_selected.length != 0 && this._selected_renderer != null) {
       // Insert a new point after the selected vertex and enter draw mode
       const index = point_cds.selected.indices[0]
       if (this._drawing) {
@@ -62,7 +62,7 @@ export class PolyEditToolView extends PolyToolView {
     const vsync_ds = vsync_renderer.data_source
 
     const renderers = this._select_event(ev, "replace", this.model.renderers)
-    if (!renderers.length) {
+    if (renderers.length == 0) {
       this._set_vertices([], [])
       this._selected_renderer = null
       this._drawing = false
@@ -137,7 +137,7 @@ export class PolyEditToolView extends PolyToolView {
     const point = this._map_drag(ev.sx, ev.sy, renderer)
     if (point == null)
       return
-    else if (this._drawing && this._selected_renderer) {
+    else if (this._drawing && this._selected_renderer != null) {
       let [x, y] = point
       const cds = renderer.data_source
       // Type once dataspecs are typed
@@ -169,7 +169,7 @@ export class PolyEditToolView extends PolyToolView {
   }
 
   _remove_vertex(): void {
-    if (!this._drawing || !this._selected_renderer)
+    if (!this._drawing || this._selected_renderer == null)
       return
     const renderer = this.model.vertex_renderer
     if (renderer == null)
@@ -198,7 +198,7 @@ export class PolyEditToolView extends PolyToolView {
     if (this.model.vertex_renderer == null)
       return
     this._drag_points(ev, [this.model.vertex_renderer])
-    if (this._selected_renderer)
+    if (this._selected_renderer != null)
       this._selected_renderer.data_source.change.emit()
   }
 
@@ -209,7 +209,7 @@ export class PolyEditToolView extends PolyToolView {
       return
     this._drag_points(ev, [this.model.vertex_renderer])
     this._emit_cds_changes(this.model.vertex_renderer.data_source, false, true, true)
-    if (this._selected_renderer) {
+    if (this._selected_renderer != null) {
       this._emit_cds_changes(this._selected_renderer.data_source)
     }
     this._basepoint = null
@@ -219,7 +219,7 @@ export class PolyEditToolView extends PolyToolView {
     if (!this.model.active || !this._mouse_in_frame)
       return
     let renderers: GlyphRenderer[]
-    if (this._selected_renderer) {
+    if (this._selected_renderer != null) {
       const {vertex_renderer} = this.model
       renderers = vertex_renderer != null ? [vertex_renderer] : []
     } else {
@@ -228,14 +228,14 @@ export class PolyEditToolView extends PolyToolView {
     for (const renderer of renderers) {
       if (ev.key == "Backspace") {
         this._delete_selected(renderer)
-        if (this._selected_renderer) {
+        if (this._selected_renderer != null) {
           this._emit_cds_changes(this._selected_renderer.data_source)
         }
       } else if (ev.key == "Escape") {
         if (this._drawing) {
           this._remove_vertex()
           this._drawing = false
-        } else if (this._selected_renderer) {
+        } else if (this._selected_renderer != null) {
           this._hide_vertices()
         }
         renderer.data_source.selection_manager.clear()
@@ -244,7 +244,7 @@ export class PolyEditToolView extends PolyToolView {
   }
 
   override deactivate(): void {
-    if (!this._selected_renderer) {
+    if (this._selected_renderer == null) {
       return
     } else if (this._drawing) {
       this._remove_vertex()

--- a/bokehjs/src/lib/models/tools/edit/poly_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_tool.ts
@@ -41,14 +41,14 @@ export abstract class PolyToolView extends EditToolView {
   }
 
   _snap_to_vertex(ev: UIEvent, x: number, y: number): [number, number] {
-    if (this.model.vertex_renderer) {
+    if (this.model.vertex_renderer != null) {
       // If an existing vertex is hit snap to it
       const vertex_selected = this._select_event(ev, "replace", [this.model.vertex_renderer])
       const point_ds = this.model.vertex_renderer.data_source
       // Type once dataspecs are typed
       const point_glyph: any = this.model.vertex_renderer.glyph
       const [pxkey, pykey] = [point_glyph.x.field, point_glyph.y.field]
-      if (vertex_selected.length) {
+      if (vertex_selected.length != 0) {
         const index = point_ds.selected.indices[0]
         if (pxkey)
           x = point_ds.data[pxkey][index]

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -394,7 +394,7 @@ export class Toolbar extends UIElement {
       const gesture = this.gestures[et]
       gesture.tools = sort_by(new_gestures[et].tools, (tool) => tool.default_order)
 
-      if (gesture.active && every(gesture.tools, (tool) => tool.id != gesture.active?.id)) {
+      if (gesture.active != null && every(gesture.tools, (tool) => tool.id != gesture.active?.id)) {
         gesture.active = null
       }
     }
@@ -465,7 +465,7 @@ export class Toolbar extends UIElement {
     for (const [event_role, gesture] of entries(this.gestures)) {
       const et = event_role as EventRole
       const active_attr = _get_active_attr(et)
-      if (active_attr) {
+      if (active_attr != null) {
         const active_tool = this[active_attr]
         if (active_tool == "auto") {
           if (gesture.tools.length != 0 && _supports_auto(et)) {

--- a/bokehjs/src/lib/models/widgets/picker_base.ts
+++ b/bokehjs/src/lib/models/widgets/picker_base.ts
@@ -88,7 +88,7 @@ export abstract class PickerBaseView extends InputWidgetView {
     //   window.scrollY +
     //   inputBounds.top +
     //   (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2)
-    const top = self.config.appendTo
+    const top = self.config.appendTo != null
       ? inputBounds.top +
         (!showOnTop ? positionElement.offsetHeight + 2 : -calendarHeight - 2)
       : window.scrollY +

--- a/bokehjs/src/lib/models/widgets/tables/data_cube.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_cube.ts
@@ -35,9 +35,9 @@ function indentFormatter(formatter?: Formatter<Item>, indent?: number): Formatte
       class: "slick-group-toggle",
       style: {"margin-left": `${(indent ?? 0) * 15}px`},
     })
-    const formatted = formatter ? formatter(row, cell, value, columnDef, dataContext) : `${value}`
+    const formatted = formatter != null ? formatter(row, cell, value, columnDef, dataContext) : `${value}`
 
-    return `${spacer.outerHTML}${formatted && formatted.replace(/^<div/, "<span").replace(/div>$/, "span>")}`
+    return `${spacer.outerHTML}${formatted.replace(/^<div/, "<span").replace(/div>$/, "span>")}`
   }
 }
 
@@ -117,15 +117,15 @@ export class DataCubeProvider extends TableDataProvider {
   private extractGroups(rows: number[], parentGroup?: Group<number>): Group<number>[] {
     const groups: Group<number>[] = []
     const groupsByValue: Map<any, Group<number>> = new Map()
-    const level = parentGroup ? parentGroup.level + 1 : 0
+    const level = (parentGroup != null) ? parentGroup.level + 1 : 0
     const {comparer, getter} = this.groupingInfos[level]
 
     rows.forEach((row) => {
       const value = this.source.data[getter][row]
       let group = groupsByValue.get(value)
 
-      if (!group) {
-        const groupingKey = parentGroup ? `${parentGroup.groupingKey}${this.groupingDelimiter}${value}` : `${value}`
+      if (group == null) {
+        const groupingKey = parentGroup != null ? `${parentGroup.groupingKey}${this.groupingDelimiter}${value}` : `${value}`
         group = Object.assign(new Group(), {value, level, groupingKey}) as any
         groups.push(group!)
         groupsByValue.set(value, group!)
@@ -166,7 +166,7 @@ export class DataCubeProvider extends TableDataProvider {
         this.addTotals(group.groups, level + 1)
       }
 
-      if (aggregators.length && group.rows.length) {
+      if (aggregators.length != 0 && group.rows.length != 0) {
         group.totals = this.calculateTotals(group, aggregators)
       }
 
@@ -194,7 +194,7 @@ export class DataCubeProvider extends TableDataProvider {
     const groups = this.extractGroups([...this.view.indices])
     const labels = this.source.data[this.columns[0].field!]
 
-    if (groups.length) {
+    if (groups.length != 0) {
       this.addTotals(groups)
       this.rows = this.flattenedGroupedRows(groups)
       this.target.data = {
@@ -230,11 +230,11 @@ export class DataCubeProvider extends TableDataProvider {
       const {field: myField, formatter} = column
       const aggregator = aggregators.find(({field_}) => field_ === myField)
 
-      if (aggregator) {
+      if (aggregator != null) {
         const {key} = aggregator
         return {
           formatter(row: number, cell: number, _value: unknown, columnDef: Column<Item>, dataContext: Item): string {
-            return formatter ? formatter(row, cell, dataContext.totals[key][myField!], columnDef, dataContext) : ""
+            return formatter != null ? formatter(row, cell, dataContext.totals[key][myField!], columnDef, dataContext) : ""
           },
         }
       }

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -106,10 +106,12 @@ export class TableDataProvider implements DataProvider<Item> {
         const v1 = records[old_index.indexOf(i1)][field!]
         if (v0 === v1)
           continue
-        if (isNumber(v0) && isNumber(v1))
+        if (isNumber(v0) && isNumber(v1)) {
+          /* eslint-disable @typescript-eslint/strict-boolean-expressions */
           return sign*(v0 - v1 || +isNaN(v0) - +isNaN(v1))
-        else
+        } else {
           return `${v0}` > `${v1}` ? sign : -sign
+        }
       }
       return 0
     })

--- a/bokehjs/src/lib/models/widgets/widget.ts
+++ b/bokehjs/src/lib/models/widgets/widget.ts
@@ -34,7 +34,7 @@ export abstract class WidgetView extends LayoutDOMView {
   }
 
   process_tex(text: string): string {
-    if (!this.provider.MathJax)
+    if (this.provider.MathJax == null)
       return text
 
     const tex_parts = this.provider.MathJax.find_tex(text)
@@ -55,7 +55,7 @@ export abstract class WidgetView extends LayoutDOMView {
   }
 
   protected contains_tex_string(text: string): boolean {
-    if (!this.provider.MathJax)
+    if (this.provider.MathJax == null)
       return false
 
     return this.provider.MathJax.find_tex(text).length > 0

--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -122,7 +122,7 @@ async function run_tests(): Promise<boolean> {
     try {
       function collect_trace(stackTrace: Protocol.Runtime.StackTrace): CallFrame[] {
         return stackTrace.callFrames.map(({functionName, url, lineNumber, columnNumber}) => {
-          return {name: functionName ? functionName : "(anonymous)", url, line: lineNumber+1, col: columnNumber+1}
+          return {name: functionName != "" ? functionName : "(anonymous)", url, line: lineNumber+1, col: columnNumber+1}
         })
       }
 
@@ -133,7 +133,7 @@ async function run_tests(): Promise<boolean> {
           url: url ?? "(inline)",
           line: lineNumber+1,
           col: columnNumber+1,
-          trace: stackTrace ? collect_trace(stackTrace) : [],
+          trace: stackTrace != null ? collect_trace(stackTrace) : [],
         }
       }
 
@@ -655,7 +655,7 @@ async function run_tests(): Promise<boolean> {
         progress.stop()
       }
 
-      if (out_stream) {
+      if (out_stream != null) {
         out_stream.write("\n")
         out_stream.write(`Tests finished on ${new Date().toISOString()} with ${failures} failures.\n`)
         out_stream.end()
@@ -709,7 +709,7 @@ async function run_tests(): Promise<boolean> {
       console.error(`INTERNAL ERROR: ${msg}`)
     }
   } finally {
-    if (client) {
+    if (client != null) {
       await client.close()
     }
   }

--- a/bokehjs/test/unit/assertions.ts
+++ b/bokehjs/test/unit/assertions.ts
@@ -243,7 +243,7 @@ function Throws(fn: () => unknown) {
       }
 
       if (pattern instanceof RegExp) {
-        if (!error.message.match(pattern)) {
+        if (error.message.match(pattern) == null) {
           throw new ExpectationError(`expected ${to_string(fn)} to throw an exception matching ${to_string(pattern)}, got ${to_string(error)}`)
         }
       } else if (isString(pattern)) {
@@ -285,7 +285,7 @@ function NotThrows(fn: () => unknown) {
 
         if (pattern != null && error instanceof Error) {
           if (pattern instanceof RegExp) {
-            if (error.message.match(pattern))
+            if (error.message.match(pattern) != null)
               throw new ExpectationError(`expected ${to_string(fn)} to not throw an exception matching ${to_string(pattern)}, got ${to_string(error)}`)
           } else if (isString(pattern)) {
             if (error.message.includes(pattern))


### PR DESCRIPTION
With this rule for non-boolean `x` in a conditional context, one has to use explicit comparisons instead of `if (x) ...`, `x ? ... : ...` or `while (x) ...`. I will finish this after PR #12792, to avoid merge conflicts.