### PR TITLE
Improve performance of invalidation of refs in bokehjs

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -522,7 +522,7 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
         refs.add(value)
         if (recursive) {
           for (const prop of value.syncable_properties()) {
-            if (!prop.is_unset) {
+            if (!prop.is_unset && prop.may_have_refs) {
               const value = prop.get_value()
               HasProps._value_record_references(value, refs, {recursive})
             }

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -173,6 +173,8 @@ export abstract class Property<T = unknown> {
     return this._dirty
   }
 
+  readonly may_have_refs: boolean
+
   readonly change: Signal0<HasProps>
 
   /*readonly*/ internal: boolean
@@ -191,6 +193,7 @@ export abstract class Property<T = unknown> {
     this.readonly = options.readonly ?? false
     this.convert = options.convert
     this.on_update = options.on_update
+    this.may_have_refs = kind.may_have_refs()
   }
 
   //protected abstract _update(attr_value: T): void

--- a/bokehjs/src/lib/core/util/bitset.ts
+++ b/bokehjs/src/lib/core/util/bitset.ts
@@ -2,9 +2,13 @@ import type {Equatable, Comparator} from "./eq"
 import {equals} from "./eq"
 import type {Arrayable, ArrayableNew} from "../types"
 import {assert} from "./assert"
+import {has_refs} from "core/util/refs"
 
 export class BitSet implements Equatable {
   readonly [Symbol.toStringTag] = "BitSet"
+
+  static readonly [has_refs] = false
+
   private static readonly _word_length = 32
 
   private readonly _array: Uint32Array

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -6,10 +6,11 @@ const {hasOwnProperty} = Object.prototype
 export const {keys, values, entries, assign, fromEntries: to_object} = Object
 export const extend = assign
 
-export function fields<T extends object>(obj: T): (keyof T)[]
-export function fields(obj: object): string[] {
-  return keys(obj)
-}
+export const typed_keys: <T extends object>(obj: T) => (keyof T)[] = keys
+
+export const typed_values: <T extends object>(obj: T) => T[keyof T][] = values
+
+export const typed_entries: <T extends object>(obj: T) => [keyof T, T[keyof T]][] = entries
 
 export function clone<T>(obj: PlainObject<T>): PlainObject<T> {
   return {...obj}

--- a/bokehjs/src/lib/core/util/refs.ts
+++ b/bokehjs/src/lib/core/util/refs.ts
@@ -1,5 +1,5 @@
 import type {Attrs} from "../types"
-import {isPlainObject} from "./types"
+import {isPlainObject, isObject} from "./types"
 
 export type Struct = {
   id: string
@@ -13,4 +13,29 @@ export type Ref = {
 
 export function is_ref(obj: unknown): obj is Ref {
   return isPlainObject(obj) && "id" in obj && !("type" in obj)
+}
+
+export const has_refs = Symbol("has_refs")
+
+export interface HasRefs {
+  readonly [has_refs]: boolean
+}
+
+export function _is_HasRefs(v: object): v is HasRefs {
+  return has_refs in v
+}
+
+export function is_HasRefs(v: unknown): v is HasRefs {
+  return isObject(v) && _is_HasRefs(v)
+}
+
+export function may_have_refs(obj: object): boolean {
+  if (_is_HasRefs(obj)) {
+    return obj[has_refs]
+  }
+  const type = obj.constructor
+  if (_is_HasRefs(type)) {
+    return type[has_refs]
+  }
+  return true
 }

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -9,7 +9,7 @@ import {Logo, Location} from "core/enums"
 import type {EventType} from "core/ui_events"
 import {every, sort_by, includes, intersection, split, clear} from "core/util/array"
 import {join} from "core/util/iterator"
-import {fields, values, entries} from "core/util/object"
+import {typed_keys, values, entries} from "core/util/object"
 import {isArray} from "core/util/types"
 import type {EventRole} from "./tool"
 import {Tool} from "./tool"
@@ -416,7 +416,7 @@ export class Toolbar extends UIElement {
         new_gestures[tool.event_role].tools.push(tool)
       }
     }
-    for (const et of fields(new_gestures)) {
+    for (const et of typed_keys(new_gestures)) {
       const gesture = this.gestures[et]
       gesture.tools = sort_by(new_gestures[et].tools, (tool) => tool.default_order)
 

--- a/bokehjs/test/unit/core/kinds.ts
+++ b/bokehjs/test/unit/core/kinds.ts
@@ -2,6 +2,7 @@ import {expect} from "assertions"
 
 import * as k from "@bokehjs/core/kinds"
 import {HasProps} from "@bokehjs/core/has_props"
+import {BitSet} from "@bokehjs/core/util/bitset"
 
 class SomeModel extends HasProps {}
 class OtherModel extends HasProps {}
@@ -11,12 +12,14 @@ describe("core/kinds module", () => {
     const tp = k.Any
     expect(`${tp}`).to.be.equal("Any")
     expect(tp.valid(undefined)).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(true)
   })
 
   it("should support Unknown kind", () => {
     const tp = k.Unknown
     expect(`${tp}`).to.be.equal("Unknown")
     expect(tp.valid(undefined)).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(true)
   })
 
   it("should support Boolean kind", () => {
@@ -27,6 +30,7 @@ describe("core/kinds module", () => {
     expect(tp.valid(0)).to.be.false
     expect(tp.valid(1)).to.be.false
     expect(tp.valid("a")).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support Number kind", () => {
@@ -35,6 +39,7 @@ describe("core/kinds module", () => {
     expect(tp.valid(0)).to.be.true
     expect(tp.valid(0.1)).to.be.true
     expect(tp.valid("a")).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support Int kind", () => {
@@ -43,11 +48,13 @@ describe("core/kinds module", () => {
     expect(tp.valid(0)).to.be.true
     expect(tp.valid(0.1)).to.be.false
     expect(tp.valid("a")).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support Bytes kind", () => {
     const tp = k.Bytes
     expect(`${tp}`).to.be.equal("Bytes")
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support String kind", () => {
@@ -55,6 +62,7 @@ describe("core/kinds module", () => {
     expect(`${tp}`).to.be.equal("String")
     expect(tp.valid(0)).to.be.false
     expect(tp.valid("a")).to.be.true
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support Regex kind", () => {
@@ -65,6 +73,7 @@ describe("core/kinds module", () => {
     expect(tp.valid("a")).to.be.true
     expect(tp.valid("ab")).to.be.true
     expect(tp.valid("ba")).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support Null kind", () => {
@@ -75,6 +84,7 @@ describe("core/kinds module", () => {
     expect(tp.valid(0)).to.be.false
     expect(tp.valid(1)).to.be.false
     expect(tp.valid("a")).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support Nullable kind", () => {
@@ -85,6 +95,8 @@ describe("core/kinds module", () => {
     expect(tp.valid(0)).to.be.true
     expect(tp.valid(1)).to.be.true
     expect(tp.valid("a")).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect(k.Nullable(k.AnyRef()).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Opt kind", () => {
@@ -95,6 +107,8 @@ describe("core/kinds module", () => {
     expect(tp.valid(0)).to.be.true
     expect(tp.valid(1)).to.be.true
     expect(tp.valid("a")).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect(k.Opt(k.AnyRef()).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Or kind", () => {
@@ -106,6 +120,8 @@ describe("core/kinds module", () => {
     expect(tp.valid(null)).to.be.false
     expect(tp.valid(undefined)).to.be.false
     expect(tp.valid([])).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect(k.Or(k.Int, k.AnyRef()).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Tuple kind", () => {
@@ -122,6 +138,8 @@ describe("core/kinds module", () => {
     expect(tp.valid("a")).to.be.false
     expect(tp.valid(null)).to.be.false
     expect(tp.valid(undefined)).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect(k.Tuple(k.Int, k.AnyRef()).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Struct kind", () => {
@@ -135,6 +153,10 @@ describe("core/kinds module", () => {
     expect(tp.valid({a: 0, b: "a", c: [1]})).to.be.true
     expect(tp.valid({a: 0, b: "a", d: [1]})).to.be.false
     expect(tp.valid({a: 0, b: "a", c: [1], d: [1]})).to.be.false
+
+    expect(tp.may_have_refs()).to.be.equal(false)
+    const tp1 = k.Struct({a: k.Int, b: k.String, c: k.Opt(k.Array(k.AnyRef()))})
+    expect(tp1.may_have_refs()).to.be.equal(true)
   })
 
   it("should support PartialStruct kind", () => {
@@ -149,6 +171,10 @@ describe("core/kinds module", () => {
     expect(tp.valid({a: 0, b: "a", c: [1]})).to.be.true
     expect(tp.valid({a: 0, b: "a", d: [1]})).to.be.false
     expect(tp.valid({a: 0, b: "a", c: [1], d: [1]})).to.be.false
+
+    expect(tp.may_have_refs()).to.be.equal(false)
+    const tp1 = k.PartialStruct({a: k.Int, b: k.String, c: k.Opt(k.Array(k.AnyRef()))})
+    expect(tp1.may_have_refs()).to.be.equal(true)
   })
 
   it("should support Arrayable kind", () => {
@@ -158,6 +184,9 @@ describe("core/kinds module", () => {
     expect(tp.valid([0, 1, 2])).to.be.true
     expect(tp.valid([0, "a"])).to.be.true // no item validation
     expect(tp.valid(["a"])).to.be.true    // no item validation
+
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect((k.Arrayable(k.AnyRef())).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Array kind", () => {
@@ -167,6 +196,8 @@ describe("core/kinds module", () => {
     expect(tp.valid([0, 1, 2])).to.be.true
     expect(tp.valid([0, "a"])).to.be.false
     expect(tp.valid(["a"])).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect((k.Array(k.AnyRef())).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Dict kind", () => {
@@ -177,6 +208,8 @@ describe("core/kinds module", () => {
     expect(tp.valid({a: 0, b: 1})).to.be.true
     expect(tp.valid({a: "a"})).to.be.false
     expect(tp.valid({a: 0, b: "a"})).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect((k.Dict(k.AnyRef())).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Map kind", () => {
@@ -186,6 +219,9 @@ describe("core/kinds module", () => {
     expect(tp.valid(new Map([[0, "a"]]))).to.be.true
     expect(tp.valid(new Map([[0, "a"], [1, "b"]]))).to.be.true
     expect(tp.valid(new Map([[0, 1]]))).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect((k.Map(k.Int, k.AnyRef())).may_have_refs()).to.be.equal(true)
+    expect((k.Map(k.AnyRef(), k.Int)).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Set kind", () => {
@@ -195,6 +231,8 @@ describe("core/kinds module", () => {
     expect(tp.valid(new Set([0]))).to.be.true
     expect(tp.valid(new Set([0, 1]))).to.be.true
     expect(tp.valid(new Set(["a"]))).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
+    expect((k.Set(k.AnyRef())).may_have_refs()).to.be.equal(true)
   })
 
   it("should support Enum kind", () => {
@@ -205,6 +243,7 @@ describe("core/kinds module", () => {
     expect(tp.valid("c")).to.be.true
     expect(tp.valid("d")).to.be.false
     expect(tp.valid(1)).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support Ref kind", () => {
@@ -215,6 +254,8 @@ describe("core/kinds module", () => {
     expect(tp.valid(new class {})).to.be.false
     expect(tp.valid("a")).to.be.false
     expect(tp.valid(1)).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(true)
+    expect(k.Ref(BitSet).may_have_refs()).to.be.equal(false)
   })
 
   it("should support AnyRef kind", () => {
@@ -225,6 +266,7 @@ describe("core/kinds module", () => {
     expect(tp.valid(new class {})).to.be.true
     expect(tp.valid("a")).to.be.false
     expect(tp.valid(1)).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(true)
   })
 
   it("should support Function kind", () => {
@@ -238,6 +280,7 @@ describe("core/kinds module", () => {
     expect(tp.valid(new class {})).to.be.false
     expect(tp.valid("a")).to.be.false
     expect(tp.valid(1)).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support DOMNode kind", () => {
@@ -248,6 +291,7 @@ describe("core/kinds module", () => {
     expect(tp.valid(new class {})).to.be.false
     expect(tp.valid("a")).to.be.false
     expect(tp.valid(1)).to.be.false
+    expect(tp.may_have_refs()).to.be.equal(false)
   })
 
   it("should support NonNegative(T) kind", () => {
@@ -270,6 +314,8 @@ describe("core/kinds module", () => {
     expect(tp1.valid(-1.1)).to.be.false
     expect(tp1.valid(0.0)).to.be.true
     expect(tp1.valid(1.1)).to.be.true
+
+    expect(tp0.may_have_refs()).to.be.equal(false)
   })
 
   it("should support Positive(T) kind", () => {
@@ -292,5 +338,7 @@ describe("core/kinds module", () => {
     expect(tp1.valid(-1.1)).to.be.false
     expect(tp1.valid(0.0)).to.be.false
     expect(tp1.valid(1.1)).to.be.true
+
+    expect(tp0.may_have_refs()).to.be.equal(false)
   })
 })

--- a/bokehjs/test/unit/core/properties.ts
+++ b/bokehjs/test/unit/core/properties.ts
@@ -11,6 +11,7 @@ import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import {named_colors} from  "@bokehjs/core/util/svg_colors"
 import {Transform} from  "@bokehjs/models/transforms/transform"
 import {Expression} from  "@bokehjs/models/expressions/expression"
+import {BitSet} from "@bokehjs/core/util/bitset"
 
 class TestTransform extends Transform {
   compute(x: number): number {
@@ -43,7 +44,8 @@ namespace Some {
     array: p.Property<number[]>
     boolean: p.Property<boolean>
     color: p.Property<Color>
-    instance: p.Property<HasProps>
+    instance_has_props: p.Property<HasProps>
+    instance_bitset: p.Property<BitSet>
     number: p.Property<number>
     int: p.Property<number>
     angle: p.Property<number>
@@ -82,7 +84,8 @@ class Some extends HasProps {
       array: [ kinds.Array(kinds.Number) ],
       boolean: [ kinds.Boolean ],
       color: [ kinds.Color ],
-      instance: [ kinds.Ref(HasProps) ],
+      instance_has_props: [ kinds.Ref(HasProps) ],
+      instance_bitset: [ kinds.Ref(BitSet) ],
       number: [ kinds.Number ],
       int: [ kinds.Int ],
       angle: [ kinds.Angle ],
@@ -561,22 +564,54 @@ describe("properties module", () => {
   })
 
   describe("Instance", () => {
-    const obj = new Some({instance: new Some()})
-    const prop = obj.properties.instance
+    describe("of HasProps", () => {
+      const obj = new Some({instance_has_props: new Some()})
+      const prop = obj.properties.instance_has_props
 
-    describe("valid", () => {
-      it("should return undefined on HasProps", () => {
-        const value = new Some()
-        expect(prop.valid(value)).to.be.true
+      describe("valid", () => {
+        it("should accept HasProps instances", () => {
+          const value = new Some()
+          expect(prop.valid(value)).to.be.true
+        })
+
+        it("should not accept any other inputs", () => {
+          expect(prop.valid(new BitSet(10))).to.be.false
+          expect(prop.valid(true)).to.be.false
+          expect(prop.valid(10)).to.be.false
+          expect(prop.valid(10.2)).to.be.false
+          expect(prop.valid("foo")).to.be.false
+          expect(prop.valid({})).to.be.false
+          expect(prop.valid([])).to.be.false
+        })
       })
 
-      it.skip("should throw an Error on other input", () => {
-        expect(prop.valid(true)).to.be.false
-        expect(prop.valid(10)).to.be.false
-        expect(prop.valid(10.2)).to.be.false
-        expect(prop.valid("foo")).to.be.false
-        expect(prop.valid({})).to.be.false
-        expect(prop.valid([])).to.be.false
+      it("should support may_have_refs", () => {
+        expect(prop.may_have_refs).to.be.true
+      })
+    })
+
+    describe("of BitSet", () => {
+      const obj = new Some({instance_bitset: new BitSet(10)})
+      const prop = obj.properties.instance_bitset
+
+      describe("valid", () => {
+        it("should accept BitSet instances", () => {
+          expect(prop.valid(new BitSet(10))).to.be.true
+        })
+
+        it("should not accept any other inputs", () => {
+          expect(prop.valid(new Some())).to.be.false
+          expect(prop.valid(true)).to.be.false
+          expect(prop.valid(10)).to.be.false
+          expect(prop.valid(10.2)).to.be.false
+          expect(prop.valid("foo")).to.be.false
+          expect(prop.valid({})).to.be.false
+          expect(prop.valid([])).to.be.false
+        })
+      })
+
+      it("should support may_have_refs", () => {
+        expect(prop.may_have_refs).to.be.false
       })
     })
   })

--- a/bokehjs/test/unit/core/util/bitset.ts
+++ b/bokehjs/test/unit/core/util/bitset.ts
@@ -2,6 +2,7 @@ import {expect} from "assertions"
 import {BitSet} from "@bokehjs/core/util/bitset"
 import {range} from "@bokehjs/core/util/array"
 import {is_equal} from "@bokehjs/core/util/eq"
+import {may_have_refs} from "@bokehjs/core/util/refs"
 
 describe("core/util/bitset module", () => {
 
@@ -164,6 +165,10 @@ describe("core/util/bitset module", () => {
       const bs2 = BitSet.from_indices(159, [])
       const bs3 = BitSet.from_indices(159, [158])
       expect(is_equal(bs2, bs3)).to.be.equal(false)
+    })
+
+    it("doesn't have refs", () => {
+      expect(may_have_refs(new BitSet(10))).to.be.equal(false)
     })
   })
 })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev_template = "{tag}+{ccount}.g{sha}"
 dirty_template = "{tag}+{ccount}.g{sha}.dirty"
 
 [tool.pytest.ini_options]
-timeout = 60
+timeout = 90
 asyncio_mode = "strict"
 norecursedirs = "build _build node_modules tests/support"
 python_files = "*_tests.py *_test.py test_*.py"


### PR DESCRIPTION
This makes bokehjs' properties system aware of refs, making the invalidation of refs less expensive or allowing to skip it altogether. The duality of this design is required both to efficiently handle fully typed properties and those dynamically typed (using `Any` or `AnyRef` and combinations).