### PR TITLE
Increase the number of iterations in CSS safe ID generator

### DIFF
--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -289,7 +289,7 @@ def make_globally_unique_css_safe_id() -> ID:
         str
 
     '''
-    max_iter = 10
+    max_iter = 100
 
     for _i in range(0, max_iter):
         id = make_globally_unique_id()


### PR DESCRIPTION
This should resolve the problem of failing serialization utils' unit tests.