### PR TITLE
Clarify CODE_OF_CONDUCT.md escalation section

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -91,7 +91,7 @@ members of the project's leadership.
 
 ### Escalation
 
-In the event it is necessary to make a report involving someone on the NumFocus committee itself, please use the general [NumFocus CoC reporting form](https://numfocus.org/code-of-conduct).
+In the event it is necessary to make a report involving someone on the [Conduct Sub-committee](https://github.com/bokeh/bokeh/wiki/BEP-4:-Project-Roles#conduct-sub-committee) itself, please use the general [NumFocus CoC reporting form](https://numfocus.org/code-of-conduct).
 
 ### Attribution
 


### PR DESCRIPTION
Noticed while updating a broken link that the verbiage here for escalation was potentially confusing. "NumFOCUS committee" here really meant "Bokeh's committee that interfaces with NumFOCUS" which does not seem entirely clear. In any event the intent is really for an ultimate escape hatch to that the conduct committee would not be investigating itself. 

