### PR TITLE
12821 serialize pandas typed arrays

### DIFF
--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -452,7 +452,8 @@ class Serializer:
         module = type(obj).__module__
         if module is not None and module.startswith("pandas"):
             import pandas as pd
-            if isinstance(obj, (pd.Series, pd.Index)):
+            from pandas.core.arrays import PandasArray
+            if isinstance(obj, (pd.Series, pd.Index, PandasArray)):
                 return self._encode_ndarray(transform_series(obj))
 
         self.error(f"can't serialize {type(obj)}")

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -349,11 +349,14 @@ def transform_series(series: pd.Series[Any] | pd.Index) -> npt.NDArray[Any]:
 
     '''
     import pandas as pd
+    from pandas.core.arrays import PandasArray
 
     # not checking for pd here, this function should only be called if it
     # is already known that series is a Pandas Series type
     if isinstance(series, pd.PeriodIndex):
         vals = series.to_timestamp().values  # type: ignore
+    elif isinstance(series, PandasArray):
+        vals = series.to_numpy()
     else:
         vals = series.values
     return vals

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -45,6 +45,7 @@ from .strings import format_docstring
 if TYPE_CHECKING:
     import numpy.typing as npt
     import pandas as pd
+    from pandas.core.arrays import PandasArray
     from typing_extensions import TypeGuard
 
 #-----------------------------------------------------------------------------
@@ -338,7 +339,7 @@ def transform_array(array: npt.NDArray[Any]) -> npt.NDArray[Any]:
 
     return array
 
-def transform_series(series: pd.Series[Any] | pd.Index) -> npt.NDArray[Any]:
+def transform_series(series: pd.Series[Any] | pd.Index | PandasArray) -> npt.NDArray[Any]:
     ''' Transforms a Pandas series into serialized form
 
     Args:

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -803,7 +803,13 @@ class TestDeserializer:
 
         rep4 = SliceRep(type="slice", start=None, stop=None, step=None)
         assert decoder.decode(rep4) == slice(None, None, None)
-
+    
+    def test_pandas_string_array(self) -> None:
+        data = ['This is', 'some text', 'data.']
+        arr = pd.array(data, dtype='string')
+        serialized = Serializer().serialize(arr)
+        deserialized = Deserializer().deserialize(serialized)
+        assert (deserialized == np.array(data)).all()
 """
     def test_set_data_from_json_list(self) -> None:
         ds = bms.ColumnDataSource()

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -803,7 +803,7 @@ class TestDeserializer:
 
         rep4 = SliceRep(type="slice", start=None, stop=None, step=None)
         assert decoder.decode(rep4) == slice(None, None, None)
-    
+
     def test_pandas_string_array(self) -> None:
         data = ['This is', 'some text', 'data.']
         arr = pd.array(data, dtype='string')


### PR DESCRIPTION
- [x] issues: fixes #12821 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

Added a check to `_encode_other` that will serialize any instance of `pandas.core.arrays.PandasArray` by calling `.to_numpy()`.

I added a test for string arrays specifically (I wasn't sure why so many tests were commented out in test_serialization though).

One thing I noticed is that pandas arrays convert `None` to `pd.NA` which cannot be serialized by Bokeh.
