### PR TITLE
Fix support for well known icons in Tools

### DIFF
--- a/src/bokeh/core/property/visual.py
+++ b/src/bokeh/core/property/visual.py
@@ -24,9 +24,10 @@ log = logging.getLogger(__name__)
 import base64
 import datetime  # lgtm [py/import-and-import-from]
 import re
+import tempfile
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 # External imports
 import PIL.Image
@@ -172,7 +173,8 @@ class Image(Property):
         if isinstance(value, str):
             return value
 
-        if isinstance(value, Path):
+        # tempfile doesn't implement IO interface (https://bugs.python.org/issue33762)
+        if isinstance(value, (Path, BinaryIO, tempfile._TemporaryFileWrapper)):
             value = PIL.Image.open(value)
 
         if isinstance(value, PIL.Image.Image):

--- a/src/bokeh/core/property/visual.py
+++ b/src/bokeh/core/property/visual.py
@@ -32,7 +32,6 @@ from typing import Any
 import PIL.Image
 
 # Bokeh imports
-from ...util.deprecation import deprecated
 from ...util.serialization import convert_datetime_type
 from .. import enums
 from .auto import Auto
@@ -170,12 +169,8 @@ class Image(Property):
         if isinstance(value, np.ndarray):
             value = PIL.Image.fromarray(value)
 
-        if isinstance(value, str) and value.startswith("data:image/"):
-            return value
-
         if isinstance(value, str):
-            deprecated((2, 4, 0), "raw string path", "pathlib.Path")
-            value = Path(value)
+            return value
 
         if isinstance(value, Path):
             value = PIL.Image.open(value)

--- a/tests/unit/bokeh/core/property/test_visual.py
+++ b/tests/unit/bokeh/core/property/test_visual.py
@@ -19,6 +19,7 @@ import pytest ; pytest
 # Standard library imports
 import base64
 import datetime
+import tempfile
 from io import BytesIO
 from pathlib import Path
 from typing import Literal
@@ -28,7 +29,7 @@ import numpy as np
 import PIL.Image
 
 # Bokeh imports
-from bokeh.core.enums import MarkerType
+from bokeh.core.enums import MarkerType, ToolIcon
 from bokeh.core.has_props import HasProps
 from tests.support.util.api import verify_all
 
@@ -271,6 +272,20 @@ class Test_Image:
     def test_transform_data_url(self) -> None:
         prop = bcpv.Image()
         image = "data:image/png;base64,"
+        assert prop.transform(image) == image
+
+    def test_transform_path(self) -> None:
+        temp_dir = Path(tempfile.gettempdir())
+        with tempfile.NamedTemporaryFile() as file:
+            location = temp_dir / file.name
+        image = PIL.Image.new('RGBA', size=(50, 50), color=(155, 0, 0))
+        image.save(location, 'png')
+        prop = bcpv.Image()
+        assert prop.transform(location).startswith("data:image/png")
+
+    def test_transform_string(self) -> None:
+        prop = bcpv.Image()
+        image = ToolIcon.zoom_in
         assert prop.transform(image) == image
 
     def test_transform_numpy(self) -> None:

--- a/tests/unit/bokeh/core/property/test_visual.py
+++ b/tests/unit/bokeh/core/property/test_visual.py
@@ -275,12 +275,19 @@ class Test_Image:
         assert prop.transform(image) == image
 
     def test_transform_path(self) -> None:
-        with tempfile.NamedTemporaryFile() as file:
-            path = Path(file.name)
-            image = PIL.Image.new('RGBA', size=(50, 50), color=(155, 0, 0))
-            image.save(file, 'png')
+        with tempfile.TemporaryDirectory() as dir:
+            path = Path(dir) / "image.png"
+            image = PIL.Image.new("RGBA", size=(50, 50), color=(155, 0, 0))
+            image.save(path, "png")
             prop = bcpv.Image()
             assert prop.transform(path).startswith("data:image/png")
+
+    def test_transform_file(self) -> None:
+        with tempfile.NamedTemporaryFile() as file:
+            image = PIL.Image.new("RGBA", size=(50, 50), color=(155, 0, 0))
+            image.save(file, "png")
+            prop = bcpv.Image()
+            assert prop.transform(file).startswith("data:image/png")
 
     def test_transform_string(self) -> None:
         prop = bcpv.Image()

--- a/tests/unit/bokeh/core/property/test_visual.py
+++ b/tests/unit/bokeh/core/property/test_visual.py
@@ -275,13 +275,12 @@ class Test_Image:
         assert prop.transform(image) == image
 
     def test_transform_path(self) -> None:
-        temp_dir = Path(tempfile.gettempdir())
         with tempfile.NamedTemporaryFile() as file:
-            location = temp_dir / file.name
-        image = PIL.Image.new('RGBA', size=(50, 50), color=(155, 0, 0))
-        image.save(location, 'png')
-        prop = bcpv.Image()
-        assert prop.transform(location).startswith("data:image/png")
+            path = Path(file.name)
+            image = PIL.Image.new('RGBA', size=(50, 50), color=(155, 0, 0))
+            image.save(file, 'png')
+            prop = bcpv.Image()
+            assert prop.transform(path).startswith("data:image/png")
 
     def test_transform_string(self) -> None:
         prop = bcpv.Image()


### PR DESCRIPTION
This stops a `FileNotFoundError` exception from being raised when the icon option is set to a well known icon by returning its value.

https://stackoverflow.com/questions/76691027/bokeh-tool-change-icon

- [x] issues: fixes #13257
