### PR TITLE
Add more options for specifying contour colors

### DIFF
--- a/docs/bokeh/source/docs/user_guide/topics/contour.rst
+++ b/docs/bokeh/source/docs/user_guide/topics/contour.rst
@@ -60,14 +60,15 @@ All visual properties can be scalar or vector of the correct length. Color
 visual properties ``line_color``, ``fill_color`` and ``hatch_color`` support a
 few extra options for how they can be specified:
 
-* A sequence of colors that is longer than required will be resampled using
-  :func:`~bokeh.palettes.linear_palette`. The length 256 palettes such as
-  ``Cividis256`` are useful here.
+* A sequence of colors that is longer or shorter than required will be
+  resampled using :func:`~bokeh.palettes.interp_palette`. The length 256
+  palettes such as ``Cividis256`` are useful here.
 
-* A dictionary that maps from palette length (number of colors) to palette may
-  be used, in which case a lookup into the dictionary is performed to return a
-  palette of the correct length. The example here uses the palette collection
-  ``Cividis``.
+* A palette collection such as ``Cividis`` may be used, which is a dictionary
+  that maps from palette length (number of colors) to palette. If the
+  collection contains a palette of the correct length then that is used.
+  If the required length is outside of those available in the collection then
+  the palette with the nearest length is used, linearly interpolated.
 
 :func:`~bokeh.models.ContourRenderer.construct_color_bar` accepts other
 keyword arguments that are passed to the

