### PR TITLE
Allow to zoom secondary ranges/scales independently

### DIFF
--- a/bokehjs/src/lib/core/util/bbox.ts
+++ b/bokehjs/src/lib/core/util/bbox.ts
@@ -267,10 +267,10 @@ export class BBox implements Rect, Equatable {
   get x_range(): Interval { return {start: this.x0, end: this.x1} }
   get y_range(): Interval { return {start: this.y0, end: this.y1} }
 
-  get h_range(): Interval { return {start: this.x0, end: this.x1} }
-  get v_range(): Interval { return {start: this.y0, end: this.y1} }
+  get h_range(): Interval { return this.x_range }
+  get v_range(): Interval { return this.y_range }
 
-  get ranges(): [Interval, Interval] { return [this.h_range, this.v_range] }
+  get ranges(): [Interval, Interval] { return [this.x_range, this.y_range] }
 
   get aspect(): number { return this.width/this.height }
 

--- a/bokehjs/src/lib/core/util/zoom.ts
+++ b/bokehjs/src/lib/core/util/zoom.ts
@@ -1,20 +1,26 @@
 import type {Interval} from "../types"
-
-import type {CartesianFrame} from "models/canvas/cartesian_frame"
 import type {Scale} from "models/scales/scale"
 
-// Module for zoom-related functions
+type Bounds = [number, number]
+type Scales = Map<string, Scale>
+type Intervals = Map<string, Interval>
 
-export function scale_highlow(range: Interval, factor: number, center?: number): [number, number] {
+export type ScaleRanges = {
+  xrs: Intervals
+  yrs: Intervals
+  factor: number
+}
+
+export function scale_highlow(range: Interval, factor: number, center?: number | null): Bounds {
   const [low, high] = [range.start, range.end]
-  const x = center != null ? center : (high + low) / 2.0
+  const x = center ?? (high + low) / 2.0
   const x0 = low - (low - x) * factor
   const x1 = high - (high - x) * factor
   return [x0, x1]
 }
 
-export function get_info(scales: Map<string, Scale>, [sxy0, sxy1]: [number, number]): Map<string, Interval> {
-  const info: Map<string, Interval> = new Map()
+export function get_info(scales: Scales, [sxy0, sxy1]: Bounds): Intervals {
+  const info: Intervals = new Map()
   for (const [name, scale] of scales) {
     const [start, end] = scale.r_invert(sxy0, sxy1)
     info.set(name, {start, end})
@@ -22,39 +28,19 @@ export function get_info(scales: Map<string, Scale>, [sxy0, sxy1]: [number, numb
   return info
 }
 
-export type ScaleRange = {
-  xrs: Map<string, Interval>
-  yrs: Map<string, Interval>
-  factor: number
-}
-
-export function scale_range(frame: CartesianFrame, factor: number,
-    h_axis: boolean = true, v_axis: boolean = true, center?: {x: number, y: number}): ScaleRange {
+export function scale_range(x_scales: Scales, y_scales: Scales, x_range: Interval, y_range: Interval, factor: number,
+    x_axis: boolean = true, y_axis: boolean = true, center?: {x?: number | null, y?: number | null} | null): ScaleRanges {
   /*
    * Utility function for zoom tools to calculate/create the zoom_info object
-   * of the form required by ``PlotView.update_range``
-   *
-   * Parameters:
-   *   frame : CartesianFrame
-   *   factor : Number
-   *   h_axis : Boolean, optional
-   *     whether to zoom the horizontal axis (default = true)
-   *   v_axis : Boolean, optional
-   *     whether to zoom the horizontal axis (default = true)
-   *   center : object, optional
-   *     of form {'x': Number, 'y', Number}
-   *
-   * Returns:
-   *   ScaleRange
+   * of the form required by `PlotView.update_range`.
    */
+  const x_factor = x_axis ? factor : 0
+  const [sx0, sx1] = scale_highlow(x_range, x_factor, center?.x)
+  const xrs = get_info(x_scales, [sx0, sx1])
 
-  const hfactor = h_axis ? factor : 0
-  const [sx0, sx1] = scale_highlow(frame.bbox.h_range, hfactor, center != null ? center.x : undefined)
-  const xrs = get_info(frame.x_scales, [sx0, sx1])
-
-  const vfactor = v_axis ? factor : 0
-  const [sy0, sy1] = scale_highlow(frame.bbox.v_range, vfactor, center != null ? center.y : undefined)
-  const yrs = get_info(frame.y_scales, [sy0, sy1])
+  const y_factor = y_axis ? factor : 0
+  const [sy0, sy1] = scale_highlow(y_range, y_factor, center?.y)
+  const yrs = get_info(y_scales, [sy0, sy1])
 
   // OK this sucks we can't set factor independently in each direction. It is used
   // for GMap plots, and GMap plots always preserve aspect, so effective the value

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -27,6 +27,7 @@ import type {IterViews} from "core/build_views"
 import {build_view} from "core/build_views"
 import {unreachable} from "core/util/assert"
 import {isString} from "core/util/types"
+import type {BBox} from "core/util/bbox"
 import {parse_delimited_string} from "models/text/utils"
 
 const {abs} = Math
@@ -51,6 +52,10 @@ export class AxisView extends GuideRendererView {
 
   panel: Panel
   layout: Layoutable
+
+  get bbox(): BBox {
+    return this.layout.bbox
+  }
 
   /*private*/ _axis_label_view: BaseTextView | null = null
   /*private*/ _major_label_views: Map<string | number, BaseTextView> = new Map()

--- a/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/gmap_plot_canvas.ts
@@ -100,7 +100,7 @@ export class GMapPlotView extends PlotView {
     if (range_info == null) {
       this.map.setCenter({lat: this.initial_lat, lng: this.initial_lng})
       this.map.setOptions({zoom: this.initial_zoom})
-      super.update_range(null, options)
+      super.reset_range()
 
     // PAN ----------------------------
     } else if (range_info.sdx != null || range_info.sdy != null) {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -555,14 +555,16 @@ export class PlotView extends LayoutDOMView implements Renderable {
     return views
   }
 
-  update_range(range_info: RangeInfo | null, options?: RangeOptions): void {
+  update_range(range_info: RangeInfo, options?: RangeOptions): void {
     this.pause()
     this._range_manager.update(range_info, options)
     this.unpause()
   }
 
   reset_range(): void {
-    this.update_range(null)
+    this.pause()
+    this._range_manager.reset()
+    this.unpause()
     this.trigger_ranges_update_event()
   }
 

--- a/bokehjs/src/lib/models/plots/range_manager.ts
+++ b/bokehjs/src/lib/models/plots/range_manager.ts
@@ -27,33 +27,30 @@ export class RangeManager {
 
   invalidate_dataranges: boolean = true
 
-  update(range_info: RangeInfo | null, options: RangeOptions = {}): void {
+  update(range_info: RangeInfo, options: RangeOptions = {}): void {
     const {x_ranges, y_ranges} = this.frame
-    if (range_info == null) {
-      for (const [, range] of x_ranges) {
-        range.reset()
-      }
-      for (const [, range] of y_ranges) {
-        range.reset()
-      }
-      this.update_dataranges()
-    } else {
-      const range_info_iter: [Range, Interval][] = []
-      for (const [name, range] of x_ranges) {
-        range_info_iter.push([range, range_info.xrs.get(name)!])
-      }
-      for (const [name, range] of y_ranges) {
-        range_info_iter.push([range, range_info.yrs.get(name)!])
-      }
-      if (options.scrolling ?? false) {
-        this._update_ranges_together(range_info_iter)   // apply interval bounds while keeping aspect
-      }
-      this._update_ranges_individually(range_info_iter, options)
+    const range_info_iter: [Range, Interval][] = []
+    for (const [name, interval] of range_info.xrs) {
+      range_info_iter.push([x_ranges.get(name)!, interval])
     }
+    for (const [name, interval] of range_info.yrs) {
+      range_info_iter.push([y_ranges.get(name)!, interval])
+    }
+    if (options.scrolling ?? false) {
+      this._update_ranges_together(range_info_iter)   // apply interval bounds while keeping aspect
+    }
+    this._update_ranges_individually(range_info_iter, options)
   }
 
   reset(): void {
-    this.update(null)
+    const {x_ranges, y_ranges} = this.frame
+    for (const range of x_ranges.values()) {
+      range.reset()
+    }
+    for (const range of y_ranges.values()) {
+      range.reset()
+    }
+    this.update_dataranges()
   }
 
   protected _update_dataranges(frame: CartesianFrame | CoordinateMapping): void {

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -4,6 +4,7 @@ import {RenderLevel} from "core/enums"
 import type * as p from "core/properties"
 import {Model} from "../../model"
 import type {CanvasLayer} from "core/util/canvas"
+import {assert} from "core/util/assert"
 import type {Plot, PlotView} from "../plots/plot"
 import type {CanvasView} from "../canvas/canvas"
 import {CoordinateTransform, CoordinateMapping} from "../coordinates/coordinate_mapping"
@@ -73,8 +74,10 @@ export abstract class RendererView extends View implements visuals.Renderable {
       return coordinates.get_transform(frame)
     } else {
       const {x_range_name, y_range_name} = this.model
-      const x_scale = frame.x_scales.get(x_range_name)!
-      const y_scale = frame.y_scales.get(y_range_name)!
+      const x_scale = frame.x_scales.get(x_range_name)
+      const y_scale = frame.y_scales.get(y_range_name)
+      assert(x_scale != null, `missing '${x_range_name}' range`)
+      assert(y_scale != null, `missing '${y_range_name}' range`)
       return new CoordinateTransform(x_scale, y_scale)
     }
   }

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -1,4 +1,5 @@
 import {PlotActionTool, PlotActionToolView} from "./plot_action_tool"
+import {DataRenderer} from "../../renderers/data_renderer"
 import {Dimensions} from "core/enums"
 import {scale_range} from "core/util/zoom"
 import type * as p from "core/properties"
@@ -16,7 +17,29 @@ export abstract class ZoomBaseToolView extends PlotActionToolView {
 
     const {frame} = this.plot_view
     const {x_range, y_range} = frame.bbox
-    const {x_scales, y_scales} = frame
+
+    const x_scales = new Map(frame.x_scales)
+    const y_scales = new Map(frame.y_scales)
+
+    const {renderers} = this.model
+    if (renderers != "auto") {
+      const x_range_names = new Set<string>()
+      const y_range_names = new Set<string>()
+
+      for (const renderer of renderers) {
+        x_range_names.add(renderer.x_range_name)
+        y_range_names.add(renderer.y_range_name)
+      }
+
+      for (const name of x_scales.keys()) {
+        if (!x_range_names.has(name))
+          x_scales.delete(name)
+      }
+      for (const name of y_scales.keys()) {
+        if (!y_range_names.has(name))
+          y_scales.delete(name)
+      }
+    }
 
     const zoom_info = scale_range(x_scales, y_scales, x_range, y_range, this.factor, x_axis, y_axis)
 
@@ -35,6 +58,7 @@ export namespace ZoomBaseTool {
   export type Props = PlotActionTool.Props & {
     factor: p.Property<number>
     dimensions: p.Property<Dimensions>
+    renderers: p.Property<DataRenderer[] | "auto">
   }
 }
 
@@ -49,9 +73,10 @@ export abstract class ZoomBaseTool extends PlotActionTool {
   }
 
   static {
-    this.define<ZoomBaseTool.Props>(({Percent}) => ({
+    this.define<ZoomBaseTool.Props>(({Percent, Or, Array, Ref, Auto}) => ({
       factor:     [ Percent,    0.1    ],
       dimensions: [ Dimensions, "both" ],
+      renderers:  [ Or(Array(Ref(DataRenderer)), Auto), "auto" ],
     }))
   }
 

--- a/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_base_tool.ts
@@ -6,17 +6,19 @@ import type * as p from "core/properties"
 export abstract class ZoomBaseToolView extends PlotActionToolView {
   declare model: ZoomBaseTool
 
+  abstract get factor(): number
+
   doit(): void {
-    const frame = this.plot_view.frame
-    const dims = this.model.dimensions
-
     // restrict to axis configured in tool's dimensions property
-    const h_axis = dims == "width"  || dims == "both"
-    const v_axis = dims == "height" || dims == "both"
+    const {dimensions} = this.model
+    const x_axis = dimensions == "width"  || dimensions == "both"
+    const y_axis = dimensions == "height" || dimensions == "both"
 
-    const factor = this.model.get_factor()
+    const {frame} = this.plot_view
+    const {x_range, y_range} = frame.bbox
+    const {x_scales, y_scales} = frame
 
-    const zoom_info = scale_range(frame, factor, h_axis, v_axis)
+    const zoom_info = scale_range(x_scales, y_scales, x_range, y_range, this.factor, x_axis, y_axis)
 
     this.plot_view.state.push("zoom_out", {range: zoom_info})
     this.plot_view.update_range(zoom_info, {scrolling: true, maintain_focus: this.model.maintain_focus})
@@ -58,6 +60,4 @@ export abstract class ZoomBaseTool extends PlotActionTool {
   }
 
   abstract readonly maintain_focus: boolean
-
-  abstract get_factor(): number
 }

--- a/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_in_tool.ts
@@ -3,6 +3,10 @@ import {tool_icon_zoom_in} from "styles/icons.css"
 
 export class ZoomInToolView extends ZoomBaseToolView {
   declare model: ZoomBaseTool
+
+  get factor(): number {
+    return this.model.factor
+  }
 }
 
 export interface ZoomInTool extends ZoomBaseTool.Attrs {}
@@ -23,10 +27,6 @@ export class ZoomInTool extends ZoomBaseTool {
     this.register_alias("zoom_in", () => new ZoomInTool({dimensions: "both"}))
     this.register_alias("xzoom_in", () => new ZoomInTool({dimensions: "width"}))
     this.register_alias("yzoom_in", () => new ZoomInTool({dimensions: "height"}))
-  }
-
-  get_factor(): number {
-    return this.factor
   }
 
   override tool_name = "Zoom In"

--- a/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/zoom_out_tool.ts
@@ -4,6 +4,11 @@ import type * as p from "core/properties"
 
 export class ZoomOutToolView extends ZoomBaseToolView {
   declare model: ZoomBaseTool
+
+  get factor(): number {
+    const {factor} = this.model
+    return -factor / (1 - factor)
+  }
 }
 
 export namespace ZoomOutTool {
@@ -36,10 +41,6 @@ export class ZoomOutTool extends ZoomBaseTool {
     this.register_alias("zoom_out", () => new ZoomOutTool({dimensions: "both"}))
     this.register_alias("xzoom_out", () => new ZoomOutTool({dimensions: "width"}))
     this.register_alias("yzoom_out", () => new ZoomOutTool({dimensions: "height"}))
-  }
-
-  get_factor(): number {
-    return -this.factor / (1 - this.factor)
   }
 
   override tool_name = "Zoom Out"

--- a/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
@@ -7,6 +7,9 @@ import {WheelZoomTool} from "@bokehjs/models/tools/gestures/wheel_zoom_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import type {PlotView} from "@bokehjs/models/plots/plot"
 import {Plot} from "@bokehjs/models/plots/plot"
+//import {LinearAxis} from "@bokehjs/models/axes/linear_axis"
+
+const modifiers = {ctrl: false, shift: false, alt: false}
 
 describe("WheelZoomTool", () => {
 
@@ -34,14 +37,20 @@ describe("WheelZoomTool", () => {
   })
 
   describe("View", () => {
-    // Note default plot dimensions is 600 x 600 (height x width)
+    // Note default plot dimensions is 600 x 600 (width x height)
     // This is why zooming at {sx: 300, sy: 300} causes the x/y ranges to zoom equally
     async function mkplot(tool: Tool): Promise<PlotView> {
       const plot = new Plot({
         x_range: new Range1d({start: -1, end: 1}),
         y_range: new Range1d({start: -1, end: 1}),
+        toolbar_location: null,
+        min_border: 0,
+        inner_width: 600 - 2*5,
+        inner_height: 600 - 2*5,
       })
       plot.add_tools(tool)
+      //plot.add_layout(new LinearAxis(), "below")
+      //plot.add_layout(new LinearAxis(), "right")
       const {view} = await display(plot)
       return view
     }
@@ -53,13 +62,13 @@ describe("WheelZoomTool", () => {
       const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers: {ctrl: false, shift: false, alt: false}}
+      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers}
 
       // perform the tool action
       wheel_zoom_view._scroll(zoom_event)
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-0.825958, 0.840707])
+      expect([hr.start, hr.end]).to.be.similar([-0.833333, 0.833333])
 
       const vr = plot_view.frame.y_range
       expect([vr.start, vr.end]).to.be.similar([-0.833333, 0.833333])
@@ -72,13 +81,13 @@ describe("WheelZoomTool", () => {
       const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom out
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: -100, modifiers: {ctrl: false, shift: false, alt: false}}
+      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: -100, modifiers}
 
       // perform the tool action
       wheel_zoom_view._scroll(zoom_event)
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-1.174041, 1.159292])
+      expect([hr.start, hr.end]).to.be.similar([-1.166666, 1.166666])
 
       const vr = plot_view.frame.y_range
       expect([vr.start, vr.end]).to.be.similar([-1.166666, 1.166666])
@@ -91,13 +100,13 @@ describe("WheelZoomTool", () => {
       const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers: {ctrl: false, shift: false, alt: false}}
+      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers}
 
       // perform the tool action
       wheel_zoom_view._scroll(zoom_event)
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-0.825958, 0.840707])
+      expect([hr.start, hr.end]).to.be.similar([-0.833333, 0.833333])
 
       const vr = plot_view.frame.y_range
       expect([vr.start, vr.end]).to.be.similar([-1.0, 1.0])
@@ -110,13 +119,13 @@ describe("WheelZoomTool", () => {
       const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 0, delta: 100, modifiers: {ctrl: false, shift: false, alt: false}}
+      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 0, delta: 100, modifiers}
 
       // perform the tool action
       wheel_zoom_view._scroll(zoom_event)
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-0.825958, 0.840707])
+      expect([hr.start, hr.end]).to.be.similar([-0.833333, 0.833333])
 
       const vr = plot_view.frame.y_range
       expect([vr.start, vr.end]).to.be.similar([-1.0, 1.0])
@@ -129,7 +138,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers: {ctrl: false, shift: false, alt: false}}
+      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers}
 
       // perform the tool action
       wheel_zoom_view._scroll(zoom_event)
@@ -148,7 +157,7 @@ describe("WheelZoomTool", () => {
       const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 0, sy: 300, delta: 100, modifiers: {ctrl: false, shift: false, alt: false}}
+      const zoom_event = {type: "wheel" as "wheel", sx: 0, sy: 300, delta: 100, modifiers}
 
       // perform the tool action
       wheel_zoom_view._scroll(zoom_event)
@@ -167,16 +176,21 @@ describe("WheelZoomTool", () => {
       const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
 
       // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 100, sy: 100, delta: 100, modifiers: {ctrl: false, shift: false, alt: false}}
+      const zoom_event = {type: "wheel" as "wheel", sx: 100, sy: 100, delta: 100, modifiers}
 
       // perform the tool action
       wheel_zoom_view._scroll(zoom_event)
 
       const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-0.943952, 0.722713])
-
       const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.similar([-0.720338, 0.946327])
+
+      expect({
+        x_axis: [hr.start, hr.end],
+        y_axis: [vr.start, vr.end],
+      }).to.be.similar({
+        x_axis: [-0.944444, 0.722222],
+        y_axis: [-0.722222, 0.944444],
+      })
     })
   })
 })

--- a/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
@@ -2,7 +2,6 @@ import {expect} from "assertions"
 import {display} from "../../../_util"
 
 import type {Tool} from "@bokehjs/models/tools/tool"
-import type {WheelZoomToolView} from "@bokehjs/models/tools/gestures/wheel_zoom_tool"
 import {WheelZoomTool} from "@bokehjs/models/tools/gestures/wheel_zoom_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import type {PlotView} from "@bokehjs/models/plots/plot"
@@ -21,6 +20,7 @@ function xy_axis(plot_view: PlotView) {
   }
 }
 
+// frame dimensions is 300x300, thus zooming at {sx: 150, sy: 150} causes the x/y ranges to zoom equally
 async function make_plot<T extends Tool>(tool: T): Promise<{view: PlotView, tool_view: ViewOf<T>}> {
   const plot = new Plot({
     x_range: new Range1d({start: -1, end: 1}),
@@ -65,98 +65,57 @@ describe("WheelZoomTool", () => {
   })
 
   describe("View", () => {
-    // Note default plot dimensions is 600 x 600 (width x height)
-    // This is why zooming at {sx: 300, sy: 300} causes the x/y ranges to zoom equally
-    async function mkplot(tool: Tool): Promise<PlotView> {
-      const plot = new Plot({
-        x_range: new Range1d({start: -1, end: 1}),
-        y_range: new Range1d({start: -1, end: 1}),
-        toolbar_location: null,
-        min_border: 0,
-        inner_width: 600 - 2*5,
-        inner_height: 600 - 2*5,
-      })
-      plot.add_tools(tool)
-      //plot.add_layout(new LinearAxis(), "below")
-      //plot.add_layout(new LinearAxis(), "right")
-      const {view} = await display(plot)
-      return view
-    }
 
     it("should zoom in both ranges", async () => {
       const wheel_zoom = new WheelZoomTool()
-      const plot_view = await mkplot(wheel_zoom)
+      const {view, tool_view} = await make_plot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
+      const zoom_event = {type: "wheel" as "wheel", sx: 150, sy: 150, delta: 100, modifiers}
+      tool_view._scroll(zoom_event)
 
-      // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers}
-
-      // perform the tool action
-      wheel_zoom_view._scroll(zoom_event)
-
-      const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-0.833333, 0.833333])
-
-      const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.similar([-0.833333, 0.833333])
+      expect(xy_axis(view)).to.be.similar({
+        x: [-0.833333, 0.833333],
+        y: [-0.833333, 0.833333],
+      })
     })
 
     it("should zoom out both ranges", async () => {
       const wheel_zoom = new WheelZoomTool()
-      const plot_view = await mkplot(wheel_zoom)
+      const {view, tool_view} = await make_plot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
+      const zoom_event = {type: "wheel" as "wheel", sx: 150, sy: 150, delta: -100, modifiers}
+      tool_view._scroll(zoom_event)
 
-      // positive delta will zoom out
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: -100, modifiers}
-
-      // perform the tool action
-      wheel_zoom_view._scroll(zoom_event)
-
-      const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-1.166666, 1.166666])
-
-      const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.similar([-1.166666, 1.166666])
+      expect(xy_axis(view)).to.be.similar({
+        x: [-1.166666, 1.166666],
+        y: [-1.166666, 1.166666],
+      })
     })
 
     it("should zoom the x-axis only because dimensions arg is set", async () => {
       const wheel_zoom = new WheelZoomTool({dimensions: "width"})
-      const plot_view = await mkplot(wheel_zoom)
+      const {view, tool_view} = await make_plot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
+      const zoom_event = {type: "wheel" as "wheel", sx: 150, sy: 150, delta: 100, modifiers}
+      tool_view._scroll(zoom_event)
 
-      // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers}
-
-      // perform the tool action
-      wheel_zoom_view._scroll(zoom_event)
-
-      const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-0.833333, 0.833333])
-
-      const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.similar([-1.0, 1.0])
+      expect(xy_axis(view)).to.be.similar({
+        x: [-0.833333, 0.833333],
+        y: [-1.0, 1.0],
+      })
     })
 
     it("should zoom the y-axis only because dimensions arg is set", async () => {
       const wheel_zoom = new WheelZoomTool({dimensions: "height"})
-      const plot_view = await mkplot(wheel_zoom)
+      const {view, tool_view} = await make_plot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
+      const zoom_event = {type: "wheel" as "wheel", sx: 150, sy: 150, delta: 100, modifiers}
+      tool_view._scroll(zoom_event)
 
-      // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 300, sy: 300, delta: 100, modifiers}
-
-      // perform the tool action
-      wheel_zoom_view._scroll(zoom_event)
-
-      const hr = plot_view.frame.x_range
-      expect([hr.start, hr.end]).to.be.similar([-1.0, 1.0])
-
-      const vr = plot_view.frame.y_range
-      expect([vr.start, vr.end]).to.be.similar([-0.833333, 0.833333])
+      expect(xy_axis(view)).to.be.similar({
+        x: [-1.0, 1.0],
+        y: [-0.833333, 0.833333],
+      })
     })
 
     it("should zoom the x-axis only because sy is off frame", async () => {
@@ -187,25 +146,14 @@ describe("WheelZoomTool", () => {
 
     it("should zoom centered around the zoom point", async () => {
       const wheel_zoom = new WheelZoomTool({dimensions: "both"})
-      const plot_view = await mkplot(wheel_zoom)
+      const {view, tool_view} = await make_plot(wheel_zoom)
 
-      const wheel_zoom_view = plot_view.tool_views.get(wheel_zoom)! as WheelZoomToolView
+      const zoom_event = {type: "wheel" as "wheel", sx: 50, sy: 50, delta: 100, modifiers}
+      tool_view._scroll(zoom_event)
 
-      // positive delta will zoom in
-      const zoom_event = {type: "wheel" as "wheel", sx: 100, sy: 100, delta: 100, modifiers}
-
-      // perform the tool action
-      wheel_zoom_view._scroll(zoom_event)
-
-      const hr = plot_view.frame.x_range
-      const vr = plot_view.frame.y_range
-
-      expect({
-        x_axis: [hr.start, hr.end],
-        y_axis: [vr.start, vr.end],
-      }).to.be.similar({
-        x_axis: [-0.944444, 0.722222],
-        y_axis: [-0.722222, 0.944444],
+      expect(xy_axis(view)).to.be.similar({
+        x: [-0.944444, 0.722222],
+        y: [-0.722222, 0.944444],
       })
     })
   })

--- a/examples/basic/axes/twin_axes.py
+++ b/examples/basic/axes/twin_axes.py
@@ -9,7 +9,7 @@ for the label values.
 '''
 from numpy import arange, linspace, pi, sin
 
-from bokeh.models import LinearAxis, Range1d, ZoomInTool, ZoomOutTool
+from bokeh.models import LinearAxis, Range1d, WheelZoomTool, ZoomInTool, ZoomOutTool
 from bokeh.palettes import Sunset6
 from bokeh.plotting import figure, show
 
@@ -19,7 +19,7 @@ y2 = linspace(0, 100, len(x))
 
 blue, red = Sunset6[2], Sunset6[5]
 
-p = figure(x_range=(-2*pi, 2*pi), y_range=(-1, 1))
+p = figure(x_range=(-2*pi, 2*pi), y_range=(-1, 1), tools="pan,box_zoom,save,reset")
 p.background_fill_color = "#fafafa"
 
 blue_circles = p.scatter(x, y, line_color="black", fill_color=blue, size=12)
@@ -49,11 +49,15 @@ ax3 = LinearAxis(
 ax3.axis_label_text_color = red
 p.add_layout(ax3, 'below')
 
+wheel_zoom = WheelZoomTool(zoom_on_axis="individual")
+p.add_tools(wheel_zoom)
+
 zoom_in_blue = ZoomInTool(renderers=[blue_circles], description="Zoom in blue circles")
 zoom_out_blue = ZoomOutTool(renderers=[blue_circles], description="Zoom out blue circles")
+p.add_tools(zoom_in_blue, zoom_out_blue)
+
 zoom_in_red = ZoomInTool(renderers=[red_circles], description="Zoom in red circles")
 zoom_out_red = ZoomOutTool(renderers=[red_circles], description="Zoom out red circles")
-p.add_tools(zoom_in_blue, zoom_out_blue)
 p.add_tools(zoom_in_red, zoom_out_red)
 
 show(p)

--- a/examples/basic/axes/twin_axes.py
+++ b/examples/basic/axes/twin_axes.py
@@ -9,7 +9,7 @@ for the label values.
 '''
 from numpy import arange, linspace, pi, sin
 
-from bokeh.models import LinearAxis, Range1d
+from bokeh.models import LinearAxis, Range1d, ZoomInTool, ZoomOutTool
 from bokeh.palettes import Sunset6
 from bokeh.plotting import figure, show
 
@@ -22,15 +22,38 @@ blue, red = Sunset6[2], Sunset6[5]
 p = figure(x_range=(-2*pi, 2*pi), y_range=(-1, 1))
 p.background_fill_color = "#fafafa"
 
-p.scatter(x, y, line_color="black", fill_color=blue, size=12)
-p.yaxis.axis_label = "light blue circles"
-p.yaxis.axis_label_text_color = blue
+blue_circles = p.scatter(x, y, line_color="black", fill_color=blue, size=12)
+p.axis.axis_label = "light blue circles"
+p.axis.axis_label_text_color = blue
 
+p.extra_x_ranges['foo'] = Range1d(-2*pi, 2*pi)
 p.extra_y_ranges['foo'] = Range1d(0, 100)
-p.scatter(x, y2, color=red, size=8, y_range_name="foo")
+red_circles = p.scatter(x, y2, color=red, size=8,
+    x_range_name="foo",
+    y_range_name="foo",
+)
 
-ax2 = LinearAxis(y_range_name="foo", axis_label="red circles")
+ax2 = LinearAxis(
+    axis_label="red circles",
+    x_range_name="foo",
+    y_range_name="foo",
+)
 ax2.axis_label_text_color = red
 p.add_layout(ax2, 'left')
+
+ax3 = LinearAxis(
+    axis_label="red circles",
+    x_range_name="foo",
+    y_range_name="foo",
+)
+ax3.axis_label_text_color = red
+p.add_layout(ax3, 'below')
+
+zoom_in_blue = ZoomInTool(renderers=[blue_circles], description="Zoom in blue circles")
+zoom_out_blue = ZoomOutTool(renderers=[blue_circles], description="Zoom out blue circles")
+zoom_in_red = ZoomInTool(renderers=[red_circles], description="Zoom in red circles")
+zoom_out_red = ZoomOutTool(renderers=[red_circles], description="Zoom out red circles")
+p.add_tools(zoom_in_blue, zoom_out_blue)
+p.add_tools(zoom_in_red, zoom_out_red)
 
 show(p)

--- a/examples/basic/axes/twin_axes.py
+++ b/examples/basic/axes/twin_axes.py
@@ -9,7 +9,9 @@ for the label values.
 '''
 from numpy import arange, linspace, pi, sin
 
-from bokeh.models import LinearAxis, Range1d, WheelZoomTool, ZoomInTool, ZoomOutTool
+from bokeh.layouts import column
+from bokeh.models import (CustomJS, LinearAxis, Range1d, Select,
+                          WheelZoomTool, ZoomInTool, ZoomOutTool)
 from bokeh.palettes import Sunset6
 from bokeh.plotting import figure, show
 
@@ -49,8 +51,10 @@ ax3 = LinearAxis(
 ax3.axis_label_text_color = red
 p.add_layout(ax3, 'below')
 
-wheel_zoom = WheelZoomTool(zoom_on_axis="individual")
+wheel_zoom = WheelZoomTool()
 p.add_tools(wheel_zoom)
+
+p.toolbar.active_scroll = wheel_zoom
 
 zoom_in_blue = ZoomInTool(renderers=[blue_circles], description="Zoom in blue circles")
 zoom_out_blue = ZoomOutTool(renderers=[blue_circles], description="Zoom out blue circles")
@@ -60,4 +64,13 @@ zoom_in_red = ZoomInTool(renderers=[red_circles], description="Zoom in red circl
 zoom_out_red = ZoomOutTool(renderers=[red_circles], description="Zoom out red circles")
 p.add_tools(zoom_in_red, zoom_out_red)
 
-show(p)
+select = Select(title="Zoom together:", options=["none", "cross", "all"], value=wheel_zoom.zoom_together)
+select.js_on_change("value", CustomJS(
+    args=dict(select=select, wheel_zoom=wheel_zoom),
+    code="""\
+export default ({select, wheel_zoom}) => {
+  wheel_zoom.zoom_together = select.value
+}
+""",
+))
+show(column(select, p))

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -546,9 +546,11 @@ class WheelZoomTool(Scroll):
     that causes overall focus or aspect ratio to change.
     """)
 
-    zoom_on_axis = Bool(default=True, help="""
+    zoom_on_axis = Either(Bool, Enum("individual", "individual_linked"))(default=True, help="""
     Whether scrolling on an axis (outside the central plot area) should zoom
-    that dimension.
+    that dimension. If set to ``"individual"``, then only the range associated
+    with the pointed axis will be affected. If set to ``"individual_linked"``,
+    then also the cross range will be affected.
     """)
 
     speed = Float(default=1/600, help="""

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -865,7 +865,20 @@ class BoxZoomTool(Drag):
     (top-left or bottom-right depending on direction) or the center of the box.
     """)
 
-class ZoomInTool(PlotActionTool):
+@abstract
+class ZoomBaseTool(PlotActionTool):
+    """ Abstract base class for zoom action tools. """
+
+    # explicit __init__ to support Init signatures
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    renderers = Either(Auto, List(Instance(DataRenderer)), default="auto", help="""
+    Restrict zoom to ranges used by the provided data renderers. If ``"auto"``
+    then all ranges provided by the cartesian frame will be used.
+    """)
+
+class ZoomInTool(ZoomBaseTool):
     ''' *toolbar icon*: |zoom_in_icon|
 
     The zoom-in tool allows users to click a button to zoom in
@@ -893,7 +906,7 @@ class ZoomInTool(PlotActionTool):
     Percentage to zoom for each click of the zoom-in tool.
     """)
 
-class ZoomOutTool(PlotActionTool):
+class ZoomOutTool(ZoomBaseTool):
     ''' *toolbar icon*: |zoom_out_icon|
 
     The zoom-out tool allows users to click a button to zoom out

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -546,11 +546,22 @@ class WheelZoomTool(Scroll):
     that causes overall focus or aspect ratio to change.
     """)
 
-    zoom_on_axis = Either(Bool, Enum("individual", "individual_linked"))(default=True, help="""
+    zoom_on_axis = Bool(default=True, help="""
     Whether scrolling on an axis (outside the central plot area) should zoom
-    that dimension. If set to ``"individual"``, then only the range associated
-    with the pointed axis will be affected. If set to ``"individual_linked"``,
-    then also the cross range will be affected.
+    that dimension. If enabled, the behavior of this feature can be configured
+    with ``zoom_together`` property.
+    """)
+
+    zoom_together = Enum("none", "cross", "all", default="all", help="""
+    Defines the behavior of the tool when zooming on an axis:
+
+    - ``"none"`` - zoom only the axis that's being interacted with. Any cross
+    axes, nor any other axes in the dimension of this axis will be affected.
+    - ``"cross"`` - zoom the axis that's being interactd with and its cross
+    axis, if configured. No other axes in this or cross dimension will be
+    affected.
+    - ``"all"`` - zoom all axes in the dimension of the axis that's being
+    interacted with. All cross axes will be unaffected.
     """)
 
     speed = Float(default=1/600, help="""

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -5478,6 +5478,7 @@
     dimensions: "both",
     maintain_focus: true,
     zoom_on_axis: true,
+    zoom_together: "all",
     speed: 0.0016666666666666668,
   },
   CustomAction: {

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -5543,13 +5543,17 @@
     match_aspect: false,
     origin: "corner",
   },
-  ZoomInTool: {
+  ZoomBaseTool: {
     __extends__: "PlotActionTool",
+    renderers: "auto",
+  },
+  ZoomInTool: {
+    __extends__: "ZoomBaseTool",
     dimensions: "both",
     factor: 0.1,
   },
   ZoomOutTool: {
-    __extends__: "PlotActionTool",
+    __extends__: "ZoomBaseTool",
     dimensions: "both",
     factor: 0.1,
     maintain_focus: true,


### PR DESCRIPTION
This is functionally ready. This PR allows for wheel zoom of individual axes (`zoom_on_axis="individual"`) and on linked (or perhaps a better term is cross) axes (`zoom_on_axis="individual_linked"`). The original behavior of `zoom_on_axis` with a boolean value is left unchanged. Additionally `ZoomInTool` and `ZoomOutTool` can be configured with `renderers`, which are used to determine which ranges will be affected by zoom: 

This example shows `WheelZoomTool(zoom_on_axis="individual")`, and `ZoomInTool` and `ZoomOutTool` configured with a single renderer:


https://github.com/bokeh/bokeh/assets/27475/d8f1ad93-1d29-4fbf-817b-4f27d881674f



TODO:
- [x] fix unit tests
- [ ] add tests for the new behavior

fixes #12829
