### PR TITLE
Add optional tooltip to tabpanels

### DIFF
--- a/bokehjs/src/lib/models/layouts/tab_panel.ts
+++ b/bokehjs/src/lib/models/layouts/tab_panel.ts
@@ -1,3 +1,4 @@
+import {Tooltip} from "models/ui/tooltip"
 import {Model} from "../../model"
 import {UIElement} from "../ui/ui_element"
 import type * as p from "core/properties"
@@ -7,6 +8,7 @@ export namespace TabPanel {
 
   export type Props = Model.Props & {
     title: p.Property<string>
+    tooltip: p.Property<Tooltip | null>
     child: p.Property<UIElement>
     closable: p.Property<boolean>
     disabled: p.Property<boolean>
@@ -23,8 +25,9 @@ export class TabPanel extends Model {
   }
 
   static {
-    this.define<TabPanel.Props>(({Boolean, String, Ref}) => ({
+    this.define<TabPanel.Props>(({Boolean, String, Ref, Nullable}) => ({
       title:    [ String, "" ],
+      tooltip:  [ Nullable(Ref(Tooltip)), null ],
       child:    [ Ref(UIElement) ],
       closable: [ Boolean, false ],
       disabled: [ Boolean, false ],

--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -16,7 +16,6 @@ import type {TooltipView} from "../ui/tooltip"
 import tabs_css, * as tabs from "styles/tabs.css"
 import icons_css from "styles/icons.css"
 
-
 export class TabsView extends LayoutDOMView {
   declare model: Tabs
 

--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -38,7 +38,7 @@ export class TabsView extends LayoutDOMView {
   override async lazy_initialize(): Promise<void> {
     await super.lazy_initialize()
     const {tabs} = this.model
-    this.tooltips = await Promise.all(tabs.map(tab => tab.tooltip ? build_view(tab.tooltip, {parent: this}) : Promise.resolve(null)))
+    this.tooltips = await Promise.all(tabs.map(tab => (tab.tooltip !== null)  ? build_view(tab.tooltip, {parent: this}) : Promise.resolve(null)))
   }
 
   override stylesheets(): StyleSheetLike[] {
@@ -112,12 +112,12 @@ export class TabsView extends LayoutDOMView {
           this.change_active(i)
       })
       const tooltip = this.tooltips[i]
-      if (tooltip) {
-        tooltip?.model.setv({
+      if (tooltip !== null) {
+        tooltip.model.setv({
           target: el,
         })
         const toggle_tooltip = (visible: boolean) => {
-          tooltip.model.visible = visible;
+          tooltip.model.visible = visible
         }
         el.addEventListener("mouseenter", () => {
           toggle_tooltip(true)

--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -114,20 +114,17 @@ export class TabsView extends LayoutDOMView {
       })
       const tooltip = this.tooltips[i]
       if (tooltip) {
-        tooltip.useRelativeBoundingBox = false
         tooltip?.model.setv({
           target: el,
         })
-        const toggleTooltip = (visible: boolean) => {
-          tooltip.model.setv({
-            visible,
-          })
+        const toggle_tooltip = (visible: boolean) => {
+          tooltip.model.visible = visible;
         }
         el.addEventListener("mouseenter", () => {
-          toggleTooltip(true)
+          toggle_tooltip(true)
         })
         el.addEventListener("mouseleave", () => {
-          toggleTooltip(false)
+          toggle_tooltip(false)
         })
       }
       if (tab.closable) {

--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -19,7 +19,7 @@ import icons_css from "styles/icons.css"
 export class TabsView extends LayoutDOMView {
   declare model: Tabs
 
-  protected tooltips: (TooltipView | null)[]
+  protected tooltips: (TooltipView | null | undefined)[]
   protected header_el: HTMLElement
   protected header_els: HTMLElement[]
 
@@ -112,7 +112,7 @@ export class TabsView extends LayoutDOMView {
           this.change_active(i)
       })
       const tooltip = this.tooltips[i]
-      if (tooltip !== null) {
+      if (tooltip !== null && tooltip !== undefined) {
         tooltip.model.setv({
           target: el,
         })

--- a/bokehjs/src/lib/models/ui/tooltip.ts
+++ b/bokehjs/src/lib/models/ui/tooltip.ts
@@ -33,6 +33,8 @@ export class TooltipView extends UIElementView {
     this._target = el
   }
 
+  useRelativeBoundingBox: boolean = true
+
   protected _init_target(): void {
     const {target} = this.model
     const el = (() => {
@@ -352,6 +354,7 @@ export class TooltipView extends UIElementView {
       }
     })()
 
+    this.el.style.position = this.useRelativeBoundingBox ? 'absolute' : 'fixed'
     this.el.style.top = `${top}px`
     this.el.style.left = `${left}px`
   }

--- a/bokehjs/src/lib/models/ui/tooltip.ts
+++ b/bokehjs/src/lib/models/ui/tooltip.ts
@@ -33,8 +33,6 @@ export class TooltipView extends UIElementView {
     this._target = el
   }
 
-  useRelativeBoundingBox: boolean = true
-
   protected _init_target(): void {
     const {target} = this.model
     const el = (() => {
@@ -354,7 +352,6 @@ export class TooltipView extends UIElementView {
       }
     })()
 
-    this.el.style.position = this.useRelativeBoundingBox ? 'absolute' : 'fixed'
     this.el.style.top = `${top}px`
     this.el.style.left = `${left}px`
   }

--- a/bokehjs/test/unit/models/layouts/tabs.ts
+++ b/bokehjs/test/unit/models/layouts/tabs.ts
@@ -1,22 +1,24 @@
-import {expect} from "assertions"
+import {expect, expect_not_null} from "assertions"
 
 import {TabPanel} from "@bokehjs/models/layouts/tab_panel"
 import {Tabs} from "@bokehjs/models/layouts/tabs"
 import {Plot} from "@bokehjs/models/plots/plot"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import {Tooltip} from "@bokehjs/models/ui/tooltip"
+import {range} from "@bokehjs/core/util/array"
+import {enumerate} from "@bokehjs/core/util/iterator"
 
 describe("Tabs", () => {
-  function new_tabs(numPanels: number, addTooltip: boolean = false): Tabs {
-    const createPanel = () => {
+  function new_tabs(num_panels: number, add_tooltip: boolean = false): Tabs {
+    const create_panel = (i: number) => {
       const plot = new Plot({
         x_range: new Range1d({start: 0, end: 10}),
         y_range: new Range1d({start: 0, end: 10}),
       })
-      const tooltip = addTooltip ? new Tooltip({content: "test tooltip", position: "right"}) : null
+      const tooltip = add_tooltip ? new Tooltip({content: `Tab #${i}`, position: "bottom_center"}) : null
       return new TabPanel({child: plot, tooltip})
     }
-    const panels = Array(numPanels).map(() => createPanel())
+    const panels = range(num_panels).map(create_panel)
     return new Tabs({tabs: panels})
   }
 
@@ -32,9 +34,9 @@ describe("Tabs", () => {
 
   it("should accept a tooltip", () => {
     const tabs = new_tabs(2, true)
-    tabs.tabs.forEach(tab => {
-      expect(tab.tooltip).to.not.be.null
-      expect(tab.tooltip?.content).to.be.equal("test tooltip")
-    })
+    for (const [tab, i] of enumerate(tabs.tabs)) {
+      expect_not_null(tab.tooltip)
+      expect(tab.tooltip.content).to.be.equal(`Tab #${i}`)
+    }
   })
 })

--- a/bokehjs/test/unit/models/layouts/tabs.ts
+++ b/bokehjs/test/unit/models/layouts/tabs.ts
@@ -4,19 +4,38 @@ import {TabPanel} from "@bokehjs/models/layouts/tab_panel"
 import {Tabs} from "@bokehjs/models/layouts/tabs"
 import {Plot} from "@bokehjs/models/plots/plot"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
+import {Tooltip} from "@bokehjs/models/ui/tooltip"
 
 describe("Tabs", () => {
-  function new_tabs(): Tabs {
-    const plot = new Plot({
-      x_range: new Range1d({start: 0, end: 10}),
-      y_range: new Range1d({start: 0, end: 10}),
-    })
-    const panel = new TabPanel({child: plot})
-    return new Tabs({tabs: [panel]})
+  function new_tabs(numPanels: number, addTooltip: boolean = false): Tabs {
+    const createPanel = () => 
+    {
+      const plot = new Plot({
+        x_range: new Range1d({start: 0, end: 10}),
+        y_range: new Range1d({start: 0, end: 10}),
+      })
+      const tooltip = addTooltip ? new Tooltip({content:"test tooltip", position:"right"}) : null
+      return new TabPanel({child: plot, tooltip})
+    } 
+    const panels = Array(numPanels).map(() => createPanel())
+    return new Tabs({tabs: panels})
   }
 
   it("should have children matching tabs.child after initialization", () => {
-    const tabs = new_tabs()
+    const tabs = new_tabs(1)
     expect(tabs.tabs.length).to.be.equal(1)
+  })
+
+  it("should support multiple tabs", () => {
+    const tabs = new_tabs(3)
+    expect(tabs.tabs.length).to.be.equal(3)
+  })
+
+  it("should accept a tooltip", () => {
+    const tabs = new_tabs(2, true)
+    tabs.tabs.forEach(tab => {
+      expect(tab.tooltip).to.not.be.null
+      expect(tab.tooltip?.content).to.be.equal("test tooltip")
+    })
   })
 })

--- a/bokehjs/test/unit/models/layouts/tabs.ts
+++ b/bokehjs/test/unit/models/layouts/tabs.ts
@@ -8,15 +8,14 @@ import {Tooltip} from "@bokehjs/models/ui/tooltip"
 
 describe("Tabs", () => {
   function new_tabs(numPanels: number, addTooltip: boolean = false): Tabs {
-    const createPanel = () => 
-    {
+    const createPanel = () => {
       const plot = new Plot({
         x_range: new Range1d({start: 0, end: 10}),
         y_range: new Range1d({start: 0, end: 10}),
       })
-      const tooltip = addTooltip ? new Tooltip({content:"test tooltip", position:"right"}) : null
+      const tooltip = addTooltip ? new Tooltip({content: "test tooltip", position: "right"}) : null
       return new TabPanel({child: plot, tooltip})
-    } 
+    }
     const panels = Array(numPanels).map(() => createPanel())
     return new Tabs({tabs: panels})
   }

--- a/examples/interaction/widgets/tab_panes.py
+++ b/examples/interaction/widgets/tab_panes.py
@@ -1,4 +1,5 @@
-from bokeh.models import TabPanel, Tabs
+from bokeh.models import TabPanel, Tabs, Tooltip
+from bokeh.models.layouts import Row
 from bokeh.plotting import figure, show
 
 p1 = figure(width=300, height=300)
@@ -9,4 +10,12 @@ p2 = figure(width=300, height=300)
 p2.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], line_width=3, color="navy", alpha=0.5)
 tab2 = TabPanel(child=p2, title="line")
 
-show(Tabs(tabs=[tab1, tab2]))
+p3 = figure(width=300, height=300)
+p3.circle([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], size=20, color="navy", alpha=0.5)
+tab3 = TabPanel(child=p1, title="circle", tooltip=Tooltip(content="test tooltip", position="right"))
+
+p4 = figure(width=300, height=300)
+p4.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], line_width=3, color="navy", alpha=0.5)
+tab4 = TabPanel(child=p2, title="line", tooltip=Tooltip(content="test tooltip", position="right"))
+
+show(Row(Tabs(tabs=[tab1, tab2]), Tabs(tabs=[tab3, tab4])))

--- a/examples/interaction/widgets/tab_panes.py
+++ b/examples/interaction/widgets/tab_panes.py
@@ -4,18 +4,24 @@ from bokeh.plotting import figure, show
 
 p1 = figure(width=300, height=300)
 p1.circle([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], size=20, color="navy", alpha=0.5)
-tab1 = TabPanel(child=p1, title="circle")
 
 p2 = figure(width=300, height=300)
 p2.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], line_width=3, color="navy", alpha=0.5)
-tab2 = TabPanel(child=p2, title="line")
 
 p3 = figure(width=300, height=300)
 p3.circle([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], size=20, color="navy", alpha=0.5)
-tab3 = TabPanel(child=p1, title="circle", tooltip=Tooltip(content="test tooltip", position="right"))
 
 p4 = figure(width=300, height=300)
 p4.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], line_width=3, color="navy", alpha=0.5)
-tab4 = TabPanel(child=p2, title="line", tooltip=Tooltip(content="test tooltip", position="right"))
 
-show(Row(Tabs(tabs=[tab1, tab2]), Tabs(tabs=[tab3, tab4])))
+tabs0 = Tabs(tabs=[
+    TabPanel(child=p1, title="circle"),
+    TabPanel(child=p2, title="line"),
+])
+
+tabs1 = Tabs(tabs=[
+    TabPanel(child=p1, title="circle", tooltip=Tooltip(content="This is the first tab.", position="bottom_center")),
+    TabPanel(child=p2, title="line", tooltip=Tooltip(content="This is the second tab.", position="bottom_center")),
+])
+
+show(Row(tabs0, tabs1))

--- a/src/bokeh/models/layouts.py
+++ b/src/bokeh/models/layouts.py
@@ -61,6 +61,7 @@ from ..core.validation.warnings import (
 )
 from ..model import Model
 from .ui.menus import Menu
+from .ui.tooltips import Tooltip
 from .ui.ui_element import UIElement
 
 #-----------------------------------------------------------------------------
@@ -552,6 +553,11 @@ class TabPanel(Model):
 
     title = String(default="", help="""
     The text title of the panel.
+    """)
+
+    tooltip = Nullable(Instance(Tooltip), default=None, help="""
+    A tooltip with plain text or rich HTML contents, providing general help or
+    description of a widget's or component's function.
     """)
 
     child = Instance(UIElement, help="""

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -4437,6 +4437,7 @@
   TabPanel: {
     __extends__: "Model",
     title: "",
+    tooltip: null,
     child: {
       type: "symbol",
       name: "unset",

--- a/tests/unit/bokeh/models/test_layouts__models.py
+++ b/tests/unit/bokeh/models/test_layouts__models.py
@@ -19,9 +19,10 @@ import pytest ; pytest
 # Bokeh imports
 from bokeh.models import ColumnDataSource
 from bokeh.plotting import figure
+from bokeh.models.ui import Tooltip
 
 # Module under test
-from bokeh.models.layouts import Row, Column, LayoutDOM # isort:skip
+from bokeh.models.layouts import Row, Column, LayoutDOM, TabPanel # isort:skip
 
 #-----------------------------------------------------------------------------
 # Setup
@@ -87,6 +88,20 @@ def test_LayoutDOM_backgroud() -> None:
     assert "background-color" not in obj.styles
     obj.background = "#aabbccff"
     assert obj.styles["background-color"] == "#aabbccff"
+
+
+def test_TabPanel_no_tooltip() -> None:
+    p1 = figure(width=300, height=300)
+    panel = TabPanel(child=p1, title="test panel")
+    assert panel.title == "test panel"
+    assert panel.child is not None
+    assert panel.tooltip is None
+
+
+def test_TabPanel_tooltip() -> None:
+    p1 = figure(width=300, height=300)
+    panel = TabPanel(child=p1, title="test panel", tooltip=Tooltip(content="test tooltip"))
+    assert panel.tooltip is not None
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/models/test_layouts__models.py
+++ b/tests/unit/bokeh/models/test_layouts__models.py
@@ -18,8 +18,8 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh.models import ColumnDataSource
-from bokeh.plotting import figure
 from bokeh.models.ui import Tooltip
+from bokeh.plotting import figure
 
 # Module under test
 from bokeh.models.layouts import Row, Column, LayoutDOM, TabPanel # isort:skip


### PR DESCRIPTION
This PR aims to add tooltips to the tabs at the top of TabPanel UI elements. 

~~One important change to note is the inclusion of the variable `useRelativeBoundingBox` to the `TooltipView` in tooltip.ts. By default, the tooltip uses a relative bounding box when calculating x and y coordinates for the tooltip. This sets the x and y coordinates to 0, but the DOM structure of the tabs causes the tooltip to always point to the first tab.~~

~~By including this new `useRelativeBoundingBox` variable, I am giving the option to set the absolute position of the tooltip and use the CSS style `position: fixed` while remaining backwards compatible with current implementations of tooltips. Please let me know if you have any concerns with this approach, I'd welcome suggestions for alternative ways to fix the position of the tooltip on TabPanel tabs.~~

I also added some very basic unit tests on both the Python and BokehJS sides. Let me know if more advanced tests are required.

I'm pretty new to open source contributions and this is my first PR in this project, so please point out any pieces I may be missing. Thanks!

![image](https://github.com/bokeh/bokeh/assets/27475/ae2670ad-13c6-4a56-8584-02c58f41e456)

- [x] issues: fixes #13349 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