--- a/tests/unit/bokeh/plotting/test_contour.py
+++ b/tests/unit/bokeh/plotting/test_contour.py
@@ -33,7 +33,9 @@ from bokeh.plotting.contour import (
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-    # This is to make the fixture typing simpler
+    # The following type annotation is to make the fixture typing simpler.
+    # The X, Y, Z and Levels are simple valid data passed to the contouring
+    # functions to allow testing of visual properties.
     XYZ_Levels: TypeAlias = tuple[list[float], list[float], list[list[float]], list[float]]
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/plotting/test_contour.py
+++ b/tests/unit/bokeh/plotting/test_contour.py
@@ -16,6 +16,9 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import TYPE_CHECKING
+
 # External imports
 import numpy as np
 
@@ -27,6 +30,12 @@ from bokeh.plotting.contour import (
     from_contour,
 )
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    # This is to make the fixture typing simpler
+    XYZ_Levels: TypeAlias = tuple[list[float], list[float], list[list[float]], list[float]]
+
 #-----------------------------------------------------------------------------
 # Setup
 #-----------------------------------------------------------------------------
@@ -37,7 +46,7 @@ from bokeh.plotting.contour import (
 
 class Test_contour_data:
     @pytest.mark.parametrize("xy_dim", [0, 1, 2])
-    def test_xy_dim(self, xyz_levels, xy_dim):
+    def test_xy_dim(self, xyz_levels: XYZ_Levels, xy_dim: int) -> None:
         x, y, z, levels = xyz_levels
         if xy_dim == 0:
             x = y = None
@@ -69,7 +78,7 @@ class Test_contour_data:
         assert np.allclose(line.ys[2], [])
 
     @pytest.mark.parametrize("want_fill,want_line", [(True, True), (True, False), (False, True)])
-    def test_fill_line(self, xyz_levels, want_fill, want_line):
+    def test_fill_line(self, xyz_levels: XYZ_Levels, want_fill: bool, want_line: bool) -> None:
         x, y, z, levels = xyz_levels
 
         data = contour_data(x, y, z, levels, want_fill=want_fill, want_line=want_line)
@@ -85,12 +94,12 @@ class Test_contour_data:
         else:
             assert line is None
 
-    def test_neither(self, xyz_levels):
+    def test_neither(self, xyz_levels: XYZ_Levels) -> None:
         _, _, z, levels = xyz_levels
         with pytest.raises(ValueError, match="Neither fill nor line requested in contour_data"):
             contour_data(z=z, levels=levels, want_fill=False, want_line=False)
 
-    def test_invalid_args(self):
+    def test_invalid_args(self) -> None:
         with pytest.raises(ValueError, match="No contour levels specified"):
             contour_data(z=[[0, 1], [2, 3]])
 
@@ -105,7 +114,7 @@ class Test_contour_data:
 
 class Test_from_contour:
     @pytest.mark.parametrize("want_fill,want_line", [(True, True), (True, False), (False, True)])
-    def test_fill_line(self, xyz_levels, want_fill, want_line):
+    def test_fill_line(self, xyz_levels: XYZ_Levels, want_fill: bool, want_line: bool) -> None:
         x, y, z, levels = xyz_levels
 
         kwargs = {}
@@ -152,37 +161,59 @@ class Test_from_contour:
         else:
             assert line_data == dict(xs=[], ys=[], levels=[])
 
-    def test_neither(self, xyz_levels):
+    def test_neither(self, xyz_levels: XYZ_Levels) -> None:
         _, _, z, levels = xyz_levels
         with pytest.raises(ValueError, match="Neither fill nor line requested in contour_data"):
             from_contour(z=z, levels=levels)  # No fill_color or line_color specified
 
-    def test_invalid_args(self, xyz_levels):
+    def test_invalid_args(self, xyz_levels: XYZ_Levels) -> None:
         _, _, z, levels = xyz_levels
         with pytest.raises(ValueError, match="Unknown keyword arguments in 'from_contour': invalid_kwarg"):
             from_contour(z=z, levels=levels, fill_color="red", invalid_kwarg=23)
 
-    def test_insufficient_colors(self, xyz_levels):
+    def test_color_dict(self, xyz_levels: XYZ_Levels) -> None:
+        # palette collection is dict[int, palette]
         x, y, z, levels = xyz_levels
-        with pytest.raises(ValueError, match="Insufficient number of colors"):
-            from_contour(x, y, z, levels, line_color=["red", "green"])
+        colors_dict = {3: ["red", "green", "blue"], 4: ["red", "yellow", "green", "blue"]}
 
-    def test_color_dict(self, xyz_levels):
-        x, y, z, levels = xyz_levels
-        colors_dict = {3: ["red", "green", "blue"]}
+        # Required length is in dict
         cr = from_contour(x, y, z, levels, line_color=colors_dict)
         assert cr.line_renderer.data_source.data["line_color"] == ["red", "green", "blue"]
 
-        with pytest.raises(ValueError, match="Dict of colors does not contain a key of 2"):
-            from_contour(x, y, z, [1, 2], line_color=colors_dict)
+        # Required length greater than max dict key
+        cr = from_contour(x, y, z, [0, 1, 2, 3, 4], line_color=colors_dict)
+        assert cr.line_renderer.data_source.data["line_color"] == ('#ff0000', '#ffbf00', '#7fbf00', '#00603f', '#0000ff')
 
-    def test_color_longer_sequence(self, xyz_levels):
+        # Required length less than min dict key
+        cr = from_contour(x, y, z, [1, 2], line_color=colors_dict)
+        assert cr.line_renderer.data_source.data["line_color"] == ("#ff0000", "#0000ff")
+
+    def test_color_dict_empty(self, xyz_levels: XYZ_Levels) -> None:
+        x, y, z, levels = xyz_levels
+        colors_dict = {}
+        with pytest.raises(ValueError, match="PaletteCollection is empty"):
+            from_contour(x, y, z, levels, line_color=colors_dict)
+
+    def test_color_dict_non_int_key(self, xyz_levels: XYZ_Levels) -> None:
+        x, y, z, levels = xyz_levels
+        colors_dict = {"key": ["red", "blue"]}
+        with pytest.raises(ValueError, match="Unable to extract or interpolate palette of length 3 from PaletteCollection"):
+            from_contour(x, y, z, levels, line_color=colors_dict)
+
+    def test_color_longer_sequence(self, xyz_levels: XYZ_Levels) -> None:
         x, y, z, levels = xyz_levels
         colors = ["red", "yellow", "green", "purple", "blue"]
         cr = from_contour(x, y, z, levels, line_color=colors)
-        assert cr.line_renderer.data_source.data["line_color"] == ("red", "green", "blue")
+        assert cr.line_renderer.data_source.data["line_color"] == ("#ff0000", "#008000", "#0000ff")
 
-    def test_visuals(self, xyz_levels):
+    def test_color_shorter_sequence(self, xyz_levels) -> None:
+        x, y, z, levels = xyz_levels
+        colors = ["blue", "green"]
+        cr = from_contour(x, y, z, levels, line_color=colors)
+        assert cr.line_renderer.data_source.data["line_color"] == ("#0000ff", "#00407f", "#008000")
+
+    def test_visuals_scalar(self, xyz_levels: XYZ_Levels) -> None:
+        # Test every visual property as a scalar
         x, y, z, levels = xyz_levels
         kwargs = dict(
             fill_color="orange", fill_alpha=0.3,
@@ -209,7 +240,7 @@ class Test_from_contour:
         assert line.line_dash_offset == 3
 
     @pytest.mark.parametrize("kwarg_none", ["line_color", "fill_color"])
-    def test_ignore_kwarg_None(self, xyz_levels, kwarg_none):
+    def test_ignore_kwarg_None(self, xyz_levels: XYZ_Levels, kwarg_none: str) -> None:
         x, y, z, levels = xyz_levels
         kwargs = dict(line_color="red", fill_color="blue")
         kwargs[kwarg_none] = None
@@ -230,7 +261,7 @@ class Test_from_contour:
         else:
             assert line_len > 0
 
-def test_contour_colorbar(xyz_levels):
+def test_contour_colorbar(xyz_levels: XYZ_Levels) -> None:
     x, y, z, levels = xyz_levels
     cr = from_contour(x, y, z, levels, fill_color="red", line_color="black")
     color_bar = cr.construct_color_bar()
@@ -243,5 +274,5 @@ def test_contour_colorbar(xyz_levels):
 #-----------------------------------------------------------------------------
 
 @pytest.fixture
-def xyz_levels():
+def xyz_levels() -> XYZ_Levels:
     return [0, 1, 2], [0, 1], [[0, 1, 2], [1, 2, 3]], [-0.5, 1.5, 3.5]


### PR DESCRIPTION
This adds a few more options for specifying colors (`line_color`, `fill_color` and/or `hatch_color`) of contour plots, as outlined in the contouring roadmap https://github.com/bokeh/bokeh/discussions/12234.

It has always been possible to use:

- A palette of exactly the correct length, e.g. `Cividis8` when 8 colors are required.
- A palette longer than required, e.g. `Cividis256`, which is interpolated to the correct length.
- A palette collection such as `Cividis` containing a palette with exactly the correct length.

This adds:

- A palette shorter than required, e.g. `["red", "blue"]`, is linearly interpolated to the correct length.
- If a palette collection contains palettes that are all too short, the longest palette available is linearly interpolated. This is particularly useful as many of our palette collections have a maximum length of around 11.
- If a palette collection contains palettes that are all too long, the shortest palette available is linearly interpolated. This is less useful but included for consistency.

For interpolation the new-ish function `interp_palette` (#12789) is used instead of the older `linear_palette`. The former uses floating-point interpolation to return colors that lie between the input colors, whereas the latter uses integer-rounded interpolation to only return colors that are in the input palette. This is important for palettes that are shorter than required, otherwise when interpolating them we could end up with adjacent colors that are the same which is almost never desired.

I have also added type annotations to `test_contour.py` as I omitted them originally.