### PR TITLE
Added link to gallery

### DIFF
--- a/docs/bokeh/source/index.rst
+++ b/docs/bokeh/source/index.rst
@@ -90,7 +90,7 @@ You can also find more information about Bokeh on `Twitter`_, `Medium`_, and
     :alt: A collage of 36 thumbnails of Bokeh plots
     :target: _gallery
 
-.. _galery: https://docs.bokeh.org/en/latest/docs/gallery.html
+.. _gallery: https://docs.bokeh.org/en/latest/docs/gallery.html
 .. _Interactive tutorial notebooks: https://mybinder.org/v2/gh/bokeh/bokeh-notebooks/HEAD?labpath=index.ipynb
 .. _Bokeh community: https://bokeh.org/community/
 .. _Bokeh Discourse: https://discourse.bokeh.org

--- a/docs/bokeh/source/index.rst
+++ b/docs/bokeh/source/index.rst
@@ -88,7 +88,7 @@ You can also find more information about Bokeh on `Twitter`_, `Medium`_, and
 .. image:: _images/bokeh-hero.png
     :width: 100%
     :alt: A collage of 36 thumbnails of Bokeh plots
-    :target: _galery
+    :target: _gallery
 
 .. _galery: https://docs.bokeh.org/en/latest/docs/gallery.html
 .. _Interactive tutorial notebooks: https://mybinder.org/v2/gh/bokeh/bokeh-notebooks/HEAD?labpath=index.ipynb

--- a/docs/bokeh/source/index.rst
+++ b/docs/bokeh/source/index.rst
@@ -88,8 +88,9 @@ You can also find more information about Bokeh on `Twitter`_, `Medium`_, and
 .. image:: _images/bokeh-hero.png
     :width: 100%
     :alt: A collage of 36 thumbnails of Bokeh plots
+    :target: _galery
 
-
+.. _galery: https://docs.bokeh.org/en/latest/docs/gallery.html
 .. _Interactive tutorial notebooks: https://mybinder.org/v2/gh/bokeh/bokeh-notebooks/HEAD?labpath=index.ipynb
 .. _Bokeh community: https://bokeh.org/community/
 .. _Bokeh Discourse: https://discourse.bokeh.org


### PR DESCRIPTION
I think the picture on the index should point to the gallery as I instinctively click on it just to realize it only opens the picture, ideally it would be a collage that goes to every project, but the gallery already has al of these projects, so I think is ok.

Anyway I'm not very familiar with .rst files, so if anyone can tell me if this is the standard way of doing this or i need to change something, would be nice. 

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [] release document entry (if new feature or API change)
