### PR TITLE
fix cited section because of wrong indent in formatters.py [skip ci]

### DIFF
--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -367,15 +367,14 @@ class CustomJSTickFormatter(TickFormatter):
 
     Additionally available variables are:
 
-      * ``ticks``, an array of all axis ticks as positioned by the ticker,
-      * ``index``, the position of ``tick`` within ``ticks``, and
-      * the keys of ``args`` mapping, if any.
+    * ``ticks``, an array of all axis ticks as positioned by the ticker,
+    * ``index``, the position of ``tick`` within ``ticks``, and
+    * the keys of ``args`` mapping, if any.
 
     Finding yourself needing to cache an expensive ``ticks``-dependent
     computation, you can store it on the ``this`` variable.
 
     Example:
-
         .. code-block:: javascript
 
             code = '''


### PR DESCRIPTION
This is a pull request with no ticket. In the docs in the section for the `CustomJSTickFormatter` some parts are looking like a quote.

![grafik](https://github.com/bokeh/bokeh/assets/68053396/17b55236-6d25-4834-8a0c-649c43cbef93)

With the suggested solution the header "Example" is bold. If this is not wanted, the complete code block could move to the left but the deleted line should stay.

![grafik](https://github.com/bokeh/bokeh/assets/68053396/2f39c9b7-a8f1-49f9-9315-fbed38634924)

I am not sure which version is the better one.