### PR TITLE
Axes improvements for scale indicator annotation

### DIFF
--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -53,6 +53,9 @@ export const Direction = Enum("clock", "anticlock")
 export type Distribution = "uniform" | "normal"
 export const Distribution = Enum("uniform", "normal")
 
+export type Face = typeof Face["__type__"]
+export const Face = Enum("front", "back")
+
 export type FlowMode = typeof FlowMode["__type__"]
 export const FlowMode = Enum("block", "inline")
 

--- a/bokehjs/src/lib/models/annotations/base_color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/base_color_bar.ts
@@ -428,7 +428,8 @@ export abstract class BaseColorBarView extends AnnotationView {
     const {_axis_view} = this
     _axis_view.panel = new Panel(side)
     _axis_view.update_layout()
-    stack.children.push(_axis_view.layout)
+    if (_axis_view.layout != null)
+      stack.children.push(_axis_view.layout)
 
     if (this.panel != null) {
       const outer = new Grid([{layout, row: 0, col: 0}])

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -8,14 +8,14 @@ import type * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import type * as p from "core/properties"
 import type {SerializableState} from "core/view"
-import type {Side} from "core/enums"
-import {LabelOrientation} from "core/enums"
+import type {HAlign, VAlign} from "core/enums"
+import {Align, Face, LabelOrientation} from "core/enums"
 import type {Size, Layoutable} from "core/layout"
 import {Indices} from "core/types"
-import type {Panel, Orient} from "core/layout/side_panel"
-import {SideLayout} from "core/layout/side_panel"
+import type {Orient, Normal, Dimension} from "core/layout/side_panel"
+import {Panel, SideLayout} from "core/layout/side_panel"
 import type {Context2d} from "core/util/canvas"
-import {sum} from "core/util/array"
+import {sum, repeat} from "core/util/array"
 import {Dict} from "core/util/object"
 import {isNumber, isPlainObject} from "core/util/types"
 import {GraphicsBoxes, TextBox} from "core/graphics"
@@ -27,7 +27,7 @@ import type {IterViews} from "core/build_views"
 import {build_view} from "core/build_views"
 import {unreachable} from "core/util/assert"
 import {isString} from "core/util/types"
-import type {BBox} from "core/util/bbox"
+import {BBox} from "core/util/bbox"
 import {parse_delimited_string} from "models/text/utils"
 
 const {abs} = Math
@@ -41,7 +41,7 @@ export type Extents = {
 
 export type Coords = [number[], number[]]
 
-export interface TickCoords {
+export type TickCoords = {
   major: Coords
   minor: Coords
 }
@@ -50,15 +50,46 @@ export class AxisView extends GuideRendererView {
   declare model: Axis
   declare visuals: Axis.Visuals
 
-  panel: Panel
-  layout: Layoutable
+  layout?: Layoutable
 
-  get bbox(): BBox {
-    return this.layout.bbox
+  private _panel: Panel
+  get panel(): Panel {
+    return this._panel
+  }
+  set panel(panel: Panel) {
+    this._panel = new Panel(panel.side, this.model.face)
   }
 
   /*private*/ _axis_label_view: BaseTextView | null = null
   /*private*/ _major_label_views: Map<string | number, BaseTextView> = new Map()
+
+  get bbox(): BBox {
+    // TODO Fixed axes should not participate in layout at all.
+    if (this.layout != null && this.model.fixed_location == null) {
+      return this.layout.bbox
+    } else if (this.is_renderable) {
+      const {extents} = this
+      const depth = Math.round(extents.tick + extents.tick_label + extents.axis_label)
+
+      let {sx0, sy0, sx1, sy1} = this.rule_scoords
+      const {dimension, face} = this
+      if (dimension == 0) {
+        if (face == "front")
+          sy0 -= depth
+        else
+          sy1 += depth
+      } else {
+        if (face == "front")
+          sx0 -= depth
+        else
+          sx1 += depth
+      }
+
+      return BBox.from_lrtb({left: sx0, top: sy0, right: sx1, bottom: sy1})
+    } else {
+      return new BBox()
+    }
+  }
 
   override *children(): IterViews {
     yield* super.children()
@@ -117,6 +148,7 @@ export class AxisView extends GuideRendererView {
 
     const ctx = this.layer.ctx
     ctx.save()
+    this._draw_background(ctx, extents)
     this._draw_rule(ctx, extents)
     this._draw_major_ticks(ctx, extents, tick_coords)
     this._draw_minor_ticks(ctx, extents, tick_coords)
@@ -154,24 +186,26 @@ export class AxisView extends GuideRendererView {
 
   // drawing sub functions -----------------------------------------------------
 
+  protected _draw_background(ctx: Context2d, _extents: Extents): void {
+    if (!this.visuals.background_fill.doit)
+      return
+
+    ctx.beginPath()
+    const {x, y, width, height} = this.bbox
+    ctx.rect(x, y, width, height)
+    this.visuals.background_fill.apply(ctx)
+  }
+
   protected _draw_rule(ctx: Context2d, _extents: Extents): void {
     if (!this.visuals.axis_line.doit)
       return
 
-    const [xs, ys]     = this.rule_coords
-    const [sxs, sys]   = this.coordinates.map_to_screen(xs, ys)
-    const [nx, ny]     = this.normals
-    const [xoff, yoff] = this.offsets
-
-    this.visuals.axis_line.set_value(ctx)
+    const {sx0, sy0, sx1, sy1} = this.rule_scoords
 
     ctx.beginPath()
-    for (let i = 0; i < sxs.length; i++) {
-      const sx = Math.round(sxs[i] + nx*xoff)
-      const sy = Math.round(sys[i] + ny*yoff)
-      ctx.lineTo(sx, sy)
-    }
-    ctx.stroke()
+    ctx.moveTo(sx0, sy0)
+    ctx.lineTo(sx1, sy1)
+    this.visuals.axis_line.apply(ctx)
   }
 
   protected _draw_major_ticks(ctx: Context2d, _extents: Extents, tick_coords: TickCoords): void {
@@ -197,7 +231,7 @@ export class AxisView extends GuideRendererView {
     const standoff = extents.tick + this.model.major_label_standoff
     const visuals  = this.visuals.major_label_text
 
-    this._draw_oriented_labels(ctx, labels, coords, orient, this.panel.side, standoff, visuals)
+    this._draw_oriented_labels(ctx, labels, coords, orient, standoff, visuals)
   }
 
   protected _axis_label_extent(): number {
@@ -224,16 +258,40 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _draw_axis_label(ctx: Context2d, extents: Extents, _tick_coords: TickCoords): void {
-    if (this._axis_label_view == null || this.model.fixed_location != null)
+    if (this._axis_label_view == null)
       return
 
-    const [sx, sy] = (() => {
-      const {bbox} = this.layout
-      switch (this.panel.side) {
-        case "above": return [bbox.hcenter, bbox.bottom]
-        case "below": return [bbox.hcenter, bbox.top]
-        case "left":  return [bbox.right, bbox.vcenter]
-        case "right": return [bbox.left, bbox.vcenter]
+    const [sx, sy/* TODO, x_anchor, y_anchor*/] = (() => {
+      const {bbox} = this
+      const {side, face} = this.panel
+      const [range] = this.ranges
+      const {axis_label_align} = this.model
+
+      switch (side) {
+        case "above":
+        case "below": {
+          const [sx, x_anchor]: [number, HAlign] = (() => {
+            switch (axis_label_align) {
+              case "start":  return !range.is_reversed ? [bbox.left, "left"] : [bbox.right, "right"]
+              case "center": return [bbox.hcenter, "center"]
+              case "end":    return !range.is_reversed ? [bbox.right, "right"] : [bbox.left, "left"]
+            }
+          })()
+          const [sy, y_anchor]: [number, VAlign] = face == "front" ? [bbox.bottom, "bottom"] : [bbox.top, "top"]
+          return [sx, sy, x_anchor, y_anchor]
+        }
+        case "left":
+        case "right": {
+          const [sy, y_anchor]: [number, VAlign] = (() => {
+            switch (axis_label_align) {
+              case "start":  return !range.is_reversed ? [bbox.bottom, "bottom"] : [bbox.top, "top"]
+              case "center": return [bbox.vcenter, "center"]
+              case "end":    return !range.is_reversed ? [bbox.top, "top"] : [bbox.bottom, "bottom"]
+            }
+          })()
+          const [sx, x_anchor]: [number, HAlign] = face == "front" ? [bbox.right, "right"] : [bbox.left, "left"]
+          return [sx, sy, x_anchor, y_anchor]
+        }
       }
     })()
 
@@ -267,8 +325,7 @@ export class AxisView extends GuideRendererView {
     if (!visuals.doit)
       return
 
-    const [x, y]       = coords
-    const [sxs, sys]   = this.coordinates.map_to_screen(x, y)
+    const [sxs, sys]   = this.scoords(coords)
     const [nx, ny]     = this.normals
     const [xoff, yoff] = this.offsets
 
@@ -289,14 +346,14 @@ export class AxisView extends GuideRendererView {
     ctx.stroke()
   }
 
-  protected _draw_oriented_labels(ctx: Context2d, labels: GraphicsBoxes, coords: Coords,
-                                  orient: Orient | number, _side: Side, standoff: number,
-                                  visuals: visuals.Text): void {
+  protected _draw_oriented_labels(
+      ctx: Context2d, labels: GraphicsBoxes, coords: Coords,
+      orient: Orient | number, standoff: number, visuals: visuals.Text,
+  ): void {
     if (!visuals.doit || labels.length == 0)
       return
 
-    const [dxs, dys] = coords
-    const [sxs, sys] = this.coordinates.map_to_screen(dxs, dys)
+    const [sxs, sys] = this.scoords(coords)
     const [xoff, yoff] = this.offsets
 
     const [nx, ny] = this.normals
@@ -343,7 +400,7 @@ export class AxisView extends GuideRendererView {
 
     const ids = [...selected.ones()]
     if (ids.length != 0) {
-      const cbox = this.parent.canvas_view.bbox
+      const cbox = this.canvas.bbox
 
       const correct_x = (k: number) => {
         const bbox = bboxes[k]
@@ -434,11 +491,11 @@ export class AxisView extends GuideRendererView {
   }
 
   // {{{ TODO: state
-  get normals(): [number, number] {
+  get normals(): [Normal, Normal] {
     return this.panel.normals
   }
 
-  get dimension(): 0 | 1 {
+  get dimension(): Dimension {
     return this.panel.dimension
   }
 
@@ -465,31 +522,30 @@ export class AxisView extends GuideRendererView {
     return new GraphicsBoxes(labels)
   }
 
-  get offsets(): [number, number] {
-    // If we have a fixed_position then we should respect that exactly and
-    // not apply any offsets (https://github.com/bokeh/bokeh/issues/8552)
-    if (this.model.fixed_location != null)
-      return [0, 0]
-
-    const {frame} = this.plot_view
-    let [xoff, yoff] = [0, 0]
-
-    switch (this.panel.side) {
-      case "below":
-        yoff = abs(this.layout.bbox.top - frame.bbox.bottom)
-        break
-      case "above":
-        yoff = abs(this.layout.bbox.bottom - frame.bbox.top)
-        break
-      case "right":
-        xoff = abs(this.layout.bbox.left - frame.bbox.right)
-        break
-      case "left":
-        xoff = abs(this.layout.bbox.right - frame.bbox.left)
-        break
+  scoords(coords: Coords): Coords {
+    /**
+     * Compute screen coordinates with respect to the bbox.
+     */
+    const [x, y] = coords
+    const [sxs, sys] = this.coordinates.map_to_screen(x, y)
+    if (this.model.fixed_location != null) {
+      return [[...sxs], [...sys]]
+    } else {
+      const {bbox} = this
+      const {face} = this.panel
+      if (this.panel.is_vertical) {
+        const sx = face == "front" ? bbox.right : bbox.left
+        return [repeat(sx, sxs.length), [...sys]]
+      } else {
+        const sy = face == "front" ? bbox.bottom : bbox.top
+        return [[...sxs], repeat(sy, sys.length)]
+      }
     }
+  }
 
-    return [xoff, yoff]
+  // TODO Remove this.
+  get offsets(): [number, number] {
+    return [0, 0]
   }
 
   get ranges(): [Range, Range] {
@@ -546,6 +602,16 @@ export class AxisView extends GuideRendererView {
     coords[j][1] = this.loc
 
     return coords
+  }
+
+  get rule_scoords(): {sx0: number, sy0: number, sx1: number, sy1: number} {
+    const [[sx0, sx1], [sy0, sy1]] = this.scoords(this.rule_coords)
+    return {
+      sx0: Math.round(sx0),
+      sy0: Math.round(sy0),
+      sx1: Math.round(sx1),
+      sy1: Math.round(sy1),
+    }
   }
 
   get tick_coords(): TickCoords {
@@ -612,12 +678,17 @@ export class AxisView extends GuideRendererView {
         return cross_range.end
     }
   }
+
+  get face(): Face {
+    return this.panel.face
+  }
+
   // }}}
 
   override serializable_state(): SerializableState {
     return {
       ...super.serializable_state(),
-      bbox: this.layout.bbox,
+      bbox: this.bbox,
     }
   }
 
@@ -653,12 +724,15 @@ export namespace Axis {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = GuideRenderer.Props & {
+    dimension: p.Property<0 | 1 | "auto">
+    face:  p.Property<Face | "auto">
     bounds: p.Property<[number, number] | "auto">
     ticker: p.Property<Ticker>
     formatter: p.Property<TickFormatter>
     axis_label: p.Property<string | BaseText | null>
     axis_label_standoff: p.Property<number>
     axis_label_orientation: p.Property<LabelOrientation | number>
+    axis_label_align: p.Property<Align>
     major_label_standoff: p.Property<number>
     major_label_orientation: p.Property<LabelOrientation | number>
     major_label_overrides: p.Property<Map<string /*Cat*/ | number, string | BaseText>>
@@ -675,7 +749,8 @@ export namespace Axis {
     mixins.MajorTickLine  &
     mixins.MinorTickLine  &
     mixins.MajorLabelText &
-    mixins.AxisLabelText
+    mixins.AxisLabelText  &
+    mixins.BackgroundFill
 
   export type Visuals = GuideRenderer.Visuals & {
     axis_line: visuals.Line
@@ -683,6 +758,7 @@ export namespace Axis {
     minor_tick_line: visuals.Line
     major_label_text: visuals.Text
     axis_label_text: visuals.Text
+    background_fill: visuals.Fill
   }
 }
 
@@ -705,15 +781,19 @@ export class Axis extends GuideRenderer {
       ["minor_tick_",  mixins.Line],
       ["major_label_", mixins.Text],
       ["axis_label_",  mixins.Text],
+      ["background_",  mixins.Fill],
     ])
 
-    this.define<Axis.Props>(({Any, Int, Number, String, Ref, Map, Tuple, Or, Nullable, Auto}) => ({
+    this.define<Axis.Props>(({Any, Int, Number, String, Ref, Map, Tuple, Or, Nullable, Auto, Enum}) => ({
+      dimension:               [ Or(Enum(0, 1), Auto), "auto" ],
+      face:                    [ Or(Face, Auto), "auto" ],
       bounds:                  [ Or(Tuple(Number, Number), Auto), "auto" ],
       ticker:                  [ Ref(Ticker) ],
       formatter:               [ Ref(TickFormatter) ],
       axis_label:              [ Nullable(Or(String, Ref(BaseText))), null],
       axis_label_standoff:     [ Int, 5 ],
       axis_label_orientation:  [ Or(LabelOrientation, Number), "parallel" ],
+      axis_label_align:        [ Align, "center" ],
       major_label_standoff:    [ Int, 5 ],
       major_label_orientation: [ Or(LabelOrientation, Number), "horizontal" ],
       major_label_overrides:   [ Map(Or(String, Number), Or(String, Ref(BaseText))), new globalThis.Map(), {
@@ -741,6 +821,8 @@ export class Axis extends GuideRenderer {
 
       axis_label_text_font_size: "13px",
       axis_label_text_font_style: "italic",
+
+      background_fill_color: null,
     })
   }
 }

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -69,7 +69,7 @@ export class CategoricalAxisView extends AxisView {
     let standoff = extents.tick + this.model.major_label_standoff
     for (let i = 0; i < info.length; i++) {
       const [labels, coords, orient, visuals] = info[i]
-      this._draw_oriented_labels(ctx, labels, coords, orient, this.panel.side, standoff, visuals)
+      this._draw_oriented_labels(ctx, labels, coords, orient, standoff, visuals)
       standoff += extents.tick_labels[i]
     }
   }

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -391,11 +391,11 @@ export class PlotView extends LayoutDOMView implements Renderable {
       }
     }
 
-    const set_layout = (side: Side, model: Annotation | Axis): Layoutable => {
+    const set_layout = (side: Side, model: Annotation | Axis): Layoutable | undefined => {
       const view = this.renderer_view(model)!
       view.panel = new Panel(side)
       view.update_layout?.()
-      return view.layout!
+      return view.layout
     }
 
     const set_layouts = (side: Side, panels: Panels) => {
@@ -406,12 +406,14 @@ export class PlotView extends LayoutDOMView implements Renderable {
         if (isArray(panel)) {
           const items = panel.map((subpanel) => {
             const item = set_layout(side, subpanel)
+            if (item == null)
+              return undefined
             if (subpanel instanceof ToolbarPanel) {
               const dim = horizontal ? "width_policy" : "height_policy"
               item.set_sizing({...item.sizing, [dim]: "min"})
             }
             return item
-          })
+          }).filter((item): item is Layoutable => item != null)
 
           let layout: Row | Column
           if (horizontal) {
@@ -424,8 +426,11 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
           layout.absolute = true
           layouts.push(layout)
-        } else
-          layouts.push(set_layout(side, panel))
+        } else {
+          const layout = set_layout(side, panel)
+          if (layout != null)
+            layouts.push(layout)
+        }
       }
 
       return layouts

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -29,7 +29,7 @@ export class WheelZoomToolView extends GestureToolView {
   override _scroll(ev: ScrollEvent): void {
     const {sx, sy} = ev
 
-    const axis_view = this.plot_view.axis_views.find((view) => view.layout.bbox.contains(sx, sy))
+    const axis_view = this.plot_view.axis_views.find((view) => view.bbox.contains(sx, sy))
     if (axis_view != null && !this.model.zoom_on_axis) {
       return
     }

--- a/bokehjs/test/baselines/linux/Grid__should_support_cross_bounds.blf
+++ b/bokehjs/test/baselines/linux/Grid__should_support_cross_bounds.blf
@@ -1,4 +1,4 @@
 Plot bbox=[0, 0, 300, 300]
   CartesianFrame bbox=[5, 5, 290, 290]
-  LinearAxis bbox=[5, 295, 290, 0]
-  LinearAxis bbox=[5, 5, 0, 290]
+  LinearAxis bbox=[18, 216, 132, 22]
+  LinearAxis bbox=[55, 18, 29, 264]

--- a/src/bokeh/models/axes.py
+++ b/src/bokeh/models/axes.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from ..core.enums import LabelOrientation
+from ..core.enums import Align, LabelOrientation
 from ..core.has_props import abstract
 from ..core.properties import (
     Auto,
@@ -44,7 +44,7 @@ from ..core.properties import (
     TextLike,
     Tuple,
 )
-from ..core.property_mixins import ScalarLineProps, ScalarTextProps
+from ..core.property_mixins import ScalarFillProps, ScalarLineProps, ScalarTextProps
 from .formatters import (
     BasicTickFormatter,
     CategoricalTickFormatter,
@@ -92,6 +92,13 @@ class Axis(GuideRenderer):
     # explicit __init__ to support Init signatures
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+
+    dimension = Either(Auto, Int, default="auto", help="""
+    """)
+
+    face = Either(Auto, Enum("front", "back"))(default="auto", help="""
+    The direction toward which the axis will face.
+    """)
 
     bounds = Either(Auto, Tuple(Float, Float), Tuple(Datetime, Datetime), help="""
     Bounds for the rendered axis. If unset, the axis will span the
@@ -141,6 +148,10 @@ class Axis(GuideRenderer):
     axis_label_orientation = Either(Enum(LabelOrientation), Float)(default="parallel", help="""
     What direction the asix label text should be oriented. If a number
     is supplied, the angle of the text is measured from horizontal.
+    """)
+
+    axis_label_align = Enum(Align, default="center", help="""
+    The alignment of axis label along the axis.
     """)
 
     axis_label_props = Include(ScalarTextProps, prefix="axis_label", help="""
@@ -221,6 +232,12 @@ class Axis(GuideRenderer):
         Axes labels are suppressed when axes are positioned at fixed locations
         inside the central plot area.
     """)
+
+    background_props = Include(ScalarFillProps, prefix="background", help="""
+    The {prop} of the axis background.
+    """)
+
+    background_fill_color = Override(default=None)
 
 @abstract
 class ContinuousAxis(Axis):

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -3393,6 +3393,8 @@
   },
   Axis: {
     __extends__: "GuideRenderer",
+    dimension: "auto",
+    face: "auto",
     bounds: "auto",
     ticker: {
       type: "symbol",
@@ -3405,6 +3407,7 @@
     axis_label: null,
     axis_label_standoff: 5,
     axis_label_orientation: "parallel",
+    axis_label_align: "center",
     axis_label_text_color: "#444444",
     axis_label_text_outline_color: null,
     axis_label_text_alpha: 1.0,
@@ -3459,6 +3462,8 @@
     minor_tick_in: 0,
     minor_tick_out: 4,
     fixed_location: null,
+    background_fill_color: null,
+    background_fill_alpha: 1.0,
   },
   ContinuousAxis: {
     __extends__: "Axis",


### PR DESCRIPTION
This PR is a preparatory work for adding support for scale indicator annotation. The goal of this PR is to make axes less dependent of layout, especially outside of side panels (i.e. `fixed_location != null`), add support for configuring axis face (instead of relying on side panels to dictate the facing of an axis). As a side effect, this also adds support for axis label alignment setting and additional visuals (e.g. background; this will be later generalized for all panel-like UI elements on the canvas).

![image](https://user-images.githubusercontent.com/27475/235329336-1fab2c3c-c2eb-4f6f-aec5-77e35bd15887.png)
