### PR TITLE
Reset WebGL changed flags on data glyph not visual glyphs

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/multi_line.ts
@@ -33,8 +33,8 @@ export class MultiLineGL extends BaseLineGL {
     }
 
     if (data_changed_or_mapped) {
-      this.data_changed = false
-      this.data_mapped = false
+      main_gl_glyph.data_changed = false
+      main_gl_glyph.data_mapped = false
     }
 
     const {data_size} = this.glyph  // Number of lines

--- a/bokehjs/src/lib/models/glyphs/webgl/single_line.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/single_line.ts
@@ -30,8 +30,8 @@ export abstract class SingleLineGL extends BaseLineGL {
     }
 
     if (data_changed_or_mapped) {
-      this.data_changed = false
-      this.data_mapped = false
+      main_gl_glyph.data_changed = false
+      main_gl_glyph.data_mapped = false
     }
 
     // Get show buffer to account for selected indices.


### PR DESCRIPTION
Fixes #13284.

This gives a slight performance improvement in some situations for WebGL line rendering. See issue #13284 for more details.