### PR TITLE
Fix intersphinx link

### DIFF
--- a/docs/bokeh/source/docs/reference.rst
+++ b/docs/bokeh/source/docs/reference.rst
@@ -57,10 +57,10 @@ Developers of other packages that make use of Bokeh might want to use
 `intersphinx <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_
 to link to specific classes or functions in the Bokeh docs from their Sphinx
 documentation. The file needed for that is located at
-``https://docs.bokeh.org/en/<version>/objects.inv``
+``https://docs.bokeh.org/en/<version>/``
 where ``<version>`` can be the number of a released version, or "latest". For example
 the entry in the ``conf.py`` file for Sphinx might look like this:
 
 .. code-block:: python
 
-    intersphinx_mapping = {'bokeh': ('https://docs.bokeh.org/en/latest/objects.inv ', None)}
+    intersphinx_mapping = {'bokeh': ('https://docs.bokeh.org/en/latest/', None)}


### PR DESCRIPTION
This is mildly embarrassing, given that I just added this line two days ago, but the intersphinx link should show only the directory, not the filename, which is determined by the second element of the tuple (None means "default", which is objects.inv).

[skip ci]

- [x] issues: fixes #13392
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
