### PR TITLE
Fix tiny error in doc code-block

### DIFF
--- a/docs/bokeh/source/docs/dev_guide/setup.rst
+++ b/docs/bokeh/source/docs/dev_guide/setup.rst
@@ -91,7 +91,7 @@ upstream with the following commands:
 
     .. tab-item:: HTTPS
 
-        ..code-block:: sh
+        .. code-block:: sh
 
             git remote add upstream https://github.com/bokeh/bokeh.git
             git fetch upstream


### PR DESCRIPTION
There was a missing whitespace in the docs between `..` and `code-block`, which is fixed by this PR.
