### PR TITLE
Reenable search bar in docs left sidebar

### DIFF
--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -203,6 +203,7 @@ html_sidebars = {
     "docs/examples/**": [],
     "docs/gallery": [],
     "index": [],
+    "**": ["search-field.html", "sidebar-nav-bs.html"],
 }
 
 favicons = [

--- a/docs/bokeh/source/docs/dev_guide/documentation.rst
+++ b/docs/bokeh/source/docs/dev_guide/documentation.rst
@@ -126,7 +126,7 @@ root level of your *source checkout* directory to update ``bkdev``:
 
 .. code-block:: sh
 
-    conda env update --name bkdev -file <environment file> --prune
+    conda env update --name bkdev --file <environment file> --prune
 
 using the environment file you originally used to create ``bkdev``.
 


### PR DESCRIPTION
Fixes #13222.

I found the solution documented at https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/search.html. Locally-built docs show:

<img width="611" alt="Screenshot 2023-06-20 at 20 19 08" src="https://github.com/bokeh/bokeh/assets/580326/629b4fe5-a8e8-41f6-ba83-de098df74241">

It still has the magnifying glass icon along the top navigation bar, if you click it the focus moves to the search bar on the left rather than creating a new popup. Maybe the magnifying glass isn't needed, but I haven't looked into that.

Also corrected the `conda env update` command in the doc building section.