### PR TITLE
Remove unneeded backslash in LaTeX [skip ci]

### DIFF
--- a/examples/styling/mathtext/latex_axis_labels_titles_labels.py
+++ b/examples/styling/mathtext/latex_axis_labels_titles_labels.py
@@ -10,7 +10,7 @@ p = figure(height=250, title=r"\[\sin(x)\text{ for }x\text{ between }-2\pi\text{
 p.circle(x, y, alpha=0.6, size=7)
 
 label = Label(
-    text=r"$$y = \sin(x)\$$",
+    text=r"$$y = \sin(x)$$",
     x=150, y=130,
     x_units="screen", y_units="screen",
 )


### PR DESCRIPTION
This remove an unneeded backslash in one of the LaTeX examples in the docs. It didn't produce any wrong output, it just isn't needed.