### PR TITLE
Use ubuntu-latest and nodejs 18.x in CI

### DIFF
--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
-        node-version: [16.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [18.x]
 
     steps:
       - name: Checkout the repository

--- a/conda/environment-build.yml
+++ b/conda/environment-build.yml
@@ -8,7 +8,7 @@ dependencies:
   - conda-build=3.22.0
   - conda-verify=3.4.2
   - libiconv
-  - nodejs 16.*
+  - nodejs 18.*
   - ripgrep=0.10.0
   - setuptools
   - yaml

--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -11,7 +11,7 @@ dependencies:
   - conda-build=3.22.0
   - conda-verify=3.4.2
   - libiconv
-  - nodejs 16.*
+  - nodejs 18.*
   - ripgrep=0.10.0
   - setuptools
   - yaml

--- a/conda/environment-release-deploy.yml
+++ b/conda/environment-release-deploy.yml
@@ -8,7 +8,7 @@ dependencies:
   - anaconda-client
   - boto
   - colorama
-  - nodejs 16.*
+  - nodejs 18.*
   - setuptools
   - twine
   - yaml

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -30,7 +30,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 16.*
+  - nodejs 18.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -30,7 +30,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 16.*
+  - nodejs 18.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -30,7 +30,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 16.*
+  - nodejs 18.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -30,7 +30,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 16.*
+  - nodejs 18.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -29,7 +29,7 @@ dependencies:
   - isort 5.8
   - json5
   - nbconvert >=5.4
-  - nodejs 16.*
+  - nodejs 18.*
   - pre-commit
   - psutil
   - pygments


### PR DESCRIPTION
Depending on `ubuntu-20.04` in bokehjs' CI workflow is a legacy artifact. Also upgrades to the most recent nodejs LTS.