### PR TITLE
Don't re-render when `css_classes` or `stylesheets` change

### DIFF
--- a/bokehjs/src/lib/core/dom.ts
+++ b/bokehjs/src/lib/core/dom.ts
@@ -425,6 +425,10 @@ export abstract class StyleSheet {
   install(el: HTMLElement | ShadowRoot): void {
     el.append(this.el)
   }
+
+  uninstall(): void {
+    this.el.remove()
+  }
 }
 
 export class InlineStyleSheet extends StyleSheet {

--- a/bokehjs/src/lib/core/dom_view.ts
+++ b/bokehjs/src/lib/core/dom_view.ts
@@ -29,11 +29,11 @@ export abstract class DOMView extends View {
     super.remove()
   }
 
-  css_classes(): string[] {
+  stylesheets(): StyleSheetLike[] {
     return []
   }
 
-  styles(): StyleSheetLike[] {
+  css_classes(): string[] {
     return []
   }
 
@@ -76,8 +76,8 @@ export abstract class DOMComponentView extends DOMElementView {
     this.shadow_el = this.el.attachShadow({mode: "open"})
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), base_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), base_css]
   }
 
   empty(): void {
@@ -94,7 +94,7 @@ export abstract class DOMComponentView extends DOMElementView {
   }
 
   protected *_stylesheets(): Iterable<StyleSheet> {
-    for (const style of this.styles()) {
+    for (const style of this.stylesheets()) {
       yield isString(style) ? new InlineStyleSheet(style) : style
     }
   }

--- a/bokehjs/src/lib/core/dom_view.ts
+++ b/bokehjs/src/lib/core/dom_view.ts
@@ -1,5 +1,5 @@
 import {View} from "./view"
-import {createElement, remove, empty, InlineStyleSheet, StyleSheetLike, ClassList} from "./dom"
+import {createElement, remove, empty, StyleSheet, InlineStyleSheet, StyleSheetLike, ClassList} from "./dom"
 import {isString} from "./util/types"
 import base_css from "styles/base.css"
 
@@ -83,33 +83,48 @@ export abstract class DOMComponentView extends DOMElementView {
   empty(): void {
     empty(this.shadow_el)
     this.class_list.clear()
+    this._applied_css_classes = []
+    this._applied_stylesheets = []
   }
 
   render(): void {
     this.empty()
-    this._apply_stylesheets(this.styles())
-    this._apply_classes(this.css_classes())
+    this._update_stylesheets()
+    this._update_css_classes()
   }
 
-  protected _apply_stylesheets(stylesheets: StyleSheetLike[]): void {
-    /*
-    if (supports_adopted_stylesheets) {
-      const sheets: CSSStyleSheet[] = []
-      for (const style of this.styles()) {
-        const sheet = new CSSStyleSheet()
-        sheet.replaceSync(style)
-        sheets.push(sheet)
-      }
-      this.shadow_el.adoptedStyleSheets = sheets
-    } else {
-    */
-    for (const style of stylesheets) {
-      const stylesheet = isString(style) ? new InlineStyleSheet(style) : style
-      stylesheet.install(this.shadow_el)
+  protected *_stylesheets(): Iterable<StyleSheet> {
+    for (const style of this.styles()) {
+      yield isString(style) ? new InlineStyleSheet(style) : style
     }
   }
 
-  protected _apply_classes(classes: string[]): void {
+  protected *_css_classes(): Iterable<string> {
+    yield `bk-${this.model.type.replace(/\./g, "-")}`
+    yield* this.css_classes()
+  }
+
+  protected _applied_stylesheets: StyleSheet[] = []
+  protected _apply_stylesheets(stylesheets: StyleSheet[]): void {
+    this._applied_stylesheets.push(...stylesheets)
+    stylesheets.forEach((stylesheet) => stylesheet.install(this.shadow_el))
+  }
+
+  protected _applied_css_classes: string[] = []
+  protected _apply_css_classes(classes: string[]): void {
+    this._applied_css_classes.push(...classes)
     this.class_list.add(...classes)
+  }
+
+  protected _update_stylesheets(): void {
+    this._applied_stylesheets.forEach((stylesheet) => stylesheet.uninstall())
+    this._applied_stylesheets = []
+    this._apply_stylesheets([...this._stylesheets()])
+  }
+
+  protected _update_css_classes(): void {
+    this.class_list.remove(this._applied_css_classes)
+    this._applied_css_classes = []
+    this._apply_css_classes([...this._css_classes()])
   }
 }

--- a/bokehjs/src/lib/core/util/menus.ts
+++ b/bokehjs/src/lib/core/util/menus.ts
@@ -151,8 +151,8 @@ export class ContextMenu { //extends DOMComponentView {
     style.bottom = pos.bottom != null ? `${origin.bottom - pos.bottom}px` : "auto"
   }
 
-  styles(): StyleSheetLike[] {
-    return [base_css, /*...super.styles(), */ menus_css, icons_css, ...this.extra_styles]
+  stylesheets(): StyleSheetLike[] {
+    return [base_css, /*...super.stylesheets(), */ menus_css, icons_css, ...this.extra_styles]
   }
 
   empty(): void {
@@ -163,7 +163,7 @@ export class ContextMenu { //extends DOMComponentView {
   render(): void {
     this.empty()
 
-    for (const style of this.styles()) {
+    for (const style of this.stylesheets()) {
       const stylesheet = isString(style) ? new InlineStyleSheet(style) : style
       stylesheet.install(this.shadow_el)
     }

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -119,8 +119,8 @@ export class CanvasView extends UIElementView {
     super.remove()
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), canvas_css, this._size]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), canvas_css, this._size]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/layouts/group_box.ts
+++ b/bokehjs/src/lib/models/layouts/group_box.ts
@@ -10,8 +10,8 @@ export class GroupBoxView extends LayoutDOMView {
   checkbox_el: HTMLInputElement
   fieldset_el: HTMLFieldSetElement
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), group_box_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), group_box_css]
   }
 
   override connect_signals(): void {

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -95,7 +95,13 @@ export abstract class LayoutDOMView extends UIElementView {
       this.disabled.emit(this.model.disabled)
     })
 
+    this.on_change(p.css_classes, () => {
+      this._apply_classes(this.model.css_classes)
+    })
+
     this.on_change([
+      p.css_classes,
+      p.stylesheets,
       p.width, p.height,
       p.min_width, p.min_height,
       p.max_width, p.max_height,
@@ -105,11 +111,6 @@ export abstract class LayoutDOMView extends UIElementView {
       p.aspect_ratio,
       p.visible,
     ], () => this.invalidate_layout())
-
-    this.on_change([
-      p.css_classes,
-      p.stylesheets,
-    ], () => this.invalidate_render())
   }
 
   override css_classes(): string[] {

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -95,10 +95,6 @@ export abstract class LayoutDOMView extends UIElementView {
       this.disabled.emit(this.model.disabled)
     })
 
-    this.on_change(p.css_classes, () => {
-      this._apply_classes(this.model.css_classes)
-    })
-
     this.on_change([
       p.css_classes,
       p.stylesheets,
@@ -111,10 +107,6 @@ export abstract class LayoutDOMView extends UIElementView {
       p.aspect_ratio,
       p.visible,
     ], () => this.invalidate_layout())
-  }
-
-  override css_classes(): string[] {
-    return [...super.css_classes(), ...this.model.css_classes]
   }
 
   override *children(): IterViews {
@@ -148,8 +140,6 @@ export abstract class LayoutDOMView extends UIElementView {
 
   override render(): void {
     super.render()
-
-    this.class_list.add(...this.css_classes())
 
     for (const child_view of this.child_views) {
       child_view.render()
@@ -634,7 +624,6 @@ export namespace LayoutDOM {
     sizing_mode: p.Property<SizingMode | null>
     disabled: p.Property<boolean>
     align: p.Property<Align | [Align, Align] | "auto">
-    css_classes: p.Property<string[]>
     context_menu: p.Property<Menu | null>
     resizable: p.Property<boolean | Dimensions>
   }
@@ -652,7 +641,7 @@ export abstract class LayoutDOM extends UIElement {
 
   static {
     this.define<LayoutDOM.Props>((types) => {
-      const {Boolean, Number, String, Auto, Array, Tuple, Or, Null, Nullable, Ref} = types
+      const {Boolean, Number, Auto, Tuple, Or, Null, Nullable, Ref} = types
       const Number2 = Tuple(Number, Number)
       const Number4 = Tuple(Number, Number, Number, Number)
       return {
@@ -670,7 +659,6 @@ export abstract class LayoutDOM extends UIElement {
         sizing_mode:   [ Nullable(SizingMode), null ],
         disabled:      [ Boolean, false ],
         align:         [ Or(Align, Tuple(Align, Align), Auto), "auto" ],
-        css_classes:   [ Array(String), [] ],
         context_menu:  [ Nullable(Ref(Menu)), null ],
         resizable:     [ Or(Boolean, Dimensions), false ],
       }

--- a/bokehjs/src/lib/models/layouts/scroll_box.ts
+++ b/bokehjs/src/lib/models/layouts/scroll_box.ts
@@ -7,8 +7,8 @@ import * as p from "core/properties"
 export class ScrollBoxView extends LayoutDOMView {
   declare model: ScrollBox
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles()]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets()]
   }
 
   override connect_signals(): void {

--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -30,8 +30,8 @@ export class TabsView extends LayoutDOMView {
     })
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), tabs_css, icons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), tabs_css, icons_css]
   }
 
   get child_models(): UIElement[] {

--- a/bokehjs/src/lib/models/menus/menu.ts
+++ b/bokehjs/src/lib/models/menus/menu.ts
@@ -11,8 +11,8 @@ import menus_css, * as menus from "styles/menus.css"
 export class MenuView extends UIElementView {
   declare model: Menu
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), menus_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), menus_css]
   }
 
   protected readonly items: ViewStorage<MenuItem> = new Map()

--- a/bokehjs/src/lib/models/menus/menu_item.ts
+++ b/bokehjs/src/lib/models/menus/menu_item.ts
@@ -8,8 +8,8 @@ import icons_css from "styles/icons.css"
 export abstract class MenuItemView extends UIElementView {
   declare model: MenuItem
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), menus_css, icons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), menus_css, icons_css]
   }
 }
 

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -183,7 +183,7 @@ export class GMapPlotView extends PlotView {
 
     // wire up listeners so that changes to properties are reflected
     this.connect(this.model.properties.map_options.change, () => this._update_options())
-    this.connect(this.model.map_options.properties.styles.change, () => this._update_styles())
+    this.connect(this.model.map_options.properties.styles.change, () => this._update_styling())
     this.connect(this.model.map_options.properties.lat.change, () => this._update_center("lat"))
     this.connect(this.model.map_options.properties.lng.change, () => this._update_center("lng"))
     this.connect(this.model.map_options.properties.zoom.change, () => this._update_zoom())
@@ -248,14 +248,14 @@ export class GMapPlotView extends PlotView {
   }
 
   protected _update_options(): void {
-    this._update_styles()
+    this._update_styling()
     this._update_center("lat")
     this._update_center("lng")
     this._update_zoom()
     this._update_map_type()
   }
 
-  protected _update_styles(): void {
+  protected _update_styling(): void {
     const {styles} = this.model.map_options
     this.map.setOptions({styles: styles != null ? JSON.parse(styles) : null})
   }

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -56,8 +56,8 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
   protected _computed_style = new InlineStyleSheet()
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), plots_css, this._computed_style]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), plots_css, this._computed_style]
   }
 
   protected _title?: Title

