### PR TITLE
12839 serialize pandas numeric arrays

### DIFF
--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -452,8 +452,7 @@ class Serializer:
         module = type(obj).__module__
         if module is not None and module.startswith("pandas"):
             import pandas as pd
-            from pandas.core.arrays import PandasArray
-            if isinstance(obj, (pd.Series, pd.Index, PandasArray)):
+            if isinstance(obj, (pd.Series, pd.Index, pd.api.extensions.ExtensionArray)):
                 return self._encode_ndarray(transform_series(obj))
 
         self.error(f"can't serialize {type(obj)}")

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -45,7 +45,6 @@ from .strings import format_docstring
 if TYPE_CHECKING:
     import numpy.typing as npt
     import pandas as pd
-    from pandas.core.arrays import PandasArray
     from typing_extensions import TypeGuard
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -339,7 +339,7 @@ def transform_array(array: npt.NDArray[Any]) -> npt.NDArray[Any]:
 
     return array
 
-def transform_series(series: pd.Series[Any] | pd.Index | PandasArray) -> npt.NDArray[Any]:
+def transform_series(series: pd.Series[Any] | pd.Index | pd.api.extensions.ExtensionArray) -> npt.NDArray[Any]:
     ''' Transforms a Pandas series into serialized form
 
     Args:
@@ -350,13 +350,12 @@ def transform_series(series: pd.Series[Any] | pd.Index | PandasArray) -> npt.NDA
 
     '''
     import pandas as pd
-    from pandas.core.arrays import PandasArray
 
     # not checking for pd here, this function should only be called if it
     # is already known that series is a Pandas Series type
     if isinstance(series, pd.PeriodIndex):
         vals = series.to_timestamp().values  # type: ignore
-    elif isinstance(series, PandasArray):
+    elif isinstance(series, pd.api.extensions.ExtensionArray):
         vals = series.to_numpy()
     else:
         vals = series.values

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -804,12 +804,6 @@ class TestDeserializer:
         rep4 = SliceRep(type="slice", start=None, stop=None, step=None)
         assert decoder.decode(rep4) == slice(None, None, None)
 
-    def test_pandas_string_array(self) -> None:
-        data = ['This is', 'some text', 'data.']
-        arr = pd.array(data, dtype='string')
-        serialized = Serializer().serialize(arr)
-        deserialized = Deserializer().deserialize(serialized)
-        assert (deserialized == np.array(data)).all()
 """
     def test_set_data_from_json_list(self) -> None:
         ds = bms.ColumnDataSource()

--- a/tests/unit/bokeh/util/test_util__serialization.py
+++ b/tests/unit/bokeh/util/test_util__serialization.py
@@ -171,6 +171,53 @@ def test_transform_series() -> None:
     out = bus.transform_series(df)
     assert isinstance(out, np.ndarray)
 
+    # boolean array
+    arr = pd.array([True, False])
+    assert isinstance(arr, pd.arrays.BooleanArray)
+    out = bus.transform_series(arr)
+    assert isinstance(out, np.ndarray)
+
+    # string array
+    arr = pd.array(['hello', 'world'])
+    assert isinstance(arr, pd.arrays.StringArray)
+    out = bus.transform_series(arr)
+    assert isinstance(out, np.ndarray)
+
+    # floating array
+    arr = pd.array([1.0, 42.0, np.nan])
+    assert isinstance(arr, pd.core.arrays.floating.FloatingArray)
+    out = bus.transform_series(arr)
+    assert isinstance(out, np.ndarray)
+
+    # integer array
+    arr = pd.array([0, 1])
+    assert isinstance(arr, pd.core.arrays.integer.IntegerArray)
+    out = bus.transform_series(arr)
+    assert isinstance(out, np.ndarray)
+
+    # sparse array
+    arr = pd.arrays.SparseArray([1.0, 2.0, np.nan, np.nan, 5.0])
+    out = bus.transform_series(arr)
+    assert isinstance(out, np.ndarray)
+
+    # datetime array
+    arr = pd.array([pd.NaT, datetime.datetime.today(), pd.Timestamp.today()])
+    assert isinstance(arr, pd.arrays.DatetimeArray)
+    out = bus.transform_series(arr)
+    assert isinstance(out, np.ndarray)
+
+    # timdelta array
+    arr = pd.array([datetime.timedelta(seconds=1), pd.Timedelta(0, unit='s')])
+    assert isinstance(arr, pd.arrays.TimedeltaArray)
+    out = bus.transform_series(arr)
+    assert isinstance(out, np.ndarray)
+
+    # categorical array
+    arr = pd.array(pd.Series(['dog', 'cat', 'dog']).astype('category'))
+    assert isinstance(arr, pd.arrays.Categorical)
+    out = bus.transform_series(arr)
+    assert isinstance(out, np.ndarray)
+
 def test_array_encoding_disabled_by_dtype() -> None:
 
     assert len(bus.BINARY_ARRAY_TYPES) > 0


### PR DESCRIPTION
`pandas.api.extensions.ExtensionArray` is the ancestor for all of the pandas array types. This PR adds a type check for objects of a descendant type and uses the `.to_numpy()` method. Note: this causes pandas `SparseArray`s to be made into dense arrays.
- [x] fixes #12507
- [x] fixes #12839
- [x] fixes #12821
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
