### PR TITLE
Fix alignment in `_templates/file.html`

### DIFF
--- a/src/bokeh/core/_templates/file.html
+++ b/src/bokeh/core/_templates/file.html
@@ -23,7 +23,7 @@ that accepts these same parameters.
     <meta charset="utf-8">
     <title>{% block title %}{{ title | e if title else "Bokeh Plot" }}{% endblock %}</title>
   {%  block preamble -%}{%- endblock %}
-  {%  block resources -%}
+  {%  block resources %}
     <style>
       html, body {
         box-sizing: border-box;


### PR DESCRIPTION
Previously file template would produce this:
```html
  <head>
    <meta charset="utf-8">
    <title>Bokeh Plot</title>
<style>
      html, body {
        box-sizing: border-box;
        height: 100%;
        margin: 0;
        padding: 0;
      }
    </style>
```
This PR fixes the alignment of `<style>` tag.