### PR TITLE
Increased alpha of the circle plot 

### DIFF
--- a/examples/basic/annotations/slope.py
+++ b/examples/basic/annotations/slope.py
@@ -13,7 +13,7 @@ p = figure(width=450, height=450, x_axis_label='x', y_axis_label='y',
            background_fill_color="#fafafa")
 p.y_range.start = 0
 
-p.circle(xpts, ypts, size=6, alpha=0.6, fill_color=None)
+p.circle(xpts, ypts, size=6, alpha=0.8, fill_color=None)
 
 slope = Slope(gradient=slope, y_intercept=intercept,
               line_color='orange', line_dash='dashed', line_width=4)


### PR DESCRIPTION
As seen in #11481, colors need to be improved for some example plots.
The alpha of the circle plot looked quite faint and has almost the same color as the background image. To make it less faint I increased the alpha to 0.8.
![slope-edited](https://user-images.githubusercontent.com/52848633/225091482-d1e2c346-927d-47be-8d60-9e4d0b082e24.PNG)
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
