### PR TITLE
List installed software and versions in CI

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -91,6 +91,11 @@ jobs:
           source-tree: 'keep'
           sampledata: 'cache'
 
+      - name: List installed software
+        run: |
+          conda info
+          conda list
+
       - name: Run codebase checks
         run: pytest --color=yes tests/codebase
 
@@ -113,7 +118,6 @@ jobs:
           sampledata: 'cache'
 
       - name: Install chromium
-        if: runner.os == 'Linux'
         run: |
           if [[ "$(chromium --version | cut -d' ' -f2)" = "$CHROME_VER" ]]; then
             echo "Using pre-installed version of chromium"
@@ -125,6 +129,12 @@ jobs:
             sudo snap ack $CHROME_REV.assert
             sudo snap install $CHROME_REV.snap
           fi
+
+      - name: List installed software
+        run: |
+          conda info
+          conda list
+          chromium --version
 
       - name: Start chrome headless
         working-directory: ./bokehjs
@@ -166,6 +176,11 @@ jobs:
           source-tree: 'delete'
           sampledata: 'cache'
 
+      - name: List installed software
+        run: |
+          conda info
+          conda list
+
       - name: Run tests
         run: pytest -v --cov=bokeh --cov-report=xml --tb=short --driver chrome --color=yes tests/integration
 
@@ -201,6 +216,11 @@ jobs:
 
       - name: Ensure Python version
         run: if [[ ! "$(python --version | cut -d' ' -f2)" == "${{ matrix.python-version }}"* ]]; then exit 1; fi
+
+      - name: List installed software
+        run: |
+          conda info
+          conda list
 
       - name: Test defaults
         run: pytest tests/test_defaults.py
@@ -238,6 +258,11 @@ jobs:
           source-tree: 'delete'
           sampledata: 'none' # no sampledata for minimal tests
 
+      - name: List installed software
+        run: |
+          conda info
+          conda list
+
       - name: Run tests
         run: pytest -m "not sampledata" --cov=bokeh --cov-report=xml --color=yes tests/unit
 
@@ -261,6 +286,11 @@ jobs:
           test-env: '3.8'
           source-tree: 'delete'
           sampledata: 'download' # test at least one real download
+
+      - name: List installed software
+        run: |
+          conda info
+          conda list
 
       - name: Build docs
         run: bash scripts/ci/build_docs.sh
@@ -287,6 +317,11 @@ jobs:
 
       - name: Install downstream packages
         run: bash scripts/ci/install_downstream_packages.sh
+
+      - name: List installed software
+        run: |
+          conda info
+          conda list
 
       - name: Run tests
         run: bash scripts/ci/run_downstream_tests.sh

--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Post install status
         run: |
-          echo "$(which node) @ $(node --version)"
-          echo "$(which npm) @ $(npm --version)"
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
           conda info
           conda list
 

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -57,6 +57,23 @@ jobs:
         run: |
           npm ci --no-progress
 
+      - name: List installed software
+        working-directory: ./bokehjs
+        shell: bash
+        run: |
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            chromium --version
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            # TODO: this hangs; version is reported in tests
+            # c:/Program\ Files/Google/Chrome/Application/chrome.EXE --version
+            echo "Chromium ??? (see tests)"
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version
+          fi
+          npm list
+
       - name: Build bokehjs
         working-directory: ./bokehjs
         shell: bash

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upgrade npm
         shell: bash
         run: |
-          npm install --location=global npm@8
+          npm install --location=global npm
 
       - name: Install chromium
         if: runner.os == 'Linux'

--- a/docs/bokeh/source/docs/dev_guide/setup.rst
+++ b/docs/bokeh/source/docs/dev_guide/setup.rst
@@ -156,7 +156,7 @@ directory, and run the following commands:
 .. code-block:: sh
 
     cd bokehjs
-    npm install --location=global npm@8
+    npm install --location=global npm
 
 If you do not want to install npm globally, leave out the ``--location=global``
 flag. In this case, you need to adjust all subsequent ``npm`` commands to use

--- a/scripts/ci/install_node_modules.sh
+++ b/scripts/ci/install_node_modules.sh
@@ -3,7 +3,7 @@
 set -x #echo on
 
 cd bokehjs
-npm install --location=global npm@8
+npm install --location=global npm
 npm ci --no-progress
 node make examples --no-build
 git restore package*.json # avoid .dirty in the package version


### PR DESCRIPTION
This PR lists installed software (not necessarily Python packages) in each job in bokeh-ci and bokehjs-ci workflows. This way we will have one, easily accessible location with all software and versions, which should help resolve issues with CI and comparing behavior between CI and local environments. Currently we have to go through install log, which isn't particularly useful.

As an additional and somewhat related change, I'm removing `@8` from `npm install -g npm@8`. Since we recently switched to nodejs 18.x, it's better to let npm install the most recent version, which will be 9.x.

fixes #11335
