### PR TITLE
Warn about already known references, but don't fail

### DIFF
--- a/bokehjs/src/lib/core/serialization/deserializer.ts
+++ b/bokehjs/src/lib/core/serialization/deserializer.ts
@@ -1,3 +1,4 @@
+import {logger} from "../logging"
 import {type HasProps} from "../has_props"
 import {type ModelResolver} from "../resolvers"
 import {ID, Attrs, PlainObject, TypedArray} from "../types"
@@ -301,8 +302,11 @@ export class Deserializer {
   }
 
   protected _decode_object_ref(obj: ObjectRefRep): HasProps {
-    if (this.references.has(obj.id))
-      this.error(`reference already known '${obj.id}'`)
+    const ref = this.references.get(obj.id)
+    if (ref != null) {
+      this.warning(`reference already known '${obj.id}'`)
+      return ref
+    }
 
     const {id, name: type, attributes} = obj
 
@@ -319,6 +323,10 @@ export class Deserializer {
 
   error(message: string): never {
     throw new DeserializationError(message)
+  }
+
+  warning(message: string): void {
+    logger.warn(message)
   }
 
   private _resolve_type(type: string): any {

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -60,6 +60,7 @@ from ..util.serialization import (
     transform_array,
     transform_series,
 )
+from ..util.warnings import BokehUserWarning, warn
 from .types import ID
 
 if TYPE_CHECKING:
@@ -302,7 +303,7 @@ class Serializer:
         if -_MAX_SAFE_INT < obj <= _MAX_SAFE_INT:
             return obj
         else:
-            log.warning("out of range integer may result in loss of precision")
+            warn("out of range integer may result in loss of precision", BokehUserWarning)
             return self._encode_float(float(obj))
 
     def _encode_float(self, obj: float) -> NumberRep | float:
@@ -667,7 +668,8 @@ class Deserializer:
         id = obj["id"]
         instance = self._references.get(id)
         if instance is not None:
-            self.error(f"reference already known '{id}'")
+            warn(f"reference already known '{id}'", BokehUserWarning)
+            return instance
 
         name = obj["name"]
         attributes = obj.get("attributes")


### PR DESCRIPTION
There are situations observed in panel and related software, that we don't yet fully understand, that can make deserializer fail with "already known reference" exception. Those situations are usually recoverable, so in this PR I change the exception to a warning, and let bokeh continue running. I'm leaving a warning, so that this gets actually fixed in the future.
