### PR TITLE
Improve reliability of async server tests

### DIFF
--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -181,7 +181,12 @@ class BaseServer:
 
         '''
         self._http.stop()
-        self.io_loop.add_callback(self._http.close_all_connections)
+
+        import asyncio
+        task = asyncio.create_task(self._http.close_all_connections())
+        def callback(_future: asyncio.Future[Any]) -> None:
+            log.debug("done with HTTPServer.close_all_connections()")
+        self.io_loop.add_future(task, callback)
 
     def run_until_shutdown(self) -> None:
         ''' Run the Bokeh Server until shutdown is requested by the user,

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -146,7 +146,7 @@ class HookTestHandler(Handler):
 # General API
 #-----------------------------------------------------------------------------
 
-def test_prefix(ManagedServerLoop: MSL) -> None:
+async def test_prefix(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         assert server.prefix == ""
@@ -154,7 +154,7 @@ def test_prefix(ManagedServerLoop: MSL) -> None:
     with ManagedServerLoop(application, prefix="foo") as server:
         assert server.prefix == "/foo"
 
-def test_index(ManagedServerLoop: MSL) -> None:
+async def test_index(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         assert server.index is None
@@ -240,12 +240,12 @@ def resource_files_requested(response, requested=True):
         else:
             assert file not in response
 
-def test_use_xheaders(ManagedServerLoop: MSL) -> None:
+async def test_use_xheaders(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application, use_xheaders=True) as server:
         assert server._http.xheaders is True
 
-def test_ssl_args_plumbing(ManagedServerLoop: MSL) -> None:
+async def test_ssl_args_plumbing(ManagedServerLoop: MSL) -> None:
     with mock.patch.object(ssl, 'SSLContext'):
         with ManagedServerLoop({}, ssl_certfile="foo") as server:
             assert server._http.ssl_options.load_cert_chain.call_args[0] == ()
@@ -365,7 +365,7 @@ async def test__exclude_cookies(ManagedServerLoop: MSL) -> None:
 
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="Lifecycle hooks order different on Windows (TODO open issue)")
-def test__lifecycle_hooks(ManagedServerLoop: MSL) -> None:
+async def test__lifecycle_hooks(ManagedServerLoop: MSL) -> None:
     application = Application()
     handler = HookTestHandler()
     application.add(handler)
@@ -819,7 +819,7 @@ def test__server_multiple_processes() -> None:
             else mock.call(3),
         ]
 
-def test__existing_ioloop_with_multiple_processes_exception(ManagedServerLoop, event_loop) -> None:
+async def test__existing_ioloop_with_multiple_processes_exception(ManagedServerLoop, event_loop) -> None:
     application = Application()
     loop = IOLoop.current()
     with pytest.raises(RuntimeError):

--- a/tests/unit/bokeh/server/test_session__server.py
+++ b/tests/unit/bokeh/server/test_session__server.py
@@ -55,7 +55,7 @@ def test_subscribe() -> None:
     s.unsubscribe('connection2')
     assert s.connection_count == 0
 
-def test_destroy_calls() -> None:
+async def test_destroy_calls() -> None:
     d = Document()
     s = bss.ServerSession('some-id', d, 'ioloop')
     with mock.patch('bokeh.document.modules.DocumentModuleManager.destroy') as docdm:

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -47,7 +47,7 @@ logging.basicConfig(level=logging.DEBUG)
 # General API
 #-----------------------------------------------------------------------------
 
-def test_default_resources(ManagedServerLoop: MSL) -> None:
+async def test_default_resources(ManagedServerLoop: MSL) -> None:
     application = Application()
 
     with ManagedServerLoop(application) as server:
@@ -123,14 +123,14 @@ def test_default_resources(ManagedServerLoop: MSL) -> None:
         assert r.root_url == f"http://localhost:{server.port}/foo/bar/"
         assert r.path_versioner == StaticHandler.append_version
 
-def test_env_resources(ManagedServerLoop: MSL) -> None:
+async def test_env_resources(ManagedServerLoop: MSL) -> None:
     with envset(BOKEH_RESOURCES="cdn"):
         application = Application()
         with ManagedServerLoop(application) as server:
             r = server._tornado.resources()
             assert r.mode == "cdn"
 
-def test_dev_resources(ManagedServerLoop: MSL) -> None:
+async def test_dev_resources(ManagedServerLoop: MSL) -> None:
     with envset(BOKEH_DEV="yes"):
         application = Application()
         with ManagedServerLoop(application) as server:
@@ -138,7 +138,7 @@ def test_dev_resources(ManagedServerLoop: MSL) -> None:
             assert r.mode == "absolute"
             assert r.dev
 
-def test_index(ManagedServerLoop: MSL) -> None:
+async def test_index(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         assert server._tornado.index is None
@@ -146,7 +146,7 @@ def test_index(ManagedServerLoop: MSL) -> None:
     with ManagedServerLoop(application, index='foo') as server:
         assert server._tornado.index == "foo"
 
-def test_prefix(ManagedServerLoop: MSL) -> None:
+async def test_prefix(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         assert server._tornado.prefix == ""
@@ -187,7 +187,7 @@ def test_websocket_compression_level() -> None:
     assert ws_rule.target_kwargs.get('compression_level') == 2
     assert ws_rule.target_kwargs.get('mem_level') == 3
 
-def test_websocket_origins(ManagedServerLoop, unused_tcp_port) -> None:
+async def test_websocket_origins(ManagedServerLoop, unused_tcp_port) -> None:
     application = Application()
     with ManagedServerLoop(application, port=unused_tcp_port) as server:
         assert server._tornado.websocket_origins == {f"localhost:{unused_tcp_port}"}
@@ -218,7 +218,7 @@ def test_default_app_paths() -> None:
 # tried to use capsys to test what's actually logged and it wasn't
 # working, in the meantime at least this tests that log_stats
 # doesn't crash in various scenarios
-def test_log_stats(ManagedServerLoop: MSL) -> None:
+async def test_log_stats(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
         server._tornado._log_stats()

--- a/tests/unit/bokeh/server/views/test_multi_root_static_handler.py
+++ b/tests/unit/bokeh/server/views/test_multi_root_static_handler.py
@@ -39,7 +39,7 @@ import bokeh.server.views.multi_root_static_handler as bsvm # isort:skip
 # General API
 #-----------------------------------------------------------------------------
 
-def test_multi_root_static_handler(ManagedServerLoop: MSL) -> None:
+async def test_multi_root_static_handler(ManagedServerLoop: MSL) -> None:
     application = Application()
 
     static_path = Path(serverdir()) / "static" # TODO: PR #13042


### PR DESCRIPTION
This PR attempts to resolve `Task was destroyed but it is pending!` issues, which are both annoying and can influence other tests (like in PR #13070). For now I dealt with `HTTPServer.close_all_connections()` not being awaited for and now I'm working on issues related to reuse of `IOLoop` in `pull_session()`. 
