### PR TITLE
Improve handling of resources in lower level embed APIs

### DIFF
--- a/examples/models/basic_plot.py
+++ b/examples/models/basic_plot.py
@@ -14,7 +14,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Circle, ColumnDataSource, LinearAxis,
                           PanTool, Plot, WheelZoomTool)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 x = arange(-2*pi, 2*pi, 0.1)
@@ -41,6 +40,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "basic_plot.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Basic Glyph Plot"))
+        f.write(file_html(doc, title="Basic Glyph Plot"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/buttons.py
+++ b/examples/models/buttons.py
@@ -17,7 +17,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Button, CheckboxButtonGroup, CheckboxGroup, Column,
                           CustomJS, Dropdown, RadioButtonGroup, RadioGroup, Toggle)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 button = Button(label="Button (enabled) - has click event", button_type="primary")
@@ -74,6 +73,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "buttons.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Button widgets"))
+        f.write(file_html(doc, title="Button widgets"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/calendars.py
+++ b/examples/models/calendars.py
@@ -19,7 +19,6 @@ from bokeh.embed import file_html
 from bokeh.layouts import gridplot
 from bokeh.models import (CategoricalAxis, CategoricalScale, ColumnDataSource,
                           FactorRange, HoverTool, Plot, Rect, Text)
-from bokeh.resources import INLINE
 from bokeh.sampledata.us_holidays import us_holidays
 from bokeh.util.browser import view
 
@@ -103,6 +102,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "calendars.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Calendar 2014"))
+        f.write(file_html(doc, title="Calendar 2014"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/colors.py
+++ b/examples/models/colors.py
@@ -20,7 +20,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (CategoricalAxis, CategoricalScale, ColumnDataSource,
                           FactorRange, HoverTool, OpenURL, Plot, Rect, TapTool)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 data = []
@@ -68,6 +67,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "colors.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "CSS3 Color Names"))
+        f.write(file_html(doc, title="CSS3 Color Names"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/custom.py
+++ b/examples/models/custom.py
@@ -3,7 +3,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Callback, Circle, ColumnDataSource, LinearAxis,
                           PanTool, Plot, TapTool, WheelZoomTool)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 from bokeh.util.compiler import TypeScript
 
@@ -116,6 +115,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "custom.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Demonstration of user-defined models"))
+        f.write(file_html(doc, title="Demonstration of user-defined models"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/customjs.py
+++ b/examples/models/customjs.py
@@ -2,7 +2,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Circle, ColumnDataSource, CustomJS, LinearAxis,
                           PanTool, Plot, TapTool, WheelZoomTool)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 source = ColumnDataSource(
@@ -37,6 +36,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "customjs.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Demonstration of custom callback written in TypeScript"))
+        f.write(file_html(doc, title="Demonstration of custom callback written in TypeScript"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/dateaxis.py
+++ b/examples/models/dateaxis.py
@@ -6,7 +6,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Circle, ColumnDataSource, DatetimeAxis,
                           PanTool, Plot, WheelZoomTool)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 N = 200
@@ -35,6 +34,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "dateaxis.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Date Axis Example"))
+        f.write(file_html(doc, title="Date Axis Example"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/daylight.py
+++ b/examples/models/daylight.py
@@ -18,7 +18,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (ColumnDataSource, DatetimeAxis, DatetimeTickFormatter,
                           FixedTicker, Legend, LegendItem, Line, Patch, Plot, Text)
-from bokeh.resources import INLINE
 from bokeh.sampledata import daylight
 from bokeh.util.browser import view
 
@@ -106,6 +105,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "daylight.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Daylight Plot"))
+        f.write(file_html(doc, title="Daylight Plot"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/gauges.py
+++ b/examples/models/gauges.py
@@ -6,7 +6,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Arc, Circle, ColumnDataSource, Plot,
                           PolarTransform, Range1d, Ray, Text)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 xdr = Range1d(start=-1.25, end=1.25)
@@ -109,6 +108,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "gauges.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Gauges"))
+        f.write(file_html(doc, title="Gauges"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/glyphs.py
+++ b/examples/models/glyphs.py
@@ -8,7 +8,6 @@ from bokeh.models import (AnnularWedge, Annulus, Arc, Bezier, Circle, Column,
                           Line, LinearAxis, MultiLine, MultiPolygons, Paragraph,
                           Patch, Patches, Plot, Quad, Quadratic, Ray, Rect,
                           Scatter, Segment, TabPanel, Tabs, Text, Wedge)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 N = 9
@@ -114,6 +113,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "glyphs.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Glyphs"))
+        f.write(file_html(doc, title="Glyphs"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/maps.py
+++ b/examples/models/maps.py
@@ -3,7 +3,6 @@ from bokeh.embed import file_html
 from bokeh.models import (BoxSelectTool, Circle, ColumnDataSource, GMapOptions,
                           GMapPlot, Label, LinearAxis, MercatorTicker,
                           MercatorTickFormatter, PanTool, WheelZoomTool)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 # JSON style string taken from: https://snazzymaps.com/style/1/pale-dawn
@@ -58,6 +57,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "maps.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Google Maps Example"))
+        f.write(file_html(doc, title="Google Maps Example"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/maps_cities.py
+++ b/examples/models/maps_cities.py
@@ -12,7 +12,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Circle, ColumnDataSource, GMapOptions,
                           GMapPlot, Label, PanTool, WheelZoomTool)
-from bokeh.resources import INLINE
 from bokeh.sampledata.world_cities import data
 from bokeh.util.browser import view
 
@@ -45,6 +44,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "maps_cities.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Google Maps - World cities Example"))
+        f.write(file_html(doc, title="Google Maps - World cities Example"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/sliders.py
+++ b/examples/models/sliders.py
@@ -13,7 +13,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Column, CustomJS, DateRangeSlider,
                           DateSlider, Div, RangeSlider, Row, Slider)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 slider = Slider(title="Numerical", value=50, start=0, end=96, step=5)
@@ -73,6 +72,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "sliders.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "sliders"))
+        f.write(file_html(doc, title="sliders"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/tile_source.py
+++ b/examples/models/tile_source.py
@@ -11,7 +11,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (BoxZoomTool, PanTool, Plot, Range1d,
                           WheelZoomTool, WMTSTileSource)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 # set to roughly full extent of web mercator projection
@@ -37,6 +36,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "tile_source.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Tile Source Example"))
+        f.write(file_html(doc, title="Tile Source Example"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/trail.py
+++ b/examples/models/trail.py
@@ -8,7 +8,6 @@ from bokeh.embed import file_html
 from bokeh.models import (Column, ColumnDataSource, GMapOptions, GMapPlot,
                           Grid, Label, Line, LinearAxis, PanTool, Patches,
                           Plot, Range1d, ResetTool, WheelZoomTool)
-from bokeh.resources import INLINE
 from bokeh.sampledata.mtb import obiszow_mtb_xcm
 from bokeh.util.browser import view
 
@@ -136,6 +135,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "trail.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Trail map and altitude profile"))
+        f.write(file_html(doc, title="Trail map and altitude profile"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/twin_axis.py
+++ b/examples/models/twin_axis.py
@@ -13,7 +13,6 @@ from bokeh.document import Document
 from bokeh.embed import file_html
 from bokeh.models import (Circle, ColumnDataSource, LinearAxis,
                           PanTool, Plot, Range1d, WheelZoomTool)
-from bokeh.resources import INLINE
 from bokeh.util.browser import view
 
 x = arange(-2*pi, 2*pi, 0.1)
@@ -56,6 +55,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "twin_axis.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Twin Axis Plot"))
+        f.write(file_html(doc, title="Twin Axis Plot"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/models/widgets.py
+++ b/examples/models/widgets.py
@@ -28,7 +28,6 @@ from bokeh.models import (AutocompleteInput, BuiltinIcon, Button, ByCSS, Checkbo
                           TextInput, TimePicker, Toggle, Tooltip)
 from bokeh.models.dom import HTML, ValueOf
 from bokeh.plotting import figure
-from bokeh.resources import INLINE
 from bokeh.sampledata.autompg2 import autompg2 as mpg
 from bokeh.sampledata.iris import flowers
 from bokeh.util.browser import view
@@ -250,6 +249,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "widgets.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, "Widgets"))
+        f.write(file_html(doc, title="Widgets"))
     print(f"Wrote {filename}")
     view(filename)

--- a/examples/output/apis/file_html.py
+++ b/examples/output/apis/file_html.py
@@ -5,7 +5,6 @@ from bokeh.document import Document
 from bokeh.models import (CDSView, Circle, ColumnDataSource, DataRange1d,
                           Grid, HoverTool, IndexFilter, LinearAxis, Plot,
                           Range1d, SingleIntervalTicker, Text)
-from bokeh.resources import INLINE
 from bokeh.sampledata.sprint import sprint
 from bokeh.themes import Theme
 
@@ -121,6 +120,6 @@ if __name__ == "__main__":
     doc.validate()
     filename = "file_html.html"
     with open(filename, "w") as f:
-        f.write(file_html(doc, INLINE, plot.title.text))
+        f.write(file_html(doc, title=plot.title.text))
     print(f"Wrote {filename}")
     view(filename)

--- a/src/bokeh/embed/standalone.py
+++ b/src/bokeh/embed/standalone.py
@@ -43,7 +43,7 @@ from ..core.templates import (
 )
 from ..document.document import DEFAULT_TITLE, Document
 from ..model import Model
-from ..resources import Resources
+from ..resources import Resources, ResourcesLike
 from ..themes import Theme
 from .bundle import Script, bundle_for_objs_and_resources
 from .elements import html_page_for_render_items, script_for_render_items
@@ -292,8 +292,9 @@ def components(models: Model | Sequence[Model] | dict[str, Model], wrap_script: 
     return script, result
 
 def file_html(models: Model | Document | Sequence[Model],
-              resources: Resources | None,
+              resources: ResourcesLike | None = None,
               title: str | None = None,
+              *,
               template: Template | str = FILE,
               template_variables: dict[str, Any] = {},
               theme: ThemeLike = None,
@@ -309,8 +310,8 @@ def file_html(models: Model | Document | Sequence[Model],
         models (Model or Document or seq[Model]) : Bokeh object or objects to render
             typically a Model or Document
 
-        resources (Resources) :
-            A resource configuration for Bokeh JS & CSS assets.
+        resources (ResourcesLike) :
+            A resources configuration for Bokeh JS & CSS assets.
 
         title (str, optional) :
             A title for the HTML document ``<title>`` tags or None. (default: None)
@@ -342,7 +343,6 @@ def file_html(models: Model | Document | Sequence[Model],
         UTF-8 encoded HTML
 
     '''
-
     models_seq: Sequence[Model] = []
     if isinstance(models, Model):
         models_seq = [models]
@@ -352,6 +352,8 @@ def file_html(models: Model | Document | Sequence[Model],
         models_seq = models.roots
     else:
         models_seq = models
+
+    resources = Resources.build(resources)
 
     with OutputDocumentFor(models_seq, apply_theme=theme, always_new=_always_new) as doc:
         (docs_json, render_items) = standalone_docs_json_and_render_items(models_seq, suppress_callback_warning=suppress_callback_warning)

--- a/src/bokeh/io/export.py
+++ b/src/bokeh/io/export.py
@@ -318,7 +318,15 @@ def get_layout_html(obj: UIElement | Document, *, resources: Resources = INLINE,
     """
 
     def html() -> str:
-        return file_html(obj, resources, title="", template=template, theme=theme, suppress_callback_warning=True, _always_new=True)
+        return file_html(
+            obj,
+            resources=resources,
+            title="",
+            template=template,
+            theme=theme,
+            suppress_callback_warning=True,
+            _always_new=True,
+        )
 
     if width is not None or height is not None:
         # Defer this import, it is expensive

--- a/src/bokeh/io/saving.py
+++ b/src/bokeh/io/saving.py
@@ -161,7 +161,7 @@ def _save_helper(obj: UIElement | Sequence[UIElement], filename: PathLike, resou
 
     '''
     from ..embed import file_html
-    html = file_html(obj, resources, title=title, template=template or FILE, theme=theme)
+    html = file_html(obj, resources=resources, title=title, template=template or FILE, theme=theme)
 
     with open(filename, mode="w", encoding="utf-8") as f:
         f.write(html)

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -647,8 +647,11 @@ def _get_cdn_urls(version: str | None = None, minified: bool = True) -> Urls:
     return result
 
 
-def _get_server_urls(root_url: str, minified: bool = True,
-        path_versioner: PathVersioner | None = None) -> Urls:
+def _get_server_urls(
+    root_url: str = DEFAULT_SERVER_HTTP_URL,
+    minified: bool = True,
+    path_versioner: PathVersioner | None = None,
+) -> Urls:
     _minified = ".min" if minified else ""
 
     def mk_url(comp: str, kind: Kind) -> str:

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -415,6 +415,13 @@ class Resources:
 
     __str__ = __repr__
 
+    @classmethod
+    def build(cls, resources: ResourcesLike | None = None) -> Resources:
+        if isinstance(resources, Resources):
+            return resources
+        else:
+            return Resources(mode=settings.resources(resources))
+
     # Properties --------------------------------------------------------------
 
     @property

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -438,6 +438,9 @@ class PrioritizedSetting(Generic[T]):
     def __set__(self, instance: Any, value: str | T) -> None:
         self.set_value(value)
 
+    def __delete__(self, instance: Any) -> None:
+        self.unset_value()
+
     def set_value(self, value: str | T) -> None:
         ''' Specify a value for this setting programmatically.
 

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -37,7 +37,8 @@ from bokeh.document import Document
 from bokeh.embed.util import RenderRoot, standalone_docs_json
 from bokeh.io import curdoc
 from bokeh.plotting import figure
-from bokeh.resources import CDN
+from bokeh.resources import CDN, Resources
+from bokeh.settings import settings
 from bokeh.themes import Theme
 
 # Module under test
@@ -346,6 +347,46 @@ class Test_file_html:
         doc = Document()
         with pytest.raises(ValueError, match="Document has no root Models"):
             bes.file_html(doc, CDN)
+
+    def test_resources(self, test_plot: figure) -> None:
+        cdn_url = "https://cdn.bokeh.org/bokeh/"
+        server_url = "http://localhost:5006/static/js/bokeh.js"
+
+        html0 = bes.file_html(test_plot, resources=None)
+        assert cdn_url in html0
+
+        html1 = bes.file_html(test_plot, resources=CDN)
+        assert cdn_url in html1
+
+        html2 = bes.file_html(test_plot, resources="cdn")
+        assert cdn_url in html2
+
+        html3 = bes.file_html(test_plot, resources=Resources(mode="server-dev"))
+        assert server_url in html3
+
+        html4 = bes.file_html(test_plot, resources="server-dev")
+        assert server_url in html4
+
+        settings.resources = "server-dev"
+        try:
+            html5 = bes.file_html(test_plot, resources=None)
+            assert server_url in html5
+        finally:
+            del settings.resources
+
+        settings.resources = "server-dev"
+        try:
+            html6 = bes.file_html(test_plot, resources=CDN)
+            assert cdn_url in html6 and server_url not in html6
+        finally:
+            del settings.resources
+
+        settings.resources = "server-dev"
+        try:
+            html7 = bes.file_html(test_plot, resources="cdn")
+            assert cdn_url in html7 and server_url not in html7
+        finally:
+            del settings.resources
 
 JSON_ITEMS_KEYS = {"target_id", "root_id", "doc", "version"}
 

--- a/tests/unit/bokeh/embed/test_standalone.py
+++ b/tests/unit/bokeh/embed/test_standalone.py
@@ -37,7 +37,12 @@ from bokeh.document import Document
 from bokeh.embed.util import RenderRoot, standalone_docs_json
 from bokeh.io import curdoc
 from bokeh.plotting import figure
-from bokeh.resources import CDN, Resources
+from bokeh.resources import (
+    CDN,
+    Resources,
+    _get_cdn_urls,
+    _get_server_urls,
+)
 from bokeh.settings import settings
 from bokeh.themes import Theme
 
@@ -349,8 +354,8 @@ class Test_file_html:
             bes.file_html(doc, CDN)
 
     def test_resources(self, test_plot: figure) -> None:
-        cdn_url = "https://cdn.bokeh.org/bokeh/"
-        server_url = "http://localhost:5006/static/js/bokeh.js"
+        [cdn_url] = _get_cdn_urls(minified=True).urls(["bokeh"], "js")
+        [server_url] = _get_server_urls(minified=False).urls(["bokeh"], "js")
 
         html0 = bes.file_html(test_plot, resources=None)
         assert cdn_url in html0

--- a/tests/unit/bokeh/io/test_saving.py
+++ b/tests/unit/bokeh/io/test_saving.py
@@ -115,13 +115,15 @@ def test__get_save_args_missing_title(mock_warn: MagicMock) -> None:
 @patch("bokeh.embed.file_html")
 def test__save_helper(mock_file_html: MagicMock, mock_open: MagicMock) -> None:
     obj = Plot()
+
     filename, resources, title = bis._get_save_args(curstate(), "filename", "inline", "title")
+    mock_open.reset_mock() # remove this entry: call('/usr/share/zoneinfo/UTC', 'rb')
 
     bis._save_helper(obj, filename, resources, title, None)
 
     assert mock_file_html.call_count == 1
-    assert mock_file_html.call_args[0] == (obj, resources)
-    assert mock_file_html.call_args[1] == dict(title="title", template=FILE, theme=None)
+    assert mock_file_html.call_args[0] == (obj,)
+    assert mock_file_html.call_args[1] == dict(resources=resources, title="title", template=FILE, theme=None)
 
     assert mock_open.call_count == 1
     assert mock_open.call_args[0] == (filename,)

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -31,7 +31,7 @@ import bokeh.util.version as buv
 from bokeh import __version__
 from bokeh.models import Model
 from bokeh.resources import RuntimeMessage, _get_cdn_urls
-from bokeh.settings import LogLevel
+from bokeh.settings import LogLevel, settings
 
 # Module under test
 import bokeh.resources as resources  # isort:skip
@@ -127,6 +127,31 @@ class TestResources:
 
         r3 = resources.Resources(mode="server-dev", components=["bokeh", "bokeh-gl"])
         assert str(r3) == "Resources(mode='server', dev=True, components=['bokeh', 'bokeh-gl'])"
+
+    def test_build(self) -> None:
+        r0 = resources.Resources(mode="cdn")
+        settings.resources = "inline"
+        try:
+            r = resources.Resources.build(r0)
+            assert r is r0
+        finally:
+            del settings.resources
+
+        r1 = "cdn"
+        settings.resources = "inline"
+        try:
+            r = resources.Resources.build(r1)
+            assert r.mode == "cdn"
+        finally:
+            del settings.resources
+
+        r2 = None
+        settings.resources = "inline"
+        try:
+            r = resources.Resources.build(r2)
+            assert r.mode == "inline"
+        finally:
+            del settings.resources
 
     def test_log_level(self) -> None:
         r = resources.Resources()

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -326,6 +326,8 @@ class TestPrioritizedSetting:
         assert s.bar() == 10
         s.bar = 20
         assert s.bar() == 20
+        del s.bar
+        assert s.bar() == 10
 
 class TestDefaults:
 


### PR DESCRIPTION
This is partially a fix to issues introduced in PR #13041. That PR handles the high level API well (`save`, `show`, etc.), but not the lower level API (e.g. `file_html`).
