### PR TITLE
Add location of intersphinx mapping

### DIFF
--- a/docs/bokeh/source/docs/reference.rst
+++ b/docs/bokeh/source/docs/reference.rst
@@ -49,7 +49,6 @@ be especially useful.
 :ref:`bokeh.settings`
     All Bokeh-related environment variables, which can be used to control
     things like resources, minification, and log levels, are documented here.
-    
 Linking to the Bokeh documentation
 ----------------------------------
 

--- a/docs/bokeh/source/docs/reference.rst
+++ b/docs/bokeh/source/docs/reference.rst
@@ -49,16 +49,17 @@ be especially useful.
 :ref:`bokeh.settings`
     All Bokeh-related environment variables, which can be used to control
     things like resources, minification, and log levels, are documented here.
-
-
 Linking to the Bokeh documentation
 ----------------------------------
+
 Developers of other packages that make use of Bokeh might want to use
 `intersphinx <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_
 to link to specific classes or functions in the Bokeh docs from their Sphinx
 documentation. The file needed for that is located at
-https://docs.bokeh.org/en/<version>/objects.inv
-where "<version>" can be the number of a released version or "latest", for example
-the entry in the ``conf.py`` file for Sphinx might look like this::
+``https://docs.bokeh.org/en/<version>/objects.inv``
+where ``<version>`` can be the number of a released version, or "latest". For example
+the entry in the ``conf.py`` file for Sphinx might look like this:
+
+.. code-block:: python
 
     intersphinx_mapping = {'bokeh': ('https://docs.bokeh.org/en/latest/objects.inv ', None)}

--- a/docs/bokeh/source/docs/reference.rst
+++ b/docs/bokeh/source/docs/reference.rst
@@ -49,3 +49,16 @@ be especially useful.
 :ref:`bokeh.settings`
     All Bokeh-related environment variables, which can be used to control
     things like resources, minification, and log levels, are documented here.
+
+
+Linking to the Bokeh documentation
+----------------------------------
+Developers of other packages that make use of Bokeh might want to use 
+`intersphinx <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_
+to link to specific classes or functions in the Bokeh docs from their Sphinx
+documentation. The file needed for that is located at 
+https://docs.bokeh.org/en/<version>/objects.inv 
+where "<version>" can be the number of a released version or "latest", for example
+the entry in the ``conf.py`` file for Sphinx might look like this::
+
+    intersphinx_mapping = {'bokeh': ('https://docs.bokeh.org/en/latest/objects.inv ', None)}

--- a/docs/bokeh/source/docs/reference.rst
+++ b/docs/bokeh/source/docs/reference.rst
@@ -53,11 +53,11 @@ be especially useful.
 
 Linking to the Bokeh documentation
 ----------------------------------
-Developers of other packages that make use of Bokeh might want to use 
+Developers of other packages that make use of Bokeh might want to use
 `intersphinx <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_
 to link to specific classes or functions in the Bokeh docs from their Sphinx
-documentation. The file needed for that is located at 
-https://docs.bokeh.org/en/<version>/objects.inv 
+documentation. The file needed for that is located at
+https://docs.bokeh.org/en/<version>/objects.inv
 where "<version>" can be the number of a released version or "latest", for example
 the entry in the ``conf.py`` file for Sphinx might look like this::
 

--- a/docs/bokeh/source/docs/reference.rst
+++ b/docs/bokeh/source/docs/reference.rst
@@ -49,6 +49,7 @@ be especially useful.
 :ref:`bokeh.settings`
     All Bokeh-related environment variables, which can be used to control
     things like resources, minification, and log levels, are documented here.
+    
 Linking to the Bokeh documentation
 ----------------------------------
 

--- a/docs/bokeh/source/docs/reference.rst
+++ b/docs/bokeh/source/docs/reference.rst
@@ -49,6 +49,7 @@ be especially useful.
 :ref:`bokeh.settings`
     All Bokeh-related environment variables, which can be used to control
     things like resources, minification, and log levels, are documented here.
+
 Linking to the Bokeh documentation
 ----------------------------------
 


### PR DESCRIPTION
While it is possible to guess the location of the intersphinx files that bokeh provides, it is useful to spell that out explicitly so users know that that's the correct location and they don't accidentally pick up an old or unmaintained version.

- [x] issues: fixes #13385
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
