### PR TITLE
Update tutorial URL

### DIFF
--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -180,7 +180,7 @@ html_theme_options = {
         "plausible_analytics_url": "https://plausible.io/js/script.js",
     },
     "external_links": [
-        {"name": "Tutorial",  "url": "https://mybinder.org/v2/gh/bokeh/bokeh-notebooks/HEAD?labpath=index.ipynb"},
+        {"name": "Tutorial",  "url": "https://mybinder.org/v2/gh/bokeh/tutorial/main?filepath=notebooks%2F01_introduction.ipynb"},
         {"name": "Community", "url": "https://discourse.bokeh.org"},
     ],
     "github_url": "https://github.com/bokeh/bokeh",


### PR DESCRIPTION
Update the URL for "Tutorials" to point to the new tutorials (https://github.com/bokeh/tutorial) on binder

- [x] issues: fixes #13356
