### PR TITLE
Small fixes to user guide basic section

### DIFF
--- a/docs/bokeh/source/docs/user_guide/basic/areas.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/areas.rst
@@ -13,7 +13,7 @@ Rectangles
 Bars
 ~~~~
 
-.. TODO: refs to bars
+See :ref:`ug_basic_bars`
 
 Quads
 ~~~~~
@@ -34,8 +34,8 @@ glyph function:
 .. bokeh-plot:: __REPO__/examples/basic/areas/block.py
     :source-position: above
 
-Rotatable
-~~~~~~~~~
+Rectangles
+~~~~~~~~~~
 
 To draw arbitrary rectangles by specifying center coordinates, ``width``,
 ``height``, and ``angle``, use the |rect| glyph function:

--- a/docs/bokeh/source/docs/user_guide/basic/axes.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/axes.rst
@@ -101,8 +101,8 @@ Twin axes
 ---------
 
 You can add multiple axes representing different ranges to a single plot. To do
-this, configure the plot with "extra" named ranges in the ``extra_x_range`` and
-``extra_y_range`` properties. You can then refer to these named ranges when
+this, configure the plot with "extra" named ranges in the ``extra_x_ranges`` and
+``extra_y_ranges`` properties. You can then refer to these named ranges when
 adding new glyph methods as well as when adding new axis objects with the
 ``add_layout`` method of the |plot|. Here's an example:
 

--- a/docs/bokeh/source/docs/user_guide/basic/axes.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/axes.rst
@@ -69,10 +69,6 @@ these parameters.
 .. bokeh-plot:: __REPO__/examples/basic/axes/datetime_axis.py
     :source-position: above
 
-.. note::
-    Future versions of Bokeh will attempt to auto-detect situations when
-    datetime axes are appropriate and add them automatically.
-
 Log scale axes
 ~~~~~~~~~~~~~~
 

--- a/docs/bokeh/source/docs/user_guide/basic/data.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/data.rst
@@ -226,15 +226,12 @@ For example: If a ``DataFrame`` has the columns ``'year'`` and ``'mpg'``,
 passing ``df.groupby('year')`` to a ColumnDataSource will result in columns such
 as ``'mpg_mean'``.
 
-.. note::
-    Adapting ``GroupBy`` objects requires pandas version 0.20.0 or above.
-
 .. _ug_basic_data_cds_streaming:
 
 Appending data to a ColumnDataSource
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-|ColumnDataSource| streaming is an efficient way to append new data to a
+ColumnDataSource streaming is an efficient way to append new data to a
 ColumnDataSource. When you use the
 :func:`~bokeh.models.sources.ColumnDataSource.stream` method, Bokeh only sends
 new data to the browser instead of sending the entire dataset.
@@ -403,8 +400,9 @@ transformed values:
     plot.line(x='aapl_date', y=transform('aapl_close', normalize), line_width=2,
               color='#cf3c4d', alpha=0.6,legend="Apple", source=aapl_source)
 
-The code in this example converts raw price data into a sequence of normalized
-returns that are relative to the first data point:
+See the full example at :bokeh-tree:`examples/basic/data/transform_customjs.py` that
+converts raw price data into a sequence of normalized returns that are relative to
+the first data point:
 
 .. bokeh-plot:: __REPO__/examples/basic/data/transform_customjs.py
     :source-position: none
@@ -426,9 +424,9 @@ A |CDSView| has one property, ``filter``:
 
 * ``filter`` is an instance of |Filter| model, listed and described below.
 
-In this example, you create a |CDSView| called ``view``. ``view`` uses the
-ColumnDataSource ``source`` and an intersection of two filters, ``filter1``
-and ``filter2``. ``view`` is then passed to a :func:`~bokeh.plotting.figure.circle`
+In this example, you create a ColumnDataSource ``source`` and a |CDSView| called ``view``
+that uses intersection of two filters, ``filter1`` and ``filter2``.
+The ``source`` and ``view`` are then passed to a :func:`~bokeh.plotting.figure.circle`
 renderer function:
 
 .. code-block:: python
@@ -483,7 +481,7 @@ In the example below, the data set ``flowers`` contains a categorical variable
 called ``species``. All data belongs to one of the three species categories
 ``setosa``, ``versicolor``, or ``virginica``. The second plot in this example
 uses a |GroupFilter| to only display data points that are a member of the
-category ``setosa``:
+category ``versicolor``:
 
 .. bokeh-plot:: __REPO__/examples/basic/data/filter_group.py
     :source-position: above
@@ -537,7 +535,7 @@ interval. It then uses the data from the endpoint to update the data locally.
 Updating data locally can happen in two ways: either by replacing the existing
 local data entirely or by appending the new data to the existing data (up to a
 configurable ``max_size``). Replacing local data is the default setting. Pass
-either ``"replace"`` or ``"append"``as the AjaxDataSource's ``mode`` argument to
+either ``"replace"`` or ``"append"`` as the AjaxDataSource's ``mode`` argument to
 control this behavior.
 
 The endpoint that you are using with your ``AjaxDataSource`` should return a

--- a/docs/bokeh/source/docs/user_guide/basic/lines.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/lines.rst
@@ -73,7 +73,7 @@ and |hline_stack| convenience methods.
     :source-position: above
 
 .. note::
-    This and other examples in this chapter rely on ```ColumnDataSource`` for
+    This and other examples in this chapter rely on ``ColumnDataSource`` for
     data structuring. For information on how to work with this data structure,
     see :ref:`ug_basic_data`.
 

--- a/docs/bokeh/source/docs/user_guide/basic/scatters.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/scatters.rst
@@ -75,7 +75,7 @@ Image URLs
 
 It is also possible to make scatter plots using arbitrary images for markers
 using the |image_url| glyph method. The example below demonstrates using a
-single image, but it is possible to pass a column of differnet URLs for every
+single image, but it is possible to pass a column of different URLs for every
 point.
 
 .. note::

--- a/docs/bokeh/source/docs/user_guide/intro.rst
+++ b/docs/bokeh/source/docs/user_guide/intro.rst
@@ -322,7 +322,7 @@ For example, to create and configure a |Rect| glyph object:
 .. code-block:: python
 
     # configure attributes when initializing a model object
-    glyph = Rect(x="x", y="y2", w=10, h=20, line_color=None)
+    glyph = Rect(x="x", y="y2", width=10, height=20, line_color=None)
 
     # assign values to attributes to an existing model object
     glyph.fill_alpha = 0.5


### PR DESCRIPTION
Small fixes and improvements to  `docs/bokeh/source/docs/user_guide/basic` RST files.

Two more things I noticed are split out since I wasn't sure how to fix them: #13165 and #13164
