### PR TITLE
Avoid calling MercatorTileSource.get_tiles_by_extent for undefined extents

### DIFF
--- a/bokehjs/src/lib/models/tiles/mercator_tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/mercator_tile_source.ts
@@ -190,6 +190,10 @@ export class MercatorTileSource extends TileSource {
   }
 
   get_tiles_by_extent(extent: Extent, level: number, tile_border: number = 1): [number, number, number, Bounds][] {
+    // skip calculation if any axis has undefined extent
+    if (extent.filter(value => isNaN(value)).length)
+      return []
+
     // unpack extent and convert to tile coordinates
     const [xmin, ymin, xmax, ymax] = extent
     let [txmin, tymin] = this.meters_to_tile(xmin, ymin, level)


### PR DESCRIPTION
This is a fix for a case where an undefined extent is passed into `MercatorTileSource.get_tiles_by_extent`. This occurs primarily in notebooks where the plot is collapsed along the x-axis in certain scenarios resulting in an undefined extent along with a large zoom level value, which causes a huge amount of tiles to be pre-fetched. This check ensures we do not pre-fetch any tiles if any part of the extent is undefined.

- [x] issues: fixes #13248
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
