### PR TITLE
Show how to reference the same field multiple times in hover tool's formatters

### DIFF
--- a/examples/plotting/customjs_hover.py
+++ b/examples/plotting/customjs_hover.py
@@ -1,4 +1,4 @@
-''' A map of North Africa and South Europe with three interactive location
+""" A map of North Africa and South Europe with three interactive location
 points. When hovering over the points, its lat-lon is shown. This example
 demonstrates using CustomJSHover model and HoverTool to customize the
 formatting of values in tooltip fields.
@@ -8,34 +8,58 @@ formatting of values in tooltip fields.
     :refs: :ref:`ug_interaction_tools_formatting_tooltip_fields`
     :keywords: hover tool, CustomJSHover
 
-'''
+"""
 from bokeh.models import CustomJSHover, HoverTool
 from bokeh.plotting import figure, show
 
 # range bounds supplied in web mercator coordinates
-p = figure(x_range=(-2000000, 6000000), y_range=(-1000000, 7000000),
-           x_axis_type="mercator", y_axis_type="mercator")
-p.add_tile("CartoDB Positron")
+p = figure(
+    x_range=(-2000000, 6000000), y_range=(-1000000, 7000000),
+    x_axis_type="mercator", y_axis_type="mercator",
+)
 
+p.add_tile("CartoDB Positron")
 p.scatter(x=[0, 2000000, 4000000], y=[4000000, 2000000, 0], size=30)
 
-code = """
-    const projections = Bokeh.require("core/util/projections");
-    const x = special_vars.x
-    const y = special_vars.y
+formatter = CustomJSHover(code="""
+    function decimal_degrees(coord) {
+        return coord.toFixed(2)
+    }
+
+    function degrees_minutes_seconds(coord, axis) {
+        const dir = axis == "lon" ? (coord < 0 ? "W" : "E") : (coord < 0 ? "S" : "N")
+        const degrees_ = Math.abs(coord)
+        const degrees  = Math.trunc(degrees_)
+        const minutes_ = (degrees_ - degrees)*60
+        const minutes  = Math.trunc(minutes_)
+        const seconds_ = (minutes_ - minutes)*60
+        const seconds  = Math.trunc(seconds_)
+        return `${dir} ${degrees}\\u00b0 ${minutes}\\u2032 ${seconds}\\u2033`
+    }
+
+    const projections = Bokeh.require("core/util/projections")
+    const {x, y} = special_vars
     const coords = projections.wgs84_mercator.invert(x, y)
-    return coords[%d].toFixed(2)
-"""
+
+    const [axis, type] = format.split("_")
+    const dim = axis == "lon" ? 0 : 1
+    const coord = coords[dim]
+
+    switch (type) {
+        case "dd":  return decimal_degrees(coord)
+        case "dms": return degrees_minutes_seconds(coord, axis)
+        default:    return "???"
+    }
+""")
 
 p.add_tools(HoverTool(
     tooltips=[
-        ( 'lon', '$x{custom}' ),
-        ( 'lat', '$y{custom}' ),
+        ("lat", "$y{lat_dd} = $y{lat_dms}"),
+        ("lon", "$x{lon_dd} = $x{lon_dms}"),
     ],
-
     formatters={
-        '$x' : CustomJSHover(code=code % 0),
-        '$y' : CustomJSHover(code=code % 1),
+        "$y": formatter,
+        "$x": formatter,
     },
 ))
 


### PR DESCRIPTION
Currently it's only possible reference a given field only once in `HoverTool.formatters`. For now I changed `customjs_hover` example to approximate the correct behavior with some syntax abuse.

![image](https://github.com/bokeh/bokeh/assets/27475/07935f18-34a1-43f5-bbaa-b46158f9420c)