### PR TITLE
Use PEP 673 `Self` type instead of `TypeVar(..., bound=...)`

### DIFF
--- a/src/bokeh/colors/color.py
+++ b/src/bokeh/colors/color.py
@@ -25,14 +25,14 @@ import colorsys
 from abc import ABCMeta, abstractmethod
 from math import sqrt
 from re import match
-from typing import TYPE_CHECKING, TypeVar, Union
+from typing import TYPE_CHECKING, Union
 
 # Bokeh imports
 from ..core.serialization import AnyRep, Serializable, Serializer
 from ..util.deprecation import deprecated
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing_extensions import Self, TypeAlias
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -50,8 +50,6 @@ __all__ = (
 RGBTuple = Union[tuple[int, int, int], tuple[int, int, int, float]]
 
 ColorLike: TypeAlias = Union[str, "Color", RGBTuple]
-
-Self = TypeVar("Self", bound="Color")
 
 class Color(Serializable, metaclass=ABCMeta):
     ''' A base class for representing color objects.
@@ -89,7 +87,7 @@ class Color(Serializable, metaclass=ABCMeta):
             return value
 
     @abstractmethod
-    def copy(self: Self) -> Self:
+    def copy(self) -> Self:
         ''' Copy this color.
 
         *Subclasses must implement this method.*
@@ -97,7 +95,7 @@ class Color(Serializable, metaclass=ABCMeta):
         '''
         raise NotImplementedError
 
-    def darken(self: Self, amount: float) -> Self:
+    def darken(self, amount: float) -> Self:
         ''' Darken (reduce the luminance) of this color.
 
         *Subclasses must implement this method.*
@@ -114,7 +112,7 @@ class Color(Serializable, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def from_hsl(cls: type[Self], value: HSL) -> Self:
+    def from_hsl(cls, value: HSL) -> Self:
         ''' Create a new color by converting from an HSL color.
 
         *Subclasses must implement this method.*
@@ -131,7 +129,7 @@ class Color(Serializable, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def from_rgb(cls: type[Self], value: RGB) -> Self:
+    def from_rgb(cls, value: RGB) -> Self:
         ''' Create a new color by converting from an RGB color.
 
         *Subclasses must implement this method.*
@@ -146,7 +144,7 @@ class Color(Serializable, metaclass=ABCMeta):
         '''
         raise NotImplementedError
 
-    def lighten(self: Self, amount: float) -> Self:
+    def lighten(self, amount: float) -> Self:
         ''' Lighten (increase the luminance) of this color.
 
         *Subclasses must implement this method.*


### PR DESCRIPTION
This switches from convoluted `Self = TypeVar("Self", bound=SomeType)` to `Self` type in e.g. `def clone(self) -> Self: ...`. This was introduced in PEP 673 (Python 3.11), but mypy and all other typecheckes support this and `Self` is available via `typing_extensions` module.
