### PR TITLE
add 'header_links_before_dropdown' to conf.py

### DIFF
--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -197,6 +197,7 @@ html_theme_options = {
     },
     "twitter_url": "https://twitter.com/bokeh",
     "use_edit_page_button": False,
+    "header_links_before_dropdown": 8
 }
 
 html_sidebars = {

--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -197,7 +197,7 @@ html_theme_options = {
     },
     "twitter_url": "https://twitter.com/bokeh",
     "use_edit_page_button": False,
-    "header_links_before_dropdown": 8
+    "header_links_before_dropdown": 8,
 }
 
 html_sidebars = {


### PR DESCRIPTION
This changes the default value of [5 items](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/header-links.html#navigation-bar-dropdown-links) in the header to 8.

- [x] issues: fixes #13329

