### PR TITLE
Allow to configure Chromium executable

### DIFF
--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -78,6 +78,8 @@ function chrome(): string {
   throw new BuildError("headless", `can't find any of ${names.join(", ")} on PATH="${path}"`)
 }
 
+const chromium_executable = argv.e as string | undefined ?? chrome()
+
 const devtools_host = argv.host as string | undefined ?? "127.0.0.1"
 
 async function headless(devtools_port: number): Promise<ChildProcess> {
@@ -100,12 +102,11 @@ async function headless(devtools_port: number): Promise<ChildProcess> {
   if (bokeh_in_docker == "1") {
     args.push("--no-sandbox")
   }
-  const executable = chrome()
-  const proc = spawn(executable, args, {stdio: "pipe"})
+  const proc = spawn(chromium_executable, args, {stdio: "pipe"})
 
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
-      reject(new BuildError("headless", `timeout starting ${executable}`))
+      reject(new BuildError("headless", `timeout starting ${chromium_executable}`))
     }, 30000)
     proc.on("error", reject)
     let buffer = ""

--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -733,28 +733,48 @@ async function get_version(): Promise<{browser: string, protocol: string}> {
   }
 }
 
-const chromium_min_version = 110
+type Version = [number, number, number, number]
+const supported_chromium_version: Version = [110, 0, 5481, 100]
 
-async function get_version_number(version: string): Promise<number> {
-  const match = version.match(/Chrome\/(?<major>\d+)\.(\d+)\.(\d+)\.(\d+)/)
-  const major = parseInt(match?.groups?.major ?? "0")
-  return major
+function get_version_tuple(version: string): Version | null {
+  const match = version.match(/(\d+)\.(\d+)\.(\d+)\.(\d+)/)
+  if (match != null) {
+    const [, a, b, c, d] = match.values()
+    return [
+      Number(a),
+      Number(b),
+      Number(c),
+      Number(d),
+    ]
+  }
+  return null
 }
 
-async function check_version(version: string, major: number): Promise<boolean> {
-  const ok = chromium_min_version <= major
-  if (!ok)
-    console.error(`${chalk.red("failed:")} ${version} is not supported, minimum supported version is ${chalk.magenta(chromium_min_version)}`)
-  return ok
+function check_version(current_chromium_version: Version | null): void {
+  if (current_chromium_version == null) {
+    const supported_str = supported_chromium_version.join(".")
+    console.error(`${chalk.yellow("warning:")} unable to determine chromium version; officially supported version is ${supported_str}`)
+    return
+  }
+
+  const [a, b, c, d] = supported_chromium_version
+  const [A, B, C, D] = current_chromium_version
+
+  if (a != A || b != B || c != C || d != D) {
+    const supported_str = chalk.magenta(supported_chromium_version.join("."))
+    const current_str = chalk.magenta(current_chromium_version.join("."))
+    console.error(`${chalk.yellow("warning:")} ${current_str} is not supported; officially supported version is ${supported_str}`)
+  }
 }
 
 async function run(): Promise<void> {
   const {browser, protocol} = await get_version()
   console.log(`Running in ${chalk.cyan(browser)} using devtools protocol ${chalk.cyan(protocol)}`)
-  const major = await get_version_number(browser)
-  const ok0 = await check_version(browser, major)
-  const ok1 = !argv.info ? await run_tests({chromium_version: major}) : true
-  process.exit(ok0 && ok1 ? 0 : 1)
+  const version = get_version_tuple(browser)
+  check_version(version)
+  const major = version != null ? version[0] : 0
+  const ok = !argv.info ? await run_tests({chromium_version: major}) : true
+  process.exit(ok ? 0 : 1)
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
This allows to work with multiple Chromium versions (e.g. via snap's parallel installations), which then allows to use non-default Chromium for testing (especially for image diff). If using snap, then install Chromium with:
```bash
git clone git@github.com:bokeh/chromium.git
sudo snap install --name chromium_r2333 ./chromium/linux/110.0.5481.100/chromium_2333.snap
```
(see https://snapcraft.io/docs/parallel-installs for details) and then run tests with:
```bash
node make test:integration -e chromium_r2333
```