### PR TITLE
Temporarily disable docker_from_wheel test in CI

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -327,6 +327,7 @@ jobs:
         run: bash scripts/ci/run_downstream_tests.sh
 
   docker_from_wheel:
+    if: ${{ false }}  # temporarily disable
     needs: build
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This temporarily disables the `docker_from_wheel` test in CI as it is failing and annoying all of our outreachy contributors.
