### PR TITLE
Do not resolve default descriptor value if already present in unstable defaults

### DIFF
--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -537,6 +537,7 @@ class PropertyDescriptor(Generic[T]):
 
         # Ensure we do not look up the default until after we check if it already present
         # in the unstable_dict because it is a very expensive operation
+        # Ref: https://github.com/bokeh/bokeh/pull/13174
         default = self.instance_default(obj)
 
         if self.has_unstable_default(obj):

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -535,6 +535,8 @@ class PropertyDescriptor(Generic[T]):
         if self.name in unstable_dict:
             return unstable_dict[self.name]
 
+        # Ensure we do not look up the default until after we check if it already present
+        # in the unstable_dict because it is a very expensive operation
         default = self.instance_default(obj)
 
         if self.has_unstable_default(obj):

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -530,12 +530,12 @@ class PropertyDescriptor(Generic[T]):
         themed_values = obj.themed_values()
         is_themed = themed_values is not None and self.name in themed_values
 
-        default = self.instance_default(obj)
-
         unstable_dict = obj._unstable_themed_values if is_themed else obj._unstable_default_values
 
         if self.name in unstable_dict:
             return unstable_dict[self.name]
+
+        default = self.instance_default(obj)
 
         if self.has_unstable_default(obj):
             if isinstance(default, PropertyValueContainer):


### PR DESCRIPTION
The initial goal of this PR is to start a discussion around some of the performance bottlenecks related to the property system and the requirement to traverse the model tree frequently. This is a very slow operation and causes bottlenecks when trying to dynamically add and remove models in a running application. As a test case I have written an app where we dynamically add widgets to a `Column`. We start with 100 widgets and then add one more and profile what happens.

The change in this PR simply defers the lookup of the instance default until we have determined it isn't already present in the `_unstable_themed_values`. This should be completely safe unless looking up the default somehow has some side-effect that is important.

In my sample application with 100 models the following profiling results demonstrate the performance improvement:

## Before

<img width="814" alt="Screen Shot 2023-06-01 at 13 50 38" src="https://github.com/bokeh/bokeh/assets/1550771/e8c96830-1370-45e1-8e1a-da1dab8dd7f5">

## After

<img width="805" alt="Screen Shot 2023-06-01 at 13 53 09" src="https://github.com/bokeh/bokeh/assets/1550771/02671df3-c016-48ef-acaa-8a2f4ee80fe9">

