### PR TITLE
Lazy evaluate `chromium_executable`

### DIFF
--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -78,7 +78,9 @@ function chrome(): string {
   throw new BuildError("headless", `can't find any of ${names.join(", ")} on PATH="${path}"`)
 }
 
-const chromium_executable = argv.e as string | undefined ?? chrome()
+function chromium_executable(): string {
+  return argv.e as string | undefined ?? chrome()
+}
 
 const devtools_host = argv.host as string | undefined ?? "127.0.0.1"
 
@@ -102,11 +104,12 @@ async function headless(devtools_port: number): Promise<ChildProcess> {
   if (bokeh_in_docker == "1") {
     args.push("--no-sandbox")
   }
-  const proc = spawn(chromium_executable, args, {stdio: "pipe"})
+  const exec = chromium_executable()
+  const proc = spawn(exec, args, {stdio: "pipe"})
 
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
-      reject(new BuildError("headless", `timeout starting ${chromium_executable}`))
+      reject(new BuildError("headless", `timeout starting ${exec}`))
     }, 30000)
     proc.on("error", reject)
     let buffer = ""


### PR DESCRIPTION
Fixes regression introduced in PR #13304.

fixes #13311
