### PR TITLE
Allow to serve bokeh examples from bokehjs' devtools server

### DIFF
--- a/bokehjs/test/devtools/bokeh_example.html
+++ b/bokehjs/test/devtools/bokeh_example.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <style>
+      html, body {
+        box-sizing: border-box;
+        margin: 0;
+      }
+      #contents {
+        white-space: pre;
+        font-family: monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="contents">{{ contents }}</div>
+  </body>
+</html>

--- a/bokehjs/test/devtools/bokeh_examples.html
+++ b/bokehjs/test/devtools/bokeh_examples.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Listing of {{ directory }}</title>
+    <style>
+      html, body {
+        box-sizing: border-box;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <ul>
+      {% for dir in dirs %}
+        <li><b><a href="{{ dir }}/">{{ dir }}/</a></b></li>
+      {% endfor %}
+    </ul>
+    <ul>
+      {% for file in files %}
+        <li><a href="{{ file }}">{{ file }}.py</a></li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -68,8 +68,8 @@ if TYPE_CHECKING:
 # Globals and constants
 # -----------------------------------------------------------------------------
 
-DEFAULT_SERVER_HOST = "localhost"
-DEFAULT_SERVER_PORT = 5006
+DEFAULT_SERVER_HOST = settings.default_server_host()
+DEFAULT_SERVER_PORT = settings.default_server_port()
 
 def server_url(host: str | None = None, port: int | None = None, ssl: bool = False) -> str:
     protocol = "https" if ssl else "http"

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -685,6 +685,14 @@ class Settings:
     See the :class:`~bokeh.resources.Resources` class reference for full details.
     """)
 
+    default_server_host: PrioritizedSetting[str] = PrioritizedSetting("default_server_host", "BOKEH_DEFAULT_SERVER_HOST", default="localhost", help="""
+    Allows to define the default host used by Bokeh's server and resources.
+    """)
+
+    default_server_port: PrioritizedSetting[int] = PrioritizedSetting("default_server_port", "BOKEH_DEFAULT_SERVER_PORT", default=5006, help="""
+    Allows to define the default port used by Bokeh's server and resources.
+    """)
+
     secret_key: PrioritizedSetting[str | None] = PrioritizedSetting("secret_key", "BOKEH_SECRET_KEY", default=None, help="""
     A long, cryptographically-random secret unique to a Bokeh deployment.
     """)

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -48,6 +48,8 @@ _expected_settings = (
     'browser',
     'cdn_version',
     'cookie_secret',
+    'default_server_host',
+    'default_server_port',
     'docs_cdn',
     'docs_version',
     'ico_path',


### PR DESCRIPTION
This is a little tool that allows to either list or build and serve bokeh's examples when working on bokehjs. This allows to avoid running into issues with static resources during development, or requiring to run `BOKEH_DEV=true bokeh static` along devtools' server, as devtools' server provides the resources (always from `bokehjs/build/` directory).

Run the server as per usual: `cd bokehjs/; node test/devtools server`.

To list a directory use e.g.: http://localhost:5777/bokeh/examples/basic/

To show an example use e.g.: http://localhost:5777/bokeh/examples/basic/scatters/color_scatter