### PR TITLE
Update docker image for branch-3.2

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -331,7 +331,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: bokeh/bokeh-dev:branch-3.1
+      IMAGE_TAG: bokeh/bokeh-dev:branch-3.2
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/bokeh-docker-test.yml
+++ b/.github/workflows/bokeh-docker-test.yml
@@ -11,7 +11,8 @@ jobs:
   docker-test:
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: bokeh/bokeh-dev:branch-3.2
+      IMAGE_TAG: bokeh/bokeh-dev:ianthomas23-docker_branch_3.2
+      #IMAGE_TAG: bokeh/bokeh-dev:branch-3.2
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/bokeh-docker-test.yml
+++ b/.github/workflows/bokeh-docker-test.yml
@@ -11,7 +11,7 @@ jobs:
   docker-test:
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: bokeh/bokeh-dev:branch-3.1
+      IMAGE_TAG: bokeh/bokeh-dev:branch-3.2
 
     steps:
       - name: Checkout the repository

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # fonts-dejavu-core needed for headless chrome unicode characters.
 RUN apt update -y && \
     apt upgrade -y && \
-    apt install -y curl fonts-dejavu-core git sudo unzip
+    apt install -y curl fonts-dejavu-core git make sudo unzip
 
 # User and group setup using fixuid.
 RUN addgroup --gid 1000 docker && \

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -6,9 +6,9 @@ ARG FIXUID_VERSION=0.5.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 # fonts-dejavu-core needed for headless chrome unicode characters.
-RUN apt update -y && \
-    apt upgrade -y && \
-    apt install -y curl fonts-dejavu-core git make sudo unzip
+RUN apt update -yq && \
+    apt upgrade -yq && \
+    apt install -yq curl fonts-dejavu-core git make sudo unzip
 
 # User and group setup using fixuid.
 RUN addgroup --gid 1000 docker && \

--- a/scripts/docker/bokeh_docker_build.sh
+++ b/scripts/docker/bokeh_docker_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 echo "Start of $0"
 

--- a/scripts/docker/bokeh_docker_from_wheel.sh
+++ b/scripts/docker/bokeh_docker_from_wheel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This installs Bokeh from a single wheel in the dist directory and runs some of the Python tests.
 
-set -eu
+set -eux
 
 echo "Start of $0"
 

--- a/scripts/docker/bokeh_docker_test.sh
+++ b/scripts/docker/bokeh_docker_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Note do not exit on error, as want remaining tests to run.
-set -u
+set -ux
 
 echo "Start of $0"
 

--- a/scripts/docker/docker_run.sh
+++ b/scripts/docker/docker_run.sh
@@ -4,7 +4,7 @@
 # Can put env vars first, e.g.
 #   BOKEH_DOCKER_PY=3.9 docker_run.sh bokeh-dev:latest
 
-set -eu
+set -eux
 
 if [ $# -ne 1 ]; then
     echo "Usage: docker_run.sh <docker image and tag>, e.g. docker_run.sh bokeh/bokeh-dev:latest"

--- a/scripts/docker/docker_run.sh
+++ b/scripts/docker/docker_run.sh
@@ -31,6 +31,6 @@ if [ "${BOKEH_DOCKER_CHROME_VERSION:-0}" == 1 ]; then
     INTERACTIVE=""
 fi
 
-CMD="docker run -v $PWD:/bokeh -u $UID_GID -p 5006:5006 $ENV_VARS $INTERACTIVE $IMAGE_AND_TAG"
+CMD="docker run -v $PWD:/bokeh -u $UID_GID -p 5006-5009:5006-5009 $ENV_VARS $INTERACTIVE $IMAGE_AND_TAG"
 echo $CMD
 $CMD

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 CONDA_DIR=/home/docker/conda_bokeh
 DEFAULT_PY=3.9

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -44,13 +44,18 @@ if [ "${BOKEH_DOCKER_CONDA:-1}" == 1 ]; then
     . $CONDA_DIR/etc/profile.d/conda.sh
 
     if [ ! -d "$CONDA_DIR/envs/$ENV_NAME" ]; then
-        # Create conda environment and install required packagaes.
+        # Create conda environment and install required packages.
         conda env create -n $ENV_NAME -f $ENV_YML_FILE
-    fi
 
-    # Ensure conda environment is activated in this shell and in new shells.
-    conda activate $ENV_NAME
-    echo "conda activate $ENV_NAME" >> ~/.bashrc
+        # Ensure conda environment is activated in this shell and in new shells.
+        conda activate $ENV_NAME
+        echo "conda activate $ENV_NAME" >> ~/.bashrc
+
+        conda install -c conda-forge pre-commit
+        pre-commit install
+    else
+        conda activate $ENV_NAME
+    fi
 fi
 
 google-chrome --version

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -45,7 +45,7 @@ if [ "${BOKEH_DOCKER_CONDA:-1}" == 1 ]; then
 
     if [ ! -d "$CONDA_DIR/envs/$ENV_NAME" ]; then
         # Create conda environment and install required packages.
-        conda env create -n $ENV_NAME -f $ENV_YML_FILE
+        conda env create -n $ENV_NAME -f $ENV_YML_FILE -q
 
         # Ensure conda environment is activated in this shell and in new shells.
         conda activate $ENV_NAME


### PR DESCRIPTION
Fixes #12803. Checklist from that issue with some extras:

- [x] Update branch to 3.2
- [ ] Tag the image by the version of chrome it uses
- [x] Setup `pre-commit` in the conda environment
- [x] Install `make` so the image can be used to build the docs
- [x] Disable progress for `conda env create`
- [ ] Disable progress for sample data download
- [x] Make sure all scripts use `set -x`, so that we know what commands are executed
- [ ] `npm install --location=global npm@8` can be removed as long as most recent LTS of `node.js` is used
- [x] Export docs server port 5009
