### PR TITLE
Ignore `renderers` property when grouping tools

### DIFF
--- a/bokehjs/src/lib/api/gridplot.ts
+++ b/bokehjs/src/lib/api/gridplot.ts
@@ -22,7 +22,9 @@ export type GridPlotOpts = {
 
 export type MergeFn = (cls: typeof Tool, group: Tool[]) => Tool | ToolProxy<Tool> | null
 
-export function group_tools(tools: ToolLike<Tool>[], merge?: MergeFn): ToolLike<Tool>[] {
+export function group_tools(tools: ToolLike<Tool>[], merge?: MergeFn,
+    ignore: Set<string> = new Set(["overlay", "renderers"])): ToolLike<Tool>[] {
+
   type ToolEntry = {tool: Tool, attrs: Attrs}
   const by_type: Map<typeof Tool, Set<ToolEntry>> = new Map()
 
@@ -33,8 +35,12 @@ export function group_tools(tools: ToolLike<Tool>[], merge?: MergeFn): ToolLike<
       computed.push(tool)
     } else {
       const attrs = tool.attributes
-      if ("overlay" in attrs)
-        delete attrs.overlay
+      for (const attr of ignore) {
+        if (attr in attrs) {
+          delete attrs[attr]
+        }
+      }
+
       const proto = tool.constructor.prototype
       let values = by_type.get(proto)
       if (values == null)

--- a/bokehjs/test/unit/api/gridplot.ts
+++ b/bokehjs/test/unit/api/gridplot.ts
@@ -1,6 +1,10 @@
 import {expect} from "assertions"
 
-import {PanTool, TapTool, ToolProxy} from "@bokehjs/models"
+import {
+  PanTool, TapTool, SaveTool, BoxSelectTool, HoverTool,
+  ToolProxy, BoxAnnotation, GlyphRenderer,
+} from "@bokehjs/models"
+
 import {group_tools} from "@bokehjs/api/gridplot"
 import {assert} from "@bokehjs/core/util/assert"
 
@@ -15,20 +19,43 @@ describe("api/gridplot module", () => {
     const tap0 = new TapTool({behavior: "select"})
     const tap1 = new TapTool({behavior: "select"})
     const tap2 = new TapTool({behavior: "inspect"})
+    const save0 = new SaveTool({filename: "foo.png"})
+    const save1 = new SaveTool({filename: "foo.png"})
+    const select0 = new BoxSelectTool({overlay: new BoxAnnotation()})
+    const select1 = new BoxSelectTool({overlay: new BoxAnnotation()})
+    const select2 = new BoxSelectTool({overlay: new BoxAnnotation()})
+    const hover0 = new HoverTool({renderers: [new GlyphRenderer()]})
+    const hover1 = new HoverTool({renderers: [new GlyphRenderer()]})
+    const hover2 = new HoverTool({renderers: [new GlyphRenderer()]})
 
-    const tools = group_tools([pan0, tap0, pan2, pan1, tap1, pan5, pan4, pan3, tap2])
+    const tools = group_tools([
+      pan0, tap0, pan2, pan1, tap1, pan5, pan4, pan3, tap2, save0,
+      save1, select0, hover0, hover1, select1, select2, hover2,
+    ], (_cls, group) => {
+      return group[0] instanceof SaveTool ? new SaveTool() : null
+    })
 
-    expect(tools.length).to.be.equal(5)
-    const [t0, t1, t2, t3, t4] = tools
+    expect(tools.length).to.be.equal(8)
+    const [t0, t1, t2, t3, t4, t5, t6, t7] = tools
 
     assert(t0 instanceof ToolProxy)
     assert(t1 instanceof ToolProxy)
+    assert(t2 instanceof PanTool)
     assert(t3 instanceof ToolProxy)
+    assert(t4 instanceof TapTool)
+    assert(t5 instanceof SaveTool)
+    assert(t6 instanceof ToolProxy)
+    assert(t7 instanceof ToolProxy)
 
     expect(t0.tools).to.be.equal([pan0, pan1])
     expect(t1.tools).to.be.equal([pan2, pan4, pan3])
     expect(t2).to.be.equal(pan5)
     expect(t3.tools).to.be.equal([tap0, tap1])
     expect(t4).to.be.equal(tap2)
+    expect(t5).to.not.be.equal(save0)
+    expect(t5).to.not.be.equal(save1)
+    expect(t5.filename).to.be.equal(null)
+    expect(t6.tools).to.be.equal([select0, select1, select2])
+    expect(t7.tools).to.be.equal([hover0, hover1, hover2])
   })
 })

--- a/tests/unit/bokeh/test_layouts.py
+++ b/tests/unit/bokeh/test_layouts.py
@@ -30,9 +30,13 @@ from bokeh.layouts import (
     row,
 )
 from bokeh.models import (
+    BoxAnnotation,
+    BoxSelectTool,
     Column,
+    GlyphRenderer,
     GridBox,
     GridPlot,
+    HoverTool,
     LayoutDOM,
     PanTool,
     Row,
@@ -212,14 +216,24 @@ def test_group_tools() -> None:
     tap0 = TapTool(behavior="select")
     tap1 = TapTool(behavior="select")
     tap2 = TapTool(behavior="inspect")
-    save0 = SaveTool()
-    save1 = SaveTool()
+    save0 = SaveTool(filename="foo.png")
+    save1 = SaveTool(filename="foo.png")
+    select0 = BoxSelectTool(overlay=BoxAnnotation())
+    select1 = BoxSelectTool(overlay=BoxAnnotation())
+    select2 = BoxSelectTool(overlay=BoxAnnotation())
+    hover0 = HoverTool(renderers=[GlyphRenderer()])
+    hover1 = HoverTool(renderers=[GlyphRenderer()])
+    hover2 = HoverTool(renderers=[GlyphRenderer()])
 
-    tools = [pan0, tap0, pan2, pan1, tap1, pan5, pan4, pan3, tap2, save0, save1]
+    tools = [
+        pan0, tap0, pan2, pan1, tap1, pan5, pan4, pan3, tap2, save0,
+        save1, select0, hover0, hover1, select1, select2, hover2,
+    ]
+
     groupped = group_tools(tools, merge=lambda cls, tools: SaveTool() if issubclass(cls, SaveTool) else None)
 
-    assert len(groupped) == 6
-    t0, t1, t2, t3, t4, t5 = groupped
+    assert len(groupped) == 8
+    t0, t1, t2, t3, t4, t5, t6, t7 = groupped
 
     assert isinstance(t0, ToolProxy)
     assert isinstance(t1, ToolProxy)
@@ -227,13 +241,17 @@ def test_group_tools() -> None:
     assert isinstance(t3, ToolProxy)
     assert isinstance(t4, TapTool)
     assert isinstance(t5, SaveTool)
+    assert isinstance(t6, ToolProxy)
+    assert isinstance(t7, ToolProxy)
 
     assert t0.tools == [pan0, pan1]
     assert t1.tools == [pan2, pan4, pan3]
     assert t2 == pan5
     assert t3.tools == [tap0, tap1]
     assert t4 == tap2
-    assert t5 != save0 and t5 != save1
+    assert t5 != save0 and t5 != save1 and t5.filename is None
+    assert t6.tools == [select0, select1, select2]
+    assert t7.tools == [hover0, hover1, hover2]
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
fixes #12864
