### PR TITLE
Don't paint undisplayed plots

### DIFF
--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -42,6 +42,10 @@ export class View implements ISignalable {
 
   protected _has_finished: boolean
 
+  mark_finished(): void {
+    this._has_finished = true
+  }
+
   /** @internal */
   protected _slots = new WeakMap<Slot<any, any>, Slot<any, any>>()
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -105,6 +105,10 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
   computed_renderers: Renderer[]
 
+  get computed_renderer_views(): RendererView[] {
+    return this.computed_renderers.map((r) => this.renderer_views.get(r)!)
+  }
+
   renderer_view<T extends Renderer>(renderer: T): T["__view_type__"] | undefined {
     const view = this.renderer_views.get(renderer)
     if (view == null) {
@@ -816,9 +820,16 @@ export class PlotView extends LayoutDOMView implements Renderable {
     if (this.is_paused)
       return
 
-    if (this.model.visible) {
+    if (this.is_displayed) {
       logger.trace(`${this.toString()}.paint()`)
       this._actual_paint()
+    } else {
+      // This is possibly the first render cycle, but plot isn't displayed,
+      // so all renderers have to be manually marked as finished, because
+      // their `render()` method didn't run.
+      for (const renderer_view of this.computed_renderer_views) {
+        renderer_view.mark_finished()
+      }
     }
 
     if (this._needs_notify) {

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -14,6 +14,7 @@ import {ImageLoader} from "core/util/image"
 import {includes} from "core/util/array"
 import {isString} from "core/util/types"
 import type {Context2d} from "core/util/canvas"
+import {assert} from "core/util/assert"
 
 import attribution_css from "styles/attribution.css"
 
@@ -30,7 +31,7 @@ export type TileData = Tile & ({img: Image, loaded: true} | {img: undefined, loa
 export class TileRendererView extends RendererView {
   declare model: TileRenderer
 
-  protected _tiles: TileData[]
+  protected _tiles: TileData[] | null = null
 
   protected extent: Extent
   protected initial_extent: Extent
@@ -42,9 +43,9 @@ export class TileRendererView extends RendererView {
 
   protected attribution_el?: HTMLElement
 
-  override initialize(): void {
+  override mark_finished(): void {
+    super.mark_finished()
     this._tiles = []
-    super.initialize()
   }
 
   override connect_signals(): void {
@@ -60,7 +61,16 @@ export class TileRendererView extends RendererView {
   }
 
   get_extent(): Extent {
-    return [this.x_range.start, this.y_range.start, this.x_range.end, this.y_range.end]
+    const {x_range, y_range} = this
+    const x_start = x_range.start
+    const y_start = y_range.start
+    const x_end = x_range.end
+    const y_end = y_range.end
+    assert(isFinite(x_start))
+    assert(isFinite(y_start))
+    assert(isFinite(x_end))
+    assert(isFinite(y_end))
+    return [x_start, y_start, x_end, y_end]
   }
 
   private get map_plot(): Plot {
@@ -166,6 +176,8 @@ export class TileRendererView extends RendererView {
     }
 
     this.model.tile_source.tiles.set(cache_key, tile)
+    if (this._tiles == null)
+      this._tiles = []
     this._tiles.push(tile)
 
     new ImageLoader(src, {
@@ -202,7 +214,7 @@ export class TileRendererView extends RendererView {
     if (!super.has_finished())
       return false
 
-    if (this._tiles.length == 0)
+    if (this._tiles == null)
       return false
 
     for (const tile of this._tiles) {


### PR DESCRIPTION
TODO:

- [x] regression tests

fixes #13248
fixes #13139 (this PR doesn't allow any painting for zero size canvas, so completes the specific partial fix implemented earlier)
