### PR TITLE
Match the type of `Selection.indices` between bokeh and bokehjs

### DIFF
--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -60,6 +60,8 @@ export type Arrayable<T = any> = {
   [n: number]: T
   [Symbol.iterator](): IterableIterator<T>
   slice(start?: number, end?: number): Arrayable<T>
+  sort(compare_fn?: (a: T, b: T) => number): Arrayable<T>
+  indexOf(element: T, from_index?: number): number
 }
 
 export type ArrayableNew = {new <T>(n: number): Arrayable<T>}

--- a/bokehjs/src/lib/core/util/array.ts
+++ b/bokehjs/src/lib/core/util/array.ts
@@ -3,13 +3,17 @@
 //     (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
+import {Arrayable} from "../types"
 import {randomIn} from "./math"
 import {assert} from "./assert"
-import {Arrayable} from "../types"
 import {isInteger} from "./types"
+import {min, min_by, max_by, includes, filter} from "./arrayable"
 
-import {map, reduce, min, min_by, max, max_by, sum, cumsum, every, some, find, find_last, find_index, find_last_index, sorted_index, is_empty} from "./arrayable"
-export {map, reduce, min, min_by, max, max_by, sum, cumsum, every, some, find, find_last, find_index, find_last_index, sorted_index, is_empty}
+export {
+  map, reduce, min, min_by, max, max_by, sum, cumsum, every, some,
+  find, find_last, find_index, find_last_index, sorted_index,
+  is_empty, includes, contains,
+} from "./arrayable"
 
 const slice = Array.prototype.slice
 
