### PR TITLE
Add support for generic `Tooltip` hover

### DIFF
--- a/examples/models/widgets.py
+++ b/examples/models/widgets.py
@@ -238,11 +238,16 @@ This example shows all widgets available in Bokeh.<br>To learn more about using 
 regarding this topic.
 """), position="top", attachment="below", target=ByCSS("body"), closable=True, visible=True)
 
+tooltip_3 = Tooltip(content=HTML("""\
+Allows users to observer and manipulate values of models' properties.
+"""), position="right", target=click_button, persistance="hover")
+
 doc = Document()
 doc.add_root(widgets)
 doc.add_root(dialog)
 doc.add_root(tooltip_0)
 doc.add_root(tooltip_2)
+doc.add_root(tooltip_3)
 
 if __name__ == "__main__":
     doc.validate()

--- a/src/bokeh/models/ui/tooltips.py
+++ b/src/bokeh/models/ui/tooltips.py
@@ -101,6 +101,10 @@ class Tooltip(UIElement):
     the contents of this tooltip, e.g. clicking links.
     """)
 
+    persistance = Enum("manual", "hover", default="manual", help="""
+    TODO
+    """)
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR allows to attach a `Tooltip` instance to any target (UI model, HTML element, etc.) and display the tooltip on hover over the target. Note the API is a proof of concept and it very likely to change.

fixes #12802