### PR TITLE
Allow document events to not be synchronized with server

### DIFF
--- a/bokehjs/src/lib/client/session.ts
+++ b/bokehjs/src/lib/client/session.ts
@@ -79,7 +79,15 @@ export class ClientSession {
   }
 
   protected _document_changed(event: DocumentEvent): void {
-    const events = event instanceof DocumentEventBatch ? event.events : [event]
+    const events = (() => {
+      const events = event instanceof DocumentEventBatch ? (event.sync ? event.events : []) : [event]
+      return events.filter((event) => event.sync)
+    })()
+
+    if (events.length == 0) {
+      return
+    }
+
     const patch = this.document.create_json_patch(events)
 
     // TODO (havocp) the connection may be closed here, which will

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -289,19 +289,28 @@ export class Document implements Equatable {
     return new_title
   }
 
-  add_root(model: HasProps): void {
-    if (this._add_roots(model))
-      this._trigger_on_change(new RootAddedEvent(this, model))
+  add_root(model: HasProps, {sync}: {sync?: boolean} = {}): void {
+    if (this._add_roots(model)) {
+      const event = new RootAddedEvent(this, model)
+      event.sync = sync ?? true
+      this._trigger_on_change(event)
+    }
   }
 
-  remove_root(model: HasProps): void {
-    if (this._remove_root(model))
-      this._trigger_on_change(new RootRemovedEvent(this, model))
+  remove_root(model: HasProps, {sync}: {sync?: boolean} = {}): void {
+    if (this._remove_root(model)) {
+      const event = new RootRemovedEvent(this, model)
+      event.sync = sync ?? true
+      this._trigger_on_change(event)
+    }
   }
 
-  set_title(title: string): void {
-    if (this._set_title(title))
-      this._trigger_on_change(new TitleChangedEvent(this, title))
+  set_title(title: string, {sync}: {sync?: boolean} = {}): void {
+    if (this._set_title(title)) {
+      const event = new TitleChangedEvent(this, title)
+      event.sync = sync ?? true
+      this._trigger_on_change(event)
+    }
   }
 
   title(): string {
@@ -543,19 +552,20 @@ export class Document implements Equatable {
           break
         }
         case "RootAdded": {
-          this._add_roots(event.model)
+          this.add_root(event.model, {sync: false})
           break
         }
         case "RootRemoved": {
-          this._remove_root(event.model)
+          this.remove_root(event.model, {sync: false})
           break
         }
         case "TitleChanged": {
-          this._set_title(event.title)
+          this.set_title(event.title, {sync: false})
           break
         }
-        default:
+        default: {
           throw new Error(`unknown patch event type '${(event as any).kind}'`) // XXX
+        }
       }
     }
 

--- a/bokehjs/src/lib/document/events.ts
+++ b/bokehjs/src/lib/document/events.ts
@@ -128,6 +128,13 @@ export abstract class DocumentEvent implements Equatable {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.document, that.document)
   }
+
+  /**
+   * Indicates whether this event should be emitted internally within bokehjs,
+   * or whether it should also be synchronized with the server, if any session
+   * is listening for such events.
+   */
+  sync: boolean = true
 }
 
 export class DocumentEventBatch<T extends DocumentChangedEvent> extends DocumentEvent {

--- a/bokehjs/src/lib/embed/standalone.ts
+++ b/bokehjs/src/lib/embed/standalone.ts
@@ -1,5 +1,4 @@
 import type {Document} from "../document"
-import type {DocumentChangedEvent} from "../document"
 import {RootAddedEvent, RootRemovedEvent, TitleChangedEvent} from "../document"
 import type {HasProps} from "../core/has_props"
 import type {View} from "../core/view"
@@ -93,7 +92,7 @@ export async function add_document_standalone(document: Document, element: Embed
     window.document.title = document.title()
   }
 
-  document.on_change((event: DocumentChangedEvent): void => {
+  document.on_change((event) => {
     if (event instanceof RootAddedEvent) {
       render_model(event.model)
     } else if (event instanceof RootRemovedEvent) {

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -967,13 +967,15 @@ describe("Document", () => {
       const patch = doc.create_json_patch([event])
       doc.apply_json_patch(patch)
 
-      expect(events.length).to.be.equal(0)
+      expect(events.filter((e) => e.sync).length).to.be.equal(0)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(doc.roots().length).to.be.equal(1)
 
       const model1 = new SomeModel({foo: 128})
       doc.add_root(model1)
 
-      expect(events.length).to.be.equal(1)
+      expect(events.filter((e) => e.sync).length).to.be.equal(1)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(doc.roots().length).to.be.equal(2)
     })
 
@@ -993,12 +995,14 @@ describe("Document", () => {
       const patch = doc.create_json_patch([event])
       doc.apply_json_patch(patch)
 
-      expect(events.length).to.be.equal(0)
+      expect(events.filter((e) => e.sync).length).to.be.equal(0)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(doc.roots().length).to.be.equal(1)
 
       doc.remove_root(model1)
 
-      expect(events.length).to.be.equal(1)
+      expect(events.filter((e) => e.sync).length).to.be.equal(1)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(doc.roots().length).to.be.equal(0)
     })
 
@@ -1014,12 +1018,14 @@ describe("Document", () => {
       const patch = doc.create_json_patch([event])
       doc.apply_json_patch(patch)
 
-      expect(events.length).to.be.equal(0)
+      expect(events.filter((e) => e.sync).length).to.be.equal(0)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(doc.title()).to.be.equal("some title")
 
       doc.set_title("other title")
 
-      expect(events.length).to.be.equal(1)
+      expect(events.filter((e) => e.sync).length).to.be.equal(1)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(doc.title()).to.be.equal("other title")
     })
 
@@ -1038,12 +1044,14 @@ describe("Document", () => {
       const patch = doc.create_json_patch([event])
       doc.apply_json_patch(patch)
 
-      expect(events.length).to.be.equal(0)
+      expect(events.filter((e) => e.sync).length).to.be.equal(0)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(model.foo).to.be.equal(128)
 
       model.foo = 129
 
-      expect(events.length).to.be.equal(1)
+      expect(events.filter((e) => e.sync).length).to.be.equal(1)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(model.foo).to.be.equal(129)
     })
 
@@ -1060,7 +1068,8 @@ describe("Document", () => {
       const patch = doc.create_json_patch([event])
       doc.apply_json_patch(patch)
 
-      expect(events.length).to.be.equal(0)
+      expect(events.filter((e) => e.sync).length).to.be.equal(0)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(source.data).to.be.equal({col1: [4, 5, 6]})
     })
 
@@ -1077,12 +1086,14 @@ describe("Document", () => {
       const patch = doc.create_json_patch([event])
       doc.apply_json_patch(patch)
 
-      expect(events.length).to.be.equal(0)
+      expect(events.filter((e) => e.sync).length).to.be.equal(0)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(source.data).to.be.equal({col0: [1, 2, 3, 4, 5, 6]})
 
       source.stream({col0: [7, 8, 9]})
 
-      expect(events.length).to.be.equal(1)
+      expect(events.filter((e) => e.sync).length).to.be.equal(1)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(source.data).to.be.equal({col0: [1, 2, 3, 4, 5, 6, 7, 8, 9]})
     })
 
@@ -1099,12 +1110,14 @@ describe("Document", () => {
       const patch = doc.create_json_patch([event])
       doc.apply_json_patch(patch)
 
-      expect(events.length).to.be.equal(0)
+      expect(events.filter((e) => e.sync).length).to.be.equal(0)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(source.data).to.be.equal({col0: [1, 20, 30, 4, 5, 6]})
 
       source.patch({col0: [[new Slice({start: 3, stop: 5}), [40, 50]]]})
 
-      expect(events.length).to.be.equal(1)
+      expect(events.filter((e) => e.sync).length).to.be.equal(1)
+      expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(source.data).to.be.equal({col0: [1, 20, 30, 40, 50, 6]})
     })
   })


### PR DESCRIPTION
This PR allows internal (within bokehjs) propagation of document change events, while not allowing boomeranging events back to the server.

TODO:

- [x] tests

fixes #13131