@@ -32,12 +36,6 @@ export function copy<T>(array: T[]): T[] {
 export function concat<T>(arrays: T[][]): T[] {
   return ([] as T[]).concat(...arrays)
 }
-
-export function includes<T>(array: T[], value: T): boolean {
-  return array.indexOf(value) !== -1
-}
-
-export const contains = includes
 
 export function nth<T>(array: T[], index: number): T {
   return array[index >= 0 ? index : array.length + index]
@@ -177,17 +175,21 @@ export function uniq_by<T, U>(array: T[], key: (item: T) => U): T[] {
   return result
 }
 
-export function union<T>(...arrays: T[][]): T[] {
+export function _union<T>(arrays: Arrayable<T>[]): Set<T> {
   const result = new Set<T>()
   for (const array of arrays) {
     for (const value of array) {
       result.add(value)
     }
   }
-  return [...result]
+  return result
 }
 
-export function intersection<T>(array: T[], ...arrays: T[][]): T[] {
+export function union<T>(...arrays: Arrayable<T>[]): T[] {
+  return [..._union(arrays)]
+}
+
+export function intersection<T>(array: Arrayable<T>, ...arrays: Arrayable<T>[]): T[] {
   const result: T[] = []
   top: for (const item of array) {
     if (includes(result, item))
@@ -201,9 +203,9 @@ export function intersection<T>(array: T[], ...arrays: T[][]): T[] {
   return result
 }
 
-export function difference<T>(array: T[], ...arrays: T[][]): T[] {
-  const rest = concat(arrays)
-  return array.filter((value) => !includes(rest, value))
+export function difference<T>(array: Arrayable<T>, ...arrays: Arrayable<T>[]): Arrayable<T> {
+  const rest = _union(arrays)
+  return filter(array, (value) => !rest.has(value))
 }
 
 export function remove_at<T>(array: T[], i: number): T[] {

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -64,14 +64,15 @@ export function prepend<T>(array: Arrayable<T>, item: T): Arrayable<T> {
   return splice(array, 0, 0, item)
 }
 
-export function indexOf<T>(array: Arrayable<T>, item: T): number {
-  for (let i = 0, n = array.length; i < n; i++) {
-    if (array[i] === item)
-      return i
-  }
-
-  return -1
+export function index_of<T>(array: Arrayable<T>, item: T): number {
+  return array.indexOf(item)
 }
+
+export function includes<T>(array: Arrayable<T>, value: T): boolean {
+  return array.indexOf(value) !== -1
+}
+
+export const contains = includes
 
 export function subselect<T>(array: Arrayable<T>, indices: Arrayable<number>): Arrayable<T> {
   const n = indices.length
@@ -294,14 +295,6 @@ export function some<T>(iter: Iterable<T>, predicate: (item: T) => boolean): boo
       return true
   }
   return false
-}
-
-export function index_of<T>(array: Arrayable<T>, value: T): number {
-  for (let i = 0, length = array.length; i < length; i++) {
-    if (array[i] === value)
-      return i
-  }
-  return -1
 }
 
 function _find_index(dir: -1 | 1) {

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -1,4 +1,4 @@
-import {PlainObject} from "../types"
+import {PlainObject, Arrayable} from "../types"
 import {concat, union} from "./array"
 
 const {hasOwnProperty} = Object.prototype
@@ -15,7 +15,7 @@ export function clone<T>(obj: PlainObject<T>): PlainObject<T> {
   return {...obj}
 }
 
-export function merge<T>(obj1: PlainObject<T[]>, obj2: PlainObject<T[]>): PlainObject<T[]> {
+export function merge<T>(obj1: PlainObject<Arrayable<T>>, obj2: PlainObject<Arrayable<T>>): PlainObject<T[]> {
   /*
    * Returns an object with the array values for obj1 and obj2 unioned by key.
    */

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -106,7 +106,6 @@ export class LineView extends XYGlyphView {
 
   protected override _hit_span(geometry: SpanGeometry): Selection {
     const {sx, sy} = geometry
-    const result = new Selection()
 
     let val: number
     let values: Arrayable<number>
@@ -118,14 +117,22 @@ export class LineView extends XYGlyphView {
       values = this._x
     }
 
+    const indices = []
     for (let i = 0, end = values.length-1; i < end; i++) {
-      if ((values[i] <= val && val <= values[i + 1]) || (values[i + 1] <= val && val <= values[i])) {
-        result.add_to_selected_glyphs(this.model)
-        result.view = this
-        result.line_indices.push(i)
+      const curr = values[i]
+      const next = values[i + 1]
+
+      if ((curr <= val && val <= next) || (next <= val && val <= curr)) {
+        indices.push(i)
       }
     }
 
+    const result = new Selection()
+    if (indices.length != 0) {
+      result.add_to_selected_glyphs(this.model)
+      result.view = this
+      result.line_indices = indices
+    }
     return result
   }
 

--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -89,7 +89,7 @@ export abstract class ContinuousColorMapper extends ColorMapper {
         const masked = renderer.view.masked
         const selected = renderer.data_source.selected.indices
 
-        let subset: number[] | undefined
+        let subset: Arrayable<number> | undefined
         if (masked != null && selected.length > 0)
           subset = intersection([...masked], selected)
         else if (masked != null)

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -291,15 +291,16 @@ export class GlyphRendererView extends DataRendererView {
 
     // selected is in full set space
     const {selected} = this.model.data_source
-    let selected_full_indices: number[]
-    if (selected.is_empty())
-      selected_full_indices = []
-    else {
-      if (this.glyph instanceof LineView && selected.selected_glyph === this.glyph.model)
-        selected_full_indices = this.model.view.convert_indices_from_subset(indices)
-      else
-        selected_full_indices = selected.indices
-    }
+    const selected_full_indices = (() => {
+      if (selected.is_empty())
+        return []
+      else {
+        if (this.glyph instanceof LineView && selected.selected_glyph === this.glyph.model)
+          return this.model.view.convert_indices_from_subset(indices)
+        else
+          return selected.indices
+      }
+    })()
 
     // inspected is in full set space
     const {inspected} = this.model.data_source

--- a/bokehjs/src/lib/models/selections/selection.ts
+++ b/bokehjs/src/lib/models/selections/selection.ts
@@ -4,8 +4,11 @@ import {SelectionMode} from "core/enums"
 import {union, intersection, difference} from "core/util/array"
 import {merge, entries, to_object} from "core/util/object"
 import type {Glyph, GlyphView} from "../glyphs/glyph"
+import {Arrayable, Int} from "../../core/kinds"
+import {map} from "core/util/arrayable"
 
-export type OpaqueIndices = number[]
+export type OpaqueIndices = typeof OpaqueIndices["__type__"]
+export const OpaqueIndices = Arrayable(Int)
 
 export type MultiIndices = {[key: string]: OpaqueIndices}
 
@@ -44,9 +47,9 @@ export class Selection extends Model {
 
   static {
     this.define<Selection.Props>(({Int, Array, Dict, Struct}) => ({
-      indices:           [ Array(Int), [] ],
-      line_indices:      [ Array(Int), [] ],
-      multiline_indices: [ Dict(Array(Int)), {} ],
+      indices:           [ OpaqueIndices, [] ],
+      line_indices:      [ OpaqueIndices, [] ],
+      multiline_indices: [ Dict(OpaqueIndices), {} ],
       image_indices:     [ Array(Struct({index: Int, i: Int, j: Int, flat_index: Int})), [] ],
     }))
 
@@ -102,7 +105,7 @@ export class Selection extends Model {
   map(mapper: (index: number) => number): Selection {
     return new Selection({
       ...this.attributes,
-      indices: this.indices.map(mapper),
+      indices: map(this.indices, mapper),
       // NOTE: line_indices don't support subset indexing
       multiline_indices: to_object(entries(this.multiline_indices).map(([index, line_indices]) => [mapper(Number(index)), line_indices])),
       image_indices: this.image_indices.map((ndx) => ({...ndx, index: mapper(ndx.index)})),

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -5,9 +5,11 @@ import {CellExternalCopyManager} from "@bokeh/slickgrid/plugins/slick.cellextern
 import {Grid as SlickGrid, DataProvider, SortColumn, OnSortEventArgs, OnSelectedRowsChangedEventArgs} from "@bokeh/slickgrid"
 import * as p from "core/properties"
 import {div, StyleSheetLike} from "core/dom"
+import {Arrayable} from "core/types"
 import {unique_id} from "core/util/string"
 import {isString, isNumber, is_defined} from "core/util/types"
 import {some, range} from "core/util/array"
+import {map} from "core/util/arrayable"
 import {keys} from "core/util/object"
 import {logger} from "core/logging"
 import {DOMBoxSizing} from "../../layouts/layout_dom"
@@ -227,11 +229,11 @@ export class DataTableView extends WidgetView {
 
     const {selected} = this.model.source
 
-    const permuted_indices = selected.indices.map((x) => this.data.index.indexOf(x)).sort()
+    const permuted_indices = map(selected.indices, (x) => this.data.index.indexOf(x)).sort()
 
     this._in_selection_update = true
     try {
-      this.grid.setSelectedRows(permuted_indices)
+      this.grid.setSelectedRows([...permuted_indices])
     } finally {
       this._in_selection_update = false
     }
@@ -484,7 +486,7 @@ export class DataTable extends TableWidget {
     this._sort_columns = sort_cols.map(({sortCol, sortAsc}) => ({field: sortCol.field!, sortAsc}))
   }
 
-  get_scroll_index(grid_range: {top: number, bottom: number}, selected_indices: number[]): number | null {
+  get_scroll_index(grid_range: {top: number, bottom: number}, selected_indices: Arrayable<number>): number | null {
     if (!this.scroll_to_selection || (selected_indices.length == 0))
       return null
 

--- a/bokehjs/test/unit/core/util/array.ts
+++ b/bokehjs/test/unit/core/util/array.ts
@@ -162,5 +162,4 @@ describe("core/util/array module", () => {
     expect(array.argmax([1, 2, 3, 4])).to.be.equal(3)
     expect(array.argmax([4, 3, 2, 1])).to.be.equal(0)
   })
-
 })

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -15,7 +15,7 @@ import {linspace} from "@bokehjs/core/util/array"
 import {ndarray} from "@bokehjs/core/util/ndarray"
 import {base64_to_buffer} from "@bokehjs/core/util/buffer"
 import {offset_bbox} from "@bokehjs/core/dom"
-import {Color} from "@bokehjs/core/types"
+import {Color, Arrayable} from "@bokehjs/core/types"
 import {Document, DocJson, DocumentEvent, ModelChangedEvent, MessageSentEvent} from "@bokehjs/document"
 import {DocumentReady, RangesUpdate} from "@bokehjs/core/bokeh_events"
 import {gridplot} from "@bokehjs/api/gridplot"
@@ -577,7 +577,7 @@ describe("Bug", () => {
       const {view} = await display(plot)
       const rect_view = view.owner.get_one(rect)
 
-      function hit_test(x: number, y: number): number[] | undefined {
+      function hit_test(x: number, y: number): Arrayable<number> | undefined {
         const sx = view.frame.x_scale.compute(x)
         const sy = view.frame.y_scale.compute(y)
         return rect_view.hit_test({type: "point", sx, sy})?.indices


### PR DESCRIPTION
`Selection.indices` is a good place to use ndarrays. Bokeh already allows wide `Seq(Int)` type. However, bokehjs was limited to arrays. This PR fixes this and refactors code that uses indices.

fixes #12624