### PR TITLE
Make server resource URLs root-relative by default

### DIFF
--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -610,9 +610,11 @@ class BokehTornado(TornadoApplication):
         Bokeh application sessions should load BokehJS resources from.
 
         Args:
-            absolute_url (bool):
-                An absolute URL prefix to use for locating resources. If None,
-                relative URLs are used (default: None)
+            absolute_url (str, bool):
+                An absolute URL prefix to use for locating resources. If
+                ``True``, a prefix consisting of server's protocol, host
+                and port will be used. Otherwise, root-relative URLs are
+                used (default: ``None``)
 
         '''
         mode = settings.resources(default="server")

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -605,7 +605,7 @@ class BokehTornado(TornadoApplication):
         '''
         return self._session_token_expiration
 
-    def resources(self, absolute_url: str | None = None) -> Resources:
+    def resources(self, absolute_url: str | bool | None = None) -> Resources:
         ''' Provide a :class:`~bokeh.resources.Resources` that specifies where
         Bokeh application sessions should load BokehJS resources from.
 
@@ -617,8 +617,14 @@ class BokehTornado(TornadoApplication):
         '''
         mode = settings.resources(default="server")
         if mode == "server" or mode == "server-dev":
-            root_url = urljoin(absolute_url or self._absolute_url or "", self._prefix)
-            return Resources(mode="server", root_url=root_url, path_versioner=StaticHandler.append_version)
+            if absolute_url is True:
+                absolute_url = self._absolute_url
+            if absolute_url is None or absolute_url is False:
+                absolute_url = "/"
+
+            root_url = urljoin(absolute_url, self._prefix)
+            return Resources(mode=mode, root_url=root_url, path_versioner=StaticHandler.append_version)
+
         return Resources(mode=mode)
 
     def start(self) -> None:

--- a/tests/support/plugins/selenium.py
+++ b/tests/support/plugins/selenium.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from shutil import which
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -68,13 +69,24 @@ def driver(pytestconfig: config.Config) -> Iterator[WebDriver]:
     driver_name: str = pytestconfig.getoption('driver', 'chrome').lower()
 
     def chrome() -> WebDriver:
+        for executable in ["chromedriver", "chromium.chromedriver", "chromedriver-binary"]:
+            executable_path = which(executable)
+            if executable_path is not None:
+                break
+        else:
+            raise RuntimeError("chromedriver or its variant is not installed or not present on PATH")
+
         from selenium.webdriver.chrome.options import Options
+        from selenium.webdriver.chrome.service import Service
         from selenium.webdriver.chrome.webdriver import WebDriver as Chrome
+
+        service = Service(executable_path)
         options = Options()
         options.add_argument("--headless")
         options.add_argument("--no-sandbox")
         options.add_argument("--window-size=1920x1080")
-        return Chrome(options=options)
+
+        return Chrome(service=service, options=options)
 
     def firefox() -> WebDriver:
         from selenium.webdriver.firefox.options import Options

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -49,38 +49,76 @@ logging.basicConfig(level=logging.DEBUG)
 
 def test_default_resources(ManagedServerLoop: MSL) -> None:
     application = Application()
+
     with ManagedServerLoop(application) as server:
         r = server._tornado.resources()
         assert r.mode == "server"
-        assert r.root_url == f"http://localhost:{server.port}/"
+        assert r.root_url == "/"
         assert r.path_versioner == StaticHandler.append_version
 
     with ManagedServerLoop(application, prefix="/foo/") as server:
         r = server._tornado.resources()
         assert r.mode == "server"
-        assert r.root_url == f"http://localhost:{server.port}/foo/"
+        assert r.root_url == "/foo/"
         assert r.path_versioner == StaticHandler.append_version
 
     with ManagedServerLoop(application, prefix="foo/") as server:
         r = server._tornado.resources()
         assert r.mode == "server"
-        assert r.root_url == f"http://localhost:{server.port}/foo/"
+        assert r.root_url == "/foo/"
         assert r.path_versioner == StaticHandler.append_version
 
     with ManagedServerLoop(application, prefix="foo") as server:
         r = server._tornado.resources()
         assert r.mode == "server"
-        assert r.root_url == f"http://localhost:{server.port}/foo/"
+        assert r.root_url == "/foo/"
         assert r.path_versioner == StaticHandler.append_version
 
     with ManagedServerLoop(application, prefix="/foo") as server:
         r = server._tornado.resources()
         assert r.mode == "server"
-        assert r.root_url == f"http://localhost:{server.port}/foo/"
+        assert r.root_url == "/foo/"
         assert r.path_versioner == StaticHandler.append_version
 
     with ManagedServerLoop(application, prefix="/foo/bar") as server:
         r = server._tornado.resources()
+        assert r.mode == "server"
+        assert r.root_url == "/foo/bar/"
+        assert r.path_versioner == StaticHandler.append_version
+
+
+    with ManagedServerLoop(application) as server:
+        r = server._tornado.resources(absolute_url=True)
+        assert r.mode == "server"
+        assert r.root_url == f"http://localhost:{server.port}/"
+        assert r.path_versioner == StaticHandler.append_version
+
+    with ManagedServerLoop(application, prefix="/foo/") as server:
+        r = server._tornado.resources(absolute_url=True)
+        assert r.mode == "server"
+        assert r.root_url == f"http://localhost:{server.port}/foo/"
+        assert r.path_versioner == StaticHandler.append_version
+
+    with ManagedServerLoop(application, prefix="foo/") as server:
+        r = server._tornado.resources(absolute_url=True)
+        assert r.mode == "server"
+        assert r.root_url == f"http://localhost:{server.port}/foo/"
+        assert r.path_versioner == StaticHandler.append_version
+
+    with ManagedServerLoop(application, prefix="foo") as server:
+        r = server._tornado.resources(absolute_url=True)
+        assert r.mode == "server"
+        assert r.root_url == f"http://localhost:{server.port}/foo/"
+        assert r.path_versioner == StaticHandler.append_version
+
+    with ManagedServerLoop(application, prefix="/foo") as server:
+        r = server._tornado.resources(absolute_url=True)
+        assert r.mode == "server"
+        assert r.root_url == f"http://localhost:{server.port}/foo/"
+        assert r.path_versioner == StaticHandler.append_version
+
+    with ManagedServerLoop(application, prefix="/foo/bar") as server:
+        r = server._tornado.resources(absolute_url=True)
         assert r.mode == "server"
         assert r.root_url == f"http://localhost:{server.port}/foo/bar/"
         assert r.path_versioner == StaticHandler.append_version


### PR DESCRIPTION
Fixes the regression introduced in PR #13041. This makes server resource URLs root-relative (i.e. no protocol, host or port), unless specified otherwise.

fixes #13170
