### PR TITLE
Make `GlyphView.mask_data()` always narrow indices to the viewport

### DIFF
--- a/bokehjs/src/lib/models/annotations/legend_item.ts
+++ b/bokehjs/src/lib/models/annotations/legend_item.ts
@@ -95,7 +95,7 @@ export class LegendItem extends Model {
     }
 
     const {index} = this
-    if (index != null && this.renderers.every((r) => !(index in r.view.indices_map))) {
+    if (index != null && this.renderers.every((r) => !r.view.indices_map.has(index))) {
       // this index points to nowhere, so skip this item altogether from its legend
       return []
     }

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -103,7 +103,7 @@ export class CircleView extends XYGlyphView {
     }
   }
 
-  protected override _mask_data(): Indices {
+  override mask_data(): Indices {
     const {frame} = this.renderer.plot_view
 
     const shr = frame.x_target

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -11,8 +11,8 @@ import type {Anchor} from "core/enums"
 import type {ViewStorage, IterViews} from "core/build_views"
 import {build_views} from "core/build_views"
 import {logger} from "core/logging"
-import type {Arrayable, Rect, FloatArray} from "core/types"
-import {ScreenArray, Indices} from "core/types"
+import type {Arrayable, Rect, FloatArray, Indices} from "core/types"
+import {ScreenArray} from "core/types"
 import {isString} from "core/util/types"
 import {RaggedArray} from "core/util/ragged_array"
 import {inplace_map, max} from "core/util/arrayable"
@@ -365,13 +365,14 @@ export abstract class GlyphView extends View {
 
   mask_data(): Indices {
     /** Returns subset indices in the viewport. */
-    if (this._mask_data == null)
-      return Indices.all_set(this.data_size)
-    else
-      return this._mask_data()
-  }
+    const {frame} = this.renderer.plot_view
+    const [xr, yr] = frame.bbox.ranges
 
-  protected _mask_data?(): Indices
+    const [x0, x1] = this.renderer.x_scale.r_invert(xr.start, xr.end)
+    const [y0, y1] = this.renderer.y_scale.r_invert(yr.start, yr.end)
+
+    return this.index.indices({x0, x1, y0, y1})
+  }
 
   map_data(): void {
     const self = this as any

--- a/bokehjs/src/lib/models/glyphs/marker.ts
+++ b/bokehjs/src/lib/models/glyphs/marker.ts
@@ -58,7 +58,7 @@ export abstract class MarkerView extends XYGlyphView {
     }
   }
 
-  protected override _mask_data(): Indices {
+  override mask_data(): Indices {
     // dilate the inner screen region by max_size and map back to data space for use in spatial query
     const {x_target, y_target} = this.renderer.plot_view.frame
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -4,7 +4,7 @@ import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import {minmax} from "core/util/arrayable"
 import {sum} from "core/util/arrayable"
-import type {Arrayable, Rect, FloatArray, ScreenArray, Indices} from "core/types"
+import type {Arrayable, Rect, FloatArray, ScreenArray} from "core/types"
 import type {PointGeometry, RectGeometry} from "core/geometry"
 import type {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -113,14 +113,6 @@ export class MultiPolygonsView extends GlyphView {
 
     index.finish()
     return index
-  }
-
-  protected override _mask_data(): Indices {
-    const {x_range, y_range} = this.renderer.plot_view.frame
-    return this.index.indices({
-      x0: x_range.min, x1: x_range.max,
-      y0: y_range.min, y1: y_range.max,
-    })
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: MultiPolygonsData): void {

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -3,7 +3,7 @@ import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import {minmax2, sum} from "core/util/arrayable"
-import type {Arrayable, Rect, RaggedArray, FloatArray, ScreenArray, Indices} from "core/types"
+import type {Arrayable, Rect, RaggedArray, FloatArray, ScreenArray} from "core/types"
 import type {PointGeometry, RectGeometry} from "core/geometry"
 import type {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -42,14 +42,6 @@ export class PatchesView extends GlyphView {
       const [x0, x1, y0, y1] = minmax2(xsi, ysi)
       index.add_rect(x0, y0, x1, y1)
     }
-  }
-
-  protected override _mask_data(): Indices {
-    const {x_range, y_range} = this.renderer.plot_view.frame
-    return this.index.indices({
-      x0: x_range.min, x1: x_range.max,
-      y0: y_range.min, y1: y_range.max,
-    })
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: PatchesData): void {

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -5,6 +5,7 @@ import * as mixins from "core/property_mixins"
 import type * as visuals from "core/visuals"
 import type * as p from "core/properties"
 import type {Rect} from "core/types"
+import {Indices} from "core/types"
 import {StepMode} from "core/enums"
 import type {Context2d} from "core/util/canvas"
 import {unreachable} from "core/util/assert"
@@ -24,6 +25,11 @@ export class StepView extends XYGlyphView {
   override async load_glglyph() {
     const {StepGL} = await import("./webgl/step")
     return StepGL
+  }
+
+  override mask_data(): Indices {
+    // TODO _render() doesn't like non-NaN holes in data
+    return Indices.all_set(this.data_size)
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: StepData): void {

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -8,7 +8,6 @@ import type {Rect} from "core/types"
 import {Indices} from "core/types"
 import {StepMode} from "core/enums"
 import type {Context2d} from "core/util/canvas"
-import {unreachable} from "core/util/assert"
 import type {StepGL} from "./webgl/step"
 
 export type StepData = XYGlyphData
@@ -46,35 +45,40 @@ export class StepView extends XYGlyphView {
     let prev_finite = false
     const i = indices[0]
     let is_finite = isFinite(sx[i] + sy[i])
-    if (mode == "center")
+    if (mode == "center") {
       drawing = this._render_xy(ctx, drawing, is_finite ? sx[i] : NaN, sy[i])
+    }
 
     for (const i of indices) {
       const next_finite = isFinite(sx[i+1] + sy[i+1])
       switch (mode) {
-        case "before":
+        case "before": {
           drawing = this._render_xy(ctx, drawing, is_finite ? sx[i] : NaN, sy[i])
-          if (i < sx.length-1)
+          if (i < sx.length-1) {
             drawing = this._render_xy(ctx, drawing, is_finite && next_finite ? sx[i] : NaN, sy[i+1])
+          }
           break
-        case "after":
+        }
+        case "after": {
           drawing = this._render_xy(ctx, drawing, is_finite ? sx[i] : NaN, sy[i])
-          if (i < sx.length-1)
+          if (i < sx.length-1) {
             drawing = this._render_xy(ctx, drawing, is_finite && next_finite ? sx[i+1] : NaN, sy[i])
+          }
           break
-        case "center":
+        }
+        case "center": {
           if (is_finite && next_finite) {
             const midx = (sx[i] + sx[i+1])/2
             drawing = this._render_xy(ctx, drawing, midx, sy[i])
             drawing = this._render_xy(ctx, drawing, midx, sy[i+1])
           } else {
-            if (prev_finite)
+            if (prev_finite) {
               drawing = this._render_xy(ctx, drawing, is_finite ? sx[i] : NaN, sy[i])
+            }
             drawing = this._render_xy(ctx, drawing, next_finite ? sx[i+1] : NaN, sy[i+1])
           }
           break
-        default:
-          unreachable()
+        }
       }
       prev_finite = is_finite
       is_finite = next_finite

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -77,7 +77,7 @@ export class DataRange1d extends DataRange {
   protected _initial_follow_interval: number | null
   protected _initial_default_span: number
 
-  protected _plot_bounds: Map<PlotView, Rect>
+  protected readonly _plot_bounds: Map<PlotView, Rect> = new Map()
 
   override have_updated_interactively: boolean = false
 
@@ -91,8 +91,6 @@ export class DataRange1d extends DataRange {
     this._initial_follow = this.follow
     this._initial_follow_interval = this.follow_interval
     this._initial_default_span = this.default_span
-
-    this._plot_bounds = new Map()
   }
 
   get min(): number {

--- a/bokehjs/src/lib/models/renderers/data_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/data_renderer.ts
@@ -11,12 +11,22 @@ export abstract class DataRendererView extends RendererView implements AutoRange
   declare model: DataRenderer
   declare visuals: DataRenderer.Visuals
 
-  get xscale(): Scale {
+  get x_scale(): Scale {
     return this.coordinates.x_scale
   }
 
-  get yscale(): Scale {
+  get y_scale(): Scale {
     return this.coordinates.y_scale
+  }
+
+  // TODO remove this
+  get xscale(): Scale {
+    return this.x_scale
+  }
+
+  // TODO remove this
+  get yscale(): Scale {
+    return this.y_scale
   }
 
   protected abstract get glyph_view(): GlyphView

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -14,7 +14,7 @@ import type {Color} from "core/types"
 import {Indices} from "core/types"
 import type * as p from "core/properties"
 import {filter} from "core/util/arrayable"
-import {extend, clone, entries} from "core/util/object"
+import {extend, clone} from "core/util/object"
 import type {HitTestResult} from "core/hittest"
 import type {Geometry} from "core/geometry"
 import type {SelectionManager} from "core/selection_manager"
@@ -440,9 +440,10 @@ export class GlyphRendererView extends DataRendererView {
     if (field != null) {
       const array = this.model.data_source.get_column(field)
       if (array != null) {
-        for (const [key, index] of entries(this.model.view.indices_map)) {
-          if (array[parseInt(key)] == value)
-            return index
+        for (const [fullset_index, subset_index] of this.model.view.indices_map) {
+          if (array[fullset_index] == value) {
+            return subset_index
+          }
         }
       }
     }
@@ -458,7 +459,7 @@ export class GlyphRendererView extends DataRendererView {
         return this.get_reference_point(field, label)
       else {
         const {indices_map} = this.model.view
-        return index in indices_map ? indices_map[index] : null
+        return indices_map.get(index) ?? null
       }
     })()
     if (subset_index != null) {

--- a/bokehjs/src/lib/models/scales/scale.ts
+++ b/bokehjs/src/lib/models/scales/scale.ts
@@ -1,6 +1,5 @@
 import {Transform} from "../transforms/transform"
 import {Range} from "../ranges/range"
-import {Range1d} from "../ranges/range1d"
 import type {Arrayable, FloatArray} from "core/types"
 import {ScreenArray} from "core/types"
 import type * as p from "core/properties"
@@ -10,7 +9,7 @@ export namespace Scale {
 
   export type Props = Transform.Props & {
     source_range: p.Property<Range>
-    target_range: p.Property<Range1d>
+    target_range: p.Property<Range>
   }
 }
 
@@ -26,7 +25,7 @@ export abstract class Scale<T = number> extends Transform<T, number> {
   static {
     this.internal<Scale.Props>(({Ref}) => ({
       source_range: [ Ref(Range) ],
-      target_range: [ Ref(Range1d) ],
+      target_range: [ Ref(Range) ],
     }))
   }
 

--- a/bokehjs/src/lib/models/sources/cds_view.ts
+++ b/bokehjs/src/lib/models/sources/cds_view.ts
@@ -64,7 +64,7 @@ export namespace CDSView {
     filter: p.Property<Filter>
     // internal
     indices: p.Property<Indices>
-    indices_map: p.Property<{[key: string]: number}>
+    indices_map: p.Property<Map<number, number>>
     masked: p.Property<Indices | null>
   }
 }
@@ -86,9 +86,9 @@ export class CDSView extends Model {
       filter: [ Ref(Filter), () => new AllIndices() ],
     }))
 
-    this.internal<CDSView.Props>(({Int, Dict, Ref, Nullable}) => ({
+    this.internal<CDSView.Props>(({Int, Map, Ref, Nullable}) => ({
       indices:     [ Ref(Indices) ],
-      indices_map: [ Dict(Int), {} ],
+      indices_map: [ Map(Int, Int), new globalThis.Map() ],
       masked:      [ Nullable(Ref(Indices)), null ],
     }))
   }
@@ -97,9 +97,11 @@ export class CDSView extends Model {
 
   _indices_map_to_subset(): void {
     this._indices = [...this.indices]
-    this.indices_map = {}
-    for (let i = 0; i < this._indices.length; i++) {
-      this.indices_map[this._indices[i]] = i
+    this.indices_map = new Map()
+    const n = this._indices.length
+    for (let subset_i = 0; subset_i < n; subset_i++) {
+      const fullset_i = this._indices[subset_i]
+      this.indices_map.set(fullset_i, subset_i)
     }
   }
 
@@ -108,7 +110,7 @@ export class CDSView extends Model {
   }
 
   convert_selection_to_subset(selection_full: Selection): Selection {
-    return selection_full.map((i) => this.indices_map[i])
+    return selection_full.map((i) => this.indices_map.get(i)!)
   }
 
   convert_indices_from_subset(indices: number[]): number[] {

--- a/bokehjs/test/unit/models/sources/cds_view.ts
+++ b/bokehjs/test/unit/models/sources/cds_view.ts
@@ -100,7 +100,7 @@ describe("CDSView", () => {
     it("sets indices_map, a mapping from full data set indices to subset indices", async () => {
       const view = new CDSView({filter: new IntersectionFilter({operands: [filter1, filter2]})})
       await build(view, source)
-      expect(view.indices_map).to.be.equal({1: 0, 2: 1})
+      expect(view.indices_map).to.be.equal(new Map([[1, 0], [2, 1]]))
     })
   })
 


### PR DESCRIPTION
Previously `mask_data()` usually returned all (subset) indices and only give non-trivial results for a handful of glyphs. This PR makes `mask_data()` always narrow indices to view viewport (and utilize the spatial index). There's a handful of glyphs that require special behavior, because e.g. their `_render()` method doesn't work will with non-contiguous indices. This is in preparation to fix point (1) from https://github.com/holoviz/holoviews/pull/5840#issuecomment-1663504592.