### PR TITLE
Improvements around `BOKEH_DEV=true` workflow

### DIFF
--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -467,6 +467,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/css": {
       "version": "0.0.33",
       "dev": true,
@@ -1261,6 +1270,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -2588,6 +2610,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "dev": true,
@@ -3653,6 +3684,7 @@
       ],
       "devDependencies": {
         "@types/cli-progress": "^3.11.0",
+        "@types/cors": "^2.8.13",
         "@types/express": "^4.17.16",
         "@types/node": "^20.5.6",
         "@types/nunjucks": "^3.2.3",
@@ -3663,6 +3695,7 @@
         "chalk": "^4.1.2",
         "chrome-remote-interface": "^0.33.0",
         "cli-progress": "^3.11.2",
+        "cors": "^2.8.5",
         "devtools-protocol": "^0.0.1188167",
         "express": "^4.18.2",
         "json5": "^2.2.3",

--- a/bokehjs/test/devtools/server.ts
+++ b/bokehjs/test/devtools/server.ts
@@ -4,6 +4,7 @@ import {join, resolve, dirname} from "path"
 
 import {argv} from "yargs"
 import express from "express"
+import cors from "cors"
 import nunjucks from "nunjucks"
 
 import * as sys from "./sys"
@@ -16,6 +17,7 @@ nunjucks.configure(".", {
   noCache: true,
 })
 
+app.use(cors())
 app.use("/static", express.static("build/"))
 app.use("/assets", express.static("test/assets/"))
 app.use("/cases", express.static("../tests/baselines/cross/"))

--- a/bokehjs/test/devtools/server.ts
+++ b/bokehjs/test/devtools/server.ts
@@ -134,7 +134,6 @@ with open(__file__, "rb") as example:
   const env = {
     ...process.env,
     BOKEH_DEV: "true",
-    BOKEH_RESOURCES: "server",
     BOKEH_DEFAULT_SERVER_HOST: host,
     BOKEH_DEFAULT_SERVER_PORT: `${port}`,
   }

--- a/bokehjs/test/package.json
+++ b/bokehjs/test/package.json
@@ -13,6 +13,7 @@
   ],
   "devDependencies": {
     "@types/cli-progress": "^3.11.0",
+    "@types/cors": "^2.8.13",
     "@types/express": "^4.17.16",
     "@types/node": "^20.5.6",
     "@types/nunjucks": "^3.2.3",
@@ -23,6 +24,7 @@
     "chalk": "^4.1.2",
     "chrome-remote-interface": "^0.33.0",
     "cli-progress": "^3.11.2",
+    "cors": "^2.8.5",
     "devtools-protocol": "^0.0.1188167",
     "express": "^4.18.2",
     "json5": "^2.2.3",

--- a/docs/bokeh/source/docs/dev_guide/setup.rst
+++ b/docs/bokeh/source/docs/dev_guide/setup.rst
@@ -456,29 +456,31 @@ To enable development settings, set ``BOKEH_DEV`` to ``true``:
 
             set BOKEH_DEV=true
 
-Setting ``BOKEH_DEV`` to ``true`` is equivalent to setting all of the following
-variables individually:
+Setting ``BOKEH_DEV`` to ``true`` implies the following setup:
 
 - ``BOKEH_BROWSER=none``
 - ``BOKEH_LOG_LEVEL=debug``
 - ``BOKEH_MINIFIED=false``
 - ``BOKEH_PRETTY=true``
 - ``BOKEH_PY_LOG_LEVEL=debug``
-- ``BOKEH_RESOURCES=absolute-dev``
+- ``BOKEH_RESOURCES=server``
 
-This way, Bokeh will use local and unminified BokehJS resources, the default log
-levels are increased, the generated HTML and JSON code will be more
-human-readable, and Bokeh will not open a new browser window each time |show| is
-called.
+but is not strictly equivalent to setting those variables individually.
+
+This way, Bokeh will use local and unminified BokehJS resources, the default
+log levels are increased, the generated HTML and JSON code will be more
+human-readable, and Bokeh will not open a new browser window each time |show|
+is called.
 
 .. note::
-    Setting ``BOKEH_DEV=true`` enables ``BOKEH_RESOURCES=absolute-dev``, which
-    causes rendering problems when used with :term:`Bokeh server <Server>` or in
-    :ref:`Jupyter notebooks <ug_output_jupyter>`. To avoid those problems,
-    use the following settings instead:
+    Setting ``BOKEH_DEV=true`` enables ``BOKEH_RESOURCES=server``, which
+    requires a resources server. If needed, the user can provide such server
+    by running ``BOKEH_DEV=true bokeh static`` (on Linux) command separately
+    (e.g. in a another terminal or console).
 
-    * Set ``BOKEH_RESOURCES`` to ``server`` for server
-    * Set ``BOKEH_RESOURCES`` to ``inline`` for notebooks
+    Although using server resources for development is the most robust
+    approach, users can slightly simplify their setup by setting
+    ``BOKEH_RESOURCES`` to ``inline`` instead.
 
 .. _contributor_guide_setup_test_setup:
 

--- a/docs/bokeh/source/docs/releases/3.4.0.rst
+++ b/docs/bokeh/source/docs/releases/3.4.0.rst
@@ -7,3 +7,4 @@ Bokeh version ``3.4.0`` (December 2023) is a minor milestone of Bokeh project.
 
 * Added support for ``padding``, ``border_radius``, etc. to ``Label`` and ``Title`` (:bokeh-pull:`12825`)
 * Added support for interactivity (rotation) to ``Label`` when ``editable=True`` (:bokeh-pull:`12825`)
+* ``BOKEH_DEV=true`` now defaults to server development resources (:bokeh-pull:`13042`)

--- a/src/bokeh/command/subcommands/info.py
+++ b/src/bokeh/command/subcommands/info.py
@@ -120,14 +120,14 @@ class Info(Subcommand):
 
         '''
         if args.static:
-            print(settings.bokehjsdir())
+            print(settings.bokehjs_path())
         else:
             newline = '\n'
             print(f"Python version        :  {sys.version.split(newline)[0]}")
             print(f"IPython version       :  {if_installed(_version('IPython', '__version__'))}")
             print(f"Tornado version       :  {if_installed(_version('tornado', 'version'))}")
             print(f"Bokeh version         :  {__version__}")
-            print(f"BokehJS static path   :  {settings.bokehjsdir()}")
+            print(f"BokehJS static path   :  {settings.bokehjs_path()}")
             print(f"node.js version       :  {if_installed(nodejs_version())}")
             print(f"npm version           :  {if_installed(npmjs_version())}")
             print(f"jupyter_bokeh version :  {if_installed(_version('jupyter_bokeh', '__version__'))}")

--- a/src/bokeh/command/subcommands/static.py
+++ b/src/bokeh/command/subcommands/static.py
@@ -86,7 +86,9 @@ class Static(Subcommand):
             if server.address is not None and server.address != '':
                 address_string = ' address ' + server.address
 
-            log.info("Starting Bokeh static server on port %d%s", server.port, address_string)
+            log.info(f"Starting Bokeh static server at {server.port}{address_string}")
+            log.debug(f"Serving static files from: {settings.bokehjsdir()}")
+
             server.run_until_shutdown()
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/command/subcommands/static.py
+++ b/src/bokeh/command/subcommands/static.py
@@ -87,7 +87,7 @@ class Static(Subcommand):
                 address_string = ' address ' + server.address
 
             log.info(f"Starting Bokeh static server at {server.port}{address_string}")
-            log.debug(f"Serving static files from: {settings.bokehjsdir()}")
+            log.debug(f"Serving static files from: {settings.bokehjs_path()}")
 
             server.run_until_shutdown()
 

--- a/src/bokeh/core/_templates/autoload_js.js
+++ b/src/bokeh/core/_templates/autoload_js.js
@@ -110,8 +110,8 @@ calls it with the rendered model.
   }
 
   {% if bundle %}
-  const js_urls = {{ bundle.js_urls|tojson }};
-  const css_urls = {{ bundle.css_urls|tojson }};
+  const js_urls = {{ bundle.js_urls|map(attribute="url")|list|tojson }};
+  const css_urls = {{ bundle.css_urls|map(attribute="url")|list|tojson }};
   {% else %}
   const js_urls = {{ js_urls|tojson }};
   const css_urls = {{ css_urls|tojson }};

--- a/src/bokeh/embed/bundle.py
+++ b/src/bokeh/embed/bundle.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import hashlib
 import json
+import os
 from dataclasses import dataclass
 from os.path import normpath
 from pathlib import Path
@@ -33,6 +34,7 @@ from typing import (
     Sequence,
     TypedDict,
 )
+from urllib.parse import urljoin
 
 # Bokeh imports
 from ..core.templates import CSS_RESOURCES, JS_RESOURCES
@@ -70,7 +72,7 @@ class Artifact:
 
 class ScriptRef(Artifact):
     def __init__(self, url: str, type: str = "text/javascript") -> None:
-        self.url = url
+        self.url = URL(url)
         self.type = type
 
 
@@ -82,7 +84,7 @@ class Script(Artifact):
 
 class StyleRef(Artifact):
     def __init__(self, url: str) -> None:
-        self.url = url
+        self.url = URL(url)
 
 
 class Style(Artifact):
@@ -92,14 +94,14 @@ class Style(Artifact):
 
 class Bundle:
 
-    js_files: list[str]
+    js_files: list[URL]
     js_raw: list[str]
-    css_files: list[str]
+    css_files: list[URL]
     css_raw: list[str]
     hashes: Hashes
 
-    def __init__(self, js_files: list[str] = [], js_raw: list[str] = [],
-            css_files: list[str] = [], css_raw: list[str] = [], hashes: Hashes = {}):
+    def __init__(self, js_files: list[URL] = [], js_raw: list[str] = [],
+            css_files: list[URL] = [], css_raw: list[str] = [], hashes: Hashes = {}):
         self.js_files = js_files[:]
         self.js_raw = js_raw[:]
         self.css_files = css_files[:]
@@ -123,11 +125,11 @@ class Bundle:
             return "\n".join(self.js_raw)
 
     @property
-    def js_urls(self) -> list[str]:
+    def js_urls(self) -> list[URL]:
         return self.js_files
 
     @property
-    def css_urls(self) -> list[str]:
+    def css_urls(self) -> list[URL]:
         return self.css_files
 
     def add(self, artifact: Artifact) -> None:
@@ -167,9 +169,9 @@ def bundle_for_objs_and_resources(objs: Sequence[Model | Document] | None, resou
         use_gl      = True
         use_mathjax = True
 
-    js_files: list[str] = []
+    js_files: list[URL] = []
     js_raw: list[str] = []
-    css_files: list[str] = []
+    css_files: list[URL] = []
     css_raw: list[str] = []
 
     if resources is not None:
@@ -181,10 +183,10 @@ def bundle_for_objs_and_resources(objs: Sequence[Model | Document] | None, resou
 
         resources = resources.clone(components=components)
 
-        js_files.extend(resources.js_files)
+        js_files.extend(map(URL, resources.js_files))
         js_raw.extend(resources.js_raw)
 
-        css_files.extend(resources.css_files)
+        css_files.extend(map(URL, resources.css_files))
         css_raw.extend(resources.css_raw)
 
         extensions = _bundle_extensions(all_objs if objs else None, resources)
@@ -200,7 +202,7 @@ def bundle_for_objs_and_resources(objs: Sequence[Model | Document] | None, resou
                 else:
                     js_raw.append(Resources._inline(bundle.artifact_path))
         else:
-            js_files.extend([ str(bundle.artifact_path) for bundle in extensions ])
+            js_files.extend([ URL(str(bundle.artifact_path)) for bundle in extensions ])
 
     models = [ obj.__class__ for obj in all_objs ] if all_objs else None
     ext = bundle_models(models)
@@ -233,19 +235,32 @@ def _query_extensions(all_objs: set[Model], query: Callable[[type[Model]], bool]
 
     return False
 
-_default_cdn_host = "https://unpkg.com"
+@dataclass(frozen=True)
+class URL:
+    """ Opaque type for representing URLs. """
+
+    url: str
+
+    def __truediv__(self, path: str) -> URL:
+        url = self.url if self.url.endswith("/") else f"{self.url}/"
+        return URL(urljoin(url, path.replace(os.sep, "/")))
+
+    def __str__(self) -> str:
+        return self.url
 
 @dataclass(frozen=True)
 class ExtensionEmbed:
     artifact_path: Path
-    server_url: str
-    cdn_url: str | None = None
+    server_url: URL
+    cdn_url: URL | None = None
 
 class Pkg(TypedDict):
     name: NotRequired[str]
     version: NotRequired[str]
     module: NotRequired[str]
     main: NotRequired[str]
+
+_default_cdn_host = URL("https://unpkg.com")
 
 extension_dirs: dict[str, Path] = {}
 
@@ -275,7 +290,7 @@ def _bundle_extensions(objs: set[Model] | None, resources: Resources) -> list[Ex
         if not ext_path.exists():
             continue
 
-        server_prefix = f"{resources.root_url}static/extensions"
+        server_prefix = URL(resources.root_url) / "static" / "extensions"
         package_path = base_dir / "package.json"
 
         pkg: Pkg | None = None
@@ -287,8 +302,8 @@ def _bundle_extensions(objs: set[Model] | None, resources: Resources) -> list[Ex
                     pass
 
         artifact_path: Path
-        server_url: str
-        cdn_url: str | None = None
+        server_url: URL
+        cdn_url: URL | None = None
 
         if pkg is not None:
             pkg_name: str | None = pkg.get("name", None)
@@ -298,7 +313,7 @@ def _bundle_extensions(objs: set[Model] | None, resources: Resources) -> list[Ex
             pkg_main = pkg.get("module", pkg.get("main", None))
             if pkg_main is not None:
                 pkg_main = Path(normpath(pkg_main))
-                cdn_url = f"{_default_cdn_host}/{pkg_name}@{pkg_version}/{pkg_main}"
+                cdn_url = _default_cdn_host / f"{pkg_name}@{pkg_version}" / f"{pkg_main}"
             else:
                 pkg_main = dist_dir / f"{name}.js"
             artifact_path = base_dir / pkg_main
@@ -321,7 +336,7 @@ def _bundle_extensions(objs: set[Model] | None, resources: Resources) -> list[Ex
                 raise ValueError(f"can't resolve artifact path for '{name}' extension")
 
         extension_dirs[name] = Path(artifacts_dir)
-        server_url = f"{server_prefix}/{server_path}"
+        server_url = server_prefix / server_path
         embed = ExtensionEmbed(artifact_path, server_url, cdn_url)
         bundles.append(embed)
 

--- a/src/bokeh/ext.py
+++ b/src/bokeh/ext.py
@@ -19,7 +19,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import os
-from os.path import join
 from subprocess import Popen
 
 # Bokeh imports
@@ -96,9 +95,9 @@ def _run_command(command: str, base_dir: PathLike, args: list[str], debug: bool 
     bokehjs_dir = settings.bokehjsdir()
 
     if debug:
-        compiler_script = join(bokehjs_dir, "js", "compiler", "main.js")
+        compiler_script = bokehjs_dir / "js" / "compiler" / "main.js"
     else:
-        compiler_script = join(bokehjs_dir, "js", "compiler.js")
+        compiler_script = bokehjs_dir / "js" / "compiler.js"
 
     cmd = [
         "--no-deprecation",

--- a/src/bokeh/ext.py
+++ b/src/bokeh/ext.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import os
+from os import fspath
 from subprocess import Popen
 
 # Bokeh imports
@@ -101,10 +101,10 @@ def _run_command(command: str, base_dir: PathLike, args: list[str], debug: bool 
 
     cmd = [
         "--no-deprecation",
-        compiler_script,
+        fspath(compiler_script),
         command,
-        "--base-dir", os.fspath(base_dir),
-        "--bokehjs-dir", bokehjs_dir,
+        "--base-dir", fspath(base_dir),
+        "--bokehjs-dir", fspath(bokehjs_dir),
         "--bokeh-version", __version__,
     ]
 

--- a/src/bokeh/ext.py
+++ b/src/bokeh/ext.py
@@ -92,7 +92,7 @@ def build(base_dir: PathLike, *, rebuild: bool = False, debug: bool = False) -> 
 #-----------------------------------------------------------------------------
 
 def _run_command(command: str, base_dir: PathLike, args: list[str], debug: bool = False) -> Popen[bytes]:
-    bokehjs_dir = settings.bokehjsdir()
+    bokehjs_dir = settings.bokehjs_path()
 
     if debug:
         compiler_script = bokehjs_dir / "js" / "compiler" / "main.js"

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -60,7 +60,7 @@ from .core.types import ID, PathLike
 from .model import Model
 from .settings import LogLevel, settings
 from .util.dataclasses import dataclass, field
-from .util.paths import ROOT_DIR, bokehjsdir
+from .util.paths import ROOT_DIR
 from .util.token import generate_session_id
 from .util.version import is_full_release
 
@@ -190,7 +190,7 @@ def verify_sri_hashes() -> None:
         raise ValueError("verify_sri_hashes() can only be used with full releases")
 
     from glob import glob
-    paths = [ Path(p) for p in glob(bokehjsdir() / "js" / "bokeh*.js") ]
+    paths = [ Path(p) for p in glob(settings.bokehjsdir() / "js" / "bokeh*.js") ]
 
     hashes = get_sri_hashes_for_version(__version__)
 
@@ -364,7 +364,7 @@ class Resources:
             server = self._server_urls()
             self.messages.extend(server.messages)
 
-        self.base_dir = Path(base_dir) if base_dir is not None else bokehjsdir(self.dev)
+        self.base_dir = Path(base_dir) if base_dir is not None else settings.bokehjsdir()
 
     def clone(self, *, components: list[Component] | None = None) -> Resources:
         """ Make a clone of a resources instance allowing to override its components. """

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -188,7 +188,7 @@ def verify_sri_hashes() -> None:
     if not is_full_release():
         raise ValueError("verify_sri_hashes() can only be used with full releases")
 
-    paths = list((settings.bokehjsdir() / "js").glob("bokeh*.js"))
+    paths = list((settings.bokehjs_path() / "js").glob("bokeh*.js"))
     hashes = get_sri_hashes_for_version(__version__)
 
     if len(hashes) < len(paths):
@@ -361,7 +361,7 @@ class Resources:
             server = self._server_urls()
             self.messages.extend(server.messages)
 
-        self.base_dir = Path(base_dir) if base_dir is not None else settings.bokehjsdir()
+        self.base_dir = Path(base_dir) if base_dir is not None else settings.bokehjs_path()
 
     def clone(self, *, components: list[Component] | None = None) -> Resources:
         """ Make a clone of a resources instance allowing to override its components. """

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -341,7 +341,7 @@ class Resources:
         del root_dir
         self.version = settings.cdn_version(version)
         del version
-        self.minified = settings.minified(minified)
+        self.minified = settings.minified(minified if minified is not None else not self.dev)
         del minified
         self.log_level = settings.log_level(log_level)
         del log_level

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -38,7 +38,6 @@ log = logging.getLogger(__name__)
 import json
 import os
 import re
-from glob import glob
 from os.path import relpath
 from pathlib import Path
 from typing import (
@@ -189,9 +188,7 @@ def verify_sri_hashes() -> None:
     if not is_full_release():
         raise ValueError("verify_sri_hashes() can only be used with full releases")
 
-    from glob import glob
-    paths = [ Path(p) for p in glob(settings.bokehjsdir() / "js" / "bokeh*.js") ]
-
+    paths = list((settings.bokehjsdir() / "js").glob("bokeh*.js"))
     hashes = get_sri_hashes_for_version(__version__)
 
     if len(hashes) < len(paths):

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -36,8 +36,10 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import json
+import os
 import re
 from glob import glob
+from os.path import relpath
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -284,7 +286,7 @@ class Resources:
 
     """
 
-    _default_root_dir = Path(".").resolve()
+    _default_root_dir = Path(os.curdir)
     _default_root_url = DEFAULT_SERVER_HTTP_URL
 
     mode: BaseMode
@@ -460,7 +462,7 @@ class Resources:
             raw = [self._inline(path) for path in paths]
         elif self.mode == "relative":
             root_dir = self.root_dir or self._default_root_dir
-            files = [str(path.relative_to(root_dir)) for path in paths]
+            files = [str(relpath(path, root_dir)) for path in paths]
         elif self.mode == "absolute":
             files = list(map(str, paths))
         elif self.mode == "cdn":

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -422,7 +422,7 @@ class Resources:
         return [comp for comp in self.components if comp in self._component_defs[kind]]
 
     def _file_paths(self, kind: Kind) -> list[Path]:
-        minified = ".min" if not self.dev and self.minified else ""
+        minified = ".min" if self.minified else ""
 
         files = [f"{component}{minified}.{kind}" for component in self.components_for(kind)]
         paths = [self.base_dir / kind / file for file in files]
@@ -449,7 +449,7 @@ class Resources:
         return _get_cdn_urls(self.version, self.minified)
 
     def _server_urls(self) -> Urls:
-        return _get_server_urls(self.root_url, False if self.dev else self.minified, self.path_versioner)
+        return _get_server_urls(self.root_url, self.minified, self.path_versioner)
 
     def _resolve(self, kind: Kind) -> tuple[list[str], list[str], Hashes]:
         paths = self._file_paths(kind)

--- a/src/bokeh/server/views/static_handler.py
+++ b/src/bokeh/server/views/static_handler.py
@@ -48,7 +48,7 @@ class StaticHandler(StaticFileHandler):
 
     '''
     def __init__(self, tornado_app, *args, **kw) -> None:
-        kw['path'] = settings.bokehjsdir()
+        kw['path'] = settings.bokehjs_path()
 
         # Note: tornado_app is stored as self.application
         super().__init__(tornado_app, *args, **kw)
@@ -69,7 +69,7 @@ class StaticHandler(StaticFileHandler):
         if settings.dev:
             return path
         else:
-            version = StaticFileHandler.get_version(dict(static_path=settings.bokehjsdir()), path)
+            version = StaticFileHandler.get_version(dict(static_path=settings.bokehjs_path()), path)
             return f"{path}?v={version}"
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -690,7 +690,7 @@ class Settings:
 
     """)
 
-    resources: PrioritizedSetting[ResourcesMode] = PrioritizedSetting("resources", "BOKEH_RESOURCES", default="cdn", dev_default="absolute-dev", help="""
+    resources: PrioritizedSetting[ResourcesMode] = PrioritizedSetting("resources", "BOKEH_RESOURCES", default="cdn", dev_default="server", help="""
     What kind of BokehJS resources to configure, e.g ``inline`` or ``cdn``
 
     See the :class:`~bokeh.resources.Resources` class reference for full details.

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -119,6 +119,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import os
 from os.path import abspath, expanduser, join
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -763,7 +764,7 @@ class Settings:
 
     # Non-settings methods
 
-    def bokehjsdir(self) -> str:
+    def bokehjsdir(self) -> Path:
         ''' The location of the BokehJS source tree.
 
         '''

--- a/src/bokeh/util/compiler.py
+++ b/src/bokeh/util/compiler.py
@@ -106,7 +106,7 @@ def npmjs_version() -> str | None:
 
 def nodejs_compile(code: str, lang: str = "javascript", file: str | None = None) -> AttrDict:
     compilejs_script = join(bokehjs_dir, "js", "compiler.js")
-    output = _run_nodejs([compilejs_script], dict(code=code, lang=lang, file=file, bokehjs_dir=bokehjs_dir))
+    output = _run_nodejs([compilejs_script], dict(code=code, lang=lang, file=file, bokehjs_dir=os.fspath(bokehjs_dir)))
     lines = output.split("\n")
     for i, line in enumerate(lines):
         if not line.startswith("LOG"):
@@ -384,7 +384,7 @@ _export_template = \
 _module_template = \
 """"%(module)s": function(require, module, exports) {\n%(source)s\n}"""
 
-def _detect_nodejs() -> str:
+def _detect_nodejs() -> Path:
     nodejs_path = settings.nodejs_path()
     nodejs_paths = [nodejs_path] if nodejs_path is not None else ["nodejs", "node"]
 
@@ -404,34 +404,33 @@ def _detect_nodejs() -> str:
             version = tuple(int(v) for v in match.groups())
 
             if version >= nodejs_min_version:
-                return nodejs_path
+                return Path(nodejs_path)
 
     # if we've reached here, no valid version was found
     version_repr = ".".join(str(x) for x in nodejs_min_version)
     raise RuntimeError(f'node.js v{version_repr} or higher is needed to allow compilation of custom models ' +
                        '("conda install nodejs" or follow https://nodejs.org/en/download/)')
 
-_nodejs = None
-_npmjs = None
+_nodejs: Path | None = None
+_npmjs: Path | None = None
 
-def _nodejs_path() -> str:
+def _nodejs_path() -> Path:
     global _nodejs
     if _nodejs is None:
         _nodejs = _detect_nodejs()
     return _nodejs
 
-def _npmjs_path() -> str:
+def _npmjs_path() -> Path:
     global _npmjs
     if _npmjs is None:
-        _npmjs = join(dirname(_nodejs_path()), "npm")
-        if sys.platform == "win32":
-            _npmjs += '.cmd'
+        executable = "npm.cmd" if sys.platform == "win32" else "npm"
+        _npmjs = _nodejs_path().parent / executable
     return _npmjs
 
 def _crlf_cr_2_lf(s: str) -> str:
     return re.sub(r"\\r\\n|\\r|\\n", r"\\n", s)
 
-def _run(app: str, argv: list[str], input: dict[str, Any] | None = None) -> str:
+def _run(app: Path, argv: list[str], input: dict[str, Any] | None = None) -> str:
     proc = Popen([app, *argv], stdout=PIPE, stderr=PIPE, stdin=PIPE)
     (stdout, errout) = proc.communicate(input=None if input is None else json.dumps(input).encode())
 

--- a/src/bokeh/util/compiler.py
+++ b/src/bokeh/util/compiler.py
@@ -95,7 +95,7 @@ class CompilationError(RuntimeError):
     def __str__(self) -> str:
         return "\n" + self.text.strip()
 
-bokehjs_dir = settings.bokehjsdir()
+bokehjs_dir = settings.bokehjs_path()
 nodejs_min_version = (18, 0, 0)
 
 def nodejs_version() -> str | None:

--- a/src/bokeh/util/paths.py
+++ b/src/bokeh/util/paths.py
@@ -18,52 +18,49 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import sys
-from os.path import (
-    abspath,
-    dirname,
-    isdir,
-    join,
-    normpath,
-    realpath,
-)
+from pathlib import Path
 
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
 
 # Root dir of Bokeh package
-ROOT_DIR = dirname(dirname(abspath(__file__)))
+ROOT_DIR = Path(__file__).absolute().resolve().parent.parent
 
 __all__ = (
-    'serverdir',
-    'bokehjsdir',
+    "serverdir",
+    "bokehjsdir",
 )
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-def serverdir() -> str:
-    """ Get the location of the server subpackage
+def serverdir() -> Path:
     """
-    path = join(ROOT_DIR, 'server')
-    path = normpath(path)
-    if sys.platform == 'cygwin': path = realpath(path)
-    return path
-
-
-def bokehjsdir(dev: bool = False) -> str:
-    """ Get the location of the bokehjs source files. If dev is True,
-    the files in bokehjs/build are preferred. Otherwise uses the files
-    in bokeh/server/static.
+    Get the location of the server subpackage.
     """
-    dir1 = join(ROOT_DIR, '..', 'bokehjs', 'build')
-    dir2 = join(serverdir(), 'static')
-    if dev and isdir(dir1):
-        return dir1
+    return ROOT_DIR / "server"
+
+def staticdir() -> Path:
+    """
+    Get the location of server's static directory.
+    """
+    return serverdir() / "static"
+
+def bokehjsdir(dev: bool = False) -> Path:
+    """
+    Get the location of the bokehjs source files.
+
+    If ``dev`` is ``True``, the files in ``bokehjs/build`` are preferred.
+    Otherwise uses the files in ``bokeh/server/static``.
+    """
+    if dev:
+        js_dir = ROOT_DIR.parent.parent / "bokehjs" / "build"
+        assert js_dir.is_dir(), f"{js_dir} doesn't exist"
+        return js_dir
     else:
-        return dir2
+        return staticdir()
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/util/paths.py
+++ b/src/bokeh/util/paths.py
@@ -57,7 +57,8 @@ def bokehjsdir(dev: bool = False) -> Path:
     """
     if dev:
         js_dir = ROOT_DIR.parent.parent / "bokehjs" / "build"
-        assert js_dir.is_dir(), f"{js_dir} doesn't exist"
+        if not js_dir.is_dir():
+            raise RuntimeError(f"bokehjs' build directory '{js_dir}' doesn't exist; required by 'settings.dev'")
         return js_dir
     else:
         return staticdir()

--- a/src/bokeh/util/paths.py
+++ b/src/bokeh/util/paths.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from pathlib import Path
 
+# Bokeh imports
+from .deprecation import deprecated
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -28,34 +31,40 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).absolute().resolve().parent.parent
 
 __all__ = (
-    "serverdir",
+    "bokehjs_path",
     "bokehjsdir",
+    "server_path",
+    "serverdir",
+    "static_path",
 )
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-def serverdir() -> Path:
-    """
-    Get the location of the server subpackage.
+def server_path() -> Path:
+    """ Get the location of the server subpackage.
+
     """
     return ROOT_DIR / "server"
 
-def staticdir() -> Path:
-    """
-    Get the location of server's static directory.
-    """
-    return serverdir() / "static"
+def static_path() -> Path:
+    """ Get the location of server's static directory.
 
-def bokehjsdir(dev: bool = False) -> Path:
     """
-    Get the location of the bokehjs source files.
+    return server_path() / "static"
+
+def bokehjs_path(dev: bool = False) -> Path:
+    """ Get the location of the bokehjs source files.
 
     By default the files in ``bokeh/server/static`` are used.  If ``dev``
     is ``True``, then the files in ``bokehjs/build`` preferred. However,
     if not available, then a warning is issued and the former files are
     used as a fallback.
+
+    .. note:
+        This is a low-level API. Prefer using ``settings.bokehjs_path()``
+        instead of this function.
     """
     if dev:
         js_dir = ROOT_DIR.parent.parent / "bokehjs" / "build"
@@ -64,7 +73,38 @@ def bokehjsdir(dev: bool = False) -> Path:
         else:
             log.warning(f"bokehjs' build directory '{js_dir}' doesn't exist; required by 'settings.dev'")
 
-    return staticdir()
+    return static_path()
+
+#-----------------------------------------------------------------------------
+# Legacy API
+#-----------------------------------------------------------------------------
+
+def serverdir() -> str:
+    """ Get the location of the server subpackage.
+
+    .. deprecated:: 3.4.0
+        Use ``server_path()`` instead.
+    """
+    deprecated((3, 4, 0), "serverdir()", "server_path()")
+    return str(server_path())
+
+def bokehjsdir(dev: bool = False) -> str:
+    """ Get the location of the bokehjs source files.
+
+    By default the files in ``bokeh/server/static`` are used.  If ``dev``
+    is ``True``, then the files in ``bokehjs/build`` preferred. However,
+    if not available, then a warning is issued and the former files are
+    used as a fallback.
+
+    .. note:
+        This is a low-level API. Prefer using ``settings.bokehjsdir()``
+        instead of this function.
+
+    .. deprecated:: 3.4.0
+        Use ``bokehjs_path()`` instead.
+    """
+    deprecated((3, 4, 0), "bokehjsdir()", "bokehjs_path()")
+    return str(bokehjs_path(dev))
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/util/paths.py
+++ b/src/bokeh/util/paths.py
@@ -52,16 +52,19 @@ def bokehjsdir(dev: bool = False) -> Path:
     """
     Get the location of the bokehjs source files.
 
-    If ``dev`` is ``True``, the files in ``bokehjs/build`` are preferred.
-    Otherwise uses the files in ``bokeh/server/static``.
+    By default the files in ``bokeh/server/static`` are used.  If ``dev``
+    is ``True``, then the files in ``bokehjs/build`` preferred. However,
+    if not available, then a warning is issued and the former files are
+    used as a fallback.
     """
     if dev:
         js_dir = ROOT_DIR.parent.parent / "bokehjs" / "build"
-        if not js_dir.is_dir():
-            raise RuntimeError(f"bokehjs' build directory '{js_dir}' doesn't exist; required by 'settings.dev'")
-        return js_dir
-    else:
-        return staticdir()
+        if js_dir.is_dir():
+            return js_dir
+        else:
+            log.warning(f"bokehjs' build directory '{js_dir}' doesn't exist; required by 'settings.dev'")
+
+    return staticdir()
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -275,7 +275,6 @@ with open(filename, 'rb') as example:
     env = os.environ.copy()
     env['BOKEH_IGNORE_FILENAME'] = 'true'
     env['BOKEH_RESOURCES'] = 'server-dev'
-    env['BOKEH_MINIFIED'] = 'false'
     env['BOKEH_BROWSER'] = 'none'
 
     class Timeout(Exception):
@@ -292,7 +291,6 @@ with open(filename, 'rb') as example:
     with subprocess.Popen(
         cmd, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     ) as proc:
-
         status: ProcStatus
         try:
             status = proc.wait()

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -22,7 +22,7 @@ from os.path import dirname, join
 # Bokeh imports
 from bokeh.core.has_props import _default_resolver
 from bokeh.document import Document
-from bokeh.embed.bundle import extension_dirs
+from bokeh.embed.bundle import URL, extension_dirs
 from bokeh.ext import build
 from bokeh.models import Plot
 from bokeh.resources import CDN, INLINE, Resources
@@ -107,10 +107,10 @@ class Test_bundle_for_objs_and_resources:
 
     def test_no_objs_all_resources_bundled(self) -> None:
         b = beb.bundle_for_objs_and_resources(None, ABSOLUTE)
-        assert any('bokeh-widgets' in f for f in b.js_files)
-        assert any('bokeh-gl' in f for f in b.js_files)
-        assert any('bokeh-tables' in f for f in b.js_files)
-        assert any('bokeh-mathjax' in f for f in b.js_files)
+        assert any('bokeh-widgets' in f.url for f in b.js_files)
+        assert any('bokeh-gl' in f.url for f in b.js_files)
+        assert any('bokeh-tables' in f.url for f in b.js_files)
+        assert any('bokeh-mathjax' in f.url for f in b.js_files)
 
 class Test_bundle_custom_extensions:
 
@@ -139,7 +139,7 @@ class Test_bundle_custom_extensions:
         plot.add_layout(LatexLabel(x=0, y=0))
         bundle = beb.bundle_for_objs_and_resources([plot], CDN)
         assert len(bundle.js_files) == 2
-        assert bundle.js_files[1] == "https://unpkg.com/latex_label@0.0.1/dist/latex_label.js"
+        assert bundle.js_files[1] == URL("https://unpkg.com/latex_label@0.0.1/dist/latex_label.js")
 
     def test_with_Server_resources(self) -> None:
         from latex_label import LatexLabel
@@ -149,7 +149,7 @@ class Test_bundle_custom_extensions:
         version_hash = "6b13789e43e5485634533de16a65d8ba9d34c4c9758588b665805435f80eb115"
         assert len(bundle.js_files) == 2
         assert (bundle.js_files[1] ==
-                f"http://localhost:5006/static/extensions/latex_label/latex_label.js?v={version_hash}")
+                URL(f"http://localhost:5006/static/extensions/latex_label/latex_label.js?v={version_hash}"))
 
     def test_with_Server_resources_dev(self) -> None:
         from latex_label import LatexLabel
@@ -158,7 +158,7 @@ class Test_bundle_custom_extensions:
         with envset(BOKEH_DEV="true"):
             bundle = beb.bundle_for_objs_and_resources([plot], SERVER)
         assert len(bundle.js_files) == 2
-        assert bundle.js_files[1] == "http://localhost:5006/static/extensions/latex_label/latex_label.js"
+        assert bundle.js_files[1] == URL("http://localhost:5006/static/extensions/latex_label/latex_label.js")
 
 class Test_bundle_ext_package_no_main:
 

--- a/tests/unit/bokeh/embed/test_bundle.py
+++ b/tests/unit/bokeh/embed/test_bundle.py
@@ -155,7 +155,7 @@ class Test_bundle_custom_extensions:
         from latex_label import LatexLabel
         plot = Plot()
         plot.add_layout(LatexLabel(x=0, y=0))
-        with envset(BOKEH_RESOURCES="server", BOKEH_DEV="true"):
+        with envset(BOKEH_DEV="true"):
             bundle = beb.bundle_for_objs_and_resources([plot], SERVER)
         assert len(bundle.js_files) == 2
         assert bundle.js_files[1] == "http://localhost:5006/static/extensions/latex_label/latex_label.js"

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -135,7 +135,7 @@ def test_dev_resources(ManagedServerLoop: MSL) -> None:
         application = Application()
         with ManagedServerLoop(application) as server:
             r = server._tornado.resources()
-            assert r.mode == "absolute"
+            assert r.mode == "server"
             assert r.dev
 
 def test_index(ManagedServerLoop: MSL) -> None:

--- a/tests/unit/bokeh/server/views/test_multi_root_static_handler.py
+++ b/tests/unit/bokeh/server/views/test_multi_root_static_handler.py
@@ -25,7 +25,7 @@ from tornado.httputil import HTTPConnection, HTTPServerRequest
 
 # Bokeh imports
 from bokeh.application import Application
-from bokeh.util.paths import serverdir
+from bokeh.util.paths import server_path
 from tests.support.plugins.managed_server_loop import MSL
 
 # Module under test
@@ -42,7 +42,7 @@ import bokeh.server.views.multi_root_static_handler as bsvm # isort:skip
 def test_multi_root_static_handler(ManagedServerLoop: MSL) -> None:
     application = Application()
 
-    static_path = Path(serverdir()) / "static" # TODO: PR #13042
+    static_path = server_path() / "static"
     js_path = static_path / "js"
     lib_path = static_path / "lib"
 


### PR DESCRIPTION
This PR allows `BOKEH_DEV=true` to imply `BOKEH_RESOURCES=server`, simplifying the setup for the default development approach. Thus `BOKEH_DEV=true python an_example.py` is now sufficient to run bokeh in "full" development mode. Additionally this PR proliferates `pathlib` a bit more across the codebase.  

- [x] fixes #13421
- [x] fixes #11794
- [x] fixes #3529