### PR TITLE
Allow to set readonly properties during initialization

### DIFF
--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -50,6 +50,9 @@ if TYPE_CHECKING:
 else:
     from functools import lru_cache
 
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 # Bokeh imports
 from ..util.strings import append_docstring, nice_join
 from ..util.warnings import warn
@@ -743,7 +746,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         '''
         self.apply_theme(property_values={})
 
-    def clone(self) -> HasProps:
+    def clone(self) -> Self:
         ''' Duplicate a HasProps object.
 
         This creates a shallow clone of the original model, i.e. any

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -324,7 +324,7 @@ class PropertyDescriptor(Generic[T]):
             class_name = obj.__class__.__name__
             raise RuntimeError(f"Cannot set a property value {self.name!r} on a {class_name} instance before HasProps.__init__")
 
-        if self.property.readonly:
+        if self.property.readonly and obj._initialized:
             class_name = obj.__class__.__name__
             raise RuntimeError(f"{class_name}.{self.name} is a readonly property")
 


### PR DESCRIPTION
Readonly properties we meant to deter users from changing properties' values, e.g. so that we can avoid unnecessary change listeners in bokehjs. Thus I think it's sensible to allow setting them during initialization, which then trivially fixes cloning.

fixes #13389
