### PR TITLE
Don't `set_data()` when `FactorRange.{start,end}` changes

### DIFF
--- a/bokehjs/src/lib/models/ranges/factor_range.ts
+++ b/bokehjs/src/lib/models/ranges/factor_range.ts
@@ -4,6 +4,7 @@ import * as p from "core/properties"
 import {Or, String as Str, Array as Arr, Tuple} from "../../core/kinds"
 import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
+import {Signal0} from "core/signaling"
 import {every, sum} from "core/util/array"
 import {isArray, isNumber, isString} from "core/util/types"
 import {unreachable} from "core/util/assert"
@@ -164,7 +165,7 @@ export class FactorRange extends Range {
 
   override initialize(): void {
     super.initialize()
-    this._init(true)
+    this._init()
   }
 
   override connect_signals(): void {
@@ -177,9 +178,11 @@ export class FactorRange extends Range {
     this.connect(this.properties.range_padding_units.change, () => this.reset())
   }
 
+  readonly invalidate_synthetic = new Signal0(this, "invalidate_synthetic")
+
   reset(): void {
-    this._init(false)
-    this.change.emit()
+    this._init()
+    this.invalidate_synthetic.emit()
   }
 
   protected _lookup(x: BoxedFactor): number {
@@ -215,8 +218,6 @@ export class FactorRange extends Range {
         }
         return NaN
       }
-      default:
-        unreachable()
     }
   }
 
@@ -248,7 +249,7 @@ export class FactorRange extends Range {
     return array
   }
 
-  protected _init(silent: boolean): void {
+  protected _init(): void {
     const {levels, mapping, tops, mids, inside_padding} = (() => {
       if (every(this.factors, isString)) {
         const factors = this.factors as string[]
@@ -293,9 +294,10 @@ export class FactorRange extends Range {
       end += this.range_padding
     }
 
-    this.setv({start, end, levels}, {silent})
+    this.setv({start, end, levels}, {silent: true})
 
-    if (this.bounds == "auto")
+    if (this.bounds == "auto") {
       this.setv({bounds: [start, end]}, {silent: true})
+    }
   }
 }

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -217,13 +217,15 @@ export class GlyphRendererView extends DataRendererView {
     const {x_ranges, y_ranges} = this.plot_view.frame
 
     for (const [, range] of x_ranges) {
-      if (range instanceof FactorRange)
-        this.connect(range.change, update)
+      if (range instanceof FactorRange) {
+        this.connect(range.invalidate_synthetic, update)
+      }
     }
 
     for (const [, range] of y_ranges) {
-      if (range instanceof FactorRange)
-        this.connect(range.change, update)
+      if (range instanceof FactorRange) {
+        this.connect(range.invalidate_synthetic, update)
+      }
     }
 
     const {transformchange, exprchange} = this.model.glyph

--- a/bokehjs/test/unit/models/renderers/glyph_renderer.ts
+++ b/bokehjs/test/unit/models/renderers/glyph_renderer.ts
@@ -1,9 +1,16 @@
+import * as sinon from "sinon"
+
 import {expect} from "assertions"
+import {display} from "../../_util"
+import {PlotActions, xy} from "../../../interactive"
+
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
-import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
+import {GlyphRenderer, GlyphRendererView} from "@bokehjs/models/renderers/glyph_renderer"
 import {Circle} from "@bokehjs/models/glyphs"
 import {build_view} from "@bokehjs/core/build_views"
 import {Plot} from "@bokehjs/models/plots"
+import {FactorRange} from "@bokehjs/models/ranges"
+import {CategoricalScale} from "@bokehjs/models/scales"
 
 function mkrenderer(glyph: Circle): GlyphRenderer {
   const data_source = new ColumnDataSource({
@@ -80,5 +87,37 @@ describe("GlyphRendererView", () => {
     const {decimated_glyph} = await make_grv()
     expect((decimated_glyph.model as Circle).line_alpha).to.be.equal({value: 0.3})
     expect((decimated_glyph.model as Circle).line_color).to.be.equal({value: "grey"})
+  })
+
+  it("should call set_data() once when working with FactorRange", async () => {
+    const x_range = new FactorRange({factors: ["a", "b", "c"]})
+    const y_range = new FactorRange({factors: ["u", "v", "w"]})
+
+    const x_scale = new CategoricalScale()
+    const y_scale = new CategoricalScale()
+
+    const data_source = new ColumnDataSource({
+      data: {
+        x: ["a", "b", "c"],
+        y: ["u", "v", "w"],
+      },
+    })
+    const gr = new GlyphRenderer({glyph: new Circle({radius: 0.5}), data_source})
+
+    const bare = {toolbar_location: null, title: null, min_border: 0}
+    const p = new Plot({width: 300, height: 300, x_range, y_range, x_scale, y_scale, renderers: [gr], ...bare})
+
+    // TODO experiment with TS 5.2 'using' declarations
+    const spy = sinon.spy(GlyphRendererView.prototype, "set_data")
+    try {
+      const {view} = await display(p)
+
+      const actions = new PlotActions(view, {units: "screen"})
+      await actions.pan(xy(100, 100), xy(200, 200))
+
+      expect(spy.callCount).to.be.equal(1) // only initial set_data()
+    } finally {
+      spy.restore()
+    }
   })
 })


### PR DESCRIPTION
Previously `GlyphRendererView` depended on `FactorRange.change` signal, which would emit when `start` and/or `end` properties changed. This led to excessive `set_data()` calls, making even low-data plots with categorical ranges quite CPU hungry.