--- a/bokehjs/src/lib/models/tools/tool_button.ts
+++ b/bokehjs/src/lib/models/tools/tool_button.ts
@@ -95,8 +95,8 @@ export abstract class ToolButtonView extends UIElementView {
     super.remove()
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), tool_button_css, icons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), tool_button_css, icons_css]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -97,8 +97,8 @@ export class ToolbarView extends UIElementView {
     })
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), toolbars_css, logos_css, icons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), toolbars_css, logos_css, icons_css]
   }
 
   override remove(): void {

--- a/bokehjs/src/lib/models/ui/dialog.ts
+++ b/bokehjs/src/lib/models/ui/dialog.ts
@@ -22,8 +22,8 @@ export class DialogView extends UIElementView {
     yield this._content
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), dialogs_css, icons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), dialogs_css, icons_css]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/ui/examiner.ts
+++ b/bokehjs/src/lib/models/ui/examiner.ts
@@ -141,8 +141,8 @@ export class HTMLPrinter {
 export class ExaminerView extends UIElementView {
   declare model: Examiner
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), examiner_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), examiner_css]
   }
 
   private prev_listener: ((obj: unknown) => void) | null = null

--- a/bokehjs/src/lib/models/ui/icons/builtin_icon.ts
+++ b/bokehjs/src/lib/models/ui/icons/builtin_icon.ts
@@ -12,8 +12,8 @@ export class BuiltinIconView extends IconView {
 
   protected readonly _style = new InlineStyleSheet()
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), icons_css, this._style]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), icons_css, this._style]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/ui/icons/svg_icon.ts
+++ b/bokehjs/src/lib/models/ui/icons/svg_icon.ts
@@ -8,8 +8,8 @@ export class SVGIconView extends IconView {
 
   protected readonly _style = new InlineStyleSheet()
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), this._style]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), this._style]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/ui/icons/tabler_icon.ts
+++ b/bokehjs/src/lib/models/ui/icons/tabler_icon.ts
@@ -37,8 +37,8 @@ export class TablerIconView extends IconView {
 
   protected readonly _style = new InlineStyleSheet()
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), TablerIconView._fonts, this._tabler, this._style]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), TablerIconView._fonts, this._tabler, this._style]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/ui/tooltip.ts
+++ b/bokehjs/src/lib/models/ui/tooltip.ts
@@ -98,8 +98,8 @@ export class TooltipView extends UIElementView {
     super.remove()
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), tooltips_css, icons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), tooltips_css, icons_css]
   }
 
   get content(): Node {

--- a/bokehjs/src/lib/models/ui/ui_element.ts
+++ b/bokehjs/src/lib/models/ui/ui_element.ts
@@ -85,8 +85,8 @@ export abstract class UIElementView extends DOMComponentView {
     }
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), ui_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), ui_css]
   }
 
   update_style(): void {

--- a/bokehjs/src/lib/models/ui/ui_element.ts
+++ b/bokehjs/src/lib/models/ui/ui_element.ts
@@ -166,9 +166,11 @@ export abstract class UIElementView extends DOMComponentView {
   override connect_signals(): void {
     super.connect_signals()
 
-    const {visible, styles} = this.model.properties
+    const {visible, styles, classes, stylesheets} = this.model.properties
     this.on_change(visible, () => this._apply_visible())
     this.on_change(styles, () => this._apply_styles())
+    this.on_change(classes, () => this._apply_classes(this.model.classes))
+    this.on_change(stylesheets, () => this._apply_stylesheets(this.computed_stylesheets))
   }
 
   override remove(): void {

--- a/bokehjs/src/lib/models/widgets/abstract_button.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_button.ts
@@ -45,8 +45,8 @@ export abstract class AbstractButtonView extends ControlView {
     super.remove()
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), buttons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), buttons_css]
   }
 
   _render_button(...children: (string | HTMLElement)[]): HTMLButtonElement {

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -65,8 +65,8 @@ abstract class AbstractBaseSliderView extends OrientedControlView {
     this.on_change([value, title, show_value], () => this._update_title())
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), nouislider_css, sliders_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), nouislider_css, sliders_css]
   }
 
   _update_title(): void {

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -18,8 +18,8 @@ export class AutocompleteInputView extends TextInputView {
 
   protected menu: HTMLElement
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), dropdown_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), dropdown_css]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/widgets/checkbox.ts
+++ b/bokehjs/src/lib/models/widgets/checkbox.ts
@@ -9,8 +9,8 @@ export class CheckboxView extends ToggleInputView {
   protected checkbox_el: HTMLInputElement
   protected label_el: HTMLElement
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), checkbox_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), checkbox_css]
   }
 
   override connect_signals(): void {

--- a/bokehjs/src/lib/models/widgets/dropdown.ts
+++ b/bokehjs/src/lib/models/widgets/dropdown.ts
@@ -17,8 +17,8 @@ export class DropdownView extends AbstractButtonView {
 
   protected menu: HTMLElement
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), dropdown_css, carets_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), dropdown_css, carets_css]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -9,8 +9,8 @@ export class FileInputView extends InputWidgetView {
   declare model: FileInput
   declare input_el: HTMLInputElement
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), buttons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), buttons_css]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/widgets/input_widget.ts
+++ b/bokehjs/src/lib/models/widgets/input_widget.ts
@@ -53,8 +53,8 @@ export abstract class InputWidgetView extends ControlView {
     })
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), inputs_css, icons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), inputs_css, icons_css]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/widgets/markup.ts
+++ b/bokehjs/src/lib/models/widgets/markup.ts
@@ -37,8 +37,8 @@ export abstract class MarkupView extends WidgetView {
     })
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), clearfix_css, "p { margin: 0; }"]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), clearfix_css, "p { margin: 0; }"]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/widgets/multi_choice.ts
+++ b/bokehjs/src/lib/models/widgets/multi_choice.ts
@@ -68,8 +68,8 @@ export class MultiChoiceView extends InputWidgetView {
     })
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), choices_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), choices_css]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/widgets/password_input.ts
+++ b/bokehjs/src/lib/models/widgets/password_input.ts
@@ -9,8 +9,8 @@ export class PasswordInputView extends TextInputView {
 
   toggle_el: HTMLElement
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), password_input_css, icons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), password_input_css, icons_css]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/widgets/picker_base.ts
+++ b/bokehjs/src/lib/models/widgets/picker_base.ts
@@ -24,8 +24,8 @@ export abstract class PickerBaseView extends InputWidgetView {
     super.remove()
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), flatpickr_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), flatpickr_css]
   }
 
   override connect_signals(): void {

--- a/bokehjs/src/lib/models/widgets/switch.ts
+++ b/bokehjs/src/lib/models/widgets/switch.ts
@@ -9,8 +9,8 @@ export class SwitchView extends ToggleInputView {
   protected knob_el: HTMLElement
   protected bar_el: HTMLElement
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), switch_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), switch_css]
   }
 
   override connect_signals(): void {

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -186,8 +186,8 @@ export class DataTableView extends WidgetView {
     this.connect(this.model.source.selected.properties.indices.change, () => this.updateSelection())
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), slickgrid_css, tables_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), slickgrid_css, tables_css]
   }
 
   override _after_resize(): void {

--- a/bokehjs/src/lib/models/widgets/toggle_button_group.ts
+++ b/bokehjs/src/lib/models/widgets/toggle_button_group.ts
@@ -23,8 +23,8 @@ export abstract class ToggleButtonGroupView extends OrientedControlView {
     this.on_change(p.active,      () => this._update_active())
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), buttons_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), buttons_css]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/widgets/toggle_input_group.ts
+++ b/bokehjs/src/lib/models/widgets/toggle_input_group.ts
@@ -19,8 +19,8 @@ export abstract class ToggleInputGroupView extends ControlView {
     this.on_change([labels, inline], () => this.render())
   }
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), inputs_css, checkbox_css]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), inputs_css, checkbox_css]
   }
 }
 

