### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -210,7 +210,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -57,7 +57,7 @@ dependencies:
   - notebook
   - pandas-datareader
   - pyshp
-  #- scikit-learn
+  - scikit-learn
   #- squarify
   - sympy
 
@@ -85,4 +85,3 @@ dependencies:
     - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13407
     # move the following back to conda sections above when python 3.12 conda-forge packages available
     - squarify
-    - scikit-learn

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -57,8 +57,8 @@ dependencies:
   - notebook
   - pandas-datareader
   - pyshp
-  - scikit-learn
-  - squarify
+  #- scikit-learn
+  #- squarify
   - sympy
 
   # pip dependencies
@@ -74,7 +74,7 @@ dependencies:
     - sphinx-favicon
     - sphinxext-opengraph
     # tests
-    - pandas-stubs ==1.5.2.221213
+    #- pandas-stubs ==1.5.2.221213 # Not for python 3.12
     - ruff ==0.0.285
     - types-boto
     - types-colorama
@@ -83,3 +83,6 @@ dependencies:
     - types-pyyaml
     - types-requests
     - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13407
+    # move the following back to conda sections above when python 3.12 conda-forge packages available
+    - squarify
+    - scikit-learn

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -1,0 +1,85 @@
+name: bk-test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+
+  # runtime
+  - contourpy >=1
+  - jinja2 >=2.7
+  - numpy >=1.20.0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=4.0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=5
+  - xyzservices>=2021.09.1
+
+  # tests
+  - beautifulsoup4
+  - channels
+  - click
+  - colorama
+  - colorcet
+  - coverage
+  - firefox =>96
+  - geckodriver
+  - ipython
+  - isort 5.8
+  - json5
+  - nbconvert >=5.4
+  - networkx
+  - nodejs 18.*
+  - pre-commit
+  - psutil
+  - pygments
+  - pygraphviz
+  - pytest >=7.0
+  - pytest-asyncio >=0.18.1
+  - pytest-cov >=1.8.1
+  - pytest-html
+  - pytest-xdist
+  - pytest-timeout
+  - requests >=1.2.3
+  - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
+  - scipy
+  - pooch # required in scipy.datasets
+  - selenium 4.2
+  - toml
+  - typing_extensions >=4.0.0
+
+  # examples
+  - flask >=1.0
+  - h5py
+  - icalendar
+  - networkx
+  - notebook
+  - pandas-datareader
+  - pyshp
+  - scikit-learn
+  - squarify
+  - sympy
+
+  # pip dependencies
+  - pip
+  - pip:
+    - mypy >=0.990
+    # docs
+    - pydata_sphinx_theme
+    - requests-unixsocket >= 0.3.0
+    - sphinx
+    - sphinx-copybutton
+    - sphinx-design
+    - sphinx-favicon
+    - sphinxext-opengraph
+    # tests
+    - pandas-stubs ==1.5.2.221213
+    - ruff ==0.0.285
+    - types-boto
+    - types-colorama
+    - types-mock
+    - types-pillow
+    - types-pyyaml
+    - types-requests
+    - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13407

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: JavaScript",
     "Topic :: Office/Business",
     "Topic :: Office/Business :: Financial",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,8 @@ filterwarnings = [
     '''ignore:elementwise comparison failed; this will raise an error in the future\.:DeprecationWarning''',
     '''ignore:numba is not installed\. This example will be painfully slow\.:UserWarning''',
     '''ignore:Could not infer format, so each element will be parsed individually, falling back to `dateutil`\. To ensure parsing is consistent and as-expected, please specify a format\.:UserWarning''',
-    '''ignore:datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version:DeprecationWarning:dateutil''',
+    #'''ignore:datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version:DeprecationWarning:dateutil''',
+    '''ignore::DeprecationWarning''',
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ filterwarnings = [
     '''ignore:elementwise comparison failed; this will raise an error in the future\.:DeprecationWarning''',
     '''ignore:numba is not installed\. This example will be painfully slow\.:UserWarning''',
     '''ignore:Could not infer format, so each element will be parsed individually, falling back to `dateutil`\. To ensure parsing is consistent and as-expected, please specify a format\.:UserWarning''',
+    '''ignore:datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version:DeprecationWarning:dateutil''',
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,7 @@ filterwarnings = [
     '''ignore:elementwise comparison failed; this will raise an error in the future\.:DeprecationWarning''',
     '''ignore:numba is not installed\. This example will be painfully slow\.:UserWarning''',
     '''ignore:Could not infer format, so each element will be parsed individually, falling back to `dateutil`\. To ensure parsing is consistent and as-expected, please specify a format\.:UserWarning''',
-    #'''ignore:datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version:DeprecationWarning:dateutil''',
-    '''ignore::DeprecationWarning''',
+    '''ignore:datetime.datetime.utcfromtimestamp():DeprecationWarning:dateutil''',
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
Now that CPython 3.12 has been released, try it out in CI in the hope that it can be included in the upcoming 3.3 release. Also added 3.12 to classifiers.