### PR TITLE
Allow providing websocket origin if unix-socket is enabled

### DIFF
--- a/src/bokeh/command/subcommands/serve.py
+++ b/src/bokeh/command/subcommands/serve.py
@@ -897,7 +897,7 @@ class Serve(Subcommand):
         if 'unix_socket' in server_kwargs:
             if server_kwargs['port'] != DEFAULT_SERVER_PORT:
                 die("--port arg is not supported with a unix socket")
-            invalid_args = ['address', 'allow_websocket_origin', 'ssl_certfile', 'ssl_keyfile']
+            invalid_args = ['address', 'ssl_certfile', 'ssl_keyfile']
 
             if any(server_kwargs.get(x) for x in invalid_args):
                 die(f"{invalid_args + ['port']} args are not supported with a unix socket")

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -424,7 +424,10 @@ class Server(BaseServer):
             sockets = [netutil.bind_unix_socket(opts.unix_socket)]
             self._unix_socket = opts.unix_socket
             self._address, self._port = None, None
-            extra_websocket_origins = []
+            if opts.allow_websocket_origin:
+                extra_websocket_origins = create_hosts_allowlist(opts.allow_websocket_origin, None)
+            else:
+                extra_websocket_origins = []
         else:
             sockets, self._port = bind_sockets(opts.address, opts.port)
             self._address = opts.address

--- a/tests/unit/bokeh/command/subcommands/test_serve.py
+++ b/tests/unit/bokeh/command/subcommands/test_serve.py
@@ -495,11 +495,11 @@ def test_unix_socket_with_port() -> None:
     assert expected == out
 
 def test_unix_socket_with_invalid_args() -> None:
-    invalid_args = ['address', 'allow-websocket-origin', 'ssl-certfile', 'ssl-keyfile']
+    invalid_args = ['address', 'ssl-certfile', 'ssl-keyfile']
     for arg in invalid_args:
         unix_socket = "test.sock"
         out = check_error(["--unix-socket", unix_socket, f"--{arg}", "value"]).strip()
-        expected = "['address', 'allow_websocket_origin', 'ssl_certfile', 'ssl_keyfile', 'port'] args are not supported with a unix socket"
+        expected = "['address', 'ssl_certfile', 'ssl_keyfile', 'port'] args are not supported with a unix socket"
         assert expected == out
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unix sockets not available on windows")


### PR DESCRIPTION
@gpjt would be great if you could test this.

- [ ] issues: fixes https://github.com/bokeh/bokeh/issues/12894
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