--- a/bokehjs/test/unit/models/ui/ui_element.ts
+++ b/bokehjs/test/unit/models/ui/ui_element.ts
@@ -1,0 +1,92 @@
+import * as sinon from "sinon"
+
+import {expect} from "assertions"
+import {display} from "../../../framework"
+
+import {UIElement, UIElementView} from "@bokehjs/models/ui/ui_element"
+import {StyleSheetLike} from "@bokehjs/core/dom"
+import base_css from "@bokehjs/styles/base.css"
+
+class UIView extends UIElementView {
+  declare model: UI
+
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), ":host { background-color: #000; }"]
+  }
+
+  override css_classes(): string[] {
+    return [...super.css_classes(), "cls0", "cls1"]
+  }
+
+  override render(): void {
+    super.render()
+    this.class_list.add("render0")
+  }
+}
+
+interface UI extends UIElement {}
+
+class UI extends UIElement {
+  declare __view_type__: UIView
+
+  static {
+    this.prototype.default_view = UIView
+  }
+}
+
+describe("UIElement", () => {
+  it("should allow updating 'css_classes' without re-rendering", async () => {
+    const ui = new UI({css_classes: ["user_cls0", "user_cls1"]})
+    const {view} = await display(ui, [100, 100])
+
+    const render_spy = sinon.spy(view, "render")
+    try {
+      expect([...view.el.classList]).to.be.equal(["bk-UI", "cls0", "cls1", "user_cls0", "user_cls1", "render0"])
+
+      ui.css_classes = [...ui.css_classes, "user_cls2"]
+      await view.ready
+
+      // TODO: preserve order
+      expect([...view.el.classList]).to.be.equal(["render0", "bk-UI", "cls0", "cls1", "user_cls0", "user_cls1", "user_cls2"])
+      expect(render_spy.callCount).to.be.equal(0)
+    } finally {
+      render_spy.restore()
+    }
+  })
+
+  it("should allow updating 'stylesheets' without re-rendering", async () => {
+    const ui = new UI({stylesheets: [":host { background-color: #f00; }"]})
+    const {view} = await display(ui, [100, 100])
+
+    const render_spy = sinon.spy(view, "render")
+    try {
+      const stylesheets = () => [...view.shadow_el.children]
+        .filter((c) => c instanceof HTMLStyleElement).map((c) => c.textContent)
+
+      expect(stylesheets()).to.be.equal([
+        base_css,
+        ":host{position:relative;}",
+        ":host { background-color: #000; }",
+        "", // style
+        "", // _display
+        ":host { background-color: #f00; }",
+      ])
+
+      ui.stylesheets = [...ui.stylesheets, ":host { background-color: #ff0; }"]
+      await view.ready
+
+      expect(stylesheets()).to.be.equal([
+        base_css,
+        ":host{position:relative;}",
+        ":host { background-color: #000; }",
+        "", // style
+        "", // _display
+        ":host { background-color: #f00; }",
+        ":host { background-color: #ff0; }",
+      ])
+      expect(render_spy.callCount).to.be.equal(0)
+    } finally {
+      render_spy.restore()
+    }
+  })
+})

