### PR TITLE
Check for package-lock.json v3 in release scripts

### DIFF
--- a/release/build.py
+++ b/release/build.py
@@ -135,7 +135,7 @@ def update_bokehjs_versions(config: Config, system: System) -> ActionReturn:
         content["version"] = config.js_version
 
     def update_package_lock_json(content: dict[str, Any]) -> None:
-        assert content["lockfileVersion"] == 2, "Expected lock file v2"
+        assert content["lockfileVersion"] == 3, "Expected lock file v3"
         content["version"] = config.js_version
         for pkg in content["packages"].values():
             if pkg.get("name", "").startswith("@bokeh/"):


### PR DESCRIPTION
Fixes:
```
------ Starting task update_bokehjs_versions
+cd bokehjs # [now: /home/runner/work/bokeh/bokeh/bokehjs]
[FAIL] Unable to write new version to file 'package-lock.json'
    Expected lock file v2
```
This is a side effect of PR #12762.
