### PR TITLE
Finalize migration from plain objects to `Map`

### DIFF
--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -601,7 +601,7 @@ export const Struct = <T extends {[key: string]: unknown}>(struct_type: Kinds.Ob
 export const PartialStruct = <T extends {[key: string]: unknown}>(struct_type: Kinds.ObjectKind<T>) => new Kinds.PartialStruct(struct_type)
 export const Arrayable = <ItemType>(item_type: Kind<ItemType>) => new Kinds.Arrayable(item_type)
 export const Array = <ItemType>(item_type: Kind<ItemType>) => new Kinds.Array(item_type)
-export const Dict = <V>(item_type: Kind<V>) => new Kinds.Dict(item_type)
+export const Dict = <V>(item_type: Kind<V>) => new Kinds.Map(String, item_type)
 export const Map = <K, V>(key_type: Kind<K>, item_type: Kind<V>) => new Kinds.Map(key_type, item_type)
 export const Set = <V>(item_type: Kind<V>) => new Kinds.Set(item_type)
 export const Enum = <T extends string | number>(...values: T[]) => new Kinds.Enum(values)

--- a/bokehjs/src/lib/core/property_mixins.ts
+++ b/bokehjs/src/lib/core/property_mixins.ts
@@ -8,7 +8,7 @@ import {isString} from "./util/types"
 import type {HasProps} from "./has_props"
 
 export type HatchPattern = HatchPatternType | string
-export type HatchExtra = {[key: string]: Texture | undefined}
+export type HatchExtra = Map<string, Texture | undefined>
 
 // Primitive
 
@@ -77,7 +77,7 @@ export const Hatch: p.DefineOf<Hatch> = {
   hatch_scale:      [ k.Number, 12.0 ],
   hatch_pattern:    [ k.Nullable(k.Or(HatchPatternType, k.String)), null ],
   hatch_weight:     [ k.Number, 1.0 ],
-  hatch_extra:      [ k.Dict(k.AnyRef<Texture>()), {} ], // XXX: recursive imports
+  hatch_extra:      [ k.Dict(k.AnyRef<Texture>()), new Map() ], // XXX: recursive imports
 }
 
 export const Text: p.DefineOf<Text> = {
@@ -159,7 +159,7 @@ export const HatchScalar: p.DefineOf<HatchScalar> = {
   hatch_scale:      [ p.NumberScalar,       12.0        ],
   hatch_pattern:    [ p.NullStringScalar,   null        ],
   hatch_weight:     [ p.NumberScalar,       1.0         ],
-  hatch_extra:      [ p.AnyScalar,          {}          ],
+  hatch_extra:      [ p.AnyScalar,          new Map()   ],
 }
 
 export const TextScalar: p.DefineOf<TextScalar> = {
@@ -241,7 +241,7 @@ export const HatchVector: p.DefineOf<HatchVector> = {
   hatch_scale:      [ p.NumberSpec,     12.0        ],
   hatch_pattern:    [ p.NullStringSpec, null        ],
   hatch_weight:     [ p.NumberSpec,     1.0         ],
-  hatch_extra:      [ p.AnyScalar,      {}          ],
+  hatch_extra:      [ p.AnyScalar,      new Map()   ],
 }
 
 export const TextVector: p.DefineOf<TextVector> = {

--- a/bokehjs/src/lib/core/serialization/deserializer.ts
+++ b/bokehjs/src/lib/core/serialization/deserializer.ts
@@ -7,7 +7,7 @@ import {is_ref} from "../util/refs"
 import type {NDArray} from "../util/ndarray"
 import {ndarray} from "../util/ndarray"
 import {entries, Dict} from "../util/object"
-import {map, every} from "../util/array"
+import {map} from "../util/array"
 import {BYTE_ORDER} from "../util/platform"
 import {base64_to_buffer, swap} from "../util/buffer"
 import {isArray, isPlainObject, isString, isNumber} from "../util/types"
@@ -191,17 +191,9 @@ export class Deserializer {
     return decoded
   }
 
-  protected _decode_map(obj: MapRep): Map<unknown, unknown> | {[key: string]: unknown} {
+  protected _decode_map(obj: MapRep): Map<unknown, unknown> {
     const decoded = map(obj.entries ?? [], ([key, val]) => [this._decode(key), this._decode(val)] as const)
-    const is_str = every(decoded, ([key]) => isString(key))
-    if (is_str) {
-      const obj: {[key: string]: unknown} = {} // Object.create(null)
-      for (const [key, val] of decoded) {
-        obj[key as string] = val
-      }
-      return obj
-    } else
-      return new Map(decoded)
+    return new Map(decoded)
   }
 
   protected _decode_bytes(obj: BytesRep): ArrayBuffer {

--- a/bokehjs/src/lib/core/serialization/serializer.ts
+++ b/bokehjs/src/lib/core/serialization/serializer.ts
@@ -2,7 +2,7 @@ import type {TypedArray} from "../types"
 import {assert} from "../util/assert"
 import {entries} from "../util/object"
 import type {Ref} from "../util/refs"
-import {/*isBasicObject, */isPlainObject, isObject, isArray, isTypedArray, isBoolean, isNumber, isString, isSymbol} from "../util/types"
+import {isPlainObject, isObject, isArray, isTypedArray, isBoolean, isNumber, isString, isSymbol} from "../util/types"
 import {map} from "../util/iterator"
 import {BYTE_ORDER} from "../util/platform"
 import {Buffer, Base64Buffer} from "./buffer"
@@ -131,16 +131,6 @@ export class Serializer {
         return {type: "map"}
       else
         return {type: "map", entries: [...map(items, ([key, val]) => [this.encode(key), this.encode(val)])]}
-    /*
-    } else if (isBasicObject(obj)) {
-      return {type: "map", entries: [...map(entries(obj), ([key, val]) => [this.encode(key), this.encode(val)])]}
-    } else if (isPlainObject(obj)) {
-      const result: {[key: string]: unknown} = {}
-      for (const [key, value] of entries(obj)) {
-        result[key] = this.encode(value)
-      }
-      return result
-    */
     } else if (obj === null || isBoolean(obj) || isString(obj)) {
       return obj
     } else if (isNumber(obj)) {

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -69,7 +69,7 @@ export type ArrayableNew = {new <T>(n: number): Arrayable<T>}
 
 export type ArrayableOf<T> = T extends unknown ? Arrayable<T> : never
 
-export type Data = {[key: string]: Arrayable<unknown>}
+export type Data = Map<string, Arrayable<unknown>>
 
 export type Attrs = {[key: string]: unknown}
 

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -1,7 +1,5 @@
 import type {PlainObject, Arrayable} from "../types"
-import {concat, union} from "./array"
-
-const {hasOwnProperty} = Object.prototype
+import {union} from "./array"
 
 export const {keys, values, entries, assign, fromEntries: to_object} = Object
 export const extend = assign
@@ -16,18 +14,19 @@ export function clone<T>(obj: PlainObject<T>): PlainObject<T> {
   return {...obj}
 }
 
-export function merge<T>(obj1: PlainObject<Arrayable<T>>, obj2: PlainObject<Arrayable<T>>): PlainObject<T[]> {
+export function merge<K, V>(obj0: Map<K, Arrayable<V>>, obj1: Map<K, Arrayable<V>>): Map<K, V[]> {
   /*
    * Returns an object with the array values for obj1 and obj2 unioned by key.
    */
-  const result: PlainObject<T[]> = Object.create(Object.prototype)
-
-  const keys = concat([Object.keys(obj1), Object.keys(obj2)])
+  const result: Map<K, V[]> = new Map()
+  const keys = [...obj0.keys(), ...obj1.keys()]
 
   for (const key of keys) {
-    const arr1 = hasOwnProperty.call(obj1, key) ? obj1[key] : []
-    const arr2 = hasOwnProperty.call(obj2, key) ? obj2[key] : []
-    result[key] = union(arr1, arr2)
+    const v0 = obj0.get(key)
+    const v1 = obj1.get(key)
+    const arr0 = v0 === undefined ? [] : v0
+    const arr1 = v1 === undefined ? [] : v1
+    result.set(key, union(arr0, arr1))
   }
 
   return result

--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -12,7 +12,7 @@ export const FormatterType = Enum("numeral", "printf", "datetime")
 export type FormatterType = "numeral" | "printf" | "datetime"
 
 export type FormatterSpec = CustomJSHover | FormatterType
-export type Formatters = {[key: string]: FormatterSpec}
+export type Formatters = Map<string, FormatterSpec>
 export type FormatterFunc = (value: unknown, format: string, special_vars: Vars) => string
 export type Index = number | ImageIndex
 export type Vars = {[key: string]: unknown}
@@ -51,9 +51,8 @@ export function get_formatter(raw_spec: string, format?: string, formatters?: Fo
     return basic_formatter
 
   // format spec in the formatters dict, use that
-  if (formatters != null && raw_spec in formatters) {
-    const formatter = formatters[raw_spec]
-
+  const formatter = formatters?.get(raw_spec)
+  if (formatter != null) {
     if (isString(formatter)) {
       if (formatter in DEFAULT_FORMATTERS)
         return DEFAULT_FORMATTERS[formatter]

--- a/bokehjs/src/lib/core/visuals/hatch.ts
+++ b/bokehjs/src/lib/core/visuals/hatch.ts
@@ -29,7 +29,7 @@ export class Hatch extends VisualProperties {
     }
 
     const textures = this.hatch_extra.get_value()
-    const texture = textures[pattern]
+    const texture = textures.get(pattern)
     if (texture != null) {
       const image = texture.get_pattern(color, alpha, scale, weight)
       if (image instanceof Promise) {
@@ -82,7 +82,7 @@ export class Hatch extends VisualProperties {
 
   repetition(): CanvasPatternRepetition {
     const pattern = this.hatch_pattern.get_value()!
-    const texture = this.hatch_extra.get_value()[pattern]
+    const texture = this.hatch_extra.get_value().get(pattern)
     if (texture == null)
       return "repeat"
     else {
@@ -139,7 +139,7 @@ export class HatchScalar extends VisualUniforms {
     }
 
     const textures = this.hatch_extra.value
-    const texture = textures[pattern]
+    const texture = textures.get(pattern)
     if (texture != null) {
       const image = texture.get_pattern(color, alpha, scale, weight)
       if (image instanceof Promise) {
@@ -188,7 +188,7 @@ export class HatchScalar extends VisualUniforms {
   repetition(): CanvasPatternRepetition {
     const pattern = this.hatch_pattern.value
     if (pattern != null) {
-      const texture = this.hatch_extra.value[pattern]
+      const texture = this.hatch_extra.value.get(pattern)
       if (texture != null) {
         switch (texture.repetition) {
           case "repeat":    return "repeat"
@@ -245,7 +245,7 @@ export class HatchVector extends VisualUniforms {
     const resolve_image = (pattern: HatchPattern, color: Color, alpha: number, scale: number, weight: number,
         finalize: (image: CanvasImageSource) => void) => {
       const textures = this.hatch_extra.value
-      const texture = textures[pattern]
+      const texture = textures.get(pattern)
       if (texture != null) {
         const image = texture.get_pattern(color, alpha, scale, weight)
         if (image instanceof Promise) {
@@ -342,7 +342,7 @@ export class HatchVector extends VisualUniforms {
   repetition(i: number): CanvasPatternRepetition {
     const pattern = this.hatch_pattern.get(i)
     if (pattern != null) {
-      const texture = this.hatch_extra.value[pattern]
+      const texture = this.hatch_extra.value.get(pattern)
       if (texture != null) {
         switch (texture.repetition) {
           case "repeat":    return "repeat"

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -542,9 +542,9 @@ export class Document implements Equatable {
           const {model, attr, cols, data} = event
           if (cols != null) {
             const current_data = model.property(attr).get_value() as Data
-            for (const k in current_data) {
-              if (!(k in data)) {
-                data[k] = current_data[k]
+            for (const [name, column] of current_data) {
+              if (!data.has(name)) {
+                data.set(name, column)
               }
             }
           }

--- a/bokehjs/src/lib/models/canvas/cartesian_frame.ts
+++ b/bokehjs/src/lib/models/canvas/cartesian_frame.ts
@@ -7,12 +7,11 @@ import {DataRange1d} from "../ranges/data_range1d"
 import {FactorRange} from "../ranges/factor_range"
 
 import {BBox} from "core/util/bbox"
-import {entries} from "core/util/object"
 import {assert} from "core/util/assert"
 import {Signal0} from "core/signaling"
 
-type Ranges = {[key: string]: Range}
-type Scales = {[key: string]: Scale}
+type Ranges = Map<string, Range>
+type Scales = Map<string, Scale>
 
 export class CartesianFrame {
 
@@ -27,10 +26,10 @@ export class CartesianFrame {
               public in_y_scale: Scale,
               public x_range: Range,
               public y_range: Range,
-              public extra_x_ranges: Ranges = {},
-              public extra_y_ranges: Ranges = {},
-              public extra_x_scales: Scales = {},
-              public extra_y_scales: Scales = {}) {
+              public extra_x_ranges: Ranges = new Map(),
+              public extra_y_ranges: Ranges = new Map(),
+              public extra_x_scales: Scales = new Map(),
+              public extra_y_scales: Scales = new Map()) {
     assert(in_x_scale.properties.source_range.is_unset && in_x_scale.properties.target_range.is_unset)
     assert(in_y_scale.properties.source_range.is_unset && in_y_scale.properties.target_range.is_unset)
     this._configure_scales()
@@ -45,12 +44,14 @@ export class CartesianFrame {
   protected _x_scales: Map<string, Scale>
   protected _y_scales: Map<string, Scale>
 
-  protected _get_ranges(range: Range, extra_ranges: Ranges): Map<string, Range> {
-    return new Map(entries({...extra_ranges, default: range}))
+  protected _get_ranges(range: Range, extra_ranges: Ranges): Ranges {
+    const ranges = new Map(extra_ranges)
+    ranges.set("default", range)
+    return ranges
   }
 
-  /*protected*/ _get_scales(scale: Scale, extra_scales: Scales, ranges: Map<string, Range>, frame_range: Range): Map<string, Scale> {
-    const in_scales = new Map(entries({...extra_scales, default: scale}))
+  /*protected*/ _get_scales(scale: Scale, extra_scales: Scales, ranges: Ranges, frame_range: Range): Scales {
+    const in_scales = new Map([...extra_scales.entries(), ["default", scale]])
     const scales: Map<string, Scale> = new Map()
 
     for (const [name, range] of ranges) {

--- a/bokehjs/src/lib/models/dom/dom_element.ts
+++ b/bokehjs/src/lib/models/dom/dom_element.ts
@@ -3,7 +3,6 @@ import {Styles} from "./styles"
 import {UIElement} from "../ui/ui_element"
 import type {ViewStorage, IterViews} from "core/build_views"
 import {build_views, remove_views} from "core/build_views"
-import {entries} from "core/util/object"
 import {isString} from "core/util/types"
 import type * as p from "core/properties"
 
@@ -50,7 +49,7 @@ export abstract class DOMElementView extends DOMNodeView {
           }
         }
       } else {
-        for (const [key, value] of entries(style)) {
+        for (const [key, value] of style) {
           const name = key.replace(/_/g, "-")
           if (this.el.style.hasOwnProperty(name)) {
             this.el.style.setProperty(name, value)
@@ -76,7 +75,7 @@ export abstract class DOMElementView extends DOMNodeView {
 export namespace DOMElement {
   export type Attrs = p.AttrsOf<Props>
   export type Props = DOMNode.Props & {
-    style: p.Property<Styles | {[key: string]: string} | null>
+    style: p.Property<Styles | Map<string, string> | null>
     children: p.Property<(string | DOMNode | UIElement)[]>
   }
 }

--- a/bokehjs/src/lib/models/expressions/cumsum.ts
+++ b/bokehjs/src/lib/models/expressions/cumsum.ts
@@ -2,6 +2,7 @@ import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import {Expression} from "./expression"
 import type {Arrayable} from "core/types"
 import type * as p from "core/properties"
+import {assert} from "core/util/assert"
 
 export namespace CumSum {
   export type Attrs = p.AttrsOf<Props>
@@ -30,7 +31,8 @@ export class CumSum extends Expression {
 
   protected _v_compute(source: ColumnarDataSource): Arrayable<number> {
     const result = new Float64Array(source.get_length() ?? 0)
-    const col = source.data[this.field]
+    const col = source.data.get(this.field)
+    assert(col != null && col.length == result.length)
     const offset = this.include_zero ? 1 : 0
     result[0] = this.include_zero ? 0 : col[0]
     for (let i = 1; i < result.length; i++) {

--- a/bokehjs/src/lib/models/expressions/maximum.ts
+++ b/bokehjs/src/lib/models/expressions/maximum.ts
@@ -1,6 +1,5 @@
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import {ScalarExpression} from "./expression"
-import {dict} from "core/util/object"
 import {max} from "core/util/array"
 import type * as p from "core/properties"
 
@@ -30,7 +29,7 @@ export class Maximum extends ScalarExpression<number> {
   }
 
   protected _compute(source: ColumnarDataSource): number {
-    const column = dict(source.data).get(this.field) ?? []
+    const column = source.data.get(this.field) ?? []
     return Math.max(this.initial, max(column))
   }
 }

--- a/bokehjs/src/lib/models/expressions/minimum.ts
+++ b/bokehjs/src/lib/models/expressions/minimum.ts
@@ -1,6 +1,5 @@
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import {ScalarExpression} from "./expression"
-import {dict} from "core/util/object"
 import {min} from "core/util/array"
 import type * as p from "core/properties"
 
@@ -30,7 +29,7 @@ export class Minimum extends ScalarExpression<number> {
   }
 
   protected _compute(source: ColumnarDataSource): number {
-    const column = dict(source.data).get(this.field) ?? []
+    const column = source.data.get(this.field) ?? []
     return Math.min(this.initial, min(column))
   }
 }

--- a/bokehjs/src/lib/models/expressions/stack.ts
+++ b/bokehjs/src/lib/models/expressions/stack.ts
@@ -1,6 +1,5 @@
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import {Expression} from "./expression"
-import {dict} from "core/util/object"
 import type {Arrayable} from "core/types"
 import type * as p from "core/properties"
 
@@ -31,7 +30,7 @@ export class Stack extends Expression {
     const n = source.get_length() ?? 0
     const result = new Float64Array(n)
     for (const f of this.fields) {
-      const column = dict(source.data).get(f)
+      const column = source.data.get(f)
       if (column != null) {
         const k = Math.min(n, column.length)
         for (let i = 0; i < k; i++) {

--- a/bokehjs/src/lib/models/filters/customjs_filter.ts
+++ b/bokehjs/src/lib/models/filters/customjs_filter.ts
@@ -1,7 +1,6 @@
 import {Filter} from "./filter"
 import type * as p from "core/properties"
 import {Indices} from "core/types"
-import {keys, values} from "core/util/object"
 import {isArrayOf, isBoolean, isInteger} from "core/util/types"
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import {use_strict} from "core/util/string"
@@ -10,7 +9,7 @@ export namespace CustomJSFilter {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Filter.Props & {
-    args: p.Property<{[key: string]: unknown}>
+    args: p.Property<Map<string, unknown>>
     code: p.Property<string>
   }
 }
@@ -26,17 +25,17 @@ export class CustomJSFilter extends Filter {
 
   static {
     this.define<CustomJSFilter.Props>(({Unknown, String, Dict}) => ({
-      args: [ Dict(Unknown), {} ],
+      args: [ Dict(Unknown), new Map() ],
       code: [ String, "" ],
     }))
   }
 
-  get names(): string[] {
-    return keys(this.args)
+  get names(): Iterable<string> {
+    return this.args.keys()
   }
 
-  get values(): any[] {
-    return values(this.args)
+  get values(): Iterable<unknown> {
+    return this.args.values()
   }
 
   get func(): Function {

--- a/bokehjs/src/lib/models/formatters/customjs_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/customjs_tick_formatter.ts
@@ -1,13 +1,12 @@
 import {TickFormatter} from "./tick_formatter"
 import type * as p from "core/properties"
-import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
 
 export namespace CustomJSTickFormatter {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = TickFormatter.Props & {
-    args: p.Property<{[key: string]: unknown}>
+    args: p.Property<Map<string, unknown>>
     code: p.Property<string>
   }
 }
@@ -23,17 +22,17 @@ export class CustomJSTickFormatter extends TickFormatter {
 
   static {
     this.define<CustomJSTickFormatter.Props>(({Unknown, String, Dict}) => ({
-      args: [ Dict(Unknown), {} ],
+      args: [ Dict(Unknown), new Map() ],
       code: [ String, "" ],
     }))
   }
 
-  get names(): string[] {
-    return keys(this.args)
+  get names(): Iterable<string> {
+    return this.args.keys()
   }
 
-  get values(): unknown[] {
-    return values(this.args)
+  get values(): Iterable<unknown> {
+    return this.args.values()
   }
 
   /*protected*/ _make_func(): Function {

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -7,7 +7,6 @@ import type {Rect, RaggedArray, FloatArray, ScreenArray} from "core/types"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {minmax2} from "core/util/arrayable"
-import {to_object} from "core/util/object"
 import type {Context2d} from "core/util/canvas"
 import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
@@ -113,7 +112,7 @@ export class MultiLineView extends GlyphView {
 
     return new Selection({
       indices: [...hits.keys()],
-      multiline_indices: to_object(hits), // TODO: remove to_object()
+      multiline_indices: hits,
     })
   }
 
@@ -145,7 +144,7 @@ export class MultiLineView extends GlyphView {
 
     return new Selection({
       indices: [...hits.keys()],
-      multiline_indices: to_object(hits), // TODO: remove to_object()
+      multiline_indices: hits,
     })
   }
 

--- a/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
@@ -164,23 +164,29 @@ export class NodesAndLinkedEdges extends GraphHitTestPolicy {
   }
 
   get_linked_edges(node_source: ColumnarDataSource, edge_source: ColumnarDataSource, mode: IndicesType): Selection {
+    const index = node_source.get("index")
+
     const node_indices = (() => {
       switch (mode) {
-        case "selection":  return map(node_source.selected.indices, (i) => node_source.data.index[i])
-        case "inspection": return map(node_source.inspected.indices, (i) => node_source.data.index[i])
+        case "selection":  return map(node_source.selected.indices, (i) => index[i])
+        case "inspection": return map(node_source.inspected.indices, (i) => index[i])
       }
     })()
 
+    const start = edge_source.get("start")
+    const end = edge_source.get("end")
+
     const edge_indices = []
-    for (let i = 0; i < edge_source.data.start.length; i++) {
-      if (contains(node_indices, edge_source.data.start[i]) || contains(node_indices, edge_source.data.end[i])) {
+    const n = start.length
+    for (let i = 0; i < n; i++) {
+      if (contains(node_indices, start[i]) || contains(node_indices, end[i])) {
         edge_indices.push(i)
       }
     }
 
     const linked_edges = new Selection()
     for (const i of edge_indices) {
-      linked_edges.multiline_indices[i] = [0] //currently only supports 2-element multilines, so this is all of it
+      linked_edges.multiline_indices.set(i, [0]) //currently only supports 2-element multilines, so this is all of it
     }
     linked_edges.indices = edge_indices
 
@@ -252,13 +258,16 @@ export class EdgesAndLinkedNodes extends GraphHitTestPolicy {
       }
     })()
 
+    const start = edge_source.get("start")
+    const end = edge_source.get("end")
+
     const nodes = []
     for (const i of edge_indices) {
-      nodes.push(edge_source.data.start[i])
-      nodes.push(edge_source.data.end[i])
+      nodes.push(start[i], end[i])
     }
 
-    const node_indices = uniq(nodes).map((i) => index_of(node_source.data.index, i))
+    const index = node_source.get("index")
+    const node_indices = uniq(nodes).map((i) => index_of(index, i))
     return new Selection({indices: node_indices})
   }
 
@@ -320,30 +329,35 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
   }
 
   get_adjacent_nodes(node_source: ColumnarDataSource, edge_source: ColumnarDataSource, mode: IndicesType): Selection {
+    const index = node_source.get("index")
+
     const selected_node_indices = (() => {
       switch (mode) {
-        case "selection":  return map(node_source.selected.indices, (i) => node_source.data.index[i])
-        case "inspection": return map(node_source.inspected.indices, (i) => node_source.data.index[i])
+        case "selection":  return map(node_source.selected.indices, (i) => index[i])
+        case "inspection": return map(node_source.inspected.indices, (i) => index[i])
       }
     })()
 
+    const start = edge_source.get("start")
+    const end = edge_source.get("end")
+
     const adjacent_nodes = []
     const selected_nodes = []
-    for (let i = 0; i < edge_source.data.start.length; i++) {
-      if (contains(selected_node_indices, edge_source.data.start[i])) {
-        adjacent_nodes.push(edge_source.data.end[i])
-        selected_nodes.push(edge_source.data.start[i])
+    for (let i = 0; i < start.length; i++) {
+      if (contains(selected_node_indices, start[i])) {
+        adjacent_nodes.push(end[i])
+        selected_nodes.push(start[i])
       }
-      if (contains(selected_node_indices, edge_source.data.end[i])) {
-        adjacent_nodes.push(edge_source.data.start[i])
-        selected_nodes.push(edge_source.data.end[i])
+      if (contains(selected_node_indices, end[i])) {
+        adjacent_nodes.push(start[i])
+        selected_nodes.push(end[i])
       }
     }
     for (let i = 0; i < selected_nodes.length; i++) {
       adjacent_nodes.push(selected_nodes[i])
     }
 
-    const adjacent_node_indices = uniq(adjacent_nodes).map((i) => index_of(node_source.data.index, i))
+    const adjacent_node_indices = uniq(adjacent_nodes).map((i) => index_of(index, i))
     return new Selection({indices: adjacent_node_indices})
   }
 

--- a/bokehjs/src/lib/models/graphs/static_layout_provider.ts
+++ b/bokehjs/src/lib/models/graphs/static_layout_provider.ts
@@ -1,7 +1,6 @@
 import {LayoutProvider} from "./layout_provider"
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import type {Arrayable} from "core/types"
-import {Dict} from "core/util/object"
 import type * as p from "core/properties"
 
 export namespace StaticLayoutProvider {
@@ -28,7 +27,7 @@ export class StaticLayoutProvider extends LayoutProvider {
   }
 
   get_node_coordinates(node_source: ColumnarDataSource): [Arrayable<number>, Arrayable<number>] {
-    const data = new Dict(node_source.data)
+    const {data} = node_source
     const index = data.get("index") ?? []
     const n = index.length
     const xs = new Float64Array(n)
@@ -44,7 +43,7 @@ export class StaticLayoutProvider extends LayoutProvider {
   }
 
   get_edge_coordinates(edge_source: ColumnarDataSource): [Arrayable<number>[], Arrayable<number>[]] {
-    const data = new Dict(edge_source.data)
+    const {data} = edge_source
     const starts = data.get("start") ?? []
     const ends = data.get("end") ?? []
     const n = Math.min(starts.length, ends.length)

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -63,11 +63,11 @@ export namespace Plot {
     x_scale: p.Property<Scale>
     y_scale: p.Property<Scale>
 
-    extra_x_ranges: p.Property<{[key: string]: Range}>
-    extra_y_ranges: p.Property<{[key: string]: Range}>
+    extra_x_ranges: p.Property<Map<string, Range>>
+    extra_y_ranges: p.Property<Map<string, Range>>
 
-    extra_x_scales: p.Property<{[key: string]: Scale}>
-    extra_y_scales: p.Property<{[key: string]: Scale}>
+    extra_x_scales: p.Property<Map<string, Scale>>
+    extra_y_scales: p.Property<Map<string, Scale>>
 
     lod_factor: p.Property<number>
     lod_interval: p.Property<number>
@@ -161,11 +161,11 @@ export class Plot extends LayoutDOM {
       x_scale:           [ Ref(Scale), () => new LinearScale() ],
       y_scale:           [ Ref(Scale), () => new LinearScale() ],
 
-      extra_x_ranges:    [ Dict(Ref(Range)), {} ],
-      extra_y_ranges:    [ Dict(Ref(Range)), {} ],
+      extra_x_ranges:    [ Dict(Ref(Range)), new Map() ],
+      extra_y_ranges:    [ Dict(Ref(Range)), new Map() ],
 
-      extra_x_scales:    [ Dict(Ref(Scale)), {} ],
-      extra_y_scales:    [ Dict(Ref(Scale)), {} ],
+      extra_x_scales:    [ Dict(Ref(Scale)), new Map() ],
+      extra_y_scales:    [ Dict(Ref(Scale)), new Map() ],
 
       lod_factor:        [ Number, 10 ],
       lod_interval:      [ Number, 300 ],

--- a/bokehjs/src/lib/models/policies/labeling.ts
+++ b/bokehjs/src/lib/models/policies/labeling.ts
@@ -1,6 +1,5 @@
 import {Model} from "../../model"
 import type * as p from "core/properties"
-import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
 import type {BBox} from "core/util/bbox"
 import {isIterable} from "core/util/types"
@@ -84,7 +83,7 @@ export namespace CustomLabelingPolicy {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = LabelingPolicy.Props & {
-    args: p.Property<{[key: string]: unknown}>
+    args: p.Property<Map<string, unknown>>
     code: p.Property<string>
   }
 }
@@ -100,17 +99,17 @@ export class CustomLabelingPolicy extends LabelingPolicy {
 
   static {
     this.define<CustomLabelingPolicy.Props>(({Unknown, String, Dict}) => ({
-      args: [ Dict(Unknown), {} ],
+      args: [ Dict(Unknown), new Map() ],
       code: [ String, "" ],
     }))
   }
 
-  get names(): string[] {
-    return keys(this.args)
+  get names(): Iterable<string> {
+    return this.args.keys()
   }
 
-  get values(): any[] {
-    return values(this.args)
+  get values(): Iterable<unknown> {
+    return this.args.values()
   }
 
   get func(): GeneratorFunction {

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -456,11 +456,11 @@ export class GlyphRendererView extends DataRendererView {
       return
     }
     const subset_index = (() => {
-      if (index == null)
+      if (index == null) {
         return this.get_reference_point(field, label)
-      else {
+      } else {
         const {indices_map} = this.model.view
-        return index in indices_map ? indices_map[index] : null
+        return indices_map.get(index)
       }
     })()
     if (subset_index != null) {

--- a/bokehjs/src/lib/models/selections/selection.ts
+++ b/bokehjs/src/lib/models/selections/selection.ts
@@ -2,7 +2,7 @@ import {Model} from "../../model"
 import type * as p from "core/properties"
 import type {SelectionMode} from "core/enums"
 import {union, intersection, difference} from "core/util/array"
-import {merge, entries, to_object} from "core/util/object"
+import {merge} from "core/util/object"
 import type {Glyph, GlyphView} from "../glyphs/glyph"
 import {Arrayable, Int} from "../../core/kinds"
 import {map} from "core/util/arrayable"
@@ -10,7 +10,7 @@ import {map} from "core/util/arrayable"
 export type OpaqueIndices = typeof OpaqueIndices["__type__"]
 export const OpaqueIndices = Arrayable(Int)
 
-export type MultiIndices = {[key: string]: OpaqueIndices}
+export type MultiIndices = Map<number, OpaqueIndices>
 
 export type ImageIndex = {
   index: number
@@ -46,10 +46,10 @@ export class Selection extends Model {
   }
 
   static {
-    this.define<Selection.Props>(({Int, Array, Dict, Struct}) => ({
+    this.define<Selection.Props>(({Int, Array, Map, Struct}) => ({
       indices:           [ OpaqueIndices, [] ],
       line_indices:      [ OpaqueIndices, [] ],
-      multiline_indices: [ Dict(OpaqueIndices), {} ],
+      multiline_indices: [ Map(Int, OpaqueIndices), new globalThis.Map() ],
       image_indices:     [ Array(Struct({index: Int, i: Int, j: Int, flat_index: Int})), [] ],
     }))
 
@@ -96,7 +96,7 @@ export class Selection extends Model {
   clear(): void {
     this.indices = []
     this.line_indices = []
-    this.multiline_indices = {}
+    this.multiline_indices = new Map()
     this.image_indices = []
     this.view = null
     this.selected_glyphs = []
@@ -107,8 +107,8 @@ export class Selection extends Model {
       ...this.attributes,
       indices: map(this.indices, mapper),
       // NOTE: line_indices don't support subset indexing
-      multiline_indices: to_object(entries(this.multiline_indices).map(([index, line_indices]) => [mapper(Number(index)), line_indices])),
-      image_indices: this.image_indices.map((ndx) => ({...ndx, index: mapper(ndx.index)})),
+      multiline_indices: new Map(map([...this.multiline_indices.entries()], ([index, line_indices]) => [mapper(index), line_indices])),
+      image_indices: this.image_indices.map((image_index) => ({...image_index, index: mapper(image_index.index)})),
     })
   }
 

--- a/bokehjs/src/lib/models/sources/ajax_data_source.ts
+++ b/bokehjs/src/lib/models/sources/ajax_data_source.ts
@@ -3,7 +3,6 @@ import type {UpdateMode} from "core/enums"
 import {HTTPMethod} from "core/enums"
 import {logger} from "core/logging"
 import type * as p from "core/properties"
-import {entries} from "core/util/object"
 
 export namespace AjaxDataSource {
   export type Attrs = p.AttrsOf<Props>
@@ -11,7 +10,7 @@ export namespace AjaxDataSource {
   export type Props = WebDataSource.Props & {
     polling_interval: p.Property<number | null>
     content_type: p.Property<string>
-    http_headers: p.Property<{[key: string]: string}>
+    http_headers: p.Property<Map<string, string>>
     method: p.Property<HTTPMethod>
     if_modified: p.Property<boolean>
   }
@@ -30,7 +29,7 @@ export class AjaxDataSource extends WebDataSource {
     this.define<AjaxDataSource.Props>(({Boolean, Int, String, Dict, Nullable}) => ({
       polling_interval: [ Nullable(Int), null ],
       content_type:     [ String, "application/json" ],
-      http_headers:     [ Dict(String), {} ],
+      http_headers:     [ Dict(String), new Map() ],
       method:           [ HTTPMethod, "POST" ],
       if_modified:      [ Boolean, false ],
     }))
@@ -73,7 +72,7 @@ export class AjaxDataSource extends WebDataSource {
     xhr.setRequestHeader("Content-Type", this.content_type)
 
     const http_headers = this.http_headers
-    for (const [name, value] of entries(http_headers)) {
+    for (const [name, value] of http_headers) {
       xhr.setRequestHeader(name, value)
     }
 

--- a/bokehjs/src/lib/models/sources/cds_view.ts
+++ b/bokehjs/src/lib/models/sources/cds_view.ts
@@ -92,7 +92,7 @@ export namespace CDSView {
     filter: p.Property<Filter>
     // internal
     indices: p.Property<Indices>
-    indices_map: p.Property<{[key: string]: number}>
+    indices_map: p.Property<Map<number, number>>
     masked: p.Property<Indices | null>
   }
 }
@@ -114,9 +114,9 @@ export class CDSView extends Model {
       filter: [ Ref(Filter), () => new AllIndices() ],
     }))
 
-    this.internal<CDSView.Props>(({Int, Dict, Ref, Nullable}) => ({
+    this.internal<CDSView.Props>(({Int, Map, Ref, Nullable}) => ({
       indices:     [ Ref(Indices) ],
-      indices_map: [ Dict(Int), {} ],
+      indices_map: [ Map(Int, Int), new globalThis.Map() ],
       masked:      [ Nullable(Ref(Indices)), null ],
     }))
   }
@@ -125,9 +125,11 @@ export class CDSView extends Model {
 
   _indices_map_to_subset(): void {
     this._indices = [...this.indices]
-    this.indices_map = {}
-    for (let i = 0; i < this._indices.length; i++) {
-      this.indices_map[this._indices[i]] = i
+    this.indices_map = new Map()
+    const {_indices, indices_map} = this
+    const n = _indices.length
+    for (let i = 0; i < n; i++) {
+      indices_map.set(_indices[i], i)
     }
   }
 
@@ -136,7 +138,7 @@ export class CDSView extends Model {
   }
 
   convert_selection_to_subset(selection_full: Selection): Selection {
-    return selection_full.map((i) => this.indices_map[i])
+    return selection_full.map((i) => this.indices_map.get(i)!) // XXX ?? NaN
   }
 
   convert_indices_from_subset(indices: number[]): number[] {

--- a/bokehjs/src/lib/models/sources/column_data_source.ts
+++ b/bokehjs/src/lib/models/sources/column_data_source.ts
@@ -9,7 +9,7 @@ export namespace ColumnDataSource {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = ColumnarDataSource.Props & {
-    data: p.Property<{[key: string]: Arrayable}>
+    data: p.Property<Map<string, Arrayable>>
   }
 }
 
@@ -24,7 +24,7 @@ export class ColumnDataSource extends ColumnarDataSource {
 
   static {
     this.define<ColumnDataSource.Props>(({Any, Dict, Arrayable}) => ({
-      data: [ Dict(Arrayable(Any)), {} ],
+      data: [ Dict(Arrayable(Any)), new Map() ],
     }))
   }
 }

--- a/bokehjs/src/lib/models/sources/geojson_data_source.ts
+++ b/bokehjs/src/lib/models/sources/geojson_data_source.ts
@@ -52,7 +52,7 @@ export class GeoJSONDataSource extends ColumnarDataSource {
     }))
 
     this.internal<GeoJSONDataSource.Props>(({Any, Dict, Arrayable}) => ({
-      data: [ Dict(Arrayable(Any)), {} ],
+      data: [ Dict(Arrayable(Any)), new Map() ],
     }))
   }
 
@@ -67,7 +67,7 @@ export class GeoJSONDataSource extends ColumnarDataSource {
   }
 
   protected _update_data(): void {
-    this.data = this.geojson_to_column_data()
+    this.data = new Map(entries(this.geojson_to_column_data()))
   }
 
   protected _get_new_list_array(length: number): number[][] {

--- a/bokehjs/src/lib/models/text/math_text.ts
+++ b/bokehjs/src/lib/models/text/math_text.ts
@@ -2,6 +2,7 @@ import type * as p from "core/properties"
 import type * as visuals from "core/visuals"
 import {isNumber} from "core/util/types"
 import type {Context2d} from "core/util/canvas"
+import {to_object} from "core/util/object"
 import {load_image} from "core/util/image"
 import type {CanvasImage} from "models/glyphs/image_url"
 import {color2css, color2hexrgb, color2rgba} from "core/util/color"
@@ -563,7 +564,7 @@ export class TeXView extends MathTextView {
       display: !this.model.inline,
       em: this.base_font_size,
       ex: fmetrics.x_height,
-    }, this.model.macros)
+    }, to_object(this.model.macros))
   }
 }
 
@@ -571,7 +572,7 @@ export namespace TeX {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = MathText.Props & {
-    macros: p.Property<{[key: string]: string | [string, number]}>
+    macros: p.Property<Map<string, string | [string, number]>>
     inline: p.Property<boolean>
   }
 }
@@ -590,7 +591,7 @@ export class TeX extends MathText {
     this.prototype.default_view = TeXView
 
     this.define<TeX.Props>(({Boolean, Number, String, Dict, Tuple, Or}) => ({
-      macros: [ Dict(Or(String, Tuple(String, Number))), {} ],
+      macros: [ Dict(Or(String, Tuple(String, Number))), new Map() ],
       inline: [ Boolean, false ],
     }))
   }

--- a/bokehjs/src/lib/models/tiles/tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/tile_source.ts
@@ -1,7 +1,6 @@
 import {Model} from "../../model"
 //import {DOMElement} from "../dom"
 import type {Extent, Bounds} from "./tile_utils"
-import {entries} from "core/util/object"
 import type * as p from "core/properties"
 
 export type Tile = {
@@ -16,7 +15,7 @@ export namespace TileSource {
     tile_size: p.Property<number>
     max_zoom: p.Property<number>
     min_zoom: p.Property<number>
-    extra_url_vars: p.Property<{[key: string]: string}>
+    extra_url_vars: p.Property<Map<string, string>>
     attribution: p.Property<string/* | DOMElement | (string | DOMElement)[] | null*/>
     x_origin_offset: p.Property<number>
     y_origin_offset: p.Property<number>
@@ -39,7 +38,7 @@ export abstract class TileSource extends Model {
       tile_size:          [ Number, 256 ],
       max_zoom:           [ Number, 30 ],
       min_zoom:           [ Number, 0 ],
-      extra_url_vars:     [ Dict(String), {} ],
+      extra_url_vars:     [ Dict(String), new Map() ],
       attribution:        [ String, ""], // Or(String, Ref(DOMElement), Null), null ],
       x_origin_offset:    [ Number ],
       y_origin_offset:    [ Number ],
@@ -60,9 +59,9 @@ export abstract class TileSource extends Model {
     this.connect(this.change, () => this._clear_cache())
   }
 
-  string_lookup_replace(str: string, lookup: {[key: string]: string}): string {
+  string_lookup_replace(str: string, lookup: Map<string, string>): string {
     let result_str = str
-    for (const [key, value] of entries(lookup)) {
+    for (const [key, value] of lookup) {
       result_str = result_str.replace(`{${key}}`, value)
     }
     return result_str

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -150,7 +150,7 @@ export class BoxEditToolView extends EditToolView {
         return
       const index = length - 1
       for (const [key, val] of entries(fields)) {
-        cds.data[key][index] = val
+        cds.get(key)[index] = val
       }
     }
     this._emit_cds_changes(cds, true, false, emit)
@@ -283,7 +283,7 @@ export class BoxEditToolView extends EditToolView {
 
       for (const index of cds.selected.indices) {
         for (const [key, val] of entries(fields)) {
-          cds.data[key][index] += val
+          cds.get(key)[index] += val
         }
       }
 

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -85,7 +85,7 @@ export abstract class EditToolView extends GestureToolView {
         continue
       if (!isArray(array)) {
         array = Array.from(array)
-        cds.data[column] = array
+        cds.data.set(column, array)
       }
       array.splice(0, drop)
     }
@@ -121,10 +121,10 @@ export abstract class EditToolView extends GestureToolView {
       const [xkey, ykey] = [glyph.x.field, glyph.y.field]
       for (const index of cds.selected.indices) {
         if (xkey && (dim == "width" || dim == "both")) {
-          cds.data[xkey][index] += dx
+          cds.get(xkey)[index] += dx
         }
         if (ykey && (dim == "height" || dim == "both")) {
-          cds.data[ykey][index] += dy
+          cds.get(ykey)[index] += dy
         }
       }
       cds.change.emit()

--- a/bokehjs/src/lib/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/freehand_draw_tool.ts
@@ -29,20 +29,20 @@ export class FreehandDrawToolView extends EditToolView {
       this._pad_empty_columns(cds, [xkey, ykey])
     } else if (mode == "add") {
       if (xkey) {
-        const xidx = cds.data[xkey].length-1
+        const xidx = cds.get(xkey).length-1
         let xs = cds.get_array<number[]>(xkey)[xidx]
         if (!isArray(xs)) {
           xs = Array.from(xs)
-          cds.data[xkey][xidx] = xs
+          cds.get(xkey)[xidx] = xs
         }
         xs.push(x)
       }
       if (ykey) {
-        const yidx = cds.data[ykey].length-1
+        const yidx = cds.get(ykey).length-1
         let ys = cds.get_array<number[]>(ykey)[yidx]
         if (!isArray(ys)) {
           ys = Array.from(ys)
-          cds.data[ykey][yidx] = ys
+          cds.get(ykey)[yidx] = ys
         }
         ys.push(y)
       }

--- a/bokehjs/src/lib/models/tools/edit/line_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/line_edit_tool.ts
@@ -81,10 +81,10 @@ export class LineEditToolView extends LineToolView {
     const point_cds = this.model.intersection_renderer.data_source
     const [pxkey, pykey] = [point_glyph.x.field, point_glyph.y.field]
     if (pxkey && pykey) {
-      const x = point_cds.data[pxkey]
-      const y = point_cds.data[pykey]
-      this._selected_renderer.data_source.data[pxkey] = x
-      this._selected_renderer.data_source.data[pykey] = y
+      const x = point_cds.get(pxkey)
+      const y = point_cds.get(pykey)
+      this._selected_renderer.data_source.data.set(pxkey, x)
+      this._selected_renderer.data_source.data.set(pykey, y)
     }
     this._emit_cds_changes(this._selected_renderer.data_source, true, true, false)
   }

--- a/bokehjs/src/lib/models/tools/edit/line_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/line_tool.ts
@@ -18,13 +18,13 @@ export abstract class LineToolView extends EditToolView {
     const [pxkey, pykey] = [point_glyph.x.field, point_glyph.y.field]
     if (pxkey) {
       if (isArray(x))
-        point_cds.data[pxkey] = x
+        point_cds.data.set(pxkey, x)
       else
         point_glyph.x = {value: x}
     }
     if (pykey) {
       if (isArray(y))
-        point_cds.data[pykey] = y
+        point_cds.data.set(pykey, y)
       else
         point_glyph.y = {value: y}
     }

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -45,33 +45,37 @@ export class PolyDrawToolView extends PolyToolView {
       this._pad_empty_columns(cds, [xkey, ykey])
     } else if (mode == "edit") {
       if (xkey) {
-        const xs = cds.data[xkey][cds.data[xkey].length-1]
+        const xcol = cds.get(xkey)
+        const xs = xcol[xcol.length-1]
         xs[xs.length-1] = x
       }
       if (ykey) {
-        const ys = cds.data[ykey][cds.data[ykey].length-1]
+        const ycol = cds.get(ykey)
+        const ys = ycol[ycol.length-1]
         ys[ys.length-1] = y
       }
     } else if (mode == "add") {
       if (xkey) {
-        const xidx = cds.data[xkey].length-1
+        const xcol = cds.get(xkey)
+        const xidx = xcol.length-1
         let xs = cds.get_array<number[]>(xkey)[xidx]
         const nx = xs[xs.length-1]
         xs[xs.length-1] = x
         if (!isArray(xs)) {
           xs = Array.from(xs)
-          cds.data[xkey][xidx] = xs
+          xcol[xidx] = xs
         }
         xs.push(nx)
       }
       if (ykey) {
-        const yidx = cds.data[ykey].length-1
+        const ycol = cds.get(ykey)
+        const yidx = ycol.length-1
         let ys = cds.get_array<number[]>(ykey)[yidx]
         const ny = ys[ys.length-1]
         ys[ys.length-1] = y
         if (!isArray(ys)) {
           ys = Array.from(ys)
-          cds.data[ykey][yidx] = ys
+          ycol[yidx] = ys
         }
         ys.push(ny)
       }
@@ -133,12 +137,14 @@ export class PolyDrawToolView extends PolyToolView {
     const glyph: any = renderer.glyph
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
     if (xkey) {
-      const xidx = cds.data[xkey].length-1
+      const xcol = cds.get(xkey)
+      const xidx = xcol.length-1
       const xs = cds.get_array<number[]>(xkey)[xidx]
       xs.splice(xs.length-1, 1)
     }
     if (ykey) {
-      const yidx = cds.data[ykey].length-1
+      const ycol = cds.get(ykey)
+      const yidx = ycol.length-1
       const ys = cds.get_array<number[]>(ykey)[yidx]
       ys.splice(ys.length-1, 1)
     }
@@ -190,9 +196,13 @@ export class PolyDrawToolView extends PolyToolView {
       const [dx, dy] = [x-px, y-py]
       for (const index of cds.selected.indices) {
         let length, xs, ys
-        if (xkey) xs = cds.data[xkey][index]
+        if (xkey) {
+          const xcol = cds.get(xkey)
+          xs = xcol[index]
+        }
         if (ykey) {
-          ys = cds.data[ykey][index]
+          const ycol = cds.get(ykey)
+          ys = ycol[index]
           length = ys.length
         } else {
           length = xs.length

--- a/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_edit_tool.ts
@@ -83,23 +83,28 @@ export class PolyEditToolView extends PolyToolView {
     const index = this._cur_index
     const [xkey, ykey] = [glyph.xs.field, glyph.ys.field]
 
-    if (this._drawing) return
-    if ((index == null) && (xkey || ykey)) return
+    if (this._drawing) {
+      return
+    }
+    if ((index == null) && (xkey || ykey)) {
+      return
+    }
 
     let xs: number[]
     let ys: number[]
     if (xkey && index != null) { // redundant xkey null check to satisfy build-time checks
-      xs = cds.data[xkey][index]
-      if (!isArray(xs))
-        cds.data[xkey][index] = xs = Array.from(xs)
+      xs = cds.get(xkey)[index]
+      if (!isArray(xs)) {
+        cds.get(xkey)[index] = xs = Array.from(xs)
+      }
     } else {
       xs = glyph.xs.value
     }
 
     if (ykey && index != null) {
-      ys = cds.data[ykey][index]
+      ys = cds.get(ykey)[index]
       if (!isArray(ys))
-        cds.data[ykey][index] = ys = Array.from(ys)
+        cds.get(ykey)[index] = ys = Array.from(ys)
     } else {
       ys = glyph.ys.value
     }
@@ -123,8 +128,8 @@ export class PolyEditToolView extends PolyToolView {
       cds.selected.indices = indices
       const [xkey, ykey] = [glyph.x.field, glyph.y.field]
       const index = indices[0]
-      if (xkey) cds.data[xkey][index] = x
-      if (ykey) cds.data[ykey][index] = y
+      if (xkey) cds.get(xkey)[index] = x
+      if (ykey) cds.get(ykey)[index] = y
       cds.change.emit()
       this._selected_renderer.data_source.change.emit()
     }

--- a/bokehjs/src/lib/models/tools/edit/poly_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_tool.ts
@@ -24,13 +24,13 @@ export abstract class PolyToolView extends EditToolView {
     const [pxkey, pykey] = [point_glyph.x.field, point_glyph.y.field]
     if (pxkey) {
       if (isArray(xs))
-        point_cds.data[pxkey] = xs
+        point_cds.data.set(pxkey, xs)
       else
         point_glyph.x = {value: xs}
     }
     if (pykey) {
       if (isArray(ys))
-        point_cds.data[pykey] = ys
+        point_cds.data.set(pykey, ys)
       else
         point_glyph.y = {value: ys}
     }
@@ -52,9 +52,9 @@ export abstract class PolyToolView extends EditToolView {
       if (vertex_selected.length != 0) {
         const index = point_ds.selected.indices[0]
         if (pxkey)
-          x = point_ds.data[pxkey][index]
+          x = point_ds.get(pxkey)[index]
         if (pykey)
-          y = point_ds.data[pykey][index]
+          y = point_ds.get(pykey)[index]
         point_ds.selection_manager.clear()
       }
     }

--- a/bokehjs/src/lib/models/tools/inspectors/customjs_hover.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/customjs_hover.ts
@@ -1,13 +1,12 @@
 import {Model} from "../../../model"
 import type * as p from "core/properties"
-import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
 
 export namespace CustomJSHover {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Model.Props & {
-    args: p.Property<{[key: string]: unknown}>
+    args: p.Property<Map<string, unknown>>
     code: p.Property<string>
   }
 }
@@ -23,22 +22,25 @@ export class CustomJSHover extends Model {
 
   static {
     this.define<CustomJSHover.Props>(({Unknown, String, Dict}) => ({
-      args: [ Dict(Unknown), {} ],
+      args: [ Dict(Unknown), new Map() ],
       code: [ String, "" ],
     }))
   }
 
-  get values(): any[] {
-    return values(this.args)
+  get keys(): Iterable<string> {
+    return this.args.keys()
+  }
+  get values(): Iterable<unknown> {
+    return this.args.values()
   }
 
   /*protected*/ _make_code(valname: string, formatname: string, varsname: string, fn: string): Function {
     // this relies on keys(args) and values(args) returning keys and values
     // in the same order
-    return new Function(...keys(this.args), valname, formatname, varsname, use_strict(fn))
+    return new Function(...this.keys, valname, formatname, varsname, use_strict(fn))
   }
 
-  format(value: any, format: string, special_vars: {[key: string]: unknown}): string {
+  format(value: unknown, format: string, special_vars: {[key: string]: unknown}): string {
     const formatter = this._make_code("value", "format", "special_vars", this.code)
     return formatter(...this.values, value, format, special_vars)
   }

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -11,7 +11,6 @@ import type {MoveEvent} from "core/ui_events"
 import {assert} from "core/util/assert"
 import {color2css, color2hex} from "core/util/color"
 import {enumerate} from "core/util/iterator"
-import {is_empty} from "core/util/object"
 import type {CallbackLike1} from "core/util/callbacks"
 import {execute} from "core/util/callbacks"
 import type {Formatters} from "core/util/templating"
@@ -367,9 +366,9 @@ export class HoverToolView extends InspectToolView {
     } else {
       for (const i of subset_indices.indices) {
         // multiglyphs set additional indices, e.g. multiline_indices for different tooltips
-        if (glyph instanceof MultiLineView && !is_empty(subset_indices.multiline_indices)) {
+        if (glyph instanceof MultiLineView && subset_indices.multiline_indices.size != 0) {
           const {line_policy} = this.model
-          for (const j of subset_indices.multiline_indices[i.toString()]) { // TODO: subset_indices.multiline_indices.get(i)
+          for (const j of subset_indices.multiline_indices.get(i) ?? []) {
             const [[snap_x, snap_y], [snap_sx, snap_sy], jj] = (function() {
               if (line_policy == "interp") {
                 const [snap_x, snap_y] = glyph.get_interpolation_hit(i, j, geometry)
@@ -661,7 +660,7 @@ export class HoverTool extends InspectTool {
         ["data (x, y)",   "($x, $y)"  ],
         ["screen (x, y)", "($sx, $sy)"],
       ]],
-      formatters:   [ Dict(Or(Ref(CustomJSHover), FormatterType)), {} ],
+      formatters:   [ Dict(Or(Ref(CustomJSHover), FormatterType)), new Map() ],
       renderers:    [ Or(Array(Ref(DataRenderer)), Auto), "auto" ],
       mode:         [ HoverMode, "mouse" ],
       muted_policy: [ MutedPolicy, "show" ],

--- a/bokehjs/src/lib/models/transforms/customjs_transform.ts
+++ b/bokehjs/src/lib/models/transforms/customjs_transform.ts
@@ -1,14 +1,13 @@
 import {Transform} from "./transform"
 import type * as p from "core/properties"
 import type {Arrayable} from "core/types"
-import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
 
 export namespace CustomJSTransform {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Transform.Props & {
-    args: p.Property<{[key: string]: unknown}>
+    args: p.Property<Map<string, unknown>>
     func: p.Property<string>
     v_func: p.Property<string>
   }
@@ -25,18 +24,18 @@ export class CustomJSTransform extends Transform {
 
   static {
     this.define<CustomJSTransform.Props>(({Unknown, String, Dict}) => ({
-      args:   [ Dict(Unknown), {} ],
+      args:   [ Dict(Unknown), new Map() ],
       func:   [ String, "" ],
       v_func: [ String, "" ],
     }))
   }
 
-  get names(): string[] {
-    return keys(this.args)
+  get names(): Iterable<string> {
+    return this.args.keys()
   }
 
-  get values(): any[] {
-    return values(this.args)
+  get values(): Iterable<unknown> {
+    return this.args.values()
   }
 
   protected _make_transform(name: string, func: string): Function {

--- a/bokehjs/src/lib/models/ui/ui_element.ts
+++ b/bokehjs/src/lib/models/ui/ui_element.ts
@@ -278,7 +278,7 @@ export namespace UIElement {
     visible: p.Property<boolean>
     css_classes: p.Property<string[]>
     styles: p.Property<CSSStyles | Styles>
-    stylesheets: p.Property<(BaseStyleSheet | string | {[key: string]: CSSStyles | Styles})[]>
+    stylesheets: p.Property<(BaseStyleSheet | string | Map<string, CSSStyles | Styles>)[]>
   }
 }
 
@@ -298,7 +298,7 @@ export abstract class UIElement extends Model {
       return {
         visible: [ Boolean, true ],
         css_classes: [ Array(String), [] ],
-        styles: [ StylesLike, {} ],
+        styles: [ StylesLike, new Map() ],
         stylesheets: [ Array(Or(Ref(BaseStyleSheet), String, Dict(StylesLike))), [] ],
       }
     })

--- a/bokehjs/src/lib/models/widgets/selectbox.ts
+++ b/bokehjs/src/lib/models/widgets/selectbox.ts
@@ -1,6 +1,6 @@
 import {select, option, optgroup, empty, append} from "core/dom"
 import {isString, isArray} from "core/util/types"
-import {entries} from "core/util/object"
+import {map} from "core/util/iterator"
 import type * as p from "core/properties"
 
 import {InputWidget, InputWidgetView} from "./input_widget"
@@ -48,7 +48,7 @@ export class SelectView extends InputWidgetView {
     if (isArray(options)) {
       return build_options(options)
     } else {
-      return entries(options).map(([label, values]) => optgroup({label}, build_options(values)))
+      return [...map(options, ([label, values]) => optgroup({label}, build_options(values)))]
     }
   }
 
@@ -88,7 +88,7 @@ export namespace Select {
 
   export type Props = InputWidget.Props & {
     value: p.Property<string>
-    options: p.Property<(string | [string, string])[] | {[key: string]: (string | [string, string])[]}>
+    options: p.Property<(string | [string, string])[] | Map<string, (string | [string, string])[]>>
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/tables/data_cube.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_cube.ts
@@ -1,6 +1,7 @@
 import type * as p from "core/properties"
 import {span} from "core/dom"
 import {is_nullish} from "core/util/types"
+import {assert} from "core/util/assert"
 import type {Formatter, Column, GroupTotals, RowMetadata, ColumnMetadata} from "@bokeh/slickgrid"
 import {Grid as SlickGrid, Group} from "@bokeh/slickgrid"
 import type {Item} from "./definitions"
@@ -11,7 +12,7 @@ import type {CDSView} from "../../sources/cds_view"
 import {RowAggregator} from "./row_aggregators"
 import {Model} from "model"
 
-interface GroupDataContext {
+type GroupDataContext = {
   collapsed: boolean
   level: number
   title: string
@@ -28,6 +29,7 @@ function groupCellFormatter(_row: number, _cell: number, _value: unknown, _colum
     class: "slick-group-title",
     level,
   }, title)
+
   return `${toggle.outerHTML}${titleElement.outerHTML}`
 }
 
@@ -116,29 +118,31 @@ export class DataCubeProvider extends TableDataProvider {
     this.refresh()
   }
 
-  private extractGroups(rows: number[], parentGroup?: Group<number>): Group<number>[] {
+  private extractGroups(rows: Iterable<number>, parent_group?: Group<number>): Group<number>[] {
     const groups: Group<number>[] = []
     const groupsByValue: Map<any, Group<number>> = new Map()
-    const level = (parentGroup != null) ? parentGroup.level + 1 : 0
+    const level = parent_group != null ? parent_group.level + 1 : 0
     const {comparer, getter} = this.groupingInfos[level]
 
-    rows.forEach((row) => {
-      const value = this.source.data[getter][row]
+    for (const row of rows) {
+      const column = this.source.data.get(getter)
+      assert(column != null)
+      const value = column[row]
       let group = groupsByValue.get(value)
 
       if (group == null) {
-        const groupingKey = parentGroup != null ? `${parentGroup.groupingKey}${this.groupingDelimiter}${value}` : `${value}`
+        const groupingKey = parent_group != null ? `${parent_group.groupingKey}${this.groupingDelimiter}${value}` : `${value}`
         group = Object.assign(new Group(), {value, level, groupingKey}) as any
         groups.push(group!)
         groupsByValue.set(value, group!)
       }
       group!.rows.push(row)
-    })
+    }
 
     if (level < this.groupingInfos.length - 1) {
-      groups.forEach((group) => {
+      for (const group of groups) {
         group.groups = this.extractGroups(group.rows, group)
-      })
+      }
     }
 
     groups.sort(comparer)
@@ -148,14 +152,18 @@ export class DataCubeProvider extends TableDataProvider {
   private calculateTotals(group: Group<number>, aggregators: RowAggregator[]): GroupTotals<number> {
     const totals: GroupTotals<number> = {avg: {}, max: {}, min: {}, sum: {}} as any
     const {source: {data}} = this
-    const keys = Object.keys(data)
-    const items = group.rows.map(i => keys.reduce((o, c) => ({...o, [c]: data[c][i]}), {}))
-
-    aggregators.forEach((aggregator) => {
-      aggregator.init()
-      items.forEach((item) => aggregator.accumulate(item))
-      aggregator.storeResult(totals)
+    const names = [...data.keys()]
+    const items = group.rows.map((i) => {
+      return names.reduce((obj, name) => ({...obj, [name]: data.get(name)![i]}), {})
     })
+
+    for (const aggregator of aggregators) {
+      aggregator.init()
+      for (const item of items) {
+        aggregator.accumulate(item)
+      }
+      aggregator.storeResult(totals)
+    }
     return totals
   }
 
@@ -163,7 +171,7 @@ export class DataCubeProvider extends TableDataProvider {
     const {aggregators, collapsed: groupCollapsed} = this.groupingInfos[level]
     const toggledGroups = this.toggledGroupsByLevel[level]
 
-    groups.forEach((group) => {
+    for (const group of groups) {
       if (!is_nullish(group.groups)) { // XXX: bad typings
         this.addTotals(group.groups, level + 1)
       }
@@ -174,13 +182,13 @@ export class DataCubeProvider extends TableDataProvider {
 
       group.collapsed = groupCollapsed !== toggledGroups[group.groupingKey]
       group.title = group.value ? `${group.value}` : ""
-    })
+    }
   }
 
   private flattenedGroupedRows(groups: Group<number>[], level = 0): (Group<number> | number)[] {
     const rows: (Group<number> | number)[] = []
 
-    groups.forEach((group) => {
+    for (const group of groups) {
       rows.push(group)
       if (!group.collapsed) {
         const subRows = !is_nullish(group.groups) // XXX: bad typings
@@ -188,13 +196,14 @@ export class DataCubeProvider extends TableDataProvider {
           : group.rows
         rows.push(...subRows)
       }
-    })
+    }
     return rows
   }
 
   refresh(): void {
-    const groups = this.extractGroups([...this.view.indices])
-    const labels = this.source.data[this.columns[0].field!]
+    const groups = this.extractGroups(this.view.indices)
+    const labels = this.source.data.get(this.columns[0].field!)
+    assert(labels != null)
 
     if (groups.length != 0) {
       this.addTotals(groups)
@@ -216,34 +225,33 @@ export class DataCubeProvider extends TableDataProvider {
 
     return item instanceof Group
       ? item as Item
-      : Object.keys(data)
-        .reduce((o, c) => ({...o, [c]: data[c][item]}), {[DTINDEX_NAME]: item})
+      : [...data.keys()].reduce((obj, name) => ({...obj, [name]: data.get(name)![item]}), {[DTINDEX_NAME]: item})
   }
 
   getItemMetadata(i: number): RowMetadata<Item> {
-    const myItem = this.rows[i]
+    const my_item = this.rows[i]
     const columns = this.columns.slice(1)
 
-    const aggregators = myItem instanceof Group
-      ? this.groupingInfos[myItem.level].aggregators
+    const aggregators = my_item instanceof Group
+      ? this.groupingInfos[my_item.level].aggregators
       : []
 
     function adapter(column: Column<Item>): ColumnMetadata<Item> {
-      const {field: myField, formatter} = column
-      const aggregator = aggregators.find(({field_}) => field_ === myField)
+      const {field: my_field, formatter} = column
+      const aggregator = aggregators.find(({field_}) => field_ === my_field)
 
       if (aggregator != null) {
         const {key} = aggregator
         return {
           formatter(row: number, cell: number, _value: unknown, columnDef: Column<Item>, dataContext: Item): string {
-            return formatter != null ? formatter(row, cell, dataContext.totals[key][myField!], columnDef, dataContext) : ""
+            return formatter != null ? formatter(row, cell, dataContext.totals[key][my_field!], columnDef, dataContext) : ""
           },
         }
       }
       return {}
     }
 
-    return myItem instanceof Group
+    return my_item instanceof Group
       ? {
         selectable: false,
         focusable: false,
@@ -253,17 +261,17 @@ export class DataCubeProvider extends TableDataProvider {
       : {}
   }
 
-  collapseGroup(groupingKey: string): void {
-    const level = groupingKey.split(this.groupingDelimiter).length - 1
+  collapseGroup(grouping_key: string): void {
+    const level = grouping_key.split(this.groupingDelimiter).length - 1
 
-    this.toggledGroupsByLevel[level][groupingKey] = !this.groupingInfos[level].collapsed
+    this.toggledGroupsByLevel[level][grouping_key] = !this.groupingInfos[level].collapsed
     this.refresh()
   }
 
-  expandGroup(groupingKey: string): void {
-    const level = groupingKey.split(this.groupingDelimiter).length - 1
+  expandGroup(grouping_key: string): void {
+    const level = grouping_key.split(this.groupingDelimiter).length - 1
 
-    this.toggledGroupsByLevel[level][groupingKey] = this.groupingInfos[level].collapsed
+    this.toggledGroupsByLevel[level][grouping_key] = this.groupingInfos[level].collapsed
     this.refresh()
   }
 }

--- a/bokehjs/test/unit/core/serialization.ts
+++ b/bokehjs/test/unit/core/serialization.ts
@@ -23,7 +23,6 @@ namespace SomeModel {
   export type Props = HasProps.Props & {
     value: p.Property<number>
     array: p.Property<number[]>
-    dict: p.Property<{[key: string]: number}>
     map: p.Property<Map<number[], number>>
     set: p.Property<Set<number[]>>
     obj: p.Property<SomeModel | null>
@@ -40,10 +39,9 @@ class SomeModel extends HasProps {
   }
 
   static {
-    this.define<SomeModel.Props>(({Number, Array, Dict, Ref, Nullable}) => ({
+    this.define<SomeModel.Props>(({Number, Array, Ref, Nullable}) => ({
       value: [ Number, 1 ],
       array: [ Array(Number), [] ],
-      dict: [ Dict(Number), {} ],
       obj: [ Nullable(Ref(SomeModel)), null ],
     }))
   }

--- a/bokehjs/test/unit/core/util/object.ts
+++ b/bokehjs/test/unit/core/util/object.ts
@@ -14,10 +14,10 @@ describe("object module", () => {
     expect(object.clone(obj1)).to.be.equal(obj1)
   })
 
-  it("merge should union the array values of two objects", () => {
-    const obj1 = {key1: [], key2: [0]}
-    const obj2 = {key2: [1, 2, 3]}
-    expect(object.merge(obj1, obj2)).to.be.equal({key1: [], key2: [0, 1, 2, 3]})
+  it("merge should union the array values of two maps", () => {
+    const obj1 = new Map([["key1", []], ["key2", [0]]])
+    const obj2 = new Map([["key2", [1, 2, 3]]])
+    expect(object.merge(obj1, obj2)).to.be.equal(new Map([["key1", []], ["key2", [0, 1, 2, 3]]]))
   })
 
   it("is_empty should return true if an object has no keys", () => {

--- a/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
@@ -234,7 +234,7 @@ describe("GraphHitTestPolicy", () => {
       it("should clear edge selections if hit_test_result is empty", () => {
         // create initial inspection to clear
         const initial_selection = new Selection()
-        initial_selection.multiline_indices = {0: [0, 1], 1: [0]}
+        initial_selection.multiline_indices = new Map([[0, [0, 1]], [1, [0]]])
         edge_source.selected = initial_selection
 
         const hit_test_result = new Selection()
@@ -249,8 +249,7 @@ describe("GraphHitTestPolicy", () => {
         const policy = new NodesAndLinkedEdges()
 
         policy.do_selection(hit_test_result, gr, true, "replace")
-
-        expect(edge_source.selected.multiline_indices).to.be.equal({0: [ 0 ], 1: [ 0 ]})
+        expect(edge_source.selected.multiline_indices).to.be.equal(new Map([[0, [0]], [1, [0]]]))
       })
     })
 
@@ -259,7 +258,7 @@ describe("GraphHitTestPolicy", () => {
       it("should clear edge inspections if hit_test_result is empty", () => {
         // create initial inspection to clear
         const initial_inspection = new Selection()
-        initial_inspection.multiline_indices = {0: [0, 1], 1: [0]}
+        initial_inspection.multiline_indices = new Map([[0, [0, 1]], [1, [0]]])
         edge_source.inspected = initial_inspection
 
         const hit_test_result = new Selection()
@@ -276,7 +275,7 @@ describe("GraphHitTestPolicy", () => {
         const did_hit = policy.do_inspection(hit_test_result, {type: "point", sx: 0, sy: 0}, gv, true, "replace")
 
         expect(did_hit).to.be.true
-        expect(edge_source.inspected.multiline_indices).to.be.equal({0: [ 0 ], 1: [ 0 ]})
+        expect(edge_source.inspected.multiline_indices).to.be.equal(new Map([[0, [0]], [1, [0]]]))
       })
     })
   })

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -412,7 +412,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             name=self.__qualified_model__,
         )
 
-        properties = self.properties_with_values(include_defaults=False)
+        properties = self.properties_with_values(include_defaults=True)
         attributes = {key: serializer.encode(val) for key, val in properties.items()}
 
         if attributes:


### PR DESCRIPTION
This is a very early work in progress. The goals of this PR are:

1. Remove existing hacks related to serialization/deserialization of `type: map` objects.
2. Fully migrate all models to either use `Map` or formalized structures instead of plain objects.
3. Introduce asymmetric properties (i.e. properties with different setters and getters).
4. Provide a compatibility and usability layer for properties that previously allowed plain objects.

fixes #13378
