### PR TITLE
Use `../core/kinds` instead of `core/kinds` in imports

### DIFF
--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -5,7 +5,7 @@ import type {PinchEvent, ScrollEvent} from "core/ui_events"
 import {Dimensions} from "core/enums"
 import {is_mobile} from "core/util/platform"
 import {tool_icon_wheel_zoom} from "styles/icons.css"
-import {Enum} from "core/kinds"
+import {Enum} from "../../../core/kinds"
 
 const ZoomTogether = Enum("none", "cross", "all")
 type ZoomTogether = typeof ZoomTogether["__type__"]

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -5,7 +5,7 @@ import {empty, display, undisplay, div} from "core/dom"
 import type * as p from "core/properties"
 import {take} from "core/util/iterator"
 import {clamp} from "core/util/math"
-import {Enum} from "core/kinds"
+import {Enum} from "../../core/kinds"
 
 import dropdown_css, * as dropdown from "styles/dropdown.css"
 


### PR DESCRIPTION
This is required due to TypeScript's handling of injected imports in generated type declarations, which cannot be processed by our source transforms, so we have to do that "transform" manually.