### PR TITLE
Fix Broken Link in Documentation Using bokeh-tree Sphinx Extension

### DIFF
--- a/docs/bokeh/source/docs/first_steps/first_steps_9.rst
+++ b/docs/bokeh/source/docs/first_steps/first_steps_9.rst
@@ -192,7 +192,7 @@ widgets on the left to change the sine wave on the right:
     </div>
 
 Find the source code for this Bokeh server app in the
-`Bokeh repository on GitHub <https://github.com/bokeh/bokeh/blob/master/examples/app/sliders.py>`_.
+:bokeh-tree:`examples/server/app/sliders.py`.
 For more examples of Bokeh server applications, see the
 :ref:`gallery`.
 


### PR DESCRIPTION
This pull request addresses a broken link to the `sliders.py` example in the documentation (https://docs.bokeh.org/en/latest/docs/first_steps/first_steps_9.html).

The original link (https://github.com/bokeh/bokeh/blob/master/examples/app/sliders.py) is no longer valid due to changes in the repository structure and the renaming of the "master" branch to "main". Furthermore, the example file appears to have been moved to a new location: `examples/server/app/sliders.py`.

To resolve this issue, the broken link has been replaced with the `bokeh-tree` Sphinx role, which generates an automatically versioned link to the correct file in the repository. The updated link in the documentation is as follows: 

`:bokeh-tree:`examples/server/app/sliders.py`

This solution ensures the link remains valid even if the file location changes in future versions of the repository, providing a more resilient link structure in our documentation.

Please review this change and consider merging it into the main project.