### PR TITLE
Check if sample data files are outdated when loading them

### DIFF
--- a/src/bokeh/util/sampledata.py
+++ b/src/bokeh/util/sampledata.py
@@ -67,9 +67,8 @@ def download(progress: bool = True) -> None:
             if local_md5 == md5:
                 print(f"Skipping {file_name!r} (checksum match)")
                 continue
-            else:
-                print(f"Re-fetching {file_name!r} (checksum mismatch)")
 
+        print(f"Fetching {file_name!r}")
         _download_file(s3, file_name, data_dir, progress=progress)
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/util/sampledata.py
+++ b/src/bokeh/util/sampledata.py
@@ -90,16 +90,10 @@ def metadata() -> dict[str, str]:
         return dict(json.load(f))
 
 def external_csv(module: str, name: str, **kw: Any) -> pd.DataFrame:
-    '''
-
-    '''
     import pandas as pd
     return pd.read_csv(external_path(name), **kw)
 
 def external_data_dir(*, create: bool = False) -> Path:
-    '''
-
-    '''
     try:
         import yaml
     except ImportError:
@@ -147,22 +141,13 @@ def external_path(file_name: str) -> Path:
     return file_path
 
 def package_csv(module: str, name: str, **kw: Any) -> pd.DataFrame:
-    '''
-
-    '''
     import pandas as pd
     return pd.read_csv(package_path(name), **kw)
 
 def package_dir() -> Path:
-    '''
-
-    '''
     return Path(__file__).parents[1].joinpath("sampledata", "_data").resolve()
 
 def package_path(filename: str | Path) -> Path:
-    '''
-
-    '''
     return package_dir() / filename
 
 def load_json(filename: str | Path) -> Any:
@@ -170,9 +155,6 @@ def load_json(filename: str | Path) -> Any:
         return json.load(f)
 
 def open_csv(filename: str | Path) -> TextIO:
-    '''
-
-    '''
     return open(filename, newline='', encoding='utf8')
 
 #-----------------------------------------------------------------------------
@@ -194,9 +176,6 @@ def _bokeh_dir(create: bool = False) -> Path:
     return bokeh_dir
 
 def _download_file(base_url: str, filename: str, data_dir: Path, progress: bool = True) -> None:
-    '''
-
-    '''
     # These are actually somewhat expensive imports that added ~5% to overall
     # typical bokeh import times. Since downloading sampledata is not a common
     # action, we defer them to inside this function.


### PR DESCRIPTION
Example when `world_cities.csv` is outdated or otherwise modified:
```py
$ python examples/interaction/widgets/autocompleteinput.py 
Traceback (most recent call last):
  File "/home/mateusz/repo/bokeh/examples/interaction/widgets/autocompleteinput.py", line 3, in <module>
    from bokeh.sampledata.world_cities import data
  File "/home/mateusz/repo/bokeh/src/bokeh/sampledata/world_cities.py", line 61, in <module>
    data = external_csv('world_cities', 'world_cities.csv')
  File "/home/mateusz/repo/bokeh/src/bokeh/util/sampledata.py", line 98, in external_csv
    return pd.read_csv(external_path(name), **kw)
  File "/home/mateusz/repo/bokeh/src/bokeh/util/sampledata.py", line 147, in external_path
    raise RuntimeError(f"External data file {file_path} is outdated. Please execute bokeh.sampledata.download()")
RuntimeError: External data file /home/mateusz/.bokeh/data/world_cities.csv is outdated. Please execute bokeh.sampledata.download()
```
fixes #13058