### PR TITLE
Fix `PropertyValueColumnData._stream()` to handle `rollover=0`

### DIFF
--- a/src/bokeh/core/property/wrappers.py
+++ b/src/bokeh/core/property/wrappers.py
@@ -467,18 +467,18 @@ class PropertyValueColumnData(PropertyValueDict):
         # For arrays is reports the actual old value. For lists, the old value
         # is actually the already updated value. This is because the method
         # self._saved_copy() makes a shallow copy.
-        for k, v in new_data.items():
+        for k in new_data:
             if isinstance(self[k], np.ndarray) or isinstance(new_data[k], np.ndarray):
                 data = np.append(self[k], new_data[k])
-                if rollover and len(data) > rollover:
-                    data = data[-rollover:]
+                if rollover is not None and len(data) > rollover:
+                    data = data[len(data) - rollover:]
                 # call dict.__setitem__ directly, bypass wrapped version on base class
                 dict.__setitem__(self, k, data)
             else:
                 L = self[k]
                 L.extend(new_data[k])
                 if rollover is not None:
-                    del L[:-rollover]
+                    del L[:len(L) - rollover]
 
         from ...document.events import ColumnsStreamedEvent
         self._notify_owners(old, hint=ColumnsStreamedEvent(doc, source, "data", new_data, rollover, setter))

--- a/tests/unit/bokeh/core/property/test_wrappers__property.py
+++ b/tests/unit/bokeh/core/property/test_wrappers__property.py
@@ -190,6 +190,7 @@ def test_PropertyValueColumnData__stream_list_to_list(mock_notify: MagicMock) ->
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
     assert event.rollover is None
+    assert event.data == {'foo': [20]}
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_list_to_array(mock_notify: MagicMock) -> None:
@@ -209,6 +210,7 @@ def test_PropertyValueColumnData__stream_list_to_array(mock_notify: MagicMock) -
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
     assert event.rollover is None
+    assert event.data == {'foo': [20]}
 
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
@@ -227,6 +229,7 @@ def test_PropertyValueColumnData__stream_list_with_rollover(mock_notify: MagicMo
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
     assert event.rollover == 3
+    assert event.data == {'foo': [40]}
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_list_with_rollover_equals_zero(mock_notify: MagicMock) -> None:
@@ -244,6 +247,7 @@ def test_PropertyValueColumnData__stream_list_with_rollover_equals_zero(mock_not
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
     assert event.rollover == 0
+    assert event.data == {'foo': [40]}
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_array_to_array(mock_notify: MagicMock) -> None:
@@ -265,6 +269,7 @@ def test_PropertyValueColumnData__stream_array_to_array(mock_notify: MagicMock) 
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
     assert event.rollover is None
+    assert event.data == {'foo': [20]}
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_array_to_list(mock_notify: MagicMock) -> None:
@@ -284,6 +289,7 @@ def test_PropertyValueColumnData__stream_array_to_list(mock_notify: MagicMock) -
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
     assert event.rollover is None
+    assert event.data == {'foo': [20]}
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_array_with_rollover(mock_notify: MagicMock) -> None:
@@ -305,6 +311,7 @@ def test_PropertyValueColumnData__stream_array_with_rollover(mock_notify: MagicM
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
     assert event.rollover == 3
+    assert event.data == {'foo': [40]}
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__stream_array_with_rollover_equals_zero(mock_notify: MagicMock) -> None:
@@ -326,6 +333,7 @@ def test_PropertyValueColumnData__stream_array_with_rollover_equals_zero(mock_no
     assert isinstance(event, ColumnsStreamedEvent)
     assert event.setter == 'setter'
     assert event.rollover == 0
+    assert event.data == {'foo': [40]}
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__patch_with_simple_indices(mock_notify: MagicMock) -> None:
@@ -358,7 +366,6 @@ def test_PropertyValueColumnData__patch_with_repeated_simple_indices(mock_notify
     event = mock_notify.call_args[1]['hint']
     assert isinstance(event, ColumnsPatchedEvent)
     assert event.setter == 'setter'
-
 
 @patch('bokeh.core.property.wrappers.PropertyValueContainer._notify_owners')
 def test_PropertyValueColumnData__patch_with_slice_indices(mock_notify: MagicMock) -> None:


### PR DESCRIPTION
fixes #13238

> ### Expected behavior
>
> If `rollover` is set to 0, calling the `_stream` method within `PropertyValueColumnData` should remove all rows. This behavior can be used to delete all rows within a `ColumnDataSource`. (The documentation states that assigning an empty `dict` to `ColumnDataSource.data` achieves the same outcome, but our specific use case doesn't allow us to perform this operation.)
>
> ### Observed behavior
>
> If `rollover` is set to `0`, calling the `_stream` method within `PropertyValueColumnData` has no effect.
