### PR TITLE
Support construct_color_bar for ImageStack glyph

### DIFF
--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -217,7 +217,7 @@ class GlyphRenderer(DataRenderer):
                 raise ValueError("expected text_color to be a field with a ColorMapper transform")
             return ColorBar(color_mapper=text_color.transform, **kwargs)
 
-        elif type(self.glyph) in (Image, ImageStack):
+        elif isinstance(self.glyph, (Image, ImageStack)):
             return ColorBar(color_mapper=self.glyph.color_mapper, **kwargs)
 
         else:

--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -193,6 +193,7 @@ class GlyphRenderer(DataRenderer):
         from ..glyphs import (
             FillGlyph,
             Image,
+            ImageStack,
             LineGlyph,
             TextGlyph,
         )
@@ -216,7 +217,7 @@ class GlyphRenderer(DataRenderer):
                 raise ValueError("expected text_color to be a field with a ColorMapper transform")
             return ColorBar(color_mapper=text_color.transform, **kwargs)
 
-        elif type(self.glyph) is Image:
+        elif type(self.glyph) in (Image, ImageStack):
             return ColorBar(color_mapper=self.glyph.color_mapper, **kwargs)
 
         else:

--- a/tests/unit/bokeh/models/test_glyph_renderer.py
+++ b/tests/unit/bokeh/models/test_glyph_renderer.py
@@ -25,12 +25,14 @@ from bokeh.models import (
     GeoJSONDataSource,
     Image,
     ImageRGBA,
+    ImageStack,
     IndexFilter,
     Line,
     MultiLine,
     Patch,
     Text,
     WebDataSource,
+    WeightedStackColorMapper,
 )
 from bokeh.transform import linear_cmap, log_cmap
 
@@ -103,6 +105,14 @@ class TestGlyphRenderer_construct_color_bar:
     def test_image_good(self, mapper):
         renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
         renderer.glyph = Image(color_mapper=linear_cmap("foo", "Viridis256", 0, 100).transform)
+        cb = renderer.construct_color_bar(title="Title")
+        assert isinstance(cb, ColorBar)
+        assert cb.color_mapper is renderer.glyph.color_mapper
+        assert cb.title == "Title"
+
+    def test_image_stack_good(self):
+        renderer = bmr.GlyphRenderer(data_source=ColumnDataSource())
+        renderer.glyph = ImageStack(color_mapper=WeightedStackColorMapper())
         cb = renderer.construct_color_bar(title="Title")
         assert isinstance(cb, ColorBar)
         assert cb.color_mapper is renderer.glyph.color_mapper


### PR DESCRIPTION
This adds support for `construct_color_bar` for `ImageStack` glyph. After this, the example in the referenced issue works.

- [x] issues: fixes #13288
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
