### PR TITLE
Improve WebGL conversion to ReGL AttributeConfig

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/base_line.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base_line.ts
@@ -20,7 +20,7 @@ export abstract class BaseLineGL extends BaseGLGlyph {
 
   // visual properties
   protected readonly _linewidth = new Float32Buffer(this.regl_wrapper)
-  protected readonly _line_color = new NormalizedUint8Buffer(this.regl_wrapper)
+  protected readonly _line_color = new NormalizedUint8Buffer(this.regl_wrapper, 4)
   protected readonly _line_cap = new Uint8Buffer(this.regl_wrapper)
   protected readonly _line_join = new Uint8Buffer(this.regl_wrapper)
 
@@ -161,7 +161,7 @@ export abstract class BaseLineGL extends BaseGLGlyph {
       const n = line_dash.length
 
       if (this._dash_tex_info == null)
-        this._dash_tex_info = new Float32Buffer(this.regl_wrapper)
+        this._dash_tex_info = new Float32Buffer(this.regl_wrapper, 4)
       const dash_tex_info = this._dash_tex_info.get_sized_array(4*n)
 
       if (this._dash_scale == null)

--- a/bokehjs/src/lib/models/glyphs/webgl/base_marker.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base_marker.ts
@@ -39,15 +39,15 @@ export abstract class BaseMarkerGL extends BaseGLGlyph {
   protected readonly _linewidths = new Float32Buffer(this.regl_wrapper)
   protected readonly _line_caps = new Uint8Buffer(this.regl_wrapper)
   protected readonly _line_joins = new Uint8Buffer(this.regl_wrapper)
-  protected readonly _line_rgba = new NormalizedUint8Buffer(this.regl_wrapper)
-  protected readonly _fill_rgba = new NormalizedUint8Buffer(this.regl_wrapper)
+  protected readonly _line_rgba = new NormalizedUint8Buffer(this.regl_wrapper, 4)
+  protected readonly _fill_rgba = new NormalizedUint8Buffer(this.regl_wrapper, 4)
 
   // Only needed if have hatch pattern, either all or none of the buffers are set.
   protected _have_hatch: boolean = false
   protected readonly _hatch_patterns = new Uint8Buffer(this.regl_wrapper)
   protected readonly _hatch_scales = new Float32Buffer(this.regl_wrapper)
   protected readonly _hatch_weights = new Float32Buffer(this.regl_wrapper)
-  protected readonly _hatch_rgba = new NormalizedUint8Buffer(this.regl_wrapper)
+  protected readonly _hatch_rgba = new NormalizedUint8Buffer(this.regl_wrapper, 4)
 
   // Avoiding use of nan or inf to represent missing data in webgl as shaders may
   // have reduced floating point precision. So here using a large-ish negative

--- a/bokehjs/src/lib/models/glyphs/webgl/regl_wrap.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/regl_wrap.ts
@@ -325,38 +325,37 @@ function regl_solid_line(regl: Regl, line_geometry: Buffer, line_triangles: Elem
         divisor: 0,
       },
       a_point_prev(_, props) {
-        return props.points.to_attribute_config(Float32Array.BYTES_PER_ELEMENT*props.point_offset)
+        return props.points.to_attribute_config(props.point_offset)
       },
       a_point_start(_, props) {
-        return props.points.to_attribute_config(Float32Array.BYTES_PER_ELEMENT*(props.point_offset + 2))
+        return props.points.to_attribute_config(props.point_offset + 2)
       },
       a_point_end(_, props) {
-        return props.points.to_attribute_config(Float32Array.BYTES_PER_ELEMENT*(props.point_offset + 4))
+        return props.points.to_attribute_config(props.point_offset + 4)
       },
       a_point_next(_, props) {
-        return props.points.to_attribute_config(Float32Array.BYTES_PER_ELEMENT*(props.point_offset + 6))
+        return props.points.to_attribute_config(props.point_offset + 6)
       },
       a_show_prev(_, props) {
-        return props.show.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*(props.point_offset/2 - props.line_offset))
+        return props.show.to_attribute_config(props.point_offset/2 - props.line_offset)
       },
       a_show_curr(_, props) {
-        return props.show.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*(props.point_offset/2 - props.line_offset + 1))
+        return props.show.to_attribute_config(props.point_offset/2 - props.line_offset + 1)
       },
       a_show_next(_, props) {
-        return props.show.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*(props.point_offset/2 - props.line_offset + 2))
+        return props.show.to_attribute_config(props.point_offset/2 - props.line_offset + 2)
       },
       a_linewidth(_, props) {
-        return props.linewidth.to_attribute_config_divisor(Float32Array.BYTES_PER_ELEMENT*props.line_offset, props.nsegments + 3)
+        return props.linewidth.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_line_color(_, props) {
-        // Factor of 4 for offset as 4 uint8 per color.
-        return props.line_color.to_attribute_config_divisor(4*props.line_offset, props.nsegments + 3)
+        return props.line_color.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_line_cap(_, props) {
-        return props.line_cap.to_attribute_config_divisor(props.line_offset, props.nsegments + 3)
+        return props.line_cap.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_line_join(_, props) {
-        return props.line_join.to_attribute_config_divisor(props.line_offset, props.nsegments + 3)
+        return props.line_join.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
     },
 
@@ -413,50 +412,49 @@ ${line_fragment_shader}
         divisor: 0,
       },
       a_point_prev(_, props) {
-        return props.points.to_attribute_config(Float32Array.BYTES_PER_ELEMENT*props.point_offset)
+        return props.points.to_attribute_config(props.point_offset)
       },
       a_point_start(_, props) {
-        return props.points.to_attribute_config(Float32Array.BYTES_PER_ELEMENT*(props.point_offset + 2))
+        return props.points.to_attribute_config(props.point_offset + 2)
       },
       a_point_end(_, props) {
-        return props.points.to_attribute_config(Float32Array.BYTES_PER_ELEMENT*(props.point_offset + 4))
+        return props.points.to_attribute_config(props.point_offset + 4)
       },
       a_point_next(_, props) {
-        return props.points.to_attribute_config(Float32Array.BYTES_PER_ELEMENT*(props.point_offset + 6))
+        return props.points.to_attribute_config(props.point_offset + 6)
       },
       a_show_prev(_, props) {
-        return props.show.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*(props.point_offset/2 - props.line_offset))
+        return props.show.to_attribute_config(props.point_offset/2 - props.line_offset)
       },
       a_show_curr(_, props) {
-        return props.show.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*(props.point_offset/2 - props.line_offset + 1))
+        return props.show.to_attribute_config(props.point_offset/2 - props.line_offset + 1)
       },
       a_show_next(_, props) {
-        return props.show.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*(props.point_offset/2 - props.line_offset + 2))
+        return props.show.to_attribute_config(props.point_offset/2 - props.line_offset + 2)
       },
       a_linewidth(_, props) {
-        return props.linewidth.to_attribute_config_divisor(Float32Array.BYTES_PER_ELEMENT*props.line_offset, props.nsegments + 3)
+        return props.linewidth.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_line_color(_, props) {
-        // Factor of 4 for offset as 4 uint8 per color.
-        return props.line_color.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*props.line_offset*4, props.nsegments + 3)
+        return props.line_color.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_line_cap(_, props) {
-        return props.line_cap.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*props.line_offset, props.nsegments + 3)
+        return props.line_cap.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_line_join(_, props) {
-        return props.line_join.to_attribute_config_divisor(Uint8Array.BYTES_PER_ELEMENT*props.line_offset, props.nsegments + 3)
+        return props.line_join.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_length_so_far(_, props) {
-        return props.length_so_far.to_attribute_config_divisor(Float32Array.BYTES_PER_ELEMENT*(props.point_offset/2 - 3*props.line_offset))
+        return props.length_so_far.to_attribute_config(props.point_offset/2 - 3*props.line_offset)
       },
       a_dash_tex_info(_, props) {
-        return props.dash_tex_info.to_attribute_config_divisor(Float32Array.BYTES_PER_ELEMENT*props.line_offset*4, 4*props.nsegments)
+        return props.dash_tex_info.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_dash_scale(_, props) {
-        return props.dash_scale.to_attribute_config_divisor(Float32Array.BYTES_PER_ELEMENT*props.line_offset, props.nsegments)
+        return props.dash_scale.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
       a_dash_offset(_, props) {
-        return props.dash_offset.to_attribute_config_divisor(Float32Array.BYTES_PER_ELEMENT*props.line_offset, props.nsegments)
+        return props.dash_offset.to_attribute_config_nested(props.line_offset, props.nsegments + 3)
       },
     },
 
@@ -527,37 +525,37 @@ ${marker_fragment_shader}
         divisor: 0,
       },
       a_center(_, props) {
-        return props.center.to_attribute_config()
+        return props.center.to_attribute_config(0, props.nmarkers)
       },
       a_width(_, props) {
-        return props.width.to_attribute_config()
+        return props.width.to_attribute_config(0, props.nmarkers)
       },
       a_height(_, props) {
-        return props.height.to_attribute_config()
+        return props.height.to_attribute_config(0, props.nmarkers)
       },
       a_angle(_, props) {
-        return props.angle.to_attribute_config()
+        return props.angle.to_attribute_config(0, props.nmarkers)
       },
       a_aux(_, props) {
-        return props.aux.to_attribute_config()
+        return props.aux.to_attribute_config(0, props.nmarkers)
       },
       a_linewidth(_, props) {
-        return props.linewidth.to_attribute_config()
+        return props.linewidth.to_attribute_config(0, props.nmarkers)
       },
       a_line_color(_, props) {
-        return props.line_color.to_attribute_config()
+        return props.line_color.to_attribute_config(0, props.nmarkers)
       },
       a_fill_color(_, props) {
-        return props.fill_color.to_attribute_config()
+        return props.fill_color.to_attribute_config(0, props.nmarkers)
       },
       a_line_cap(_, props) {
-        return props.line_cap.to_attribute_config()
+        return props.line_cap.to_attribute_config(0, props.nmarkers)
       },
       a_line_join(_, props) {
-        return props.line_join.to_attribute_config()
+        return props.line_join.to_attribute_config(0, props.nmarkers)
       },
       a_show(_, props) {
-        return props.show.to_attribute_config()
+        return props.show.to_attribute_config(0, props.nmarkers)
       },
       ...attributes,
     },
@@ -596,18 +594,18 @@ ${marker_fragment_shader}
 
 function regl_marker_hatch(regl: Regl, marker_type: GLMarkerType): ReglRenderFunction {
 
-  const hatch_attributes: MaybeDynamicAttributes<t.HatchAttributes, DefaultContext, t.HatchProps> = {
+  const hatch_attributes: MaybeDynamicAttributes<t.HatchAttributes, DefaultContext, t.MarkerHatchGlyphProps> = {
     a_hatch_pattern(_, props) {
-      return props.hatch_pattern.to_attribute_config()
+      return props.hatch_pattern.to_attribute_config(0, props.nmarkers)
     },
     a_hatch_scale(_, props) {
-      return props.hatch_scale.to_attribute_config()
+      return props.hatch_scale.to_attribute_config(0, props.nmarkers)
     },
     a_hatch_weight(_, props) {
-      return props.hatch_weight.to_attribute_config()
+      return props.hatch_weight.to_attribute_config(0, props.nmarkers)
     },
     a_hatch_color(_, props) {
-      return props.hatch_color.to_attribute_config()
+      return props.hatch_color.to_attribute_config(0, props.nmarkers)
     },
   }
 


### PR DESCRIPTION
This is refactor of the WebGL-related code that passes data buffers to the GPU via ReGL `AttributeConfig`s. The intention is to make it easier to understand and maintain in the future. There is no change in any WebGL rendered output.

There are two changes. The first simpler change is that the multiplication of `BYTES_PER_ELEMENT` is moved from `regl_wrap.ts` to the buffer handling code.

The second, bigger, change is to how scalar visual properties are handled. The use case here is the rendering of a set of markers which share a WebGL buffer for e.g. the `linewidth`. If this is a vector property we use a WebGL `divisor` of 1, which means after each rendered instance (i.e. each rendered marker) we advance one along the buffer to obtain the `linewidth` for the next marker. Previously for scalar properties we used the magic WebGL value of `divisor=0` which meant we had to repeat the scalar `linewidth` in the buffer a number of times equal to the number of vertices in the rendered instance. This is 4 for markers, 5 for line segments and used to be 6 for line segments, and is defined elsewhere in the code and hence hard to follow. I have changed this now so that `divisor = nmarkers` or equivalent, so that magic "number of vertices per rendered instance" makes no difference to this part of the code now. This makes it easier for maintainers (and my future self) to understand this area of code.