### PR TITLE
Update ruff repo links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 default_stages: [push]
 
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.269
     hooks:
       - id: ruff

--- a/docs/bokeh/source/docs/dev_guide/python.rst
+++ b/docs/bokeh/source/docs/dev_guide/python.rst
@@ -206,7 +206,7 @@ To type check your code locally, run ``mypy bokeh``.
 
 .. _PEP8: https://www.python.org/dev/peps/pep-0008/
 .. _Google Python Style Guide: https://google.github.io/styleguide/pyguide.html#383-functions-and-methods
-.. _Ruff: https://github.com/charliermarsh/ruff
+.. _Ruff: https://github.com/astral-sh/ruff
 .. _isort: https://pycqa.github.io/isort/
 .. _mypy: https://mypy.readthedocs.io
 .. _stub files: https://www.python.org/dev/peps/pep-0484/#stub-files

--- a/docs/bokeh/source/docs/dev_guide/setup.rst
+++ b/docs/bokeh/source/docs/dev_guide/setup.rst
@@ -692,7 +692,7 @@ Slack`_.
 .. _npm: https://www.npmjs.com/
 .. _pre-commit: https://pre-commit.com/
 .. _Git hooks: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
-.. _Ruff: https://github.com/charliermarsh/ruff
+.. _Ruff: https://github.com/astral-sh/ruff
 .. _ESLint: https://eslint.org/
 .. _isort: https://pycqa.github.io/isort/
 .. _Bokeh's protected branches: https://github.com/bokeh/bokeh/wiki/BEP-6:-Branching-Strategy

--- a/docs/bokeh/source/docs/dev_guide/testing.rst
+++ b/docs/bokeh/source/docs/dev_guide/testing.rst
@@ -496,7 +496,7 @@ instead of pushing every commit individually. This will help you be considerate
 of others who require access to these limited resources.
 
 .. _ESLint: https://eslint.org/
-.. _Ruff: https://github.com/charliermarsh/ruff
+.. _Ruff: https://github.com/astral-sh/ruff
 .. _pytest: https://pytest.org/
 .. _pytest-xdist: https://github.com/pytest-dev/pytest-xdist
 .. _Selenium: https://www.selenium.dev/documentation/en/


### PR DESCRIPTION
The `ruff` repo has moved its github organisation, this updates our links in `pre-commit` and docs. See https://github.com/scientific-python/cookie/pull/200.