### PR TITLE
Validate ImageStack and its ColumnDataSource

### DIFF
--- a/src/bokeh/plotting/_renderer.py
+++ b/src/bokeh/plotting/_renderer.py
@@ -116,6 +116,11 @@ def create_renderer(glyphclass, plot, **kwargs):
     hover_glyph = make_glyph(glyphclass, kwargs, hover_visuals)
     muted_glyph = make_glyph(glyphclass, kwargs, muted_visuals)
 
+    # Check if glyph has a specific _validate_with_data_source method, and if so call it.
+    for g in (glyph, nonselection_glyph, selection_glyph, hover_glyph, muted_glyph):
+        if callable(getattr(g, "_validate_with_data_source", None)):
+            g._validate_with_data_source(source)
+
     glyph_renderer = GlyphRenderer(
         glyph=glyph,
         nonselection_glyph=nonselection_glyph or "auto",


### PR DESCRIPTION
Fixes #13206, no tests added yet.

This is a cheeky fix for #13206 to validate `ImageStack` glyph and its `ColumnDataSource`. I am not expecting this to be merged, but hopefully it will stimulate a conversation about how we should really tackle such validation.

It checks for the existence of a named function on each `Glyph` created and calls it, raising a `ValueError` if there are any problems. Probably it should be implemented more in line with the existing `@error` and `@warning` decorators, maybe very differently to this.