### PR TITLE
Replaced utcnow and utcfromtimestamp functions

### DIFF
--- a/src/bokeh/models/widgets/sliders.py
+++ b/src/bokeh/models/widgets/sliders.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import numbers
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 # Bokeh imports
 from ...core.has_props import abstract
@@ -205,7 +205,7 @@ class DateSlider(AbstractSlider):
             return None
 
         if isinstance(self.value, numbers.Number):
-            return datetime.utcfromtimestamp(self.value / 1000)
+            return datetime.fromtimestamp(self.value / 1000, tz=timezone.utc)
 
         return self.value
 
@@ -219,7 +219,7 @@ class DateSlider(AbstractSlider):
             return None
 
         if isinstance(self.value, numbers.Number):
-            dt = datetime.utcfromtimestamp(self.value / 1000)
+            dt = datetime.fromtimestamp(self.value / 1000, tz=timezone.utc)
             return date(*dt.timetuple()[:3])
 
         return self.value
@@ -264,11 +264,11 @@ class DateRangeSlider(AbstractSlider):
             return None
         v1, v2 = self.value
         if isinstance(v1, numbers.Number):
-            d1 = datetime.utcfromtimestamp(v1 / 1000)
+            d1 = datetime.fromtimestamp(v1 / 1000, tz=timezone.utc)
         else:
             d1 = v1
         if isinstance(v2, numbers.Number):
-            d2 = datetime.utcfromtimestamp(v2 / 1000)
+            d2 = datetime.fromtimestamp(v2 / 1000, tz=timezone.utc)
         else:
             d2 = v2
         return d1, d2
@@ -284,12 +284,12 @@ class DateRangeSlider(AbstractSlider):
             return None
         v1, v2 = self.value
         if isinstance(v1, numbers.Number):
-            dt = datetime.utcfromtimestamp(v1 / 1000)
+            dt = datetime.fromtimestamp(v1 / 1000, tz=timezone.utc)
             d1 = date(*dt.timetuple()[:3])
         else:
             d1 = v1
         if isinstance(v2, numbers.Number):
-            dt = datetime.utcfromtimestamp(v2 / 1000)
+            dt = datetime.fromtimestamp(v2 / 1000, tz=timezone.utc)
             d2 = date(*dt.timetuple()[:3])
         else:
             d2 = v2
@@ -333,11 +333,11 @@ class DatetimeRangeSlider(AbstractSlider):
             return None
         v1, v2 = self.value
         if isinstance(v1, numbers.Number):
-            d1 = datetime.utcfromtimestamp(v1 / 1000)
+            d1 = datetime.fromtimestamp(v1 / 1000, tz=timezone.utc)
         else:
             d1 = v1
         if isinstance(v2, numbers.Number):
-            d2 = datetime.utcfromtimestamp(v2 / 1000)
+            d2 = datetime.fromtimestamp(v2 / 1000, tz=timezone.utc)
         else:
             d2 = v2
         return d1, d2

--- a/src/bokeh/server/views/ws.py
+++ b/src/bokeh/server/views/ws.py
@@ -139,7 +139,7 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
             self.close()
             raise ProtocolError("No token received in subprotocol header")
 
-        now = calendar.timegm(dt.datetime.utcnow().utctimetuple())
+        now = calendar.timegm(dt.datetime.now(tz=dt.timezone.utc).timetuple())
         payload = get_token_payload(token)
         if 'session_expiry' not in payload:
             self.close()

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -84,7 +84,7 @@ BINARY_ARRAY_TYPES = {
 NP_EPOCH = np.datetime64(0, 'ms')
 NP_MS_DELTA = np.timedelta64(1, 'ms')
 
-DT_EPOCH = dt.datetime.utcfromtimestamp(0)
+DT_EPOCH = dt.datetime.fromtimestamp(0, tz=dt.timezone.utc)
 
 __doc__ = format_docstring(__doc__, binary_array_types="\n".join(f"* ``np.{x}``" for x in BINARY_ARRAY_TYPES))
 
@@ -144,7 +144,7 @@ def convert_date_to_datetime(obj: dt.date) -> float:
         datetime
 
     '''
-    return (dt.datetime(*obj.timetuple()[:6], tzinfo=None) - DT_EPOCH).total_seconds() * 1000
+    return (dt.datetime(*obj.timetuple()[:6], tzinfo=dt.timezone.utc) - DT_EPOCH).total_seconds() * 1000
 
 def convert_timedelta_type(obj: dt.timedelta | np.timedelta64) -> float:
     ''' Convert any recognized timedelta value to floating point absolute
@@ -196,7 +196,7 @@ def convert_datetime_type(obj: Any | pd.Timestamp | pd.Timedelta | dt.datetime |
 
     # Datetime (datetime is a subclass of date)
     elif isinstance(obj, dt.datetime):
-        diff = obj.replace(tzinfo=None) - DT_EPOCH
+        diff = obj.replace(tzinfo=dt.timezone.utc) - DT_EPOCH
         return diff.total_seconds() * 1000
 
     # XXX (bev) ideally this would not be here "dates are not datetimes"

--- a/src/bokeh/util/token.py
+++ b/src/bokeh/util/token.py
@@ -115,7 +115,7 @@ def generate_jwt_token(session_id: ID,
     Returns:
         str
     """
-    now = calendar.timegm(dt.datetime.utcnow().utctimetuple())
+    now = calendar.timegm(dt.datetime.now(tz=dt.timezone.utc).timetuple())
     payload = {'session_id': session_id, 'session_expiry': now + expiration}
     if extra_payload:
         if "session_id" in extra_payload:

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -933,7 +933,7 @@ class TestSerializeJson:
     def test_builtin_datetime_types(self) -> None:
         ''' should convert to millis as-is '''
 
-        DT_EPOCH = dt.datetime.utcfromtimestamp(0)
+        DT_EPOCH = dt.datetime.fromtimestamp(0, tz=dt.timezone.utc)
 
         a = dt.date(2016, 4, 28)
         b = dt.datetime(2016, 4, 28, 2, 20, 50)

--- a/tests/unit/bokeh/models/widgets/test_slider.py
+++ b/tests/unit/bokeh/models/widgets/test_slider.py
@@ -18,7 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 # Bokeh imports
 from bokeh.core.properties import UnsetValueError
@@ -93,14 +93,14 @@ class TestDateSlider:
         assert s1.value_throttled == value
 
     def test_value_as_datetime_when_set_as_datetime(self) -> None:
-        start = datetime(2017, 8, 9, 0, 0)
-        end = datetime(2017, 8, 10, 0, 0)
+        start = datetime(2017, 8, 9, 0, 0).astimezone(timezone.utc)
+        end = datetime(2017, 8, 10, 0, 0).astimezone(timezone.utc)
         s = mws.DateSlider(start=start, end=end, value=start)
         assert s.value_as_datetime == start
 
     def test_value_as_datetime_when_set_as_timestamp(self) -> None:
-        start = datetime(2017, 8, 9, 0, 0)
-        end = datetime(2017, 8, 10, 0, 0)
+        start = datetime(2017, 8, 9, 0, 0).astimezone(timezone.utc)
+        end = datetime(2017, 8, 10, 0, 0).astimezone(timezone.utc)
         s = mws.DateSlider(start=start, end=end,
             # Bokeh serializes as ms since epoch, if they get set as numbers (e.g.)
             # by client side update, this is the units they will be
@@ -139,14 +139,14 @@ class TestDateRangeSlider:
         assert s1.value_throttled == value
 
     def test_value_as_datetime_when_set_as_datetime(self) -> None:
-        start = datetime(2017, 8, 9, 0, 0)
-        end = datetime(2017, 8, 10, 0, 0)
+        start = datetime(2017, 8, 9, 0, 0).astimezone(timezone.utc)
+        end = datetime(2017, 8, 10, 0, 0).astimezone(timezone.utc)
         s = mws.DateRangeSlider(start=start, end=end, value=(start, end))
         assert s.value_as_datetime == (start, end)
 
     def test_value_as_datetime_when_set_as_timestamp(self) -> None:
-        start = datetime(2017, 8, 9, 0, 0)
-        end = datetime(2017, 8, 10, 0, 0)
+        start = datetime(2017, 8, 9, 0, 0).astimezone(timezone.utc)
+        end = datetime(2017, 8, 10, 0, 0).astimezone(timezone.utc)
         s = mws.DateRangeSlider(start=start, end=end,
             # Bokeh serializes as ms since epoch, if they get set as numbers (e.g.)
             # by client side update, this is the units they will be
@@ -154,8 +154,8 @@ class TestDateRangeSlider:
         assert s.value_as_datetime == (start, end)
 
     def test_value_as_datetime_when_set_mixed(self) -> None:
-        start = datetime(2017, 8, 9, 0, 0)
-        end = datetime(2017, 8, 10, 0, 0)
+        start = datetime(2017, 8, 9, 0, 0).astimezone(timezone.utc)
+        end = datetime(2017, 8, 10, 0, 0).astimezone(timezone.utc)
         s = mws.DateRangeSlider(start=start, end=end,
                 value=(start, convert_datetime_type(end)))
         assert s.value_as_datetime == (start, end)

--- a/tests/unit/bokeh/util/test_token.py
+++ b/tests/unit/bokeh/util/test_token.py
@@ -187,9 +187,9 @@ class TestSessionId:
         token = generate_jwt_token("foo", expiration=0)
         with patch.object(dt, "datetime", Mock(wraps=dt.datetime)) as patched_dt:
             # mock bokeh server localtime to be UTC + 10
-            patched_dt.now.return_value = dt.datetime.utcnow() + dt.timedelta(hours=10)
+            patched_dt.now.return_value = dt.datetime.now(tz=dt.timezone.utc) + dt.timedelta(hours=10)
             payload = get_token_payload(token)
-        utcnow = calendar.timegm(dt.datetime.utcnow().utctimetuple())
+        utcnow = calendar.timegm(dt.datetime.now(tz=dt.timezone.utc).timetuple())
         assert utcnow -1 <= payload['session_expiry'] <= utcnow + 1
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
The above functions have been replaced with datetime.now() and datetime.fromtimestamp() aligning to Python 3.12 deprecation

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #13125 
- [x] tests added / passed
