### PR TITLE
Use CSS-safe IDs in generated HTML

### DIFF
--- a/src/bokeh/embed/util.py
+++ b/src/bokeh/embed/util.py
@@ -38,7 +38,7 @@ from ..model import Model, collect_models
 from ..settings import settings
 from ..themes.theme import Theme
 from ..util.dataclasses import dataclass, field
-from ..util.serialization import make_globally_unique_id
+from ..util.serialization import make_globally_unique_css_safe_id, make_globally_unique_id
 
 if TYPE_CHECKING:
     from ..document.document import DocJson
@@ -320,10 +320,10 @@ def standalone_docs_json_and_render_items(models: Model | Document | Sequence[Mo
         (docid, roots) = docs[doc]
 
         if model is not None:
-            roots[model] = make_globally_unique_id()
+            roots[model] = make_globally_unique_css_safe_id()
         else:
             for model in doc.roots:
-                roots[model] = make_globally_unique_id()
+                roots[model] = make_globally_unique_css_safe_id()
 
     docs_json: dict[ID, DocJson] = {}
     for doc, (docid, _) in docs.items():

--- a/src/bokeh/io/notebook.py
+++ b/src/bokeh/io/notebook.py
@@ -442,10 +442,13 @@ def load_notebook(resources: Resources | None = None, verbose: bool = False,
     from ..embed.bundle import bundle_for_objs_and_resources
     from ..resources import Resources
     from ..settings import settings
-    from ..util.serialization import make_id
+    from ..util.serialization import make_globally_unique_css_safe_id
 
     if resources is None:
         resources = Resources(mode=settings.resources())
+
+    element_id: ID | None
+    html: str | None
 
     if not hide_banner:
         if resources.mode == 'inline':
@@ -459,7 +462,7 @@ def load_notebook(resources: Resources | None = None, verbose: bool = False,
         if _NOTEBOOK_LOADED and verbose:
             warnings.append('Warning: BokehJS previously loaded')
 
-        element_id: ID | None = make_id()
+        element_id = make_globally_unique_css_safe_id()
 
         html = NOTEBOOK_LOAD.render(
             element_id    = element_id,
@@ -482,9 +485,10 @@ def load_notebook(resources: Resources | None = None, verbose: bool = False,
 
     if html is not None:
         publish_display_data({'text/html': html})
+
     publish_display_data({
-        JS_MIME_TYPE   : nb_js,
-        LOAD_MIME_TYPE : jl_js,
+        JS_MIME_TYPE:   nb_js,
+        LOAD_MIME_TYPE: jl_js,
     })
 
 def publish_display_data(data: dict[str, Any], metadata: dict[Any, Any] | None = None, *, transient: dict[str, Any] | None = None, **kwargs: Any) -> None:

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -96,6 +96,7 @@ __all__ = (
     'convert_timedelta_type',
     'is_datetime_type',
     'is_timedelta_type',
+    'make_globally_unique_css_safe_id',
     'make_globally_unique_id',
     'make_id',
     'transform_array',
@@ -276,6 +277,26 @@ def make_globally_unique_id() -> ID:
 
     '''
     return ID(str(uuid.uuid4()))
+
+def make_globally_unique_css_safe_id() -> ID:
+    ''' Return a globally unique CSS-safe UUID.
+
+    Some situations, e.g. id'ing dynamically created Divs in HTML documents,
+    always require globally unique IDs. ID generated with this function can
+    be used in APIs like ``document.querySelector("#id")``.
+
+    Returns:
+        str
+
+    '''
+    max_iter = 10
+
+    for _i in range(0, max_iter):
+        id = make_globally_unique_id()
+        if id[0].isalpha():
+            return id
+
+    return ID(f"bk-{make_globally_unique_id()}")
 
 def array_encoding_disabled(array: npt.NDArray[Any]) -> bool:
     ''' Determine whether an array may be binary encoded.

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -217,8 +217,9 @@ class Test_components:
         assert isinstance(divs3, OrderedDict)
         assert all(isinstance(x, str) for x in divs3.keys())
 
+    @patch('bokeh.embed.util.make_globally_unique_css_safe_id', new_callable=lambda: stable_id)
     @patch('bokeh.embed.util.make_globally_unique_id', new_callable=lambda: stable_id)
-    def test_plot_dict_returned_when_wrap_plot_info_is_false(self, mock_make_id: MagicMock) -> None:
+    def test_plot_dict_returned_when_wrap_plot_info_is_false(self, mock_make_css_safe_id: MagicMock, mock_make_id: MagicMock) -> None:
         doc = Document()
         plot1 = figure()
         plot1.circle([], [])
@@ -247,6 +248,7 @@ class Test_components:
         assert len(scripts) == 1
         assert scripts[0].attrs == {'type': 'text/javascript'}
 
+    @patch('bokeh.embed.util.make_globally_unique_css_safe_id', new=stable_id)
     @patch('bokeh.embed.util.make_globally_unique_id', new=stable_id)
     def test_div_attrs(self, test_plot: figure) -> None:
         _, div = bes.components(test_plot)

--- a/tests/unit/bokeh/util/test_util__serialization.py
+++ b/tests/unit/bokeh/util/test_util__serialization.py
@@ -58,10 +58,14 @@ class Test_make_id:
             assert len(bus.make_id()) == 36
             assert isinstance(bus.make_id(), str)
 
-class Test_make_globally_unique_id:
-    def test_basic(self) -> None:
-        assert len(bus.make_globally_unique_id()) == 36
-        assert isinstance(bus.make_globally_unique_id(), str)
+def test_make_globally_unique_id() -> None:
+    assert len(bus.make_globally_unique_id()) == 36
+    assert isinstance(bus.make_globally_unique_id(), str)
+
+def test_make_globally_unique_css_safe_id() -> None:
+    assert len(bus.make_globally_unique_css_safe_id()) == 36
+    assert isinstance(bus.make_globally_unique_id(), str)
+    assert all(bus.make_globally_unique_css_safe_id()[0].isalpha() for _ in range(1000))
 
 def test_np_consts() -> None:
     assert bus.NP_EPOCH == np.datetime64(0, 'ms')


### PR DESCRIPTION
Use safe IDs only in places where they actually are used in HTML, so that APIs like `document.querySelector("#id")` can work. Note that one can always use `document.getElementById(id)`, which doesn't care about such limitations.

fixes #10547
fixes #12905
