### PR TITLE
Do not blit webgl canvas if width or height are zero

### DIFF
--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -217,7 +217,7 @@ export class CanvasView extends UIElementView {
   blit_webgl(ctx: Context2d): void {
     // This should be called when the ctx has no state except the HIDPI transform
     const {webgl} = this
-    if (webgl != null) {
+    if (webgl != null && webgl.canvas.width*webgl.canvas.height > 0) {
       // Blit gl canvas into the 2D canvas. To do 1-on-1 blitting, we need
       // to remove the hidpi transform, then blit, then restore.
       // ctx.globalCompositeOperation = "source-over"  -> OK; is the default

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -682,4 +682,22 @@ describe("Bug", () => {
       ])
     })
   })
+
+  describe("in issue #13139", () => {
+    function make_plot(width: number, height: number) {
+      const p = fig([width, height], {output_backend: "webgl"})
+      p.line([0, 1], [0, 1])
+      return p
+    }
+
+    it("raises DOMException if webgl canvas width is zero", async () => {
+      await display(make_plot(0, 100))
+    })
+    it("raises DOMException if webgl canvas height is zero", async () => {
+      await display(make_plot(100, 0))
+    })
+    it("raises DOMException if webgl canvas area is zero", async () => {
+      await display(make_plot(0, 0))
+    })
+  })
 })


### PR DESCRIPTION
Workaround for issue #13139. Actual fix for that issue will be in layout.

This adds an explicit test for the area of the WebGL canvas and it only proceeds to blit to the HTML canvas if the area is greater than zero.

(Edited to reclassify as workaround rather than fix)