### PR TITLE
fix tile_providery.py

### DIFF
--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -254,7 +254,7 @@ class figure(Plot, GlyphAPI):
                 A NumPy array of x-coordinates to bin into hexagonal tiles.
 
             y (array[float]) :
-                A NumPy array of y-coordinates to bin into hexagonal tiles
+                A NumPy array of y-coordinates to bin into hexagonal tiles.
 
             size (float) :
                 The size of the hexagonal tiling to use. The size is defined as
@@ -296,7 +296,7 @@ class figure(Plot, GlyphAPI):
 
         Any additional keyword arguments are passed to :func:`hex_tile`.
 
-        Returns
+        Returns:
             (Glyphrender, DataFrame)
                 A tuple with the ``HexTile`` renderer generated to display the
                 binning, and a Pandas ``DataFrame`` with columns ``q``, ``r``,

--- a/src/bokeh/tile_providers.py
+++ b/src/bokeh/tile_providers.py
@@ -6,40 +6,7 @@
 #-----------------------------------------------------------------------------
 ''' Pre-configured tile sources for common third party tile services.
 
-get_provider
-    Use this function to retrieve an instance of a predefined tile provider.
-
-    .. warning::
-        get_provider is deprecated as of Bokeh 3.0.0 and will be removed in a future
-        release. Use ``add_tile`` directly instead.
-
-    Args:
-        provider_name (Union[str, Vendors, xyzservices.TileProvider])
-            Name of the tile provider to supply.
-
-            Use a ``tile_providers.Vendors`` enumeration value, or the string
-            name of one of the known providers. Use
-            :class:`xyzservices.TileProvider` to pass custom tile providers.
-
-    Returns:
-        WMTSTileProviderSource: The desired tile provider instance
-
-    Raises:
-        ValueError, if the specified provider can not be found
-
-    Example:
-
-        .. code-block:: python
-
-                >>> from bokeh.tile_providers import get_provider, Vendors
-                >>> get_provider(Vendors.CARTODBPOSITRON)
-                <class 'bokeh.models.tiles.WMTSTileSource'>
-                >>> get_provider('CARTODBPOSITRON')
-                <class 'bokeh.models.tiles.WMTSTileSource'>
-
-                >>> import xyzservices.providers as xyz
-                >>> get_provider(xyz.CartoDB.Positron)
-                <class 'bokeh.models.tiles.WMTSTileSource'>
+.. autofunction:: bokeh.tile_providers.get_provider
 
 The available built-in tile providers are listed in the ``Vendors`` enum:
 
@@ -194,7 +161,41 @@ class _TileProvidersModule(types.ModuleType):
 
     Vendors = deprecated_vendors()
 
-    def get_provider(self, provider_name):
+    def get_provider(self, provider_name: str | Vendors | xyzservices.TileProvider):
+        """Use this function to retrieve an instance of a predefined tile provider.
+
+        .. warning::
+            get_provider is deprecated as of Bokeh 3.0.0 and will be removed in a future
+            release. Use ``add_tile`` directly instead.
+
+        Args:
+            provider_name (Union[str, Vendors, xyzservices.TileProvider]):
+                Name of the tile provider to supply.
+
+                Use a ``tile_providers.Vendors`` enumeration value, or the string
+                name of one of the known providers. Use
+                :class:`xyzservices.TileProvider` to pass custom tile providers.
+
+        Returns:
+            WMTSTileProviderSource: The desired tile provider instance.
+
+        Raises:
+            ValueError: if the specified provider can not be found.
+
+        Example:
+
+            .. code-block:: python
+
+                    >>> from bokeh.tile_providers import get_provider, Vendors
+                    >>> get_provider(Vendors.CARTODBPOSITRON)
+                    <class 'bokeh.models.tiles.WMTSTileSource'>
+                    >>> get_provider('CARTODBPOSITRON')
+                    <class 'bokeh.models.tiles.WMTSTileSource'>
+
+                    >>> import xyzservices.providers as xyz
+                    >>> get_provider(xyz.CartoDB.Positron)
+                    <class 'bokeh.models.tiles.WMTSTileSource'>
+        """
         deprecated((3, 0, 0), "get_provider", "add_tile directly")
         from bokeh.models import WMTSTileSource
 


### PR DESCRIPTION
I want to suggest a change in the documentation of the [tile_providers page](https://docs.bokeh.org/en/latest/docs/reference/tile_providers.html#module-bokeh.tile_providers) in the docs. 

- [ ] issues: addresses #13276 (last point in this [comment](https://github.com/bokeh/bokeh/issues/13276#issuecomment-1694644613))


| The current page looks like this|With my changes the generated page will look like this|
|--|--|
|![current_tile_provider_page](https://github.com/bokeh/bokeh/assets/68053396/d2e60d66-4e7c-4784-bcff-14fb2bbc9fdb)|![changed_tile_provider_page](https://github.com/bokeh/bokeh/assets/68053396/76b0bc8e-d0a3-4676-8876-656564c2f43d)|

