### PR TITLE
Add stack_labels property to WeightedStackColorMapper

### DIFF
--- a/bokehjs/src/lib/models/mappers/weighted_stack_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/weighted_stack_color_mapper.ts
@@ -14,7 +14,7 @@ export namespace WeightedStackColorMapper {
   export type Props = StackColorMapper.Props & {
     alpha_mapper: p.Property<ContinuousColorMapper>
     color_baseline: p.Property<number | null>
-    label: p.Property<string[] | null>
+    stack_labels: p.Property<string[] | null>
   }
 }
 
@@ -31,7 +31,7 @@ export class WeightedStackColorMapper extends StackColorMapper {
     this.define<WeightedStackColorMapper.Props>(({Array, Nullable, Number, Ref, String}) => ({
       alpha_mapper:   [ Ref(ContinuousColorMapper) ],
       color_baseline: [ Nullable(Number), null ],
-      label:          [ Nullable(Array(String)), null ],
+      stack_labels:   [ Nullable(Array(String)), null ],
     }))
   }
 

--- a/bokehjs/src/lib/models/mappers/weighted_stack_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/weighted_stack_color_mapper.ts
@@ -14,6 +14,7 @@ export namespace WeightedStackColorMapper {
   export type Props = StackColorMapper.Props & {
     alpha_mapper: p.Property<ContinuousColorMapper>
     color_baseline: p.Property<number | null>
+    label: p.Property<string[] | null>
   }
 }
 
