### PR TITLE
Update In-kind sponsors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,6 @@ Non-monetary support can help with development, collaboration, infrastructure, s
 * [Amazon Web Services](https://aws.amazon.com/)
 * [GitGuardian](https://gitguardian.com/)
 * [GitHub](https://github.com/)
-* [makepath](https://makepath.com/)
-* [Pentest Tools](https://pentest-tools.com)
 * [Pingdom](https://www.pingdom.com/website-monitoring)
 * [Slack](https://slack.com)
 * [QuestionScout](https://www.questionscout.com/)

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Non-monetary support can help with development, collaboration, infrastructure, s
 * [Amazon Web Services](https://aws.amazon.com/)
 * [GitGuardian](https://gitguardian.com/)
 * [GitHub](https://github.com/)
+* [makepath](https://makepath.com/)
 * [Pingdom](https://www.pingdom.com/website-monitoring)
 * [Slack](https://slack.com)
 * [QuestionScout](https://www.questionscout.com/)


### PR DESCRIPTION
The question about looking into `semgrep` had me consider this list:

#### pentest
  
Our free/OSS license for pentest-tools just expired last week. We never really ended up using it, I don't personally intend to spend any effort to try and get it re-instated.

#### makepath

~~AFAIK we are no longer engaged with Makepath and I am not aware that they donate any dev hours to the project on their own any more, either.~~

cc @bokeh/core is there any issue or concern with removing these two entries? 