### PR TITLE
Add support for ESM bundles to resources and embedding

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,10 +16,6 @@ prune src/bokeh/server/static
 include src/bokeh/server/static/js/bokeh*.js
 include src/bokeh/server/static/js/bokeh*.min.js
 
-# don't include ESM bundles yet
-exclude src/bokeh/server/static/js/bokeh*.esm.js
-exclude src/bokeh/server/static/js/bokeh*.esm.min.js
-
 # include extensions' compiler
 include src/bokeh/server/static/js/compiler.js
 

--- a/bokehjs/examples/anscombe/anscombe.ts
+++ b/bokehjs/examples/anscombe/anscombe.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace Anscombe {
   console.log(`Bokeh ${Bokeh.version}`)

--- a/bokehjs/examples/bokehjs.d.ts
+++ b/bokehjs/examples/bokehjs.d.ts
@@ -1,4 +1,4 @@
-declare module "*/bokeh.esm.js" {
+declare module "*/bokeh.mjs" {
   export * from "index"
   export * from "api"
 }

--- a/bokehjs/examples/burtin/burtin.ts
+++ b/bokehjs/examples/burtin/burtin.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace Burtin {
   import plt = Bokeh.Plotting

--- a/bokehjs/examples/categorical/categorical.ts
+++ b/bokehjs/examples/categorical/categorical.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace Categorical {
   import plt = Bokeh.Plotting

--- a/bokehjs/examples/charts/charts.ts
+++ b/bokehjs/examples/charts/charts.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace Charts {
   import plt = Bokeh.Plotting

--- a/bokehjs/examples/donut/donut.ts
+++ b/bokehjs/examples/donut/donut.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace WebBrowserMarketShare {
   import plt = Bokeh.Plotting

--- a/bokehjs/examples/hierarchical/hierarchical.ts
+++ b/bokehjs/examples/hierarchical/hierarchical.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 const {figure, show} = Bokeh.Plotting
 const {concat, zip} = Bokeh.LinAlg

--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace HoverfulScatter {
   import plt = Bokeh.Plotting

--- a/bokehjs/examples/legends/legends.ts
+++ b/bokehjs/examples/legends/legends.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace Legends {
   import plt = Bokeh.Plotting

--- a/bokehjs/examples/linked/linked.ts
+++ b/bokehjs/examples/linked/linked.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace LinkedBrushingAndPanning {
   import plt = Bokeh.Plotting

--- a/bokehjs/examples/stocks/stocks.ts
+++ b/bokehjs/examples/stocks/stocks.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace Stocks {
   import plt = Bokeh.Plotting

--- a/bokehjs/examples/tap/tap.ts
+++ b/bokehjs/examples/tap/tap.ts
@@ -1,5 +1,5 @@
-import Bokeh from "/static/js/bokeh.esm.js"
-import "/static/js/bokeh-api.esm.js"
+import Bokeh from "/static/js/bokeh.mjs"
+import "/static/js/bokeh-api.mjs"
 
 export namespace TappyScatter {
   import plt = Bokeh.Plotting

--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -1,6 +1,5 @@
 import {join, relative} from "path"
 import {argv} from "yargs"
-import fs from "fs"
 
 import {task, passthrough, BuildError} from "../task"
 import {rename, read, write, scan} from "@compiler/sys"
@@ -116,8 +115,8 @@ exports.VERSION = "0.0.0";
   bundle({prelude, postlude, minified: true}, outputs.map(min_js))
 
   const esm = {prelude: esm_prelude, postlude: esm_postlude}
-  bundle({...esm, minified: false}, outputs.map((name) => rename(name, {ext: ".esm.js"})))
-  bundle({...esm, minified: true}, outputs.map((name) => rename(name, {ext: ".esm.min.js"})))
+  bundle({...esm, minified: false}, outputs.map((name) => rename(name, {ext: ".mjs"})))
+  bundle({...esm, minified: true}, outputs.map((name) => rename(name, {ext: ".min.mjs"})))
 
   if (!status)
     throw new BuildError("scripts:bundle", "unable to bundle modules")
@@ -126,38 +125,3 @@ exports.VERSION = "0.0.0";
 task("lib:build", ["scripts:bundle"])
 
 task("scripts:build", ["lib:build"])
-
-task("packages:prepare", ["scripts:bundle"], async () => {
-  const bundles = ["bokeh", "bokeh-api", "bokeh-widgets", "bokeh-tables"]
-  const suffixes = ["", ".esm"]
-  const pkgs_dir = paths.build_dir.packages
-
-  for (const suffix of suffixes) {
-    const root = `@bokeh/bokeh${suffix}`
-
-    for (const bundle of bundles) {
-      const name = `@bokeh/${bundle}${suffix}`
-      const main = `${bundle}${suffix}.min.js`
-
-      const spec = {
-        name,
-        version: pkg.version,
-        description: pkg.description,
-        keywords: pkg.keywords,
-        license: pkg.license,
-        repository: pkg.repository,
-        main,
-        module: suffix == ".esm" ? main : undefined,
-        // TODO: types
-        dependencies: name != root ? [{[root]: `^${pkg.version}`}] : [],
-      }
-
-      const pkg_dir = join(pkgs_dir, name)
-
-      const json = JSON.stringify(spec, undefined, 2)
-      write(join(pkg_dir, "package.json"), json)
-
-      await fs.promises.copyFile(join(paths.build_dir.js, main), join(pkg_dir, main))
-    }
-  }
-})

--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -159,7 +159,8 @@ export class Bundle {
     const aliases_json = JSON.stringify(to_obj(aliases))
     const externals_json = JSON.stringify(to_obj(externals))
 
-    sources += `${suffix}, ${safe_id(entry)}, ${aliases_json}, ${externals_json});${postlude}`
+    sources += `${suffix}, ${safe_id(entry)}, ${aliases_json}, ${externals_json});`
+    sources += `\n${postlude}`
 
     const source_map = convert.fromBase64(sourcemap.base64()).toObject()
     return new Artifact(sources, minified ? null : source_map, aliases)

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -46,9 +46,13 @@ export async function embed_items(docs_json: string | DocsJson, render_items: Re
   return _embed_items(docs_json, render_items, app_path, absolute_url)
 }
 
-async function _embed_items(docs_json: string | DocsJson, render_items: RenderItem[], app_path?: string, absolute_url?: string): Promise<ViewManager[]> {
+type JSONString = string
+
+async function _embed_items(docs_json: JSONString | DocsJson, render_items: JSONString | RenderItem[], app_path?: string, absolute_url?: string): Promise<ViewManager[]> {
   if (isString(docs_json))
     docs_json = JSON.parse(unescape(docs_json)) as DocsJson
+  if (isString(render_items))
+    render_items = JSON.parse(unescape(render_items)) as RenderItem[]
 
   const docs: {[key: string]: Document} = {}
   for (const [docid, doc_json] of entries(docs_json)) {

--- a/release/remote.py
+++ b/release/remote.py
@@ -63,9 +63,9 @@ def publish_bokehjs_to_cdn(config: Config, system: System) -> ActionReturn:
 
         content_type = "application/javascript"
         for name in ("bokeh", "bokeh-gl", "bokeh-api", "bokeh-widgets", "bokeh-tables", "bokeh-mathjax"):
-            for suffix in ("js", "min.js", "esm.js", "esm.min.js"):
-                local_path = f"bokehjs/build/js/{name}.{suffix}"
-                cdn_path = f"bokeh/{subdir}/{name}-{version}.{suffix}"
+            for ext in (".js", ".min.js", ".mjs", ".min.mjs"):
+                local_path = f"bokehjs/build/js/{name}{ext}"
+                cdn_path = f"bokeh/{subdir}/{name}-{version}{ext}"
                 for bucket in buckets:
                     _upload_file_to_cdn(local_path, cdn_path, content_type, bucket)
         return PASSED("Uploaded BokehJS to CDN")

--- a/scripts/sri.py
+++ b/scripts/sri.py
@@ -53,7 +53,7 @@ def update_package(version):
         version not in current
     ), f"Version {version} already exists in the hash data file"
 
-    paths = (x for x in glob(join(TOP, "src/bokeh/server/static/js/bokeh*.js")) if ".esm" not in x)
+    paths = glob(join(TOP, "src/bokeh/server/static/js/bokeh*.js"))
     hashes = compute_hashes_for_paths(paths, version)
 
     new = {version: hashes}

--- a/src/bokeh/core/_templates/doc_js.js
+++ b/src/bokeh/core/_templates/doc_js.js
@@ -1,7 +1,7 @@
 {% extends "try_run.js" %}
 
 {% block code_to_run %}
-  const docs_json = {{ docs_json }};
-  const render_items = {{ render_items }};
-  root.Bokeh.embed.embed_items(docs_json, render_items{%- if app_path -%}, "{{ app_path }}" {%- endif -%}{%- if absolute_url -%}, "{{ absolute_url }}" {%- endif -%});
+    const docs_json = {{ docs_json }};
+    const render_items = {{ render_items }};
+    root.Bokeh.embed.embed_items(docs_json, render_items{%- if app_path -%}, "{{ app_path }}" {%- endif -%}{%- if absolute_url -%}, "{{ absolute_url }}" {%- endif -%});
 {% endblock %}

--- a/src/bokeh/core/json_encoder.py
+++ b/src/bokeh/core/json_encoder.py
@@ -182,11 +182,14 @@ class PayloadEncoder(JSONEncoder):
         self._threshold = threshold
 
     def default(self, obj: Any) -> Any:
+        from ..embed.util import RenderItem  # cyclic imports
         if isinstance(obj, Buffer):
             if obj.id in self._buffers: # TODO: and len(obj.data) > self._threshold:
                 return obj.ref
             else:
                 return obj.to_base64()
+        elif isinstance(obj, RenderItem):
+            return obj.to_json()
         else:
             return super().default(obj)
 

--- a/src/bokeh/embed/elements.py
+++ b/src/bokeh/embed/elements.py
@@ -79,9 +79,15 @@ def div_for_render_item(item: RenderItem) -> str:
     '''
     return PLOT_DIV.render(doc=item, macros=MACROS)
 
-def html_page_for_render_items(bundle: Bundle | tuple[str, str], docs_json: dict[ID, DocJson],
-        render_items: list[RenderItem], title: str, template: Template | str | None = None,
-        template_variables: dict[str, Any] = {}) -> str:
+def html_page_for_render_items(
+    bundle: Bundle | tuple[str, str],
+    docs_json: dict[ID, DocJson],
+    render_items: list[RenderItem],
+    *,
+    title: str | None = None,
+    template: Template | str | None = None,
+    template_variables: dict[str, Any] = {},
+) -> str:
     ''' Render an HTML page from a template and Bokeh render items.
 
     Args:

--- a/src/bokeh/embed/elements.py
+++ b/src/bokeh/embed/elements.py
@@ -87,6 +87,7 @@ def html_page_for_render_items(
     title: str | None = None,
     template: Template | str | None = None,
     template_variables: dict[str, Any] = {},
+    separate_json: bool = True,
 ) -> str:
     ''' Render an HTML page from a template and Bokeh render items.
 
@@ -118,15 +119,19 @@ def html_page_for_render_items(
 
     bokeh_js, bokeh_css = bundle
 
-    docs_json_id = make_id()
-    docs_json_str = escape(serialize_json(docs_json), quote=False)
-    docs_json_tag = wrap_in_script_tag(docs_json_str, "application/json", docs_json_id)
+    if separate_json:
+        docs_json_id = make_id()
+        docs_json_str = escape(serialize_json(docs_json), quote=False)
+        docs_json_tag = wrap_in_script_tag(docs_json_str, "application/json", docs_json_id)
 
-    render_items_id = make_id()
-    render_items_str = escape(serialize_json(render_items), quote=False)
-    render_items_tag = wrap_in_script_tag(render_items_str, "application/json", render_items_id)
+        render_items_id = make_id()
+        render_items_str = escape(serialize_json(render_items), quote=False)
+        render_items_tag = wrap_in_script_tag(render_items_str, "application/json", render_items_id)
 
-    script_tag = wrap_in_script_tag(script_for_render_items(docs_json_id, render_items_id))
+        script_tag = wrap_in_script_tag(script_for_render_items(docs_json_id, render_items_id))
+        scripts = docs_json_tag + render_items_tag + script_tag
+    else:
+        scripts = wrap_in_script_tag(script_for_render_items(docs_json, render_items))
 
     context = template_variables.copy()
 
@@ -134,7 +139,7 @@ def html_page_for_render_items(
         title = title,
         bokeh_js = bokeh_js,
         bokeh_css = bokeh_css,
-        plot_script = docs_json_tag + render_items_tag + script_tag,
+        plot_script = scripts,
         docs = render_items,
         base = FILE,
         macros = MACROS,

--- a/src/bokeh/embed/elements.py
+++ b/src/bokeh/embed/elements.py
@@ -87,7 +87,7 @@ def html_page_for_render_items(
     title: str | None = None,
     template: Template | str | None = None,
     template_variables: dict[str, Any] = {},
-    separate_json: bool = True,
+    inline_json: bool = False,
 ) -> str:
     ''' Render an HTML page from a template and Bokeh render items.
 
@@ -119,7 +119,9 @@ def html_page_for_render_items(
 
     bokeh_js, bokeh_css = bundle
 
-    if separate_json:
+    if inline_json:
+        scripts = wrap_in_script_tag(script_for_render_items(docs_json, render_items))
+    else:
         docs_json_id = make_id()
         docs_json_str = escape(serialize_json(docs_json), quote=False)
         docs_json_tag = wrap_in_script_tag(docs_json_str, "application/json", docs_json_id)
@@ -130,8 +132,6 @@ def html_page_for_render_items(
 
         script_tag = wrap_in_script_tag(script_for_render_items(docs_json_id, render_items_id))
         scripts = docs_json_tag + render_items_tag + script_tag
-    else:
-        scripts = wrap_in_script_tag(script_for_render_items(docs_json, render_items))
 
     context = template_variables.copy()
 

--- a/src/bokeh/embed/elements.py
+++ b/src/bokeh/embed/elements.py
@@ -176,15 +176,15 @@ def script_for_render_items(docs_json_or_id: ID | dict[ID, DocJson], render_item
         if isinstance(json_or_id, str):
             json_str = f"document.getElementById('{json_or_id}').textContent"
         else:
-            # XXX: encodes &, <, > and ', but not ". This is because " is used a lot in JSON,
-            # and encoding it would significantly increase size of generated files. Doing so
-            # is safe, because " in strings was already encoded by JSON, and the semi-encoded
-            # JSON string is included in JavaScript in single quotes.
+            # XXX: encodes &, <, > and `, but not " and '. This is because " is used a lot in
+            # JSON, and encoding it would significantly increase size of generated files. Doing
+            # so is safe, because " in strings was already encoded by JSON, and the semi-encoded
+            # JSON string is included in JavaScript in backtick quotes.
             json_str = serialize_json(json_or_id)      # JSON string
             json_str = escape(json_str, quote=False)   # make HTML-safe
-            json_str = json_str.replace("'", "&#x27;") # remove single quotes
+            json_str = json_str.replace("`", "&#x96;") # remove backticks
             json_str = json_str.replace("\\", "\\\\")  # double encode escapes
-            json_str = "'" + json_str + "'"            # JS string
+            json_str = "`" + json_str + "`"            # JS string
         return json_str
 
     js = DOC_JS.render(

--- a/src/bokeh/embed/elements.py
+++ b/src/bokeh/embed/elements.py
@@ -149,9 +149,6 @@ def html_page_for_render_items(
         context["doc"] = context["docs"][0]
         context["roots"] = context["doc"].roots
 
-    # XXX: backwards compatibility, remove for 1.0
-    context["plot_div"] = "\n".join(div_for_render_item(item) for item in render_items)
-
     if template is None:
         template = FILE
     elif isinstance(template, str):

--- a/src/bokeh/embed/server.py
+++ b/src/bokeh/embed/server.py
@@ -251,8 +251,8 @@ def server_html_page_for_session(session: ServerSession, resources: Resources, t
         template_variables = {}
 
     bundle = bundle_for_objs_and_resources(None, resources)
-    html = html_page_for_render_items(bundle, {}, [render_item], title,
-        template=template, template_variables=template_variables)
+    html = html_page_for_render_items(bundle, {}, [render_item],
+        title=title, template=template, template_variables=template_variables, inline_json=True)
     return html
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -58,7 +58,7 @@ def stable_id() -> ID:
 @pytest.fixture
 def test_plot() -> figure:
     from bokeh.plotting import figure
-    test_plot = figure(title="'foo'")
+    test_plot = figure(title="'foo'", tags=["'single quotes'", '"double quotes"', "`backticks`"])
     test_plot.circle(np.array([1, 2]), np.array([2, 3]))
     return test_plot
 
@@ -270,8 +270,10 @@ class Test_components:
     def test_quoting(self, test_plot: figure) -> None:
         script, _ = bes.components(test_plot)
         assert "&quot;" not in script
-        assert "'foo'" not in script
-        assert "&#x27;foo&#x27;" in script
+        assert '"single quotes"' not in script
+        assert "'single quotes'" in script
+        assert "`backticks`" not in script
+        assert "&#x96;backticks&#x96;" in script
 
     def test_output_is_without_script_tag_when_wrap_script_is_false(self, test_plot: figure) -> None:
         script, _ = bes.components(test_plot)


### PR DESCRIPTION
This is a very early WIP PR that attempts to make use of ESM bundles (formerly `*.esm{.min}.js`, now `*{.min}.mjs`) in embedding APIs. This will take awhile to complete, as handling of ES modules is vastly different from handling regular JS scripts, and our embedding APIs are unsuited for this.

fixes #12941