@@ -27,9 +28,10 @@ export class WeightedStackColorMapper extends StackColorMapper {
   }
 
   static {
-    this.define<WeightedStackColorMapper.Props>(({Nullable, Number, Ref}) => ({
+    this.define<WeightedStackColorMapper.Props>(({Array, Nullable, Number, Ref, String}) => ({
       alpha_mapper:   [ Ref(ContinuousColorMapper) ],
       color_baseline: [ Nullable(Number), null ],
+      label:          [ Nullable(Array(String)), null ],
     }))
   }
 

--- a/docs/bokeh/source/docs/releases/3.3.0.rst
+++ b/docs/bokeh/source/docs/releases/3.3.0.rst
@@ -6,3 +6,4 @@
 Bokeh version ``3.3.0`` (September 2023) is a minor milestone of Bokeh project.
 
 * Added support for inline math text expressions (:bokeh-pull:`13214`)
+* Added ``stack_labels`` property to ``WeightedStackColorMapper`` (:bokeh-pull:`13366`)

--- a/src/bokeh/core/validation/errors.py
+++ b/src/bokeh/core/validation/errors.py
@@ -233,7 +233,7 @@ INVALID_PROPERTY_VALUE = Error(
 WEIGHTED_STACK_COLOR_MAPPER_LABEL_LENGTH_MISMATCH = Error(
     1030,
     "WEIGHTED_STACK_COLOR_MAPPER_LABEL_LENGTH_MISMATCH",
-    "Number of labels does not match palette length")
+    "Number of stack labels does not match palette length")
 EXT = Error(
     9999,
     "EXT",

--- a/src/bokeh/core/validation/errors.py
+++ b/src/bokeh/core/validation/errors.py
@@ -230,6 +230,10 @@ INVALID_PROPERTY_VALUE = Error(
     1029,
     "INVALID_PROPERTY_VALUE",
     "Invalid property value")
+WEIGHTED_STACK_COLOR_MAPPER_LABEL_LENGTH_MISMATCH = Error(
+    1030,
+    "WEIGHTED_STACK_COLOR_MAPPER_LABEL_LENGTH_MISMATCH",
+    "Number of labels does not match palette length")
 EXT = Error(
     9999,
     "EXT",

--- a/src/bokeh/models/mappers.py
+++ b/src/bokeh/models/mappers.py
@@ -43,7 +43,8 @@ from ..core.properties import (
     String,
     Tuple,
 )
-from ..core.validation import warning
+from ..core.validation import error, warning
+from ..core.validation.errors import WEIGHTED_STACK_COLOR_MAPPER_LABEL_LENGTH_MISMATCH
 from ..core.validation.warnings import PALETTE_LENGTH_FACTORS_MISMATCH
 from .transforms import Transform
 
@@ -363,6 +364,26 @@ class WeightedStackColorMapper(StackColorMapper):
     evenly weighted average of the colors corresponding to all such values,
     to avoid the color being undefined.
     """)
+
+    label = Nullable(Seq(String), help="""
+    An optional sequence of strings to use as labels for the palette colors.
+    If set, the number of labels should match the number of colors.
+
+    The labels are used in hover tooltips for ``ImageStack`` glyphs that use a
+    ``WeightedStackColorMapper`` as their color mapper.
+    """)
+
+    @error(WEIGHTED_STACK_COLOR_MAPPER_LABEL_LENGTH_MISMATCH)
+    def _check_label_length(self):
+        if self.label is not None:
+            nlabel = len(self.label)
+            npalette = len(self.palette)
+            if nlabel > npalette:
+                self.label = self.label[:npalette]
+                return f"{nlabel} != {npalette}, removing unwanted labels"
+            elif nlabel < npalette:
+                self.label = list(self.label) + [""]*(npalette - nlabel)
+                return f"{nlabel} != {npalette}, padding with empty strings"
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/models/mappers.py
+++ b/src/bokeh/models/mappers.py
@@ -365,9 +365,10 @@ class WeightedStackColorMapper(StackColorMapper):
     to avoid the color being undefined.
     """)
 
-    label = Nullable(Seq(String), help="""
-    An optional sequence of strings to use as labels for the palette colors.
-    If set, the number of labels should match the number of colors.
+    stack_labels = Nullable(Seq(String), help="""
+    An optional sequence of strings to use as labels for the ``nstack`` stacks.
+    If set, the number of labels should match the number of stacks and hence
+    also the number of palette colors.
 
     The labels are used in hover tooltips for ``ImageStack`` glyphs that use a
     ``WeightedStackColorMapper`` as their color mapper.
@@ -375,14 +376,14 @@ class WeightedStackColorMapper(StackColorMapper):
 
     @error(WEIGHTED_STACK_COLOR_MAPPER_LABEL_LENGTH_MISMATCH)
     def _check_label_length(self):
-        if self.label is not None:
-            nlabel = len(self.label)
+        if self.stack_labels is not None:
+            nlabel = len(self.stack_labels)
             npalette = len(self.palette)
             if nlabel > npalette:
-                self.label = self.label[:npalette]
-                return f"{nlabel} != {npalette}, removing unwanted labels"
+                self.stack_labels = self.stack_labels[:npalette]
+                return f"{nlabel} != {npalette}, removing unwanted stack_labels"
             elif nlabel < npalette:
-                self.label = list(self.label) + [""]*(npalette - nlabel)
+                self.stack_labels = list(self.stack_labels) + [""]*(npalette - nlabel)
                 return f"{nlabel} != {npalette}, padding with empty strings"
 
 #-----------------------------------------------------------------------------

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -464,7 +464,7 @@
       name: "unset",
     },
     color_baseline: null,
-    label: null,
+    stack_labels: null,
   },
   Ticker: {
     __extends__: "Model",

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -464,6 +464,7 @@
       name: "unset",
     },
     color_baseline: null,
+    label: null,
   },
   Ticker: {
     __extends__: "Model",

--- a/tests/unit/bokeh/models/test_mappers.py
+++ b/tests/unit/bokeh/models/test_mappers.py
@@ -144,8 +144,29 @@ class Test_WeightedStackColorMapper:
             "palette",
             "nan_color",
             "alpha_mapper",
-            "color_baseline"],
+            "color_baseline",
+            "label"],
         )