--- a/examples/advanced/extensions/font-awesome/fontawesome_icon.ts
+++ b/examples/advanced/extensions/font-awesome/fontawesome_icon.ts
@@ -10,8 +10,8 @@ export class FontAwesomeIconView extends IconView {
 
   protected readonly _style = new InlineStyleSheet()
 
-  override styles(): StyleSheetLike[] {
-    return [...super.styles(), this._style]
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), this._style]
   }
 
   connect_signals(): void {

--- a/examples/advanced/extensions/ion_range_slider.ts
+++ b/examples/advanced/extensions/ion_range_slider.ts
@@ -17,9 +17,9 @@ export type SliderData = {from: number, to: number}
 export class IonRangeSliderView extends InputWidgetView {
   declare model: IonRangeSlider
 
-  override styles(): StyleSheetLike[] {
+  override stylesheets(): StyleSheetLike[] {
     return [
-      ...super.styles(),
+      ...super.stylesheets(),
       new ImportedStyleSheet("https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.1.4/css/ion.rangeSlider.css"),
       new ImportedStyleSheet("https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.1.4/css/ion.rangeSlider.skinFlat.min.css"),
     ]

--- a/src/bokeh/models/layouts.py
+++ b/src/bokeh/models/layouts.py
@@ -44,7 +44,6 @@ from ..core.properties import (
     NonNegative,
     Null,
     Nullable,
-    Seq,
     String,
     Struct,
     Tuple,
@@ -270,15 +269,6 @@ class LayoutDOM(UIElement):
     (e.g. a grid). Self alignment can be overridden by the parent container (e.g.
     grid track align).
     """)
-
-    # List in order for in-place changes to trigger changes, ref: https://github.com/bokeh/bokeh/issues/6841
-    css_classes = List(String, help="""
-    A list of CSS class names to add to this DOM element. Note: the class names are
-    simply added as-is, no other guarantees are provided.
-
-    It is also permissible to assign from tuples, however these are adapted -- the
-    property will always contain a list.
-    """).accepts(Seq(String), lambda x: list(x))
 
     context_menu = Nullable(Instance(Menu), default=None, help="""
     A menu to display when user right clicks on the component.

--- a/src/bokeh/models/ui/ui_element.py
+++ b/src/bokeh/models/ui/ui_element.py
@@ -29,6 +29,7 @@ from ...core.properties import (
     Instance,
     List,
     Nullable,
+    Seq,
     String,
 )
 from ...model import Model
@@ -63,9 +64,9 @@ class UIElement(Model):
     Whether the component should be displayed on screen.
     """)
 
-    classes = List(String, default=[], help="""
-    List of additional CSS classes to add to the underlying DOM element.
-    """)
+    css_classes = List(String, default=[], help="""
+    A list of additional CSS classes to add to the underlying DOM element.
+    """).accepts(Seq(String), lambda x: list(x))
 
     styles = Either(Dict(String, Nullable(String)), Instance(Styles), default={}, help="""
     Inline CSS styles applied to the underlying DOM element.

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -3795,7 +3795,7 @@
   UIElement: {
     __extends__: "Model",
     visible: true,
-    classes: [],
+    css_classes: [],
     styles: {
       type: "map",
     },
@@ -4048,7 +4048,6 @@
     flow_mode: "block",
     sizing_mode: null,
     align: "auto",
-    css_classes: [],
     context_menu: null,
     resizable: false,
   },


### PR DESCRIPTION
This is required for Panel 1.0. This is was the last place in bokehjs where a potentially trivial update could cause full re-render. At most, invalidation of layout is sufficient for correctness.