### PR TITLE
Check for git tags before build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,10 +118,19 @@ def build_or_install_bokehjs(packages: list[str]) -> None:
         raise ValueError(f"Unrecognized action {action!r}")
     print(f"Used {bright(yellow(kind))} BokehJS from {loc}\n")
 
+def check_tags() -> None:
+    try:
+        tags = subprocess.check_output(("git", "tag", "-l")).split()
+        if len(tags) < 5: # arbitrary "too-low" cutoff, there will always be more than 5 tags, if there are any
+            die(bright(red(MISSING_TAGS)))
+    except Exception:
+        print(bright(yellow("!!! Could not check repo tags. Please ensure full tag history")))
+
 def die(x: str) -> NoReturn:
     print(f"{x}\n")
     sys.exit(1)
 
+MISSING_TAGS = "\n!!! This repository is missing git tags! Full tag history is required to build Bokeh\n!!!\n!!! See https://docs.bokeh.org/en/latest/docs/dev_guide/setup.html#troubleshooting"  # noqa
 SUCCESS = f"{bright(green('Success!'))}\n"
 FAILED = f"{bright(red('Failed.'))}\n"
 BUILD_SUCCESS_MSG =f"{SUCCESS}\nBuild output:\n\n{{msg}}"
@@ -141,11 +150,13 @@ BUILD_FAIL_MSG = f"""{FAILED}\nERROR: 'node make build' returned the following
 
 class Build(build):  # type: ignore
     def run(self) -> None:
+        check_tags()
         build_or_install_bokehjs(self.distribution.packages)
         super().run()
 
 class EditableWheel(editable_wheel):  # type: ignore
     def run(self) -> None:
+        check_tags()
         build_or_install_bokehjs(self.distribution.packages)
         super().run()
 

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,11 @@ def die(x: str) -> NoReturn:
     print(f"{x}\n")
     sys.exit(1)
 
-MISSING_TAGS = "\n!!! This repository is missing git tags! Full tag history is required to build Bokeh\n!!!\n!!! See https://docs.bokeh.org/en/latest/docs/dev_guide/setup.html#troubleshooting"  # noqa
+MISSING_TAGS = """
+!!! This repository is missing git tags! Full tag history is required to build Bokeh.
+!!!
+!!! See https://docs.bokeh.org/en/latest/docs/dev_guide/setup.html#troubleshooting
+"""
 SUCCESS = f"{bright(green('Success!'))}\n"
 FAILED = f"{bright(red('Failed.'))}\n"
 BUILD_SUCCESS_MSG =f"{SUCCESS}\nBuild output:\n\n{{msg}}"


### PR DESCRIPTION
- [x] issues: fixes #12814

This PR adds a check for the existence of git tags during a build, and fails with a warning if they are not present. Because of the way pip works these days, the output is a little buried, but I have tried to make it stand out as much as possible:

<img width="945" alt="Screenshot 2023-03-14 at 21 46 14" src="https://user-images.githubusercontent.com/1078448/225211088-e9407c5b-c49b-4e12-ba3c-cfe532d1bde6.png">

Note that the check is not performed for the sdist action because the build does not happen inside a git repo (version should be hard-coded at that point anyway)

---

@ianthomas23 @tcmetzger I'd also like to update some docs in this PR. First off, we need a stable URL for the message above. Is the troubleshooting URL that stable URL? Maybe we can put this at the top of troubleshooting? Second I think it would be good to add an actual image like this that really illustrates what action has to be taken during the fork:

<img width="822" alt="Screenshot 2023-03-14 at 21 25 45" src="https://user-images.githubusercontent.com/1078448/225211122-5ce85203-6a30-4195-9d36-590145c23083.png">