+
+    @patch("bokeh.core.validation.check.log.error")
+    @patch("bokeh.core.validation.check.log.warning")
+    def test_label_too_many(self, mock_warn: MagicMock, mock_error: MagicMock) -> None:
+        mapper = bmm.WeightedStackColorMapper(palette=["red", "green"], label=["one", "two", "three"])
+        issues = check_integrity([mapper])
+        process_validation_issues(issues)
+        assert mock_error.called
+        assert not mock_warn.called
+        assert mapper.label == ["one", "two"]
+
+    @patch("bokeh.core.validation.check.log.error")
+    @patch("bokeh.core.validation.check.log.warning")
+    def test_label_too_few(self, mock_warn: MagicMock, mock_error: MagicMock) -> None:
+        mapper = bmm.WeightedStackColorMapper(palette=["red", "green"], label=["one"])
+        issues = check_integrity([mapper])
+        process_validation_issues(issues)
+        assert mock_error.called
+        assert not mock_warn.called
+        assert mapper.label == ["one", ""]
 
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/models/test_mappers.py
+++ b/tests/unit/bokeh/models/test_mappers.py
@@ -145,28 +145,28 @@ class Test_WeightedStackColorMapper:
             "nan_color",
             "alpha_mapper",
             "color_baseline",
-            "label"],
+            "stack_labels"],
         )
 
     @patch("bokeh.core.validation.check.log.error")
     @patch("bokeh.core.validation.check.log.warning")
-    def test_label_too_many(self, mock_warn: MagicMock, mock_error: MagicMock) -> None:
-        mapper = bmm.WeightedStackColorMapper(palette=["red", "green"], label=["one", "two", "three"])
+    def test_too_many_labels(self, mock_warn: MagicMock, mock_error: MagicMock) -> None:
+        mapper = bmm.WeightedStackColorMapper(palette=["red", "green"], stack_labels=["one", "two", "three"])
         issues = check_integrity([mapper])
         process_validation_issues(issues)
         assert mock_error.called
         assert not mock_warn.called
-        assert mapper.label == ["one", "two"]
+        assert mapper.stack_labels == ["one", "two"]
 
     @patch("bokeh.core.validation.check.log.error")
     @patch("bokeh.core.validation.check.log.warning")
-    def test_label_too_few(self, mock_warn: MagicMock, mock_error: MagicMock) -> None:
-        mapper = bmm.WeightedStackColorMapper(palette=["red", "green"], label=["one"])
+    def test_too_few_labels(self, mock_warn: MagicMock, mock_error: MagicMock) -> None:
+        mapper = bmm.WeightedStackColorMapper(palette=["red", "green"], stack_labels=["one"])
         issues = check_integrity([mapper])
         process_validation_issues(issues)
         assert mock_error.called
         assert not mock_warn.called
-        assert mapper.label == ["one", ""]
+        assert mapper.stack_labels == ["one", ""]
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This adds a `stack_labels` property to `WeightedStackColorMapper`, fixing #13200. It is not used for anything yet but will be used to provide richer hover tooltips for `ImageStack` glyphs as described in issue #13354 that will follow in another PR.

Example (though not very interesting until the tooltips have been implemented):
```python
from bokeh.models import EqHistColorMapper, WeightedStackColorMapper
from bokeh.palettes import varying_alpha_palette
from bokeh.plotting import figure, show
import numpy as np

stack = np.asarray([[[0, 1], [1, 1], [0, 1]],
                    [[1, 0], [2, 2], [3, 3]],
                    [[0, 1], [4, 1], [3, 5]]])

p = figure(width=400, height=300)
alpha_mapper = EqHistColorMapper(
    palette=varying_alpha_palette(color="#000", n=10, start_alpha=40),
    rescale_discrete_levels=False,
)
color_mapper = WeightedStackColorMapper(
    palette=["yellow", "purple"],
    nan_color=(0, 0, 0, 0),
    alpha_mapper=alpha_mapper,
    stack_labels=["some", "other"],
)

im = p.image_stack(image=[stack], x=0, y=0, dw=1, dh=1, color_mapper=color_mapper)
p.add_layout(im.construct_color_bar(), "right")
show(p)
```

The `stack_labels` is a sequence (list or tuple) of strings and must be the same length as the palette. If not an error is produced and the `stack_labels` are altered to be the correct length in the spirit of defensive programming. It could just be a warning rather than an error.

In the original issue (#13200) I considered this approach but favoured adding the property to `ImageStack` glyph. I have changed my mind as this here is simpler and more logical as the labels refer to the palette colors so should be set in the same place, and it is easy to enforce their lengths being identical.

- [x] issues: fixes #13200
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

(Edited to change property name)