### PR TITLE
Allow `static/` symlinks in `BOKEHJS_ACTION=install pip install -e .`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,16 +83,18 @@ def install_js(packages: list[str]) -> None:
     if missing:
         die(BOKEHJS_INSTALL_FAIL.format(missing=", ".join(missing)))
 
-    if PKG_JS.exists():
-        rmtree(PKG_JS)
-    copytree(BUILD_JS, PKG_JS)
+    if not PKG_JS.is_symlink():
+        if PKG_JS.exists():
+            rmtree(PKG_JS)
+        copytree(BUILD_JS, PKG_JS)
 
-    if PKG_TSLIB.exists():
-        rmtree(PKG_TSLIB)
-    if BUILD_TSLIB.exists():
-        PKG_TSLIB.mkdir()
-        for lib_file in BUILD_TSLIB.glob("lib.*.d.ts"):
-            copy(lib_file, PKG_TSLIB)
+    if not PKG_TSLIB.is_symlink():
+        if PKG_TSLIB.exists():
+            rmtree(PKG_TSLIB)
+        if BUILD_TSLIB.exists():
+            PKG_TSLIB.mkdir()
+            for lib_file in BUILD_TSLIB.glob("lib.*.d.ts"):
+                copy(lib_file, PKG_TSLIB)
 
     new = set(
         ".".join([*Path(parent).relative_to(SRC_ROOT).parts, d])


### PR DESCRIPTION
It's common for me to link `src/bokeh/server/static/{js,lib}` to `bokehjs/build/`, instead of relying on copying. However, currently `setup.py`'s `install_js()` fails on symlinks attempting to remove respective paths with `rmtree`. This PR allows to skip removing and copying directory structures if `js` and `lib` are symbolic links. Using symbolic links in `static/` is the surest way of not testing or running examples with stale `*.js` files.