### PR TITLE
Encode numpy zero-dimensional arrays

### DIFF
--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -283,7 +283,10 @@ class Serializer:
         elif isinstance(obj, TypedArray):
             return self._encode_typed_array(obj)
         elif isinstance(obj, np.ndarray):
-            return self._encode_ndarray(obj)
+            if obj.shape != ():
+                return self._encode_ndarray(obj)
+            else:
+                return self._encode(obj.item())
         elif is_dataclass(obj):
             return self._encode_dataclass(obj)
         else:

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -550,6 +550,17 @@ class TestSerializer:
             dtype="object",
         )
 
+    def test_ndarray_zero_dimensional(self):
+        encoder = Serializer()
+
+        # floating point
+        res = encoder.encode(np.array(2.4))
+        assert res == 2.4
+
+        # integer
+        res = encoder.encode(np.array(2))
+        assert res == 2
+
     def test_HasProps(self) -> None:
         val = SomeProps(p0=2, p1="a", p2=[1, 2, 3])
         encoder = Serializer()


### PR DESCRIPTION
Potential solution for encoding zero-dimensional numpy arrays as the encoding of their inner value.

- [x] issues: fixes #12315
- [x] tests added / passed

