### PR TITLE
Encode pd.NA to None

### DIFF
--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -448,13 +448,15 @@ class Serializer:
         if np.issubdtype(type(obj), np.bool_):
             return self._encode_bool(bool(obj))
 
-        # avoid importing pandashere unless it is actually in use
+        # avoid importing pandas here unless it is actually in use
         module = type(obj).__module__
         if module is not None and module.startswith("pandas"):
             import pandas as pd
             from pandas.core.arrays import PandasArray
             if isinstance(obj, (pd.Series, pd.Index, PandasArray)):
                 return self._encode_ndarray(transform_series(obj))
+            elif obj is pd.NA:
+                return None
 
         self.error(f"can't serialize {type(obj)}")
 

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -783,7 +783,7 @@ class TestSerializer:
         val = pd.Timestamp('April 28, 1948')
         rep = encoder.encode(val)
         assert rep == -684115200000
-    
+
     def test_pd_NA(self) -> None:
         encoder = Serializer()
         assert encoder.encode(pd.NA) is None

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -783,6 +783,10 @@ class TestSerializer:
         val = pd.Timestamp('April 28, 1948')
         rep = encoder.encode(val)
         assert rep == -684115200000
+    
+    def test_pd_NA(self) -> None:
+        encoder = Serializer()
+        assert encoder.encode(pd.NA) is None
 
 class TestDeserializer:
 


### PR DESCRIPTION
For this is just checked if `obj is pd.NA`. A case could also be made for using `pd.isna` but that catches other values like `np.nan`, `None` and `pd.NaT`.
- [x] issues: fixes #12838 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
