### PR TITLE
Enable `switch-exhaustiveness-checks` lint rule

### DIFF
--- a/bokehjs/eslint.json
+++ b/bokehjs/eslint.json
@@ -51,6 +51,7 @@
     }],
     "@typescript-eslint/no-unnecessary-type-assertion": ["error"],
     "@typescript-eslint/no-unnecessary-type-constraint": ["error"],
+    "@typescript-eslint/switch-exhaustiveness-check": ["error"],
     "no-self-assign": ["error", {"props": false}],
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "comma-dangle": ["off"],

--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -706,13 +706,14 @@ export class Linker {
 
     const export_type = this.es_modules ? "default" : "="
     switch (type) {
-      case "json":
+      case "json": {
         source = `\
 const json = ${source};
 export ${export_type} json;
 `
         break
-      case "json5":
+      }
+      case "json5": {
         source = `\
 const json5 = \`
 ${source}
@@ -720,13 +721,15 @@ ${source}
 export ${export_type} json5;
 `
         break
-      case "css":
+      }
+      case "css": {
         source = `\
 const css = \`${source}\`;
 export ${export_type} css;
 `
         break
-      case "yaml":
+      }
+      case "yaml": {
         source = `\
 const yaml = \`
 ${source}
@@ -734,6 +737,10 @@ ${source}
 export ${export_type} yaml;
 `
         break
+      }
+      case "js": {
+        break
+      }
     }
 
     const [base, base_path, canonical, resolution] = ((): [string, string, string | undefined, ResoType] => {

--- a/bokehjs/src/lib/core/util/buffer.ts
+++ b/bokehjs/src/lib/core/util/buffer.ts
@@ -71,5 +71,10 @@ export function swap(buffer: ArrayBuffer, dtype: NDDataType): void {
     case "float64":
       swap64(buffer)
       break
+    case "object":
+    case "uint8":
+    case "int8":
+    case "bool":
+      break
   }
 }

--- a/bokehjs/src/lib/models/annotations/legend.ts
+++ b/bokehjs/src/lib/models/annotations/legend.ts
@@ -372,6 +372,10 @@ export class LegendView extends AnnotationView {
         ctx.translate(this.title_panel.bbox.width, 0)
         break
       }
+      case "above":
+      case "below": {
+        break
+      }
     }
 
     this.title_panel.text.paint(ctx)

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -449,13 +449,13 @@ export class Toolbar extends UIElement {
 
     function _get_active_attr(et: EventType | "multi"): keyof ActiveGestureToolsProps | null {
       switch (et) {
-        case "tap": return "active_tap"
-        case "pan": return "active_drag"
+        case "tap":    return "active_tap"
+        case "pan":    return "active_drag"
         case "pinch":
         case "scroll": return "active_scroll"
-        case "multi": return "active_multi"
+        case "multi":  return "active_multi"
+        default:       return null
       }
-      return null
     }
 
     function _supports_auto(et: string): boolean {

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -68,10 +68,16 @@ export class StringFormatter extends CellFormatter {
 
     const text = div(value == null ? "" : `${value}`)
     switch (font_style) {
+      case "normal":
+        break
       case "bold":
         text.style.fontWeight = "bold"
         break
       case "italic":
+        text.style.fontStyle = "italic"
+        break
+      case "bold italic":
+        text.style.fontWeight = "bold"
         text.style.fontStyle = "italic"
         break
     }

--- a/bokehjs/test/framework.ts
+++ b/bokehjs/test/framework.ts
@@ -468,6 +468,8 @@ function _infer_layoutdom_viewport(obj: LayoutDOM): Size {
           case "right":
             width += 30
             break
+          case null:
+            break
         }
       }
     } else if (obj instanceof Toolbar) {


### PR DESCRIPTION
Improves quality of work with `switch` statements and discriminated union types (`A | B | C`). It will make sure that if a union is extended, then any `switch` statements discriminating over it will have to be updated.