### PR TITLE
Fix emit of old-style extension bundles

### DIFF
--- a/bokehjs/src/compiler/compile.ts
+++ b/bokehjs/src/compiler/compile.ts
@@ -17,6 +17,7 @@ function parse_patched_tsconfig(base_dir: string, preconfigure: ts.CompilerOptio
 export function compile_typescript(base_dir: string, inputs: Inputs, bokehjs_dir: string): {outputs?: Outputs} & TSOutput {
   const preconfigure: ts.CompilerOptions = {
     module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2017,
     paths: {
       "*": [
         path.join(bokehjs_dir, "js/lib/*"),

--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -184,6 +184,9 @@ export const StepMode = Enum("after", "before", "center")
 export type TapBehavior = "select" | "inspect"
 export const TapBehavior = Enum("select", "inspect")
 
+export type TapGesture = typeof TapGesture["__type__"]
+export const TapGesture = Enum("tap", "doubletap")
+
 export type TextAlign = "left" | "right" | "center"
 export const TextAlign = Enum("left", "right", "center")
 

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -3,10 +3,15 @@ import {CallbackLike1} from "../../callbacks/callback"
 import * as p from "core/properties"
 import {TapEvent} from "core/ui_events"
 import {PointGeometry} from "core/geometry"
-import {TapBehavior, SelectionMode} from "core/enums"
+import {TapBehavior, TapGesture, SelectionMode} from "core/enums"
 import {ColumnarDataSource} from "../../sources/columnar_data_source"
 import {DataRendererView} from "../../renderers/data_renderer"
 import {tool_icon_tap_select} from "styles/icons.css"
+
+export type TapToolCallback = CallbackLike1<TapTool, {
+  geometries: PointGeometry & {x: number, y: number}
+  source: ColumnarDataSource
+}>
 
 export class TapToolView extends SelectToolView {
   declare model: TapTool
@@ -81,11 +86,8 @@ export namespace TapTool {
 
   export type Props = SelectTool.Props & {
     behavior: p.Property<TapBehavior>
-    gesture: p.Property<"tap" | "doubletap">
-    callback: p.Property<CallbackLike1<TapTool, {
-      geometries: PointGeometry & {x: number, y: number}
-      source: ColumnarDataSource
-    }> | null>
+    gesture: p.Property<TapGesture>
+    callback: p.Property<TapToolCallback | null>
   }
 }
 
@@ -102,9 +104,9 @@ export class TapTool extends SelectTool {
   static {
     this.prototype.default_view = TapToolView
 
-    this.define<TapTool.Props>(({Any, Enum, Nullable}) => ({
+    this.define<TapTool.Props>(({Any, Nullable}) => ({
       behavior: [ TapBehavior, "select" ],
-      gesture:  [ Enum("tap", "doubletap"), "tap"],
+      gesture:  [ TapGesture, "tap"],
       callback: [ Nullable(Any /*TODO*/), null ],
     }))
 

--- a/bokehjs/test/unit/core/enums.ts
+++ b/bokehjs/test/unit/core/enums.ts
@@ -221,6 +221,10 @@ describe("enums module", () => {
     expect([...enums.TapBehavior]).to.be.equal(["select", "inspect"])
   })
 
+  it("should have TapGesture", () => {
+    expect([...enums.TapGesture]).to.be.equal(["tap", "doubletap"])
+  })
+
   it("should have TextAlign", () => {
     expect([...enums.TextAlign]).to.be.equal(["left", "right", "center"])
   })

--- a/examples/models/popup.ts
+++ b/examples/models/popup.ts
@@ -1,5 +1,6 @@
 import {Model} from "model"
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
+import {TapTool, TapToolCallback} from "models/tools/gestures/tap_tool"
 import {replace_placeholders} from "core/util/templating"
 import * as p from "core/properties"
 import {popup} from "./popup_helper"
@@ -14,7 +15,7 @@ export namespace Popup {
 
 export interface Popup extends Popup.Attrs {}
 
-export class Popup extends Model {
+export class Popup extends Model implements TapToolCallback {
   declare properties: Popup.Props
 
   constructor(attrs?: Partial<Popup.Attrs>) {
@@ -27,9 +28,9 @@ export class Popup extends Model {
     }))
   }
 
-  execute(data_source: ColumnarDataSource): void {
-    for (const i of data_source.selected.indices) {
-      const message = replace_placeholders(this.message, data_source, i)
+  execute(_: TapTool, {source}: {source: ColumnarDataSource}): void {
+    for (const i of source.selected.indices) {
+      const message = replace_placeholders(this.message, source, i)
       popup(message.toString())
     }
   }


### PR DESCRIPTION
Makes sure that `static {}` blocks and other too recent features don't appear in generated JS bundles. Also fixes `models/custom.py` example, where a callback signature wasn't updated after changes to `TapTool` in 3.0.

fixes #12757