### PR TITLE
Remove Ruff pyugrade keep-runtime-annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,12 +162,12 @@ ignore = [
     'E741', # Ambiguous variable name: I
     'RUF001',
     'RUF005',
+    # keep-runtime-annotations
+    'UP006', # Non PEP585 annotations
+    'UP007', # Non PEP604 annotations
 ]
 line-length = 165
 target-version = "py38"
-
-[tool.ruff.pyupgrade]
-keep-runtime-typing = true
 
 # For now enable each typed module individually.
 [[tool.mypy.overrides]]


### PR DESCRIPTION
Ignore UP006 and UP007 instead.
This is a breaking change introduced by Ruff 0.0.268.
We need this change in Ruff to run the ecosystem check on bokeh.

- [ ] issues: fixes #13143
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
