### PR TITLE
Allow to clone `HasProps` instances

### DIFF
--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -736,10 +736,11 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         '''
         self.apply_theme(property_values={})
 
-    def _clone(self) -> HasProps:
+    def clone(self) -> HasProps:
         ''' Duplicate a HasProps object.
 
-        Values that are containers are shallow-copied.
+        This creates a shallow clone of the original model, i.e. any
+        mutable containers or child models will not be duplicated.
 
         '''
         attrs = self.properties_with_values(include_defaults=False, include_undefined=True)


### PR DESCRIPTION
Previously we had only private `HasProps._clone()`. I find it useful to clone models and I've been occasionally suggesting to users to clone models in certain scenarios, just to realize we don't have a method for this. bokehjs has one, so we can safely allow that in bokeh as well. Perhaps having a deep variant would be useful to add as well (`HasProp.clone(deep=True)`).