### PR TITLE
Allow to recover from deserialization of a previously seen ref

### DIFF
--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -470,6 +470,12 @@ class Serializer:
 class DeserializationError(ValueError):
     pass
 
+class UnknownReferenceError(DeserializationError):
+
+    def __init__(self, id: ID) -> None:
+        super().__init__(f"can't resolve reference '{id}'")
+        self.id = id
+
 class Deserializer:
     """ Convert from serializable representations to built-in and custom types. """
 
@@ -565,7 +571,7 @@ class Deserializer:
         if instance is not None:
             return instance
         else:
-            self.error(f"can't resolve reference '{id}'")
+            self.error(UnknownReferenceError(id))
 
     def _decode_symbol(self, obj: SymbolRep) -> float:
         name = obj["name"]
@@ -712,8 +718,11 @@ class Deserializer:
             else:
                 self.error(f"can't resolve type '{type}'")
 
-    def error(self, message: str) -> NoReturn:
-        raise DeserializationError(message)
+    def error(self, error: str | DeserializationError) -> NoReturn:
+        if isinstance(error, str):
+            raise DeserializationError(error)
+        else:
+            raise error
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -46,7 +46,12 @@ from jinja2 import Template
 from ..core.enums import HoldPolicyType
 from ..core.has_props import is_DataModel
 from ..core.query import find, is_single_string_selector
-from ..core.serialization import Deserializer, Serialized, Serializer
+from ..core.serialization import (
+    Deserializer,
+    Serialized,
+    Serializer,
+    UnknownReferenceError,
+)
 from ..core.templates import FILE
 from ..core.types import ID
 from ..core.validation import check_integrity, process_validation_issues
@@ -364,7 +369,19 @@ class Document:
 
         '''
         deserializer = Deserializer(list(self.models), setter=setter)
-        patch: PatchJson = deserializer.deserialize(patch_json)
+
+        try:
+            patch: PatchJson = deserializer.deserialize(patch_json)
+        except UnknownReferenceError as error:
+            if self.models.seen(error.id):
+                logging.warning(f"""\
+Dropping a patch because it contains a previously known reference (id={error.id!r}). \
+Most of the time this is harmless and usually a result of updating a model on one \
+side of a communications channel while it was being removed on the other end.\
+""")
+                return
+            else:
+                raise
 
         events = patch["events"]
         assert isinstance(events, list) # list[DocumentPatched]

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -41,6 +41,7 @@ from bokeh.core.property.descriptors import UnsetValueError
 from bokeh.core.serialization import (
     Buffer,
     BytesRep,
+    DeserializationError,
     Deserializer,
     MapRep,
     NDArrayRep,
@@ -829,6 +830,11 @@ class TestDeserializer:
             ret = decoder.deserialize(rep)
 
         assert ret == val
+
+    def test_unknown_type(self) -> None:
+        decoder = Deserializer()
+        with pytest.raises(DeserializationError):
+            decoder.deserialize(dict(type="foo"))
 
 """
     def test_set_data_from_json_list(self) -> None:


### PR DESCRIPTION
This turns:
```py
bokeh.core.serialization.DeserializationError: can't resolve reference 'a5833f74-3458-49b9-b18c-bd8d965a7685'
```
into a warning when the reference was previously seen (i.e. a model existed and was removed before a new server message modifying it arrived). This probably needs to be replicated in bokehjs. I wouldn't also consider this fixing anything, especially given this drops entire messages or even batches of messages.

fixes https://github.com/holoviz/panel/issues/1545
