### PR TITLE
Add support for poly hit testing to `Patches` and greedy mode

### DIFF
--- a/bokehjs/src/lib/core/geometry.ts
+++ b/bokehjs/src/lib/core/geometry.ts
@@ -29,6 +29,13 @@ export type PolyGeometry = {
 
 export type Geometry = PointGeometry | SpanGeometry | RectGeometry | PolyGeometry
 
+export type HitTestPoint = PointGeometry
+export type HitTestSpan = SpanGeometry
+export type HitTestRect = RectGeometry & {greedy?: boolean}
+export type HitTestPoly = PolyGeometry & {greedy?: boolean}
+
+export type HitTestGeometry = HitTestPoint | HitTestSpan | HitTestRect | HitTestPoly
+
 export type PointGeometryData = PointGeometry & {
   x: number
   y: number

--- a/bokehjs/src/lib/core/util/algorithms.ts
+++ b/bokehjs/src/lib/core/util/algorithms.ts
@@ -1,5 +1,5 @@
 import type {Rect} from "../types"
-import {minmax} from "./arrayable"
+import {minmax2} from "./arrayable"
 
 const {abs, sqrt, min, max} = Math
 
@@ -112,12 +112,6 @@ export function cbb(
   x_bounds[n + 1] = x3
   y_bounds[n + 1] = y3
 
-  const [x_min, x_max] = minmax(x_bounds)
-  const [y_min, y_max] = minmax(y_bounds)
-  return {
-    x0: x_min,
-    x1: x_max,
-    y0: y_min,
-    y1: y_max,
-  }
+  const [x_min, x_max, y_min, y_max] = minmax2(x_bounds, y_bounds)
+  return {x0: x_min, x1: x_max, y0: y_min, y1: y_max}
 }

--- a/bokehjs/src/lib/models/annotations/poly_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/poly_annotation.ts
@@ -12,7 +12,7 @@ import {Signal} from "core/signaling"
 import type {PanEvent, Pannable, MoveEvent, Moveable, KeyModifiers} from "core/ui_events"
 import type {CoordinateMapper} from "core/util/bbox"
 import {BBox, empty} from "core/util/bbox"
-import {minmax} from "core/util/arrayable"
+import {minmax2} from "core/util/arrayable"
 import {assert} from "core/util/assert"
 import type * as p from "core/properties"
 
@@ -73,8 +73,7 @@ class Polygon {
   }
 
   get bbox(): BBox {
-    const [x0, x1] = minmax(this.xs)
-    const [y0, y1] = minmax(this.ys)
+    const [x0, x1, y0, y1] = minmax2(this.xs, this.ys)
     return new BBox({x0, x1, y0, y1})
   }
 
@@ -122,8 +121,7 @@ export class PolyAnnotationView extends AnnotationView implements Pannable, Move
     const {xs_units, ys_units} = this.model
     if (xs_units == "data" && ys_units == "data") {
       const {xs, ys} = this.model
-      const [x0, x1] = minmax(xs)
-      const [y0, y1] = minmax(ys)
+      const [x0, x1, y0, y1] = minmax2(xs, ys)
       return {x0, x1, y0, y1}
     } else
       return empty()

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -10,7 +10,7 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import * as uniforms from "core/uniforms"
 import type {SpatialIndex} from "core/util/spatial"
-import {map, minmax} from "core/util/arrayable"
+import {map, minmax2} from "core/util/arrayable"
 import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import type {Range1d} from "../ranges/range1d"
@@ -246,19 +246,20 @@ export class CircleView extends XYGlyphView {
   }
 
   protected override _hit_poly(geometry: PolyGeometry): Selection {
-    const {sx, sy} = geometry
+    const {sx: sxs, sy: sys} = geometry
 
-    const [sx0, sx1] = minmax(sx)
-    const [sy0, sy1] = minmax(sy)
+    const candidates = (() => {
+      const [sx0, sx1, sy0, sy1] = minmax2(sxs, sys)
 
-    const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
-    const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
+      const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
+      const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
 
-    const candidates = this.index.indices({x0, x1, y0, y1})
+      return this.index.indices({x0, x1, y0, y1})
+    })()
 
     const indices = []
     for (const i of candidates) {
-      if (hittest.point_in_poly(this.sx[i], this.sy[i], sx, sy)) {
+      if (hittest.point_in_poly(this.sx[i], this.sy[i], sxs, sys)) {
         indices.push(i)
       }
     }

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -4,7 +4,7 @@ import type {Arrayable, Rect} from "core/types"
 import {ScreenArray, to_screen, Indices} from "core/types"
 import {Anchor} from "core/enums"
 import * as p from "core/properties"
-import {minmax} from "core/util/arrayable"
+import {minmax2} from "core/util/arrayable"
 import type {Context2d} from "core/util/canvas"
 import type {SpatialIndex} from "core/util/spatial"
 import {ImageLoader} from "core/util/image"
@@ -126,9 +126,7 @@ export class ImageURLView extends XYGlyphView {
     } else
       ys.set(this._y, 0)
 
-    const [x0, x1] = minmax(xs)
-    const [y0, y1] = minmax(ys)
-
+    const [x0, x1, y0, y1] = minmax2(xs, ys)
     this._bounds_rect = {x0, x1, y0, y1}
   }
 

--- a/bokehjs/src/lib/models/glyphs/marker.ts
+++ b/bokehjs/src/lib/models/glyphs/marker.ts
@@ -100,22 +100,23 @@ export abstract class MarkerView extends XYGlyphView {
   protected override _hit_span(geometry: SpanGeometry): Selection {
     const {sx, sy} = geometry
     const bounds = this.bounds()
-    const ms = this.max_size/2
+    const half_size = this.max_size/2
 
-    let x0, x1, y0, y1
-    if (geometry.direction == "h") {
-      y0 = bounds.y0
-      y1 = bounds.y1
-      const sx0 = sx - ms
-      const sx1 = sx + ms
-      ;[x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
-    } else {
-      x0 = bounds.x0
-      x1 = bounds.x1
-      const sy0 = sy - ms
-      const sy1 = sy + ms
-      ;[y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-    }
+    const [x0, x1, y0, y1] = (() => {
+      if (geometry.direction == "h") {
+        const {y0, y1} = bounds
+        const sx0 = sx - half_size
+        const sx1 = sx + half_size
+        const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
+        return [x0, x1, y0, y1]
+      } else {
+        const {x0, x1} = bounds
+        const sy0 = sy - half_size
+        const sy1 = sy + half_size
+        const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
+        return [x0, x1, y0, y1]
+      }
+    })()
 
     const indices = [...this.index.indices({x0, x1, y0, y1})]
     return new Selection({indices})

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -5,7 +5,7 @@ import {generic_area_vector_legend} from "./utils"
 import {minmax2} from "core/util/arrayable"
 import {sum} from "core/util/arrayable"
 import type {Arrayable, Rect, FloatArray, ScreenArray, Indices} from "core/types"
-import type {PointGeometry, RectGeometry} from "core/geometry"
+import type {HitTestPoint, HitTestRect, HitTestPoly} from "core/geometry"
 import type {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
@@ -164,40 +164,70 @@ export class MultiPolygonsView extends GlyphView {
     }
   }
 
-  protected override _hit_rect(geometry: RectGeometry): Selection {
-    const {sx0, sx1, sy0, sy1} = geometry
-    const xs = [sx0, sx1, sx1, sx0]
-    const ys = [sy0, sy0, sy1, sy1]
-    const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
-    const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
+  protected override _hit_poly(geometry: HitTestPoly): Selection {
+    const {sx: sxs, sy: sys, greedy=false} = geometry
 
-    const candidates = this.index.indices({x0, x1, y0, y1})
+    const candidates = (() => {
+      const xs = this.renderer.xscale.v_invert(sxs)
+      const ys = this.renderer.yscale.v_invert(sys)
+
+      const [x0, x1, y0, y1] = minmax2(xs, ys)
+      return this.index.indices({x0, x1, y0, y1})
+    })()
+
     const indices = []
 
-    for (const index of candidates) {
-      const sxss = this.sxs[index]
-      const syss = this.sys[index]
-      let hit = true
-      for (let j = 0, endj = sxss.length; j < endj; j++) {
-        for (let k = 0, endk = sxss[j][0].length; k < endk; k++) {
-          const sx = sxss[j][0][k]
-          const sy = syss[j][0][k]
-          if (!hittest.point_in_poly(sx, sy, xs, ys)) {
-            hit = false
+    for (const i of candidates) {
+      const sxs_i = this.sxs[i]
+      const sys_i = this.sys[i]
+      let hit = !greedy
+
+      const nj = sxs_i.length
+      for (let j = 0; j < nj; j++) {
+        const sxs_ij0 = sxs_i[j][0]
+        const sys_ij0 = sys_i[j][0]
+
+        const nk = sxs_ij0.length
+        for (let k = 0; k < nk; k++) {
+          const sxs_ij0k = sxs_ij0[k]
+          const sys_ij0k = sys_ij0[k]
+          if (!hittest.point_in_poly(sxs_ij0k, sys_ij0k, sxs, sys)) {
+            if (!greedy) {
+              hit = false
+              break
+            }
+          } else {
+            if (greedy) {
+              hit = true
+              break
+            }
+          }
+        }
+        if (!greedy) {
+          if (!hit) {
+            break
+          }
+        } else {
+          if (hit) {
             break
           }
         }
-        if (!hit)
-          break
       }
       if (hit) {
-        indices.push(index)
+        indices.push(i)
       }
     }
     return new Selection({indices})
   }
 
-  protected override _hit_point(geometry: PointGeometry): Selection {
+  protected override _hit_rect(geometry: HitTestRect): Selection {
+    const {sx0, sx1, sy0, sy1, greedy} = geometry
+    const sxs = [sx0, sx1, sx1, sx0]
+    const sys = [sy0, sy0, sy1, sy1]
+    return this._hit_poly({type: "poly", sx: sxs, sy: sys, greedy})
+  }
+
+  protected override _hit_point(geometry: HitTestPoint): Selection {
     const {sx, sy} = geometry
 
     const x = this.renderer.xscale.invert(sx)

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -2,7 +2,7 @@ import {SpatialIndex} from "core/util/spatial"
 import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
-import {minmax} from "core/util/arrayable"
+import {minmax2} from "core/util/arrayable"
 import {sum} from "core/util/arrayable"
 import type {Arrayable, Rect, FloatArray, ScreenArray, Indices} from "core/types"
 import type {PointGeometry, RectGeometry} from "core/geometry"
@@ -57,8 +57,7 @@ export class MultiPolygonsView extends GlyphView {
         const ysij = ysi[j][0] // do not use holes
 
         if (xsij.length != 0 && ysij.length != 0) {
-          const [xij0, xij1] = minmax(xsij)
-          const [yij0, yij1] = minmax(ysij)
+          const [xij0, xij1, yij0, yij1] = minmax2(xsij, ysij)
           xi0 = min(xi0, xij0)
           xi1 = max(xi1, xij1)
           yi0 = min(yi0, yij0)
@@ -98,8 +97,7 @@ export class MultiPolygonsView extends GlyphView {
 
         if (xsij.length > 1 && ysij.length > 1) {
           for (let k = 1, endk = xsij.length; k < endk; k++) {
-            const [xij0, xij1] = minmax(xsij[k])
-            const [yij0, yij1] = minmax(ysij[k])
+            const [xij0, xij1, yij0, yij1] = minmax2(xsij[k], ysij[k])
             xi0 = min(xi0, xij0)
             xi1 = max(xi1, xij1)
             yi0 = min(yi0, yij0)

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -4,7 +4,7 @@ import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import {minmax2, sum} from "core/util/arrayable"
 import type {Arrayable, Rect, RaggedArray, FloatArray, ScreenArray, Indices} from "core/types"
-import type {PointGeometry, RectGeometry} from "core/geometry"
+import type {HitTestPoint, HitTestRect, HitTestPoly} from "core/geometry"
 import type {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
@@ -87,8 +87,44 @@ export class PatchesView extends GlyphView {
     }
   }
 
-  protected override _hit_rect(geometry: RectGeometry): Selection {
-    const {sx0, sx1, sy0, sy1} = geometry
+  protected override _hit_poly(geometry: HitTestPoly): Selection {
+    const {sx: sxs, sy: sys, greedy=true} = geometry
+    const xs = this.renderer.xscale.v_invert(sxs)
+    const ys = this.renderer.yscale.v_invert(sys)
+
+    const [x0, x1, y0, y1] = minmax2(xs, ys)
+    const candidates = this.index.indices({x0, x1, y0, y1})
+    const indices: number[] = []
+
+    for (const i of candidates) {
+      const sxs_i = this.sxs.get(i)
+      const sys_i = this.sys.get(i)
+      let hit = greedy
+      for (let j = 0, n = sxs_i.length; j < n; j++) {
+        const sx = sxs_i[j]
+        const sy = sys_i[j]
+        if (!hittest.point_in_poly(sx, sy, sxs, sys)) {
+          if (greedy) {
+            hit = false
+            break
+          }
+        } else {
+          if (!greedy) {
+            hit = true
+            break
+          }
+        }
+      }
+      if (hit) {
+        indices.push(i)
+      }
+    }
+
+    return new Selection({indices})
+  }
+
+  protected override _hit_rect(geometry: HitTestRect): Selection {
+    const {sx0, sx1, sy0, sy1, greedy=true} = geometry
     const xs = [sx0, sx1, sx1, sx0]
     const ys = [sy0, sy0, sy1, sy1]
     const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
@@ -100,13 +136,20 @@ export class PatchesView extends GlyphView {
     for (const index of candidates) {
       const sxss = this.sxs.get(index)
       const syss = this.sys.get(index)
-      let hit = true
+      let hit = greedy
       for (let j = 0, endj = sxss.length; j < endj; j++) {
         const sx = sxss[j]
         const sy = syss[j]
         if (!hittest.point_in_poly(sx, sy, xs, ys)) {
-          hit = false
-          break
+          if (greedy) {
+            hit = false
+            break
+          }
+        } else {
+          if (!greedy) {
+            hit = true
+            break
+          }
         }
       }
       if (hit) {
@@ -117,7 +160,7 @@ export class PatchesView extends GlyphView {
     return new Selection({indices})
   }
 
-  protected override _hit_point(geometry: PointGeometry): Selection {
+  protected override _hit_point(geometry: HitTestPoint): Selection {
     const {sx, sy} = geometry
 
     const x = this.renderer.xscale.invert(sx)

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -88,7 +88,7 @@ export class PatchesView extends GlyphView {
   }
 
   protected override _hit_poly(geometry: HitTestPoly): Selection {
-    const {sx: sxs, sy: sys, greedy=true} = geometry
+    const {sx: sxs, sy: sys, greedy=false} = geometry
     const xs = this.renderer.xscale.v_invert(sxs)
     const ys = this.renderer.yscale.v_invert(sys)
 
@@ -99,17 +99,21 @@ export class PatchesView extends GlyphView {
     for (const i of candidates) {
       const sxs_i = this.sxs.get(i)
       const sys_i = this.sys.get(i)
-      let hit = greedy
-      for (let j = 0, n = sxs_i.length; j < n; j++) {
+      const n = sxs_i.length
+      if (n == 0) {
+        continue
+      }
+      let hit = !greedy
+      for (let j = 0; j < n; j++) {
         const sx = sxs_i[j]
         const sy = sys_i[j]
         if (!hittest.point_in_poly(sx, sy, sxs, sys)) {
-          if (greedy) {
+          if (!greedy) {
             hit = false
             break
           }
         } else {
-          if (!greedy) {
+          if (greedy) {
             hit = true
             break
           }

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -124,40 +124,10 @@ export class PatchesView extends GlyphView {
   }
 
   protected override _hit_rect(geometry: HitTestRect): Selection {
-    const {sx0, sx1, sy0, sy1, greedy=true} = geometry
-    const xs = [sx0, sx1, sx1, sx0]
-    const ys = [sy0, sy0, sy1, sy1]
-    const [x0, x1] = this.renderer.xscale.r_invert(sx0, sx1)
-    const [y0, y1] = this.renderer.yscale.r_invert(sy0, sy1)
-
-    const candidates = this.index.indices({x0, x1, y0, y1})
-    const indices = []
-
-    for (const index of candidates) {
-      const sxss = this.sxs.get(index)
-      const syss = this.sys.get(index)
-      let hit = greedy
-      for (let j = 0, endj = sxss.length; j < endj; j++) {
-        const sx = sxss[j]
-        const sy = syss[j]
-        if (!hittest.point_in_poly(sx, sy, xs, ys)) {
-          if (greedy) {
-            hit = false
-            break
-          }
-        } else {
-          if (!greedy) {
-            hit = true
-            break
-          }
-        }
-      }
-      if (hit) {
-        indices.push(index)
-      }
-    }
-
-    return new Selection({indices})
+    const {sx0, sx1, sy0, sy1, greedy} = geometry
+    const sxs = [sx0, sx1, sx1, sx0]
+    const sys = [sy0, sy0, sy1, sy1]
+    return this._hit_poly({type: "poly", sx: sxs, sy: sys, greedy})
   }
 
   protected override _hit_point(geometry: HitTestPoint): Selection {

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -89,11 +89,15 @@ export class PatchesView extends GlyphView {
 
   protected override _hit_poly(geometry: HitTestPoly): Selection {
     const {sx: sxs, sy: sys, greedy=false} = geometry
-    const xs = this.renderer.xscale.v_invert(sxs)
-    const ys = this.renderer.yscale.v_invert(sys)
 
-    const [x0, x1, y0, y1] = minmax2(xs, ys)
-    const candidates = this.index.indices({x0, x1, y0, y1})
+    const candidates = (() => {
+      const xs = this.renderer.xscale.v_invert(sxs)
+      const ys = this.renderer.yscale.v_invert(sys)
+
+      const [x0, x1, y0, y1] = minmax2(xs, ys)
+      return this.index.indices({x0, x1, y0, y1})
+    })()
+
     const indices: number[] = []
 
     for (const i of candidates) {

--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -5,7 +5,7 @@ import type * as p from "core/properties"
 import type {SelectionMode, CoordinateUnits} from "core/enums"
 import {Dimensions, BoxOrigin} from "core/enums"
 import type {PanEvent, KeyEvent} from "core/ui_events"
-import type {RectGeometry} from "core/geometry"
+import type {HitTestRect} from "core/geometry"
 import type {CoordinateMapper, LRTB} from "core/util/bbox"
 import * as icons from "styles/icons.css"
 
@@ -170,7 +170,8 @@ export class BoxSelectToolView extends RegionSelectToolView {
   }
 
   _do_select([sx0, sx1]: [number, number], [sy0, sy1]: [number, number], final: boolean, mode: SelectionMode = "replace"): void {
-    const geometry: RectGeometry = {type: "rect", sx0, sx1, sy0, sy1}
+    const {greedy} = this.model
+    const geometry: HitTestRect = {type: "rect", sx0, sx1, sy0, sy1, greedy}
     this._select(geometry, final, mode)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/lasso_select_tool.ts
@@ -3,7 +3,7 @@ import {PolyAnnotation} from "../../annotations/poly_annotation"
 import type {Scale} from "../../scales/scale"
 import {DEFAULT_POLY_OVERLAY} from "./poly_select_tool"
 import type {SelectionMode, CoordinateUnits} from "core/enums"
-import type {PolyGeometry} from "core/geometry"
+import type {HitTestPoly} from "core/geometry"
 import type {Arrayable} from "core/types"
 import type {PanEvent, KeyEvent} from "core/ui_events"
 import type {CoordinateMapper} from "core/util/bbox"
@@ -139,7 +139,8 @@ export class LassoSelectToolView extends RegionSelectToolView {
   }
 
   _do_select(sx: NumArray, sy: NumArray, final: boolean, mode: SelectionMode): void {
-    const geometry: PolyGeometry = {type: "poly", sx, sy}
+    const {greedy} = this.model
+    const geometry: HitTestPoly = {type: "poly", sx, sy, greedy}
     this._select(geometry, final, mode)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/poly_select_tool.ts
@@ -2,7 +2,7 @@ import {RegionSelectTool, RegionSelectToolView} from "./region_select_tool"
 import {PolyAnnotation} from "../../annotations/poly_annotation"
 import type {Scale} from "../../scales/scale"
 import type {SelectionMode, CoordinateUnits} from "core/enums"
-import type {PolyGeometry} from "core/geometry"
+import type {HitTestPoly} from "core/geometry"
 import type {Arrayable} from "core/types"
 import type {TapEvent, KeyEvent, KeyModifiers} from "core/ui_events"
 import type {CoordinateMapper} from "core/util/bbox"
@@ -147,7 +147,8 @@ export class PolySelectToolView extends RegionSelectToolView {
   }
 
   _do_select(sx: NumArray, sy: NumArray, final: boolean, mode: SelectionMode): void {
-    const geometry: PolyGeometry = {type: "poly", sx, sy}
+    const {greedy} = this.model
+    const geometry: HitTestPoly = {type: "poly", sx, sy, greedy}
     this._select(geometry, final, mode)
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/region_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/region_select_tool.ts
@@ -69,7 +69,7 @@ export abstract class RegionSelectTool extends SelectTool {
     this.define<RegionSelectTool.Props>(({Boolean}) => ({
       continuous: [ Boolean, false ],
       persistent: [ Boolean, false ],
-      greedy: [ Boolean, true ],
+      greedy: [ Boolean, false ],
     }))
   }
 }

--- a/bokehjs/src/lib/models/tools/gestures/region_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/region_select_tool.ts
@@ -49,6 +49,7 @@ export namespace RegionSelectTool {
   export type Props = SelectTool.Props & {
     continuous: p.Property<boolean>
     persistent: p.Property<boolean>
+    greedy: p.Property<boolean>
   }
 }
 
@@ -68,6 +69,7 @@ export abstract class RegionSelectTool extends SelectTool {
     this.define<RegionSelectTool.Props>(({Boolean}) => ({
       continuous: [ Boolean, false ],
       persistent: [ Boolean, false ],
+      greedy: [ Boolean, true ],
     }))
   }
 }

--- a/bokehjs/test/devtools/server.ts
+++ b/bokehjs/test/devtools/server.ts
@@ -138,7 +138,7 @@ with open(__file__, "rb") as example:
   const cwd = dirname(path)
 
   console.log(`Building ${path}`)
-  const proc = spawn("python", ["-c", code], {stdio: "pipe", env, cwd, timeout: 5000})
+  const proc = spawn("python", ["-c", code], {stdio: "pipe", env, cwd, timeout: 10000})
 
   let output = ""
   proc.stdout.on("data", (data) => {

--- a/bokehjs/test/unit/models/glyphs/multi_polygons.ts
+++ b/bokehjs/test/unit/models/glyphs/multi_polygons.ts
@@ -2,47 +2,123 @@ import {expect} from "assertions"
 
 import {create_glyph_view} from "./_util"
 import {MultiPolygons} from "@bokehjs/models/glyphs/multi_polygons"
-import type {Geometry} from "@bokehjs/core/geometry"
-import {assert} from "@bokehjs/core/util/assert"
+import type {HitTestGeometry} from "@bokehjs/core/geometry"
+import {DataRange1d} from "@bokehjs/models"
+import type {Arrayable} from "@bokehjs/core/types"
+import {unzip} from "@bokehjs/core/util/array"
+
+type Point = [number, number]
 
 describe("MultiPolygons", () => {
 
   describe("MultiPolygonsView", () => {
-    it("should hit test rects for containment", async () => {
-      const data = {xs: [[[[0, 10, 5]]], [[[5, 10, 10, 5]]]], ys: [[[[0, 0, 10]]], [[[10, 10, 20, 20]]]]}
+
+    it("should rect hit testing", async () => {
+      const data = {
+        xs: [[[[1, 5, 3]]], [[[3, 5, 5, 3]]], [[[2, 3, 2, 1]]]],
+        ys: [[[[1, 1, 3]]], [[[3, 3, 5, 5]]], [[[3, 4, 5, 4]]]],
+      }
       const glyph = new MultiPolygons({
         xs: {field: "xs"},
         ys: {field: "ys"},
       })
 
-      const glyph_view = await create_glyph_view(glyph, data, {axis_type: "linear"})
+      const glyph_view = await create_glyph_view(glyph, data, {
+        axis_type: "linear",
+        x_range: new DataRange1d(),
+        y_range: new DataRange1d(),
+      })
+      const {xscale, yscale} = glyph_view.parent
 
-      const geometry1: Geometry = {type: "rect", sx0: -1, sy0: 201, sx1: 21, sy1: 179}
-      const geometry2: Geometry = {type: "rect", sx0: 1,  sy0: 200, sx1: 20, sy1: 180}
-      const geometry3: Geometry = {type: "rect", sx0: 9,  sy0: 181, sx1: 21, sy1: 159}
-      const geometry4: Geometry = {type: "rect", sx0: 10, sy0: 180, sx1: 19, sy1: 165}
-      const geometry5: Geometry = {type: "rect", sx0: 5,  sy0: 190, sx1: 15, sy1: 170}
-      const geometry6: Geometry = {type: "rect", sx0: -1, sy0: 201, sx1: 21, sy1: 159}
+      function rect([x0, y0]: Point, [x1, y1]: Point, greedy: boolean): HitTestGeometry {
+        const [sx0, sx1] = xscale.r_compute(x0, x1)
+        const [sy0, sy1] = yscale.r_compute(y0, y1)
+        return {type: "rect", sx0, sy0, sx1, sy1, greedy}
+      }
+
+      const geometry0 = rect([0, 0], [-1, 1], false)
+      const geometry1 = rect([0, 0], [-1, 1], true)
+
+      const result0 = glyph_view.hit_test(geometry0)
+      expect(result0?.indices).to.be.equal([])
 
       const result1 = glyph_view.hit_test(geometry1)
-      const result2 = glyph_view.hit_test(geometry2)
-      const result3 = glyph_view.hit_test(geometry3)
-      const result4 = glyph_view.hit_test(geometry4)
-      const result5 = glyph_view.hit_test(geometry5)
-      const result6 = glyph_view.hit_test(geometry6)
+      expect(result1?.indices).to.be.equal([])
 
-      assert(result1 != null)
-      expect(result1.indices).to.be.equal([0])
-      assert(result2 != null)
-      expect(result2.indices).to.be.equal([])
-      assert(result3 != null)
-      expect(result3.indices).to.be.equal([1])
-      assert(result4 != null)
-      expect(result4.indices).to.be.equal([])
-      assert(result5 != null)
-      expect(result5.indices).to.be.equal([])
-      assert(result6 != null)
-      expect(result6.indices).to.be.equal([0, 1])
+      const geometry2 = rect([0, 0], [6, 6], false)
+      const geometry3 = rect([0, 0], [6, 6], true)
+
+      const result2 = glyph_view.hit_test(geometry2)
+      expect(result2?.indices).to.be.equal([0, 1, 2])
+
+      const result3 = glyph_view.hit_test(geometry3)
+      expect(result3?.indices).to.be.equal([0, 1, 2])
+
+      const geometry4 = rect([0, 0], [6, 4], false)
+      const geometry5 = rect([0, 0], [6, 4], true)
+
+      const result4 = glyph_view.hit_test(geometry4)
+      expect(result4?.indices).to.be.equal([0])
+
+      const result5 = glyph_view.hit_test(geometry5)
+      expect(result5?.indices).to.be.equal([0, 1, 2])
+    })
+
+    it("should poly hit testing", async () => {
+      const data = {
+        xs: [[[[1, 5, 3]]], [[[3, 5, 5, 3]]], [[[2, 3, 2, 1]]]],
+        ys: [[[[1, 1, 3]]], [[[3, 3, 5, 5]]], [[[3, 4, 5, 4]]]],
+      }
+      const glyph = new MultiPolygons({
+        xs: {field: "xs"},
+        ys: {field: "ys"},
+      })
+
+      const glyph_view = await create_glyph_view(glyph, data, {
+        axis_type: "linear",
+        x_range: new DataRange1d(),
+        y_range: new DataRange1d(),
+      })
+      const {xscale, yscale} = glyph_view.parent
+
+      function compute(points: Point[]): {sx: Arrayable<number>, sy: Arrayable<number>} {
+        const [x=[], y=[]] = unzip(points)
+        return {
+          sx: xscale.v_compute(x),
+          sy: yscale.v_compute(y),
+        }
+      }
+
+      function poly(points: Point[], greedy: boolean): HitTestGeometry {
+        return {type: "poly", ...compute(points), greedy}
+      }
+
+      const geometry0 = poly([], false)
+      const geometry1 = poly([], true)
+
+      const result0 = glyph_view.hit_test(geometry0)
+      expect(result0?.indices).to.be.equal([])
+
+      const result1 = glyph_view.hit_test(geometry1)
+      expect(result1?.indices).to.be.equal([])
+
+      const geometry2 = poly([[0, 0], [6, 0], [6, 6], [0, 6], [0, 0]], false)
+      const geometry3 = poly([[0, 0], [6, 0], [6, 6], [0, 6], [0, 0]], true)
+
+      const result2 = glyph_view.hit_test(geometry2)
+      expect(result2?.indices).to.be.equal([0, 1, 2])
+
+      const result3 = glyph_view.hit_test(geometry3)
+      expect(result3?.indices).to.be.equal([0, 1, 2])
+
+      const geometry4 = poly([[0, 0], [6, 0], [6, 4], [0, 4], [0, 0]], false)
+      const geometry5 = poly([[0, 0], [6, 0], [6, 4], [0, 4], [0, 0]], true)
+
+      const result4 = glyph_view.hit_test(geometry4)
+      expect(result4?.indices).to.be.equal([0])
+
+      const result5 = glyph_view.hit_test(geometry5)
+      expect(result5?.indices).to.be.equal([0, 1, 2])
     })
   })
 })

--- a/docs/bokeh/source/docs/releases/3.3.0.rst
+++ b/docs/bokeh/source/docs/releases/3.3.0.rst
@@ -5,5 +5,6 @@
 
 Bokeh version ``3.3.0`` (September 2023) is a minor milestone of Bokeh project.
 
+* Expanded support for polygonal hit testing and added greedy mode (:bokeh-pull:`13277`)
 * Added support for inline math text expressions (:bokeh-pull:`13214`)
 * Added ``stack_labels`` property to ``WeightedStackColorMapper`` (:bokeh-pull:`13366`)

--- a/examples/topics/geo/choropleth.py
+++ b/examples/topics/geo/choropleth.py
@@ -24,8 +24,8 @@ EXCLUDED = ("ak", "hi", "pr", "gu", "vi", "mp", "as")
 state_xs = [states[code]["lons"] for code in states]
 state_ys = [states[code]["lats"] for code in states]
 
-county_xs=[counties[code]["lons"] for code in counties if counties[code]["state"] not in EXCLUDED]
-county_ys=[counties[code]["lats"] for code in counties if counties[code]["state"] not in EXCLUDED]
+county_xs = [counties[code]["lons"] for code in counties if counties[code]["state"] not in EXCLUDED]
+county_ys = [counties[code]["lats"] for code in counties if counties[code]["state"] not in EXCLUDED]
 
 county_colors = []
 for county_id in counties:

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -321,10 +321,10 @@ class RegionSelectTool(SelectTool):
     the annotation, to allow to modify the selection.
     """)
 
-    greedy = Bool(default=True, help="""
+    greedy = Bool(default=False, help="""
     Defines whether a hit against a glyph requires full enclosure within
-    the selection region or only an intersection (i.e. at least one point
-    within the region).
+    the selection region (non-greedy) or only an intersection (greedy)
+    (i.e. at least one point within the region).
     """)
 
 @abstract

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -321,6 +321,12 @@ class RegionSelectTool(SelectTool):
     the annotation, to allow to modify the selection.
     """)
 
+    greedy = Bool(default=True, help="""
+    Defines whether a hit against a glyph requires full enclosure within
+    the selection region or only an intersection (i.e. at least one point
+    within the region).
+    """)
+
 @abstract
 class InspectTool(GestureTool):
     ''' A base class for tools that perform "inspections", e.g. ``HoverTool``.

--- a/src/bokeh/sampledata/us_counties.py
+++ b/src/bokeh/sampledata/us_counties.py
@@ -45,6 +45,12 @@ import csv
 import xml.etree.ElementTree as et
 from typing import TYPE_CHECKING, TypedDict
 
+# External imports
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
 # Bokeh imports
 from ..util.sampledata import external_path, open_csv
 
@@ -78,8 +84,8 @@ class CountyData(TypedDict):
     name: str
     detailed_name: str
     state: str
-    lats: list[float]
-    lons: list[float]
+    lats: NDArray[np.float64]
+    lons: NDArray[np.float64]
 
 nan = float('NaN')
 
@@ -110,8 +116,8 @@ def _read_data() -> dict[tuple[State, County], CountyData]:
                 name = name,
                 detailed_name = det_name,
                 state = state,
-                lats = lats,
-                lons = lons,
+                lats = np.array(lats),
+                lons = np.array(lons),
             )
 
     return data

--- a/src/bokeh/sampledata/us_states.py
+++ b/src/bokeh/sampledata/us_states.py
@@ -44,6 +44,12 @@ import gzip
 import xml.etree.ElementTree as et
 from typing import TYPE_CHECKING, TypedDict
 
+# External imports
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
 # Bokeh imports
 from ..util.sampledata import package_path
 
@@ -75,8 +81,8 @@ State: TypeAlias = str
 class StateData(TypedDict):
     name: str
     region: str
-    lats: list[float]
-    lons: list[float]
+    lats: NDArray[np.float64]
+    lons: NDArray[np.float64]
 
 nan = float('NaN')
 
@@ -107,8 +113,8 @@ def _read_data() -> dict[State, StateData]:
             data[code] = StateData(
                 name   = name,
                 region = region,
-                lats   = lats,
-                lons   = lons,
+                lats   = np.array(lats),
+                lons   = np.array(lons),
             )
 
     return data

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -5435,7 +5435,7 @@
     __extends__: "SelectTool",
     continuous: false,
     persistent: false,
-    greedy: true,
+    greedy: false,
   },
   InspectTool: {
     __extends__: "GestureTool",

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -5435,6 +5435,7 @@
     __extends__: "SelectTool",
     continuous: false,
     persistent: false,
+    greedy: true,
   },
   InspectTool: {
     __extends__: "GestureTool",


### PR DESCRIPTION
This PR adds support for poly hit testing to `Patches` and `MultiPolygons`. It also makes hit testing procedures to use spatial index where they previously didn't and generally refactors/modernizes hit testing code.

https://github.com/bokeh/bokeh/assets/27475/34450df5-e8be-4c94-83de-259dc987badd

fixes #2325
