### PR TITLE
Allow to serialize unset readonly properties in bokehjs

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -282,7 +282,7 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
 
     const attributes: {[key: string]: AnyVal} = {}
     for (const prop of this) {
-      if (prop.syncable && (serializer.include_defaults || prop.dirty)) {
+      if (prop.syncable && (serializer.include_defaults || prop.dirty) && !(prop.readonly && prop.is_unset)) {
         const value = prop.get_value()
         attributes[prop.attr] = serializer.encode(value) as AnyVal
       }


### PR DESCRIPTION
Mirrors bokeh's behavior when it comes to unset readonly properties.

fixes #13377
