### PR TITLE
Don't allow readonly properties in model constructors

### DIFF
--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -42,6 +42,7 @@ from typing import (
     Union,
     overload,
 )
+from weakref import WeakSet
 
 if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., Any])
@@ -98,14 +99,20 @@ if TYPE_CHECKING:
 
 C = TypeVar("C", bound=type["HasProps"])
 
+_abstract_classes: WeakSet[type[HasProps]] = WeakSet()
+
 def abstract(cls: C) -> C:
     ''' A decorator to mark abstract base classes derived from |HasProps|.
 
     '''
     if not issubclass(cls, HasProps):
         raise TypeError(f"{cls.__name__} is not a subclass of HasProps")
+    _abstract_classes.add(cls)
     cls.__doc__ = append_docstring(cls.__doc__, _ABSTRACT_ADMONITION)
     return cls
+
+def is_abstract(cls: type[HasProps]) -> bool:
+    return cls in _abstract_classes
 
 def is_DataModel(cls: type[HasProps]) -> bool:
     from ..model import DataModel

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -324,8 +324,7 @@ class PropertyDescriptor(Generic[T]):
             class_name = obj.__class__.__name__
             raise RuntimeError(f"Cannot set a property value {self.name!r} on a {class_name} instance before HasProps.__init__")
 
-        if self.property.readonly and obj._initialized:
-            # Allow to set a value during object initialization (e.g. value -> value_throttled)
+        if self.property.readonly:
             class_name = obj.__class__.__name__
             raise RuntimeError(f"{class_name}.{self.name} is a readonly property")
 

--- a/src/bokeh/models/widgets/sliders.py
+++ b/src/bokeh/models/widgets/sliders.py
@@ -71,9 +71,6 @@ class AbstractSlider(Widget):
     """ """
 
     def __init__(self, *args, **kwargs) -> None:
-        if 'start' in kwargs and 'end' in kwargs:
-            if kwargs['start'] == kwargs['end']:
-                raise ValueError("Slider 'start' and 'end' cannot be equal.")
         super().__init__(*args, **kwargs)
 
         try:

--- a/src/bokeh/models/widgets/sliders.py
+++ b/src/bokeh/models/widgets/sliders.py
@@ -42,6 +42,8 @@ from ...core.properties import (
     String,
     Tuple,
 )
+from ...core.property.descriptors import UnsetValueError
+from ...core.property.singletons import Undefined
 from ...core.validation import error
 from ...core.validation.errors import EQUAL_SLIDER_START_END
 from ..formatters import TickFormatter
@@ -72,11 +74,13 @@ class AbstractSlider(Widget):
         if 'start' in kwargs and 'end' in kwargs:
             if kwargs['start'] == kwargs['end']:
                 raise ValueError("Slider 'start' and 'end' cannot be equal.")
-
-        if "value" in kwargs and "value_throttled" not in kwargs:
-            kwargs["value_throttled"] = kwargs["value"]
-
         super().__init__(*args, **kwargs)
+
+        try:
+            # synchronize the value of a readonly property `value_throttled`
+            self.lookup("value_throttled")._set(self, Undefined, self.value)
+        except UnsetValueError:
+            pass
 
     orientation = Enum("horizontal", "vertical", help="""
     Orient the slider either horizontally (default) or vertically.

--- a/src/bokeh/models/widgets/sliders.py
+++ b/src/bokeh/models/widgets/sliders.py
@@ -78,6 +78,20 @@ class AbstractSlider(Widget):
             self.lookup("value_throttled")._set(self, Undefined, self.value)
         except UnsetValueError:
             pass
+        except AttributeError:
+            # TODO Remove this when proper support for property overrides is
+            # implemented. For now this is required to make defaults' tests
+            # work, because we depend there on model instances to provide
+            # "default" values.
+            pass
+
+    # TODO value = Required(GenericType, help="""
+    # Initial or selected range.
+    # """)
+
+    # TODO value_throttled = Readonly(GenericType, help="""
+    # Initial or selected value, throttled according to report only on mouseup.
+    # """)
 
     orientation = Enum("horizontal", "vertical", help="""
     Orient the slider either horizontally (default) or vertically.

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -642,6 +642,17 @@ def test_HasProps_descriptors() -> None:
     assert d2[3].name == "f3"
     assert d2[4].name == "f4"
 
+def test_HasProps_abstract() -> None:
+    @hp.abstract
+    class Base(hp.HasProps, hp.Local):
+        pass
+
+    class Derived(Base):
+        pass
+
+    assert hp.is_abstract(Base) is True
+    assert hp.is_abstract(Derived) is False
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -391,6 +391,15 @@ class TestBasic:
             o.y
         assert o.z == 'xyz'
 
+        with pytest.raises(RuntimeError, match="ReadonlyModel.x is a readonly property"):
+            ReadonlyModel(x=20)
+
+        with pytest.raises(RuntimeError, match="ReadonlyModel.y is a readonly property"):
+            ReadonlyModel(y=30)
+
+        with pytest.raises(RuntimeError, match="ReadonlyModel.x is a readonly property"):
+            ReadonlyModel(x=20, y=30)
+
     def test_include_defaults(self) -> None:
         class IncludeDefaultsTest(HasProps):
             x = Int(12)

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -17,6 +17,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
+from bokeh.core.has_props import is_abstract
 from bokeh.core.properties import Int, List, String
 from bokeh.core.types import ID
 from bokeh.models import *  # noqa: F403
@@ -217,6 +218,8 @@ class Test_js_link:
 def test_all_builtin_models_default_constructible() -> None:
     bad = []
     for name, cls in Model.model_class_reverse_map.items():
+        if is_abstract(cls):
+            continue
         try:
             cls()
         except Exception:

--- a/tests/unit/bokeh/models/widgets/test_slider.py
+++ b/tests/unit/bokeh/models/widgets/test_slider.py
@@ -64,12 +64,6 @@ class TestRangeSlider:
         assert s1.value == (4, 6)
         assert s1.value_throttled == (4, 6)
 
-    def test_rangeslider_equal_start_end_exception(self) -> None:
-        start = 0
-        end = 0
-        with pytest.raises(ValueError):
-            mws.RangeSlider(start=start, end=end)
-
     def test_rangeslider_equal_start_end_validation(self, caplog: pytest.LogCaptureFixture) -> None:
         start = 0
         end = 10


### PR DESCRIPTION
Not both constructors and setters fail consistently:
```py
$ ipython
In [1]: from bokeh.models import *

In [2]: Plot()
Out[2]: Plot(id='p1001', ...)

In [3]: _2.inner_width = 200
RuntimeError: Plot.inner_width is a readonly property

In [4]: Plot(inner_width=100)
RuntimeError: Plot.inner_width is a readonly property
```

fixes #13196 