### PR TITLE
13211 allow inline math text

### DIFF
--- a/bokehjs/src/lib/models/text/utils.ts
+++ b/bokehjs/src/lib/models/text/utils.ts
@@ -15,14 +15,14 @@ const delimiters: Delimiter[] = [
 ]
 
 function add_backslash(m: string): string {
-  return m.split("").map(s => `\\${s}`).join("");
+  return m.split("").map(s => `\\${s}`).join("")
 }
 
 export function parse_delimited_string(text: string): BaseText {
   let matches = Array<RegExpMatchArray>()
   for (const delim of delimiters) {
     const r = RegExp(`${add_backslash(delim.start)}(.*?)${add_backslash(delim.end)}`, "g")
-    matches = matches.concat([...text.matchAll(r)]);
+    matches = matches.concat([...text.matchAll(r)])
   }
   if (0 < matches.length) {
     let tex_string = ""
@@ -36,7 +36,6 @@ export function parse_delimited_string(text: string): BaseText {
     }
     tex_string +=  _end < text.length ? `\\text{${text.slice(_end)}}` : ""
     return new TeX({text: tex_string, inline: false})
-  }
-  else
+  } else
     return new PlainText({text})
 }

--- a/bokehjs/test/unit/models/text/utils.ts
+++ b/bokehjs/test/unit/models/text/utils.ts
@@ -39,44 +39,44 @@ describe("models/text/utils module", () => {
 
     const s9 = parse_delimited_string("HTML <b>text</b> $$\\sin(x) and \\[x\\cdot\\pi\\]!")
     ;(s9 as any).id = wildcard
-    expect(s9).to.be.equal(new PlainText({text: "HTML <b>text</b> $$\\sin(x) and \\[x\\cdot\\pi\\]!"}))
+    expect(s9).to.be.equal(new TeX({text: "\\text{HTML <b>text</b> }\\sin(x)\\text{ and }x\\cdot\\pi\\]\\text{!}"}))
     const s10 = parse_delimited_string("HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!")
     ;(s10 as any).id = wildcard
-    expect(s10).to.be.equal(new PlainText({text: "HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!"}))
+    expect(s10).to.be.equal(new TeX({text: "\\text{HTML <b>text</b> }sin(x)\\text{ and [xcdotpi]!}"}))
 
     const s11 = parse_delimited_string("$$test\\]")
     ;(s11 as any).id = wildcard
     expect(s11).to.be.equal(new PlainText({text: "$$test\\]"}))
     const s12 = parse_delimited_string("$$test $$ end $$")
     ;(s12 as any).id = wildcard
-    expect(s12).to.be.equal(new PlainText({text: "$$test $$ end $$"}))
+    expect(s12).to.be.equal(new TeX({text: "test\\text{ end $$}"}))
     const s13 = parse_delimited_string("$$ \\[test end\\]")
     ;(s13 as any).id = wildcard
     expect(s13).to.be.equal(new PlainText({text: "$$ \\[test end\\]"}))
     const s14 = parse_delimited_string("text \\[text $$latex$$")
     ;(s14 as any).id = wildcard
-    expect(s14).to.be.equal(new PlainText({text: "text \\[text $$latex$$"}))
+    expect(s14).to.be.equal(new TeX({text: "\\text{text \\[text }latex"}))
     const s15 = parse_delimited_string("$$ tex [ tex ] tex $$")
     ;(s15 as any).id = wildcard
     expect(s15).to.be.equal(new TeX({text: " tex [ tex ] tex "}))
     const s16 = parse_delimited_string("$$tex$$text$$tex$$")
     ;(s16 as any).id = wildcard
-    expect(s16).to.be.equal(new PlainText({text: "$$tex$$text$$tex$$"}))
+    expect(s16).to.be.equal(new TeX({text: "tex\\text{text}tex"}))
     const s17 = parse_delimited_string("part0$$part1\\[part2\\(part3$$")
     ;(s17 as any).id = wildcard
-    expect(s17).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3$$"}))
+    expect(s17).to.be.equal(new TeX({text: "\\text{part0}part1\\[part2\\(part3"}))
     const s18 = parse_delimited_string("part0$$part1\\[part2\\(part3\\]")
     ;(s18 as any).id = wildcard
-    expect(s18).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3\\]"}))
+    expect(s18).to.be.equal(new TeX({text: "\\text{part0$$part1}part2\\(part3"}))
     const s19 = parse_delimited_string("part0$$part1\\[part2\\(part3\\)")
     ;(s19 as any).id = wildcard
-    expect(s19).to.be.equal(new PlainText({text: "part0$$part1\\[part2\\(part3\\)"}))
+    expect(s19).to.be.equal(new TeX({text: "\\text{part0$$part1\\[part2}part3"}))
 
     const s20 = parse_delimited_string("$$\ncos(x)\n$$")
     ;(s20 as any).id = wildcard
     expect(s20).to.be.equal(new TeX({text: "\ncos(x)\n"}))
     const s21 = parse_delimited_string("$$\ncos(x)$$\n")
     ;(s21 as any).id = wildcard
-    expect(s21).to.be.equal(new PlainText({text: "$$\ncos(x)$$\n"}))
+    expect(s21).to.be.equal(new TeX({text: "\ncos(x)\\text{\n}"}))
   })
 })

--- a/bokehjs/test/unit/models/text/utils.ts
+++ b/bokehjs/test/unit/models/text/utils.ts
@@ -49,7 +49,7 @@ describe("models/text/utils module", () => {
     expect(s11).to.be.equal(new PlainText({text: "$$test\\]"}))
     const s12 = parse_delimited_string("$$test $$ end $$")
     ;(s12 as any).id = wildcard
-    expect(s12).to.be.equal(new TeX({text: "test\\text{ end $$}"}))
+    expect(s12).to.be.equal(new TeX({text: "test \\text{ end $$}"}))
     const s13 = parse_delimited_string("$$ \\[test end\\]")
     ;(s13 as any).id = wildcard
     expect(s13).to.be.equal(new PlainText({text: "$$ \\[test end\\]"}))

--- a/bokehjs/test/unit/models/text/utils.ts
+++ b/bokehjs/test/unit/models/text/utils.ts
@@ -37,9 +37,9 @@ describe("models/text/utils module", () => {
     ;(s8 as any).id = wildcard
     expect(s8).to.be.equal(new PlainText({text: "\\(test"}))
 
-    const s9 = parse_delimited_string("HTML <b>text</b> $$\\sin(x) and \\[x\\cdot\\pi\\]!")
+    const s9 = parse_delimited_string("HTML <b>text</b> $$\\sin(x)$$ and \\[x\\cdot\\pi\\]!")
     ;(s9 as any).id = wildcard
-    expect(s9).to.be.equal(new TeX({text: "\\text{HTML <b>text</b> }\\sin(x)\\text{ and }x\\cdot\\pi\\]\\text{!}"}))
+    expect(s9).to.be.equal(new TeX({text: "\\text{HTML <b>text</b> }\\sin(x)\\text{ and }x\\cdot\\pi\\text{!}"}))
     const s10 = parse_delimited_string("HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!")
     ;(s10 as any).id = wildcard
     expect(s10).to.be.equal(new TeX({text: "\\text{HTML <b>text</b> }sin(x)\\text{ and [xcdotpi]!}"}))
@@ -52,7 +52,7 @@ describe("models/text/utils module", () => {
     expect(s12).to.be.equal(new TeX({text: "test \\text{ end $$}"}))
     const s13 = parse_delimited_string("$$ \\[test end\\]")
     ;(s13 as any).id = wildcard
-    expect(s13).to.be.equal(new PlainText({text: "$$ \\[test end\\]"}))
+    expect(s13).to.be.equal(new TeX({text: "\\text{$$ }test end"}))
     const s14 = parse_delimited_string("text \\[text $$latex$$")
     ;(s14 as any).id = wildcard
     expect(s14).to.be.equal(new TeX({text: "\\text{text \\[text }latex"}))

--- a/bokehjs/test/unit/models/text/utils.ts
+++ b/bokehjs/test/unit/models/text/utils.ts
@@ -2,81 +2,73 @@ import {expect} from "assertions"
 
 import {parse_delimited_string} from "@bokehjs/models/text/utils"
 import {TeX, PlainText} from "@bokehjs/models/text"
-import {wildcard} from "@bokehjs/core/util/eq"
 
 describe("models/text/utils module", () => {
   it("should provide parse_delimited_string() function", () => {
     const s0 = parse_delimited_string("$$test$$")
-    ;(s0 as any).id = wildcard // XXX: figure out how to deal with value equality with IDs
-    expect(s0).to.be.equal(new TeX({text: "test"}))
+    expect(s0).to.be.structurally.equal(new TeX({text: "test"}))
+
     const s1 = parse_delimited_string("\\[test\\]")
-    ;(s1 as any).id = wildcard
-    expect(s1).to.be.equal(new TeX({text: "test"}))
+    expect(s1).to.be.structurally.equal(new TeX({text: "test"}))
+
     const s2 = parse_delimited_string("\\(test\\)")
-    ;(s2 as any).id = wildcard
-    expect(s2).to.be.equal(new TeX({text: "test", inline: true}))
+    expect(s2).to.be.structurally.equal(new TeX({text: "test", inline: true}))
 
     const s3 = parse_delimited_string("test$$")
-    ;(s3 as any).id = wildcard
-    expect(s3).to.be.equal(new PlainText({text: "test$$"}))
+    expect(s3).to.be.structurally.equal(new PlainText({text: "test$$"}))
+
     const s4 = parse_delimited_string("$$test")
-    ;(s4 as any).id = wildcard
-    expect(s4).to.be.equal(new PlainText({text: "$$test"}))
+    expect(s4).to.be.structurally.equal(new PlainText({text: "$$test"}))
 
     const s5 = parse_delimited_string("test\\]")
-    ;(s5 as any).id = wildcard
-    expect(s5).to.be.equal(new PlainText({text: "test\\]"}))
+    expect(s5).to.be.structurally.equal(new PlainText({text: "test\\]"}))
+
     const s6 = parse_delimited_string("\\[test")
-    ;(s6 as any).id = wildcard
-    expect(s6).to.be.equal(new PlainText({text: "\\[test"}))
+    expect(s6).to.be.structurally.equal(new PlainText({text: "\\[test"}))
 
     const s7 = parse_delimited_string("test\\)")
-    ;(s7 as any).id = wildcard
-    expect(s7).to.be.equal(new PlainText({text: "test\\)"}))
+    expect(s7).to.be.structurally.equal(new PlainText({text: "test\\)"}))
+
     const s8 = parse_delimited_string("\\(test")
-    ;(s8 as any).id = wildcard
-    expect(s8).to.be.equal(new PlainText({text: "\\(test"}))
+    expect(s8).to.be.structurally.equal(new PlainText({text: "\\(test"}))
 
     const s9 = parse_delimited_string("HTML <b>text</b> $$\\sin(x)$$ and \\[x\\cdot\\pi\\]!")
-    ;(s9 as any).id = wildcard
-    expect(s9).to.be.equal(new TeX({text: "\\text{HTML <b>text</b> }\\sin(x)\\text{ and }x\\cdot\\pi\\text{!}"}))
+    expect(s9).to.be.structurally.equal(new TeX({text: "\\text{HTML <b>text</b> }\\sin(x)\\text{ and }x\\cdot\\pi\\text{!}"}))
+
     const s10 = parse_delimited_string("HTML <b>text</b> $$sin(x)$$ and [xcdotpi]!")
-    ;(s10 as any).id = wildcard
-    expect(s10).to.be.equal(new TeX({text: "\\text{HTML <b>text</b> }sin(x)\\text{ and [xcdotpi]!}"}))
+    expect(s10).to.be.structurally.equal(new TeX({text: "\\text{HTML <b>text</b> }sin(x)\\text{ and [xcdotpi]!}"}))
 
     const s11 = parse_delimited_string("$$test\\]")
-    ;(s11 as any).id = wildcard
-    expect(s11).to.be.equal(new PlainText({text: "$$test\\]"}))
+    expect(s11).to.be.structurally.equal(new PlainText({text: "$$test\\]"}))
+
     const s12 = parse_delimited_string("$$test $$ end $$")
-    ;(s12 as any).id = wildcard
-    expect(s12).to.be.equal(new TeX({text: "test \\text{ end $$}"}))
+    expect(s12).to.be.structurally.equal(new TeX({text: "test \\text{ end $$}"}))
+
     const s13 = parse_delimited_string("$$ \\[test end\\]")
-    ;(s13 as any).id = wildcard
-    expect(s13).to.be.equal(new TeX({text: "\\text{$$ }test end"}))
+    expect(s13).to.be.structurally.equal(new TeX({text: "\\text{$$ }test end"}))
+
     const s14 = parse_delimited_string("text \\[text $$latex$$")
-    ;(s14 as any).id = wildcard
-    expect(s14).to.be.equal(new TeX({text: "\\text{text \\[text }latex"}))
+    expect(s14).to.be.structurally.equal(new TeX({text: "\\text{text \\[text }latex"}))
+
     const s15 = parse_delimited_string("$$ tex [ tex ] tex $$")
-    ;(s15 as any).id = wildcard
-    expect(s15).to.be.equal(new TeX({text: " tex [ tex ] tex "}))
+    expect(s15).to.be.structurally.equal(new TeX({text: " tex [ tex ] tex "}))
+
     const s16 = parse_delimited_string("$$tex$$text$$tex$$")
-    ;(s16 as any).id = wildcard
-    expect(s16).to.be.equal(new TeX({text: "tex\\text{text}tex"}))
+    expect(s16).to.be.structurally.equal(new TeX({text: "tex\\text{text}tex"}))
+
     const s17 = parse_delimited_string("part0$$part1\\[part2\\(part3$$")
-    ;(s17 as any).id = wildcard
-    expect(s17).to.be.equal(new TeX({text: "\\text{part0}part1\\[part2\\(part3"}))
+    expect(s17).to.be.structurally.equal(new TeX({text: "\\text{part0}part1\\[part2\\(part3"}))
+
     const s18 = parse_delimited_string("part0$$part1\\[part2\\(part3\\]")
-    ;(s18 as any).id = wildcard
-    expect(s18).to.be.equal(new TeX({text: "\\text{part0$$part1}part2\\(part3"}))
+    expect(s18).to.be.structurally.equal(new TeX({text: "\\text{part0$$part1}part2\\(part3"}))
+
     const s19 = parse_delimited_string("part0$$part1\\[part2\\(part3\\)")
-    ;(s19 as any).id = wildcard
-    expect(s19).to.be.equal(new TeX({text: "\\text{part0$$part1\\[part2}part3"}))
+    expect(s19).to.be.structurally.equal(new TeX({text: "\\text{part0$$part1\\[part2}part3"}))
 
     const s20 = parse_delimited_string("$$\ncos(x)\n$$")
-    ;(s20 as any).id = wildcard
-    expect(s20).to.be.equal(new TeX({text: "\ncos(x)\n"}))
+    expect(s20).to.be.structurally.equal(new TeX({text: "\ncos(x)\n"}))
+
     const s21 = parse_delimited_string("$$\ncos(x)$$\n")
-    ;(s21 as any).id = wildcard
-    expect(s21).to.be.equal(new TeX({text: "\ncos(x)\\text{\n}"}))
+    expect(s21).to.be.structurally.equal(new TeX({text: "\ncos(x)\\text{\n}"}))
   })
 })

--- a/docs/bokeh/source/docs/releases/3.3.0.rst
+++ b/docs/bokeh/source/docs/releases/3.3.0.rst
@@ -1,0 +1,8 @@
+.. _release-3-3-0:
+
+3.3.0
+=====
+
+Bokeh version ``3.3.0`` (September 2023) is a minor milestone of Bokeh project.
+
+* Added support for inline math text expressions (:bokeh-pull:`13214`)

--- a/examples/styling/mathtext/latex_axis_labels_titles_labels.py
+++ b/examples/styling/mathtext/latex_axis_labels_titles_labels.py
@@ -1,3 +1,12 @@
+''' This example demonstrates the use of inline mathtext on titles and ``Label`` annotations.
+This example makes use of all the three LaTeX delimiters pairs ``$$...$$``, ``\[...\]`` and
+``\(...\)``.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.line, bokeh.models.annotations.Label
+    :refs: :ref:`ug_styling_mathtext`
+    :keywords: mathtext, latex
+'''
 from numpy import arange, pi, sin
 
 from bokeh.models.annotations.labels import Label
@@ -6,7 +15,7 @@ from bokeh.plotting import figure, show
 x = arange(-2*pi, 2*pi, 0.1)
 y = sin(x)
 
-p = figure(height=250, title=r"\[\sin(x)\text{ for }x\text{ between }-2\pi\text{ and }2\pi\]")
+p = figure(height=250, title=r"$$\sin(x)$$ for \[x\] between \(-2\pi\) and $$2\pi$$")
 p.circle(x, y, alpha=0.6, size=7)
 
 label = Label(
@@ -16,7 +25,7 @@ label = Label(
 )
 p.add_layout(label)
 
-p.yaxis.axis_label = r"\[\sin(x)\]"
+p.yaxis.axis_label = r"\(\sin(x)\)"
 p.xaxis.axis_label = r"\[x\pi\]"
 
 show(p)

--- a/examples/styling/mathtext/latex_axis_labels_titles_labels.py
+++ b/examples/styling/mathtext/latex_axis_labels_titles_labels.py
@@ -1,6 +1,6 @@
 ''' This example demonstrates the use of inline mathtext on titles and ``Label`` annotations.
-This example makes use of all the three LaTeX delimiters pairs ``$$...$$``, ``\[...\]`` and
-``\(...\)``.
+This example makes use of all the three LaTeX delimiters pairs ``$$...$$``, ``\\[...\\]`` and
+``\\(...\\)``.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.line, bokeh.models.annotations.Label

--- a/examples/styling/mathtext/latex_bessel.py
+++ b/examples/styling/mathtext/latex_bessel.py
@@ -21,7 +21,7 @@ p = figure(
     title=(
         r"Bessel functions of the first kind: $$J_\alpha(x) = \sum_{m=0}^{\infty}"
         r"\frac{(-1)^m}{m!\:\Gamma(m+\alpha+1)} \left(\frac{x}{2}\right)^{2m+\alpha}$$"
-    )
+    ),
 )
 p.x_range.range_padding = 0
 p.xaxis.axis_label = "$$x$$"

--- a/examples/styling/mathtext/latex_bessel.py
+++ b/examples/styling/mathtext/latex_bessel.py
@@ -18,20 +18,24 @@ from bokeh.plotting import curdoc, figure, show
 
 p = figure(
     width=700, height=500,
-    title=\
-        r"$$\color{white} \text{Bessel functions of the first kind: } J_\alpha(x) = \sum_{m=0}^{\infty}"
-        r"\frac{(-1)^m}{m!\:\Gamma(m+\alpha+1)} \left(\frac{x}{2}\right)^{2m+\alpha}$$",
+    title=(
+        r"Bessel functions of the first kind: $$J_\alpha(x) = \sum_{m=0}^{\infty}"
+        r"\frac{(-1)^m}{m!\:\Gamma(m+\alpha+1)} \left(\frac{x}{2}\right)^{2m+\alpha}$$"
+    )
 )
 p.x_range.range_padding = 0
-p.xaxis.axis_label = r"$$\color{white} x$$"
-p.yaxis.axis_label = r"$$\color{white} J_\alpha(x)$$"
-p.title.text_font_size="14px"
+p.xaxis.axis_label = "$$x$$"
+p.xaxis.axis_label_text_color = "white"
+p.yaxis.axis_label = r"$$J_\alpha(x)$$"
+p.yaxis.axis_label_text_color = "white"
+p.title.text_font_size = "14px"
+p.title.text_color = "white"
 
 x = np.linspace(0.0, 14.0, 100)
 
 for i, (xlabel, ylabel) in enumerate(zip([0.5, 1.6, 2.8, 4.2], [0.95, 0.6, 0.5, 0.45])):
     p.line(x, jv(i, x), line_width=3, color=YlOrRd4[i])
-    p.add_layout(Label(text=r"$$\color{white} J_" + str(i) + "(x)$$", x=xlabel, y=ylabel))
+    p.add_layout(Label(text=f"$$J_{i}(x)$$", x=xlabel, y=ylabel, text_color="white"))
 
 curdoc().theme = 'night_sky'
 

--- a/examples/styling/mathtext/latex_div_widget.py
+++ b/examples/styling/mathtext/latex_div_widget.py
@@ -1,3 +1,10 @@
+''' This example demonstrates the use of inline mathtext on a DIV element.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.models.widgets.Div
+    :refs: :ref:`ug_styling_mathtext`
+    :keywords: mathtext, latex
+'''
 from bokeh.io import show
 from bokeh.models import Div
 

--- a/examples/styling/mathtext/latex_schrodinger.py
+++ b/examples/styling/mathtext/latex_schrodinger.py
@@ -23,10 +23,10 @@ p.xgrid.visible = False
 p.ygrid.visible = False
 
 title = [
-    r"$$\text{Wavefunction } \psi_v(q) \text{ of first 8 mode solutions of Schrodinger's equation }" +
-        r" -\frac{1}{2}\frac{d^2\psi}{dq^2} + \frac{1}{2}q^2\psi = \frac{E}{\hbar\omega}\psi$$",
-    r"$$\text{Each wavefunction is labelled with its quantum number } v \text{ and energy } E_v$$",
-    r"$$\text{in a potential } V(q) = \frac{q^2}{2} \text{ shown by the dashed line.}$$",
+    r"Wave function $$\psi_v(q)$$ of first 8 mode solutions of Schrodinger's equation " +
+    r"$$-\frac{1}{2}\frac{d^2\psi}{dq^2} + \frac{1}{2}q^2\psi = \frac{E}{\hbar\omega}\psi$$",
+    r"Each wave function is labelled with its quantum number $$v$$ and energy $$E_v$$",
+    r"in a potential $$V(q) = \frac{q^2}{2}$$ shown by the dashed line.",
 ]
 for text in reversed(title):
     p.add_layout(Title(text=text, text_font_style="normal"), "above")
@@ -49,8 +49,8 @@ for v in range(number_of_modes):
     p.varea(q, ylower, E_v, fill_color= "#E66100")
     p.line(q, y, color="red", line_width=2)
 
-    p.add_layout(Label(x=-5.8, y=E_v, y_offset=-21, text=r"$$v = " + str(v) + r"$$"))
-    p.add_layout(Label(x=3.9, y=E_v, y_offset=-25, text=r"$$E_" + str(v) + r" = (" + str(2*v+1) + r"/2) \hbar\omega$$"))
+    p.add_layout(Label(x=-5.8, y=E_v, y_offset=-21, text=rf"$$v = {v}$$"))
+    p.add_layout(Label(x=3.9, y=E_v, y_offset=-25, text=rf"$$E_{v} = ({2*v+1}/2) \hbar\omega$$"))
 
 V = q**2 / 2
 p.line(q, V, line_color="black", line_width=2, line_dash="dashed")

--- a/examples/styling/mathtext/latex_slider_widget_title.py
+++ b/examples/styling/mathtext/latex_slider_widget_title.py
@@ -1,3 +1,10 @@
+''' This example demonstrates the use of mathtext on a ``Slider`` widget.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.models.widgets.Slider
+    :refs: :ref:`ug_styling_mathtext`
+    :keywords: mathtext, latex
+'''
 from bokeh.io import show
 from bokeh.models import Slider
 

--- a/examples/styling/mathtext/latex_tick_labels.py
+++ b/examples/styling/mathtext/latex_tick_labels.py
@@ -1,3 +1,11 @@
+''' This example demonstrates the use of mathtext on tick labels through overwriting the labels
+by adding a dictionary with pairs of position and mathtext.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.line, bokeh.plotting.figure.circle
+    :refs: :ref:`ug_styling_mathtext`
+    :keywords: mathtext, latex
+'''
 from numpy import arange
 
 from bokeh.plotting import figure, show

--- a/examples/styling/mathtext/mathml_axis_labels.py
+++ b/examples/styling/mathtext/mathml_axis_labels.py
@@ -1,3 +1,11 @@
+''' This example demonstrates the use of mathtext as an axis label using a MathML object.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.line, bokeh.models.MathML
+    :refs: :ref:`ug_styling_mathtext`
+    :keywords: mathtext
+'''
+
 from numpy import arange
 
 from bokeh.models import MathML


### PR DESCRIPTION
This is the initial version to allow inline math text. The visual appearance is not touched.  The main idea is to add the workaround `\text{...}` to any not math section in a string which contains math.

- [x] issues: fixes #13211

Kindly asking for some feedback.