### PR TITLE
Use curly brackets in bokehjs for all statements

### DIFF
--- a/bokehjs/eslint.js
+++ b/bokehjs/eslint.js
@@ -57,7 +57,6 @@ module.exports = {
     "@typescript-eslint/no-unnecessary-type-constraint": ["error"],
     "@typescript-eslint/switch-exhaustiveness-check": ["error"],
     "no-self-assign": ["error", {"props": false}],
-    "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "comma-dangle": ["off"],
     "@typescript-eslint/comma-dangle": ["error", {
       "arrays": "always-multiline",
@@ -121,6 +120,8 @@ module.exports = {
     }],
     "guard-for-in": ["error"],
     "quotes": ["error", "double", {"avoidEscape": true, "allowTemplateLiterals": false}],
+    "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
+    // "curly": ["error", "all"],
     "prefer-template": ["error"],
     "generator-star-spacing": ["error", {
       "before": false,

--- a/bokehjs/eslint.js
+++ b/bokehjs/eslint.js
@@ -121,7 +121,7 @@ module.exports = {
     "guard-for-in": ["error"],
     "quotes": ["error", "double", {"avoidEscape": true, "allowTemplateLiterals": false}],
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
-    // "curly": ["error", "all"],
+    "curly": ["error", "all"],
     "prefer-template": ["error"],
     "generator-star-spacing": ["error", {
       "before": false,
@@ -130,5 +130,23 @@ module.exports = {
       "method": {"before": true, "after": false},
     }],
     "yield-star-spacing": ["error", {"before": false, "after": true}]
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "./src/lib/core/**",
+        "./src/lib/models/annotations/**",
+        "./src/lib/models/formatters/**",
+        "./src/lib/models/glyphs/**",
+        "./src/lib/models/plots/**",
+        "./src/lib/models/ranges/**",
+        "./src/lib/models/renderers/**",
+        "./src/lib/models/sources/**",
+        "./src/lib/models/tools/**",
+      ],
+      "rules": {
+        "curly": "off",
+      },
+    },
+  ],
 }

--- a/bokehjs/examples/donut/donut.ts
+++ b/bokehjs/examples/donut/donut.ts
@@ -51,8 +51,9 @@ export namespace WebBrowserMarketShare {
         if (isNaN(shares[i])) {
           shares.splice(i, 1)
           browsers.splice(i, 1)
-        } else
+        } else {
           i++
+        }
       }
 
       const other = 100 - sum(shares)
@@ -111,16 +112,18 @@ export namespace WebBrowserMarketShare {
     fig.image_url(icons, x0, y0, NaN, NaN, {source, anchor: "center"})
 
     const texts = item.shares.map((share) => {
-      if (share <= 2.0)
+      if (share <= 2.0) {
         return null
-      else
+      } else {
         return Bokeh.sprintf("%.02f%%", share)
+      }
     })
     const text_angles = item.shares.map((share, i) => {
-      if (share <= 5.0)
+      if (share <= 5.0) {
         return half_angles[i]
-      else
+      } else {
         return 0
+      }
     })
     const [x1, y1] = unzip(half_angles.map((angle) => to_cartesian(1.0, angle)))
     fig.text(x1, y1, texts, {source, angle: text_angles, text_align: "center", text_baseline: "middle"})
@@ -149,8 +152,9 @@ export namespace WebBrowserMarketShare {
     if (!paused) {
       fig.renderers = fig.renderers.filter((r) => !(r instanceof Bokeh.GlyphRenderer))
       render(data[index])
-      if (--index < 0)
+      if (--index < 0) {
         index = data.length-1
+      }
     }
   }, 1000)
 

--- a/bokehjs/examples/hierarchical/hierarchical.ts
+++ b/bokehjs/examples/hierarchical/hierarchical.ts
@@ -16,9 +16,11 @@ export namespace Hierarchical {
   }
 
   const x: [string, string][] = []
-  for (const fruit of fruits)
-    for (const year of years)
+  for (const fruit of fruits) {
+    for (const year of years) {
       x.push([fruit, year])
+    }
+  }
 
   const counts = concat(zip(data["2015"], data["2016"], data["2017"])) // like an hstack
 

--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -26,8 +26,9 @@ export namespace HoverfulScatter {
   const radii = range(N).map((_) => random.float()*0.4 + 1.7)
 
   const colors: [number, number, number][] = []
-  for (const [r, g] of zip(xx.map((x) => 50 + 2*x), yy.map((y) => 30 + 2*y)))
+  for (const [r, g] of zip(xx.map((x) => 50 + 2*x), yy.map((y) => 30 + 2*y))) {
     colors.push([r, g, 150])
+  }
 
   const source = new Bokeh.ColumnDataSource({
     data: {x: xx, y: yy, radius: radii, colors},
@@ -51,8 +52,9 @@ export namespace HoverfulScatter {
     const div = document.createElement("div")
     div.style.width = "200px"
     div.style.height = "75px"
-    if (info.index != null)
+    if (info.index != null) {
       div.style.backgroundColor = ds.data.colors[info.index]
+    }
     return div
   }
 

--- a/bokehjs/examples/tap/tap.ts
+++ b/bokehjs/examples/tap/tap.ts
@@ -26,8 +26,9 @@ export namespace TappyScatter {
   const radii = range(N).map((_) => random.float()*0.4 + 1.7)
 
   const colors: [number, number, number][] = []
-  for (const [r, g] of zip(xx.map((x) => 50 + 2*x), yy.map((y) => 30 + 2*y)))
+  for (const [r, g] of zip(xx.map((x) => 50 + 2*x), yy.map((y) => 30 + 2*y))) {
     colors.push([r, g, 150])
+  }
 
   const source = new Bokeh.ColumnDataSource({
     data: {x: xx, y: yy, radius: radii, colors},

--- a/bokehjs/make/main.ts
+++ b/bokehjs/make/main.ts
@@ -8,9 +8,9 @@ import "./tasks"
 const {_} = argv
 
 async function main(): Promise<void> {
-  if (_.length != 0 && _[0] == "help")
+  if (_.length != 0 && _[0] == "help") {
     log(`tasks: ${task_names().filter((name) => !name.includes(":")).join(", ")}`)
-  else {
+  } else {
     const tasks = _.length != 0 ? _.map((arg) => `${arg}`) : ["default"]
     const top_level = task("top-level", tasks)
 

--- a/bokehjs/make/task.ts
+++ b/bokehjs/make/task.ts
@@ -96,21 +96,23 @@ export type TaskLike = string | Task
 export type DependencyLike = TaskLike | Dependency
 
 function _resolve_dep(dep: DependencyLike): Dependency {
-  if (dep instanceof Dependency)
+  if (dep instanceof Dependency) {
     return dep
-  else
+  } else {
     return new Dependency(_resolve_task(dep))
+  }
 }
 
 function _resolve_task(dep: TaskLike): Task {
-  if (dep instanceof Task)
+  if (dep instanceof Task) {
     return dep
-  else {
+  } else {
     const task = tasks.get(dep)
-    if (task != null)
+    if (task != null) {
       return task
-    else
+    } else {
       throw new BuildError("tasks", `can't resolve ${dep} task`)
+    }
   }
 }
 
@@ -150,12 +152,13 @@ export async function run(task: Task): Promise<Result> {
       const args = []
       for (const dep of task.deps) {
         const result = finished.get(dep.task)
-        if (result != null && result.is_Success())
+        if (result != null && result.is_Success()) {
           args.push(result.value)
-        else if (dep.passthrough)
+        } else if (dep.passthrough) {
           args.push(undefined)
-        else
+        } else {
           throw new Error(`${dep} value is not available for ${task}`)
+        }
       }
 
       const start = Date.now()
@@ -215,8 +218,9 @@ export async function run(task: Task): Promise<Result> {
   }
 
   const result = await _run(task, false)
-  if (result.is_Success() && failures.length != 0)
+  if (result.is_Success() && failures.length != 0) {
     return fail(failures)
-  else
+  } else {
     return result
+  }
 }

--- a/bokehjs/make/tasks/_util.ts
+++ b/bokehjs/make/tasks/_util.ts
@@ -35,15 +35,17 @@ export async function is_available(port: number): Promise<boolean> {
     })
 
     socket.on("error", (error: NodeJS.ErrnoException) => {
-      if (error.code === "ECONNREFUSED")
+      if (error.code === "ECONNREFUSED") {
         available = true
+      }
     })
 
     socket.on("close", () => {
-      if (!failure)
+      if (!failure) {
         resolve(available)
-      else
+      } else {
         reject(new BuildError("net", "timeout when searching for unused port"))
+      }
     })
 
     socket.connect(port, host)

--- a/bokehjs/make/tasks/compiler.ts
+++ b/bokehjs/make/tasks/compiler.ts
@@ -23,7 +23,9 @@ task("compiler:build", ["compiler:ts"], async () => {
 
   const linker = new Linker({entries, bases, externals, builtins, minify, es_modules, apply_transforms, cache})
 
-  if (!argv.rebuild) linker.load_cache()
+  if (!argv.rebuild) {
+    linker.load_cache()
+  }
   const {bundles: [bundle], status} = await linker.link()
   linker.store_cache()
 
@@ -39,6 +41,7 @@ task("compiler:build", ["compiler:ts"], async () => {
 
   bundle.assemble({prelude, postlude}).write(join(build_dir.js, "compiler.js"))
 
-  if (!status)
+  if (!status) {
     throw new BuildError("compiler:build", "unable to bundle modules")
+  }
 })

--- a/bokehjs/make/tasks/lint.ts
+++ b/bokehjs/make/tasks/lint.ts
@@ -26,15 +26,17 @@ async function eslint(dir: string): Promise<void> {
   const errors = results.some(result => result.errorCount != 0)
   const warnings = results.some(result => result.warningCount != 0)
 
-  if (fix)
+  if (fix) {
     await ESLint.outputFixes(results)
+  }
 
   if (errors || warnings) {
     const formatter = await eslint.loadFormatter("stylish")
     const output = await formatter.format(results)
 
-    for (const line of output.trim().split("\n"))
+    for (const line of output.trim().split("\n")) {
       log(line)
+    }
   }
 
   if (errors) {

--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -81,7 +81,9 @@ exports.VERSION = "0.0.0";
     },
   })
 
-  if (!argv.rebuild) linker.load_cache()
+  if (!argv.rebuild) {
+    linker.load_cache()
+  }
   const {bundles, status} = await linker.link()
   linker.store_cache()
 
@@ -120,8 +122,9 @@ exports.VERSION = "0.0.0";
   bundle({...esm, minified: false}, outputs.map((name) => rename(name, {ext: ".esm.js"})))
   bundle({...esm, minified: true}, outputs.map((name) => rename(name, {ext: ".esm.min.js"})))
 
-  if (!status)
+  if (!status) {
     throw new BuildError("scripts:bundle", "unable to bundle modules")
+  }
 })
 
 task("lib:build", ["scripts:bundle"])

--- a/bokehjs/make/tasks/server.ts
+++ b/bokehjs/make/tasks/server.ts
@@ -8,12 +8,15 @@ import {find_port, retry, terminate, keep_alive} from "./_util"
 async function server(host?: string, port?: number, inspect?: boolean): Promise<ChildProcess> {
   const args = ["--no-warnings", "./src/server", "server"]
 
-  if (host != null)
+  if (host != null) {
     args.push(`--host=${host}`)
-  if (port != null)
+  }
+  if (port != null) {
     args.push(`--port=${port}`)
-  if (inspect ?? false)
+  }
+  if (inspect ?? false) {
     args.unshift("--inspect")
+  }
 
   const proc = spawn(process.execPath, args, {stdio: ["inherit", "inherit", "inherit", "ipc"]})
   terminate(proc)
@@ -21,10 +24,11 @@ async function server(host?: string, port?: number, inspect?: boolean): Promise<
   return new Promise((resolve, reject) => {
     proc.on("error", reject)
     proc.on("message", (msg) => {
-      if (msg == "ready")
+      if (msg == "ready") {
         resolve(proc)
-      else
+      } else {
         reject(new BuildError("bokehjs-server", "failed to start"))
+      }
     })
     proc.on("exit", (code, _signal) => {
       if (code !== 0) {

--- a/bokehjs/make/tasks/styles.ts
+++ b/bokehjs/make/tasks/styles.ts
@@ -5,6 +5,7 @@ import * as paths from "../paths"
 task("styles:compile", async () => {
   const less_dir = paths.src_dir.less
   const css_dir = paths.build_dir.css
-  if (!await compile_styles(less_dir, css_dir))
+  if (!await compile_styles(less_dir, css_dir)) {
     throw new BuildError("styles:compile", "failed to compile *.less and *.css source files")
+  }
 })

--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -28,9 +28,9 @@ function node(files: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     proc.on("error", reject)
     proc.on("exit", (code, signal) => {
-      if (code === 0)
+      if (code === 0) {
         resolve()
-      else {
+      } else {
         const comment = signal === "SIGINT" || code === 130 ? "interrupted" : "failed"
         reject(new BuildError("node", `tests ${comment}`))
       }
@@ -73,8 +73,9 @@ function chrome(): string {
 
   for (const name of names) {
     const executable = which.sync(name, {nothrow: true, path})
-    if (executable != null)
+    if (executable != null) {
       return executable
+    }
   }
 
   throw new BuildError("headless", `can't find any of ${names.join(", ")} on PATH="${path}"`)
@@ -138,10 +139,11 @@ async function server(port: number): Promise<ChildProcess> {
   const args = ["--no-warnings", "./test/devtools", "server", `--port=${port}`]
 
   if (argv.debug) {
-    if (argv.debug === true)
+    if (argv.debug === true) {
       args.unshift("--inspect-brk")
-    else
+    } else {
       args.unshift(`--inspect-brk=${argv.debug}`)
+    }
   }
 
   const proc = spawn(process.execPath, args, {stdio: ["inherit", "inherit", "inherit", "ipc"]})
@@ -150,10 +152,11 @@ async function server(port: number): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
     proc.on("error", reject)
     proc.on("message", (msg) => {
-      if (msg == "ready")
+      if (msg == "ready") {
         resolve(proc)
-      else
+      } else {
         reject(new BuildError("devtools-server", "failed to start"))
+      }
     })
     proc.on("exit", (code, _signal) => {
       if (code !== 0) {
@@ -164,12 +167,13 @@ async function server(port: number): Promise<ChildProcess> {
 }
 
 function opts(name: string, value: unknown): string[] {
-  if (Array.isArray(value))
+  if (Array.isArray(value)) {
     return value.map((v) => `--${name}=${v}`)
-  else if (value != null)
+  } else if (value != null) {
     return [`--${name}=${value}`]
-  else
+  } else {
     return [""]
+  }
 }
 
 function opt(name: string, value: unknown): string {
@@ -205,10 +209,11 @@ function _devtools(devtools_port: number, user_args: string[]): Promise<void> {
   ]
 
   if (argv.debug) {
-    if (argv.debug === true)
+    if (argv.debug === true) {
       args.unshift("--inspect-brk")
-    else
+    } else {
       args.unshift(`--inspect-brk=${argv.debug}`)
+    }
   }
 
   const proc = spawn(process.execPath, args, {stdio: "inherit"})
@@ -217,9 +222,9 @@ function _devtools(devtools_port: number, user_args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     proc.on("error", reject)
     proc.on("exit", (code, signal) => {
-      if (code === 0)
+      if (code === 0) {
         resolve()
-      else {
+      } else {
         const comment = signal === "SIGINT" || code === 130 ? "interrupted" : "failed"
         reject(new BuildError("devtools", `tests ${comment}`))
       }
@@ -307,7 +312,9 @@ async function bundle(name: string): Promise<void> {
     shims: ["fs", "module"],
   })
 
-  if (!argv.rebuild) linker.load_cache()
+  if (!argv.rebuild) {
+    linker.load_cache()
+  }
   const {bundles: [bundle], status} = await linker.link()
   linker.store_cache()
 
@@ -323,8 +330,9 @@ async function bundle(name: string): Promise<void> {
 
   bundle.assemble({prelude, postlude}).write(join(paths.build_dir.test, `${name}.js`))
 
-  if (!status)
+  if (!status) {
     throw new BuildError(`${name}:bundle`, "unable to bundle modules")
+  }
 }
 
 task("test:compile:unit", async () => compile("unit", {auto_index: true}))
@@ -340,9 +348,9 @@ const build_integration = task("test:build:integration", [passthrough("test:comp
 
 task2("test:integration", [start, build_integration], async ([devtools_port, server_port]) => {
   const baselines_root = (() => {
-    if (platform == "linux")
+    if (platform == "linux") {
       return "test/baselines"
-    else {
+    } else {
       console.log(`${chalk.yellow("warning")}: baseline testing is not supported on this platform`)
       return undefined
     }

--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -65,26 +65,29 @@ type Metadata = {
 
 function is_up_to_date(base_dir: Path, file: string, metadata: Metadata) {
   const contents = read(join(base_dir, file))
-  if (contents == null)
+  if (contents == null) {
     return false
+  }
 
   const old_hash = metadata.signatures[file]
-  if (old_hash == null)
+  if (old_hash == null) {
     return false
+  }
 
   const new_hash = hash(contents)
   return old_hash == new_hash
 }
 
 function needs_install(base_dir: Path, metadata: Metadata): string | null {
-  if (!directory_exists(join(base_dir, "node_modules")))
+  if (!directory_exists(join(base_dir, "node_modules"))) {
     return "New development environment."
-  else if (!is_up_to_date(base_dir, "package.json", metadata))
+  } else if (!is_up_to_date(base_dir, "package.json", metadata)) {
     return "package.json has changed."
-  else if (!is_up_to_date(base_dir, "package-lock.json", metadata))
+  } else if (!is_up_to_date(base_dir, "package-lock.json", metadata)) {
     return "package-lock.json has changed."
-  else
+  } else {
     return null
+  }
 }
 
 export type InitOptions = {
@@ -221,10 +224,12 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
 
   const metadata = (() => {
     let obj = read_json(metadata_path) as any
-    if (obj == null)
+    if (obj == null) {
       obj = {}
-    if (obj.signatures == null)
+    }
+    if (obj.signatures == null) {
       obj.signatures = {}
+    }
     return obj as Metadata
   })()
 
@@ -262,10 +267,11 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
       return join(base_dir, "node_modules", "typescript", "lib")
     } else {
       // bokeh/server/static or bokehjs/build
-      if (is_static_dir)
+      if (is_static_dir) {
         return join(bokehjs_dir, "lib")
-      else
+      } else {
         return join(dirname(bokehjs_dir), "node_modules", "typescript", "lib")
+      }
     }
   })()
 
@@ -285,8 +291,9 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
     if (file_exists(tsconfig_path)) {
       print(`Using ${cyan(tsconfig_path)}`)
       return read_tsconfig(tsconfig_path, is_package ? undefined : preconfigure)
-    } else
+    } else {
       return parse_tsconfig(tsconfig_json, base_dir, preconfigure)
+    }
   })()
 
   if (is_failed(tsconfig)) {
@@ -306,8 +313,9 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
   const css_dir = join(dist_dir, "css")
 
   print("Compiling styles")
-  if (!await compile_styles(styles_dir, css_dir))
+  if (!await compile_styles(styles_dir, css_dir)) {
     success = false
+  }
 
   wrap_css_modules(css_dir, lib_dir, dts_dir, dts_internal_dir)
 
@@ -320,15 +328,17 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
   if (is_failed(tsoutput)) {
     print(report_diagnostics(tsoutput.diagnostics).text)
 
-    if (options.noEmitOnError ?? false)
+    if (options.noEmitOnError ?? false) {
       return false
+    }
   }
 
   const artifact = basename(base_dir)
 
   const bases = [lib_dir]
-  if (is_package)
+  if (is_package) {
     bases.push(join(base_dir, "node_modules"))
+  }
 
   const linker = new Linker({
     entries: [join(lib_dir, "index.js")],
@@ -340,10 +350,13 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
   })
 
   print("Linking modules")
-  if (!setup.rebuild) linker.load_cache()
+  if (!setup.rebuild) {
+    linker.load_cache()
+  }
   const {bundles, status} = await linker.link()
-  if (!status)
+  if (!status) {
     success = false
+  }
   linker.store_cache()
   const outputs = [join(dist_dir, `${artifact}.js`)]
 
@@ -354,10 +367,11 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
       if (isString(bokeh_ext.license.file)) {
         const license_path = join(base_dir, bokeh_ext.license.file)
         const text = read(license_path)
-        if (text != null)
+        if (text != null) {
           return text
-        else
+        } else {
           print(`Failed to license text from ${magenta(license_path)}`)
+        }
       }
       if (isString(bokeh_ext.license.text)) {
         return bokeh_ext.license.text

--- a/bokehjs/src/compiler/compile.ts
+++ b/bokehjs/src/compiler/compile.ts
@@ -31,15 +31,17 @@ export function compile_typescript(base_dir: string, inputs: Inputs, bokehjs_dir
   }
 
   const tsconfig = parse_patched_tsconfig(base_dir, preconfigure)
-  if (tsconfig.diagnostics != null)
+  if (tsconfig.diagnostics != null) {
     return {diagnostics: tsconfig.diagnostics}
+  }
 
   const tslib_dir = (() => {
     // bokeh/server/static or bokehjs/build
-    if (is_static_dir)
+    if (is_static_dir) {
       return join(bokehjs_dir, "lib")
-    else
+    } else {
       return join(dirname(bokehjs_dir), "node_modules", "typescript", "lib")
+    }
   })()
 
   const host = compiler_host(inputs, tsconfig.options, tslib_dir)
@@ -56,8 +58,9 @@ export function compile_typescript(base_dir: string, inputs: Inputs, bokehjs_dir
 
 function compile_javascript(base_dir: string, file: string, code: string): { output?: string } & TSOutput {
   const tsconfig = parse_patched_tsconfig(base_dir, {})
-  if (tsconfig.diagnostics != null)
+  if (tsconfig.diagnostics != null) {
     return {diagnostics: tsconfig.diagnostics}
+  }
 
   const {outputText, diagnostics} = ts.transpileModule(code, {
     fileName: file,

--- a/bokehjs/src/compiler/compiler.ts
+++ b/bokehjs/src/compiler/compiler.ts
@@ -69,8 +69,9 @@ export function compiler_host(inputs: Inputs, options: ts.CompilerOptions, tslib
         const sf = ts.createSourceFile(name, source, target)
         const version = default_host.createHash!(source)
         return {...sf, version} as any // version is internal to the compiler
-      } else
+      } else {
         return default_host.getSourceFile(name, target, _onError)
+      }
     },
   }
 
@@ -159,8 +160,9 @@ export function read_tsconfig(tsconfig_path: Path, preconfigure?: ts.CompilerOpt
 
 function compile_project(tsconfig_path: Path, config: CompileConfig): TSOutput {
   const tsconfig = read_tsconfig(tsconfig_path)
-  if (is_failed(tsconfig))
+  if (is_failed(tsconfig)) {
     return {diagnostics: tsconfig.diagnostics}
+  }
 
   const {files, options} = tsconfig
 

--- a/bokehjs/src/compiler/graph.ts
+++ b/bokehjs/src/compiler/graph.ts
@@ -14,8 +14,9 @@ export function detect_cycles<T>(graph: Graph<T>): T[][] {
     const node = nodes[0]
 
     const entry = state.get(node)!
-    if (entry.visited)
+    if (entry.visited) {
       return false
+    }
     if (entry.explored) {
       cycles.push(nodes)
       return true
@@ -28,8 +29,9 @@ export function detect_cycles<T>(graph: Graph<T>): T[][] {
       const {visited} = state.get(neighbor)!
       if (!visited) {
         const cycle = detect_cycle([neighbor, ...nodes])
-        if (cycle)
+        if (cycle) {
           break
+        }
       }
     }
 

--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -134,13 +134,16 @@ export class Bundle {
     for (const artifact of artifacts) {
       const {module} = artifact
 
-      if (module.canonical != null)
+      if (module.canonical != null) {
         aliases.set(module.canonical, module.id)
+      }
 
-      for (const external of module.externals)
+      for (const external of module.externals) {
         externals.set(external, true)
-      for (const external of module.shims)
+      }
+      for (const external of module.shims) {
         externals.set(external, false)
+      }
 
       const start = wrap(safe_id(module), "")
       sources += start
@@ -182,9 +185,9 @@ export class Bundle {
         }
         case "namespace": {
           const {name} = item
-          if (name != null)
+          if (name != null) {
             yield name
-          else {
+          } else {
             const module = entry.dependencies.get(item.module)
             if (module != null) {
               yield* this.collect_exported(module)
@@ -203,10 +206,11 @@ export class Artifact {
               readonly exported: Map<string, number | string>) {}
 
   full_source(name: string): string {
-    if (this.sourcemap != null)
+    if (this.sourcemap != null) {
       return `${this.source}\n${convert.generateMapFileComment(name)}\n`
-    else
+    } else {
       return `${this.source}\n`
+    }
   }
 
   get module_names(): string[] {
@@ -277,18 +281,21 @@ export class Linker {
       this.external_modules.add("module")
       this.external_modules.add("constants")
 
-      for (const lib of module.builtinModules)
+      for (const lib of module.builtinModules) {
         this.external_modules.add(lib)
+      }
     }
 
     for (const entry of this.entries) {
-      if (!file_exists(entry))
+      if (!file_exists(entry)) {
         throw new BuildError("linker", `entry path ${entry} doesn't exist or isn't a file`)
+      }
     }
 
     for (const base of this.bases) {
-      if (!directory_exists(base))
+      if (!directory_exists(base)) {
         throw new BuildError("linker", `base path ${base} doesn't exist or isn't a directory`)
+      }
     }
 
     this.cache_path = opts.cache
@@ -336,10 +343,11 @@ export class Linker {
     }
 
     const all_modules = main_modules.concat(...plugin_modules)
-    if (!this.plugin)
+    if (!this.plugin) {
       all_modules.forEach((module, i) => module.id = i)
-    else
+    } else {
       all_modules.forEach((module) => module.id = module.hash.slice(0, 10))
+    }
 
     if (this.detect_cycles) {
       function is_internal(module: ModuleInfo) {
@@ -404,13 +412,15 @@ export class Linker {
     }
 
     const deps_changed = (module: ModuleInfo, cached: ModuleInfo): boolean => {
-      if (module.dependencies.size != cached.dependencies.size)
+      if (module.dependencies.size != cached.dependencies.size) {
         return false
+      }
 
       for (const [dep, module_dep] of module.dependencies) {
         const cached_dep = cached.dependencies.get(dep)
-        if (cached_dep == null || cached_dep.id != module_dep.id)
+        if (cached_dep == null || cached_dep.id != module_dep.id) {
           return true
+        }
       }
       return false
     }
@@ -434,8 +444,9 @@ export class Linker {
           })()
           const minified = this.minify ? await minify(module, source, ecma) : {min_source: source}
           code = {source, ...minified}
-        } else
+        } else {
           code = cached!.code
+        }
 
         result.push({module, code})
       }
@@ -464,8 +475,9 @@ export class Linker {
 
   load_cache(): void {
     const {cache_path} = this
-    if (cache_path == null || !file_exists(cache_path))
+    if (cache_path == null || !file_exists(cache_path)) {
       return
+    }
 
     this.cache.clear()
 
@@ -495,16 +507,18 @@ export class Linker {
     for (const {module} of this.cache.values()) {
       for (const [dep, file] of module.dependency_paths) {
         const file_entry = this.cache.get(file)
-        if (file_entry == null)
+        if (file_entry == null) {
           throw new Error(`${file} not in cache`)
+        }
         module.dependencies.set(dep, file_entry.module)
       }
     }
   }
 
   store_cache(): void {
-    if (this.cache_path == null)
+    if (this.cache_path == null) {
       return
+    }
 
     const artifacts = []
     for (const artifact of this.cache.values()) {
@@ -535,10 +549,11 @@ export class Linker {
 
   get_package(dir: string): {[key: string]: unknown} {
     const pkg_path = join(dir, "package.json")
-    if (file_exists(pkg_path))
+    if (file_exists(pkg_path)) {
       return JSON.parse(read(pkg_path)!)
-    else
+    } else {
       return {}
+    }
   }
 
   resolve_export_map(dir: string, subpath: string): string | null {
@@ -557,29 +572,34 @@ export class Linker {
     const pkg = this.get_package(dir)
 
     const index = (() => {
-      if (this.target != null && pkg.module != null)
+      if (this.target != null && pkg.module != null) {
         return pkg.module as string
-      else if (pkg.main != null)
+      } else if (pkg.main != null) {
         return pkg.main as string
-      else
+      } else {
         return "index.js"
+      }
     })()
 
     const path = join(dir, index)
-    if (file_exists(path))
+    if (file_exists(path)) {
       return path
+    }
 
     const js_file = `${path}.js`
-    if (file_exists(js_file))
+    if (file_exists(js_file)) {
       return js_file
+    }
     const json_file = `${path}.json`
-    if (file_exists(json_file))
+    if (file_exists(json_file)) {
       return json_file
+    }
 
     if (directory_exists(path)) {
       const index = join(path, "index.js")
-      if (file_exists(index))
+      if (file_exists(index)) {
         return index
+      }
     }
 
     return null
@@ -588,8 +608,9 @@ export class Linker {
   protected resolve_relative(dep: string, parent: Parent): Path | Error {
     const path = resolve(dirname(parent.file), dep)
 
-    if (file_exists(path))
+    if (file_exists(path)) {
       return path
+    }
 
     const js_file = `${path}.js`
     const json_file = `${path}.json`
@@ -600,38 +621,44 @@ export class Linker {
     if (directory_exists(path)) {
       const pkg_file = this.resolve_package(path)
       if (pkg_file != null) {
-        if (!has_file)
+        if (!has_file) {
           return pkg_file
-        else
+        } else {
           return new BuildError("linker", `both ${has_js_file ? js_file : json_file} and ${pkg_file} exist`)
+        }
       }
     }
 
-    if (has_js_file)
+    if (has_js_file) {
       return js_file
-    else if (has_json_file)
+    } else if (has_json_file) {
       return json_file
-    else
+    } else {
       return new BuildError("linker", `can't resolve '${dep}' from '${parent.file}'`)
+    }
   }
 
   protected resolve_absolute(dep: string, parent: Parent): Path | Error {
     for (const base of this.bases) {
       let path = join(base, dep)
-      if (file_exists(path))
+      if (file_exists(path)) {
         return path
+      }
 
       const js_file = `${path}.js`
-      if (file_exists(js_file))
+      if (file_exists(js_file)) {
         return js_file
+      }
       const json_file = `${path}.json`
-      if (file_exists(json_file))
+      if (file_exists(json_file)) {
         return json_file
+      }
 
       if (directory_exists(path)) {
         const file = this.resolve_package(path)
-        if (file != null)
+        if (file != null) {
           return file
+        }
       }
 
       const [dir, ...rest] = dep.split(sep)
@@ -639,8 +666,9 @@ export class Linker {
         const path = join(base, dir)
         if (directory_exists(path)) {
           const file = this.resolve_export_map(path, rest.join(sep))
-          if (file != null)
+          if (file != null) {
             return file
+          }
         }
       }
 
@@ -650,15 +678,17 @@ export class Linker {
         while (true) {
           base_path = dirname(base_path)
 
-          if (base_path == base)
+          if (base_path == base) {
             break
+          }
 
           path = join(base_path, "node_modules", dep)
 
           if (directory_exists(path)) {
             const file = this.resolve_package(path)
-            if (file != null)
+            if (file != null) {
               return file
+            }
           }
         }
       }
@@ -668,10 +698,11 @@ export class Linker {
   }
 
   resolve_file(dep: string, parent: Parent): Path | Error {
-    if (dep.startsWith("."))
+    if (dep.startsWith(".")) {
       return this.resolve_relative(dep, parent)
-    else
+    } else {
       return this.resolve_absolute(dep, parent)
+    }
   }
 
   private parse_module({file, source}: {file: Path, source: string}): ts.SourceFile {
@@ -759,8 +790,9 @@ export ${export_type} yaml;
         while (path != base) {
           if (directory_exists(path)) {
             const pkg_path = join(path, "package.json")
-            if (file_exists(pkg_path))
+            if (file_exists(pkg_path)) {
               return {dir: path, pkg: JSON.parse(read(pkg_path)!)}
+            }
           }
           path = dirname(path)
         }
@@ -827,9 +859,9 @@ export ${export_type} yaml;
 
         // XXX: .json extension will cause an internal error
         const {output, error} = transpile(type == "json" ? `${file}.ts` : file, source, target, transform)
-        if (error != null)
+        if (error != null) {
           throw new BuildError("linker", error)
-        else {
+        } else {
           source = output
           collected = [...imports]
         }
@@ -837,17 +869,19 @@ export ${export_type} yaml;
 
       ast = this.parse_module({file, source})
 
-      if (collected == null)
+      if (collected == null) {
         collected = transforms.collect_deps(ast)
+      }
       const filtered = collected.filter((dep) => !this.is_external(dep) && !this.excluded(dep) && !this.is_shimmed(dep))
 
       dependency_paths = new Map()
       for (const dep of filtered) {
         const resolved = this.resolve_file(dep, {file})
-        if (resolved instanceof Error)
+        if (resolved instanceof Error) {
           console.log(resolved)
-        else
+        } else {
           dependency_paths.set(dep, resolved)
+        }
       }
 
       externals = new Set(collected.filter((dep) => this.is_external(dep)))
@@ -888,10 +922,12 @@ export ${export_type} yaml;
     for (;;) {
       const file = pending.shift()
 
-      if (file == null)
+      if (file == null) {
         break
-      if (visited.has(file) || this.excludes.has(file))
+      }
+      if (visited.has(file) || this.excludes.has(file)) {
         continue
+      }
 
       const module = this.new_module(file)
       visited.set(module.file, module)
@@ -915,10 +951,12 @@ export ${export_type} yaml;
     for (;;) {
       const module = pending.shift()
 
-      if (module == null)
+      if (module == null) {
         break
-      if (reached.has(module) || this.excludes.has(module.file) || is_excluded(module))
+      }
+      if (reached.has(module) || this.excludes.has(module.file) || is_excluded(module)) {
         continue
+      }
 
       reached.add(module)
       pending.unshift(...module.dependencies.values())
@@ -943,9 +981,9 @@ export function transpile(file: Path, source: string, target: ts.ScriptTarget,
     transformers,
   })
 
-  if (diagnostics == null || diagnostics.length == 0)
+  if (diagnostics == null || diagnostics.length == 0) {
     return {output}
-  else {
+  } else {
     const {text} = report_diagnostics(diagnostics)
     return {output, error: text}
   }

--- a/bokehjs/src/compiler/styles.ts
+++ b/bokehjs/src/compiler/styles.ts
@@ -9,8 +9,9 @@ export async function compile_styles(styles_dir: string, css_dir: string): Promi
   let success = true
 
   for (const src of scan(styles_dir, [".less", ".css"])) {
-    if (basename(src).startsWith("_"))
+    if (basename(src).startsWith("_")) {
       continue
+    }
 
     try {
       const style = read(src)!
@@ -31,8 +32,9 @@ export function wrap_css_modules(css_dir: string, js_dir: string, dts_dir: strin
 
   function* collect_classes(ast: CSS.Stylesheet) {
     const {stylesheet} = ast
-    if (stylesheet == null)
+    if (stylesheet == null) {
       return
+    }
 
     for (const rule of stylesheet.rules) {
       if (rule.type == "rule") {
@@ -64,8 +66,9 @@ export function wrap_css_modules(css_dir: string, js_dir: string, dts_dir: strin
 
     const classes = new Set(collect_classes(ast))
     for (const cls of classes) {
-      if (!cls.startsWith("bk-"))
+      if (!cls.startsWith("bk-")) {
         continue
+      }
       const ident = cls.replace(/^bk-/, "").replace(/-/g, "_")
       js.push(`export const ${ident} = "${cls}"`)
       dts.push(`export const ${ident}: string`)

--- a/bokehjs/src/compiler/sys.ts
+++ b/bokehjs/src/compiler/sys.ts
@@ -30,15 +30,18 @@ export type RenameOptions = {
 export function rename(path: string, options: RenameOptions): string {
   let {dir, name, ext} = parse(path)
   if (options.dir != null) {
-    if (options.base != null)
+    if (options.base != null) {
       dir = dir.replace(options.base, options.dir)
-    else
+    } else {
       dir = options.dir
+    }
   }
-  if (options.name != null)
+  if (options.name != null) {
     name = options.name(name)
-  if (options.ext != null)
+  }
+  if (options.ext != null) {
     ext = options.ext
+  }
   return format({dir, name, ext})
 }
 
@@ -53,9 +56,9 @@ export function hash_file(path: Path): string | null {
 
 export function read_json(path: Path): unknown | undefined {
   const data = read(path)
-  if (data == null)
+  if (data == null) {
     return undefined
-  else {
+  } else {
     try {
       return JSON.parse(data)
     } catch {

--- a/bokehjs/src/compiler/transforms.ts
+++ b/bokehjs/src/compiler/transforms.ts
@@ -21,8 +21,9 @@ export function relativize_modules(relativize: (file: string, module_path: strin
     const {factory} = context
     if (expr != null && ts.isStringLiteralLike(expr) && expr.text.length > 0) {
       const relative = relativize(source.fileName, expr.text)
-      if (relative != null)
+      if (relative != null) {
         return factory.createStringLiteral(relative)
+      }
     }
 
     return null
@@ -118,8 +119,9 @@ export function remove_use_strict() {
     const statements = root.statements.filter((node) => {
       if (ts.isExpressionStatement(node)) {
         const expr = node.expression
-        if (ts.isStringLiteral(expr) && expr.text == "use strict")
+        if (ts.isStringLiteral(expr) && expr.text == "use strict") {
           return false
+        }
       }
       return true
     })
@@ -151,11 +153,13 @@ export function collect_exports(exported: Exports[]) {
   return (_context: ts.TransformationContext) => (root: ts.SourceFile) => {
     for (const statement of root.statements) {
       if (ts.isExportDeclaration(statement)) {
-        if (statement.isTypeOnly)
+        if (statement.isTypeOnly) {
           continue
+        }
         const {exportClause, moduleSpecifier} = statement
-        if (moduleSpecifier == null || !ts.isStringLiteral(moduleSpecifier))
+        if (moduleSpecifier == null || !ts.isStringLiteral(moduleSpecifier)) {
           continue
+        }
         const module = moduleSpecifier.text
         if (exportClause == null) {
           // export * from "module"
@@ -201,12 +205,14 @@ export function collect_imports(imports: Set<string>) {
     function visit(node: ts.Node): ts.Node {
       if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
         const name = node.moduleSpecifier
-        if (name != null && ts.isStringLiteral(name) && name.text.length != 0)
+        if (name != null && ts.isStringLiteral(name) && name.text.length != 0) {
           imports.add(name.text)
+        }
       } else if (isImportCall(node)) {
         const [name] = node.arguments
-        if (ts.isStringLiteral(name) && name.text.length != 0)
+        if (ts.isStringLiteral(name) && name.text.length != 0) {
           imports.add(name.text)
+        }
       }
 
       return ts.visitEachChild(node, visit, context)
@@ -219,8 +225,9 @@ export function collect_deps(source: ts.SourceFile): string[] {
   function traverse(node: ts.Node): void {
     if (is_require(node)) {
       const [arg] = node.arguments
-      if (ts.isStringLiteral(arg) && arg.text.length > 0)
+      if (ts.isStringLiteral(arg) && arg.text.length > 0) {
         deps.add(arg.text)
+      }
     }
 
     ts.forEachChild(node, traverse)
@@ -286,8 +293,9 @@ export function rename_exports() {
       }
 
       return ts.visitEachChild(root, visit, context)
-    } else
+    } else {
       return root
+    }
   }
 }
 

--- a/bokehjs/src/lib/api/charts.ts
+++ b/bokehjs/src/lib/api/charts.ts
@@ -94,8 +94,9 @@ export function pie(data: PieChartData, opts: PieChartOpts = {}): Plot {
   const palette = resolve_palette(opts.palette)
 
   const colors: Color[] = []
-  for (let i = 0; i < normalized_values.length; i++)
+  for (let i = 0; i < normalized_values.length; i++) {
     colors.push(palette[i % palette.length])
+  }
   const text_colors = colors.map((c) => is_dark(color2rgba(c)) ? "white" : "black")
 
   function to_cartesian(r: number, alpha: number): [number, number] {
@@ -108,10 +109,11 @@ export function pie(data: PieChartData, opts: PieChartOpts = {}): Plot {
   text_cy = text_cy.map((y) => y + cy)
 
   const text_angles = half_angles.map((a: number): number => {
-    if (a >= Math.PI/2 && a <= 3*Math.PI/2)
+    if (a >= Math.PI/2 && a <= 3*Math.PI/2) {
       return a + Math.PI
-    else
+    } else {
       return a
+    }
   })
 
   const source = new ColumnDataSource({
@@ -196,10 +198,11 @@ export function bar(data: BarChartData, opts: BarChartOpts = {}): Plot {
   let yscale: Scale = new CategoricalScale()
 
   let xformatter: TickFormatter
-  if (opts.axis_number_format != null)
+  if (opts.axis_number_format != null) {
     xformatter = new NumeralTickFormatter({format: opts.axis_number_format})
-  else
+  } else {
     xformatter = new BasicTickFormatter()
+  }
   let xaxis: Axis = new LinearAxis({formatter: xformatter})
   let xdr: Range = new DataRange1d({start: 0})
   let xscale: Scale = new LinearScale()

--- a/bokehjs/src/lib/api/expr.ts
+++ b/bokehjs/src/lib/api/expr.ts
@@ -18,10 +18,11 @@ function evaluate(ast: Expression, refs: unknown[]): unknown {
       case IDENT:
         if (ast.name.startsWith("$")) {
           const i = Number(ast.name.slice(1))
-          if (isFinite(i) && 0 <= i && i < refs.length)
+          if (isFinite(i) && 0 <= i && i < refs.length) {
             return refs[i]
-          else
+          } else {
             throw new Error(`invalid reference: ${ast.name}`)
+          }
         }
 
         switch (ast.name) {
@@ -34,20 +35,23 @@ function evaluate(ast: Expression, refs: unknown[]): unknown {
         const obj = resolve(ast.object)
         if (obj === np) {
           const {name} = ast.member
-          if (Object.prototype.hasOwnProperty.call(np, name))
+          if (Object.prototype.hasOwnProperty.call(np, name)) {
             return (np as any)[name]
-          else
+          } else {
             throw new Error(`'np.${name}' doesn't exist`)
-        } else
+          }
+        } else {
           throw new Error("not an accessable expression")
+        }
       case INDEX:
         throw new Error("not an indexable expression")
       case CALL:
         const callee = resolve(ast.callee)
-        if (isFunction(callee))
+        if (isFunction(callee)) {
           return callee.apply(undefined, ast.args.map((arg) => resolve(arg)))
-        else
+        } else {
           throw new Error("not a callable expression")
+        }
       case UNARY: {
         const op = (() => {
           switch (ast.operator) {
@@ -58,10 +62,11 @@ function evaluate(ast: Expression, refs: unknown[]): unknown {
           }
         })()
         const x = resolve(ast.argument)
-        if (is_Numerical(x))
+        if (is_Numerical(x)) {
           return op(x)
-        else
+        } else {
           throw new Error("a number or an array was expected")
+        }
       }
       case BINARY:
         const op = (() => {
@@ -81,10 +86,11 @@ function evaluate(ast: Expression, refs: unknown[]): unknown {
         })()
         const x = resolve(ast.left)
         const y = resolve(ast.right)
-        if (is_Numerical(x) && is_Numerical(y))
+        if (is_Numerical(x) && is_Numerical(y)) {
           return op(x, y)
-        else
+        } else {
           throw new Error("a number or an array was expected")
+        }
       case COMPOUND:
       case SEQUENCE:
       case ARRAY:
@@ -107,8 +113,9 @@ export function f(strings: TemplateStringsArray, ...subs: unknown[]): unknown {
   const parser = new Parser(input)
   const ast = parser.parse()
 
-  if (ast.type != FAILURE)
+  if (ast.type != FAILURE) {
     return evaluate(ast, subs)
-  else
+  } else {
     throw new Error(ast.message)
+  }
 }

--- a/bokehjs/src/lib/api/figure.ts
+++ b/bokehjs/src/lib/api/figure.ts
@@ -94,8 +94,9 @@ class ModelProxy<T extends HasProps> implements IModelProxy<T> {
     for (const model of models) {
       for (const prop of model) {
         const {attr} = prop
-        if (!mapping.has(attr))
+        if (!mapping.has(attr)) {
           mapping.set(attr, [])
+        }
         mapping.get(attr)!.push(prop)
       }
     }
@@ -266,18 +267,20 @@ export class Figure extends BaseFigure {
     const tools = (() => {
       const {tools, toolbar} = attrs
       if (tools != null) {
-        if (toolbar != null)
+        if (toolbar != null) {
           throw new Error("'tools' and 'toolbar' can't be used together")
-        else {
+        } else {
           delete attrs.tools
 
           if (isString(tools)) {
             return tools.split(",").map((s) => s.trim()).filter((s) => s.length > 0) as (keyof ToolAliases)[]
-          } else
+          } else {
             return tools
+          }
         }
-      } else
+      } else {
         return toolbar != null ? null : _default_tools
+      }
     })()
 
     super({...attrs, x_range, y_range, x_scale, y_scale})
@@ -301,38 +304,48 @@ export class Figure extends BaseFigure {
 
     if (isString(active_drag) && active_drag != "auto") {
       const tool = tool_map.get(active_drag)
-      if (tool != null)
+      if (tool != null) {
         this.toolbar.active_drag = tool
-    } else if (active_drag !== undefined)
+      }
+    } else if (active_drag !== undefined) {
       this.toolbar.active_drag = active_drag
+    }
 
     if (isString(active_inspect) && active_inspect != "auto") {
       const tool = tool_map.get(active_inspect)
-      if (tool != null)
+      if (tool != null) {
         this.toolbar.active_inspect = tool
-    } else if (active_inspect !== undefined)
+      }
+    } else if (active_inspect !== undefined) {
       this.toolbar.active_inspect = active_inspect
+    }
 
     if (isString(active_scroll) && active_scroll != "auto") {
       const tool = tool_map.get(active_scroll)
-      if (tool != null)
+      if (tool != null) {
         this.toolbar.active_scroll = tool
-    } else if (active_scroll !== undefined)
+      }
+    } else if (active_scroll !== undefined) {
       this.toolbar.active_scroll = active_scroll
+    }
 
     if (isString(active_tap) && active_tap != "auto") {
       const tool = tool_map.get(active_tap)
-      if (tool != null)
+      if (tool != null) {
         this.toolbar.active_tap = tool
-    } else if (active_tap !== undefined)
+      }
+    } else if (active_tap !== undefined) {
       this.toolbar.active_tap = active_tap
+    }
 
     if (isString(active_multi) && active_multi != "auto") {
       const tool = tool_map.get(active_multi)
-      if (tool instanceof GestureTool)
+      if (tool instanceof GestureTool) {
         this.toolbar.active_multi = tool
-    } else if (active_multi !== undefined)
+      }
+    } else if (active_multi !== undefined) {
       this.toolbar.active_multi = active_multi
+    }
   }
 
   get coordinates(): CoordinateMapping | null {
@@ -405,10 +418,11 @@ export class Figure extends BaseFigure {
     let i = 1
     while (true) {
       const new_name = `${name}__${i}`
-      if (new_name in data)
+      if (new_name in data) {
         i += 1
-      else
+      } else {
         return new_name
+      }
     }
   }
 
@@ -452,8 +466,9 @@ export class Figure extends BaseFigure {
             }
           }
         }
-      } else
+      } else {
         unresolved_attrs.add(name)
+      }
     }
 
     return unresolved_attrs
@@ -466,10 +481,11 @@ export class Figure extends BaseFigure {
     } else if (args.length == 1) {
       attrs = {...args[0] as Attrs}
     } else {
-      if (args.length == positional.length)
+      if (args.length == positional.length) {
         attrs = {}
-      else
+      } else {
         attrs = {...args[args.length - 1] as Attrs}
+      }
 
       for (const [param, i] of enumerate(positional)) {
         attrs[param as string] = args[i]
@@ -480,12 +496,13 @@ export class Figure extends BaseFigure {
 
     const source = (() => {
       const {source} = attrs
-      if (source == null)
+      if (source == null) {
         return new ColumnDataSource()
-      else if (source instanceof ColumnarDataSource)
+      } else if (source instanceof ColumnarDataSource) {
         return source
-      else
+      } else {
         return new ColumnDataSource({data: source})
+      }
     })()
     const data = clone(source.data)
     delete attrs.source
@@ -502,8 +519,9 @@ export class Figure extends BaseFigure {
     const legend_group = attrs.legend_group
     delete attrs.legend_group
 
-    if ([legend, legend_label, legend_field, legend_group].filter((arg) => arg != null).length > 1)
+    if ([legend, legend_label, legend_field, legend_group].filter((arg) => arg != null).length > 1) {
       throw new Error("only one of legend, legend_label, legend_field, legend_group can be specified")
+    }
 
     const name = attrs.name
     delete attrs.name
@@ -565,12 +583,15 @@ export class Figure extends BaseFigure {
       coordinates,
     })
 
-    if (legend_label != null)
+    if (legend_label != null) {
       this._handle_legend_label(legend_label, this.legend, glyph_renderer)
-    if (legend_field != null)
+    }
+    if (legend_field != null) {
       this._handle_legend_field(legend_field, this.legend, glyph_renderer)
-    if (legend_group != null)
+    }
+    if (legend_group != null) {
       this._handle_legend_group(legend_group, this.legend, glyph_renderer)
+    }
 
     this.add_renderers(glyph_renderer)
     return glyph_renderer as TypedGlyphRenderer<G>
@@ -661,10 +682,11 @@ export class Figure extends BaseFigure {
         return axis
       }
       case "auto":
-        if (range instanceof FactorRange)
+        if (range instanceof FactorRange) {
           return new CategoricalAxis()
-        else
-          return new LinearAxis() // TODO: return DatetimeAxis (Date type)
+        } else {
+          return new LinearAxis()
+        } // TODO: return DatetimeAxis (Date type)
       default:
         throw new Error("shouldn't have happened")
     }
@@ -672,14 +694,16 @@ export class Figure extends BaseFigure {
 
   _get_num_minor_ticks(axis: Axis, num_minor_ticks?: number | "auto"): number {
     if (isNumber(num_minor_ticks)) {
-      if (num_minor_ticks <= 1)
+      if (num_minor_ticks <= 1) {
         throw new Error("num_minor_ticks must be > 1")
-      else
+      } else {
         return num_minor_ticks
-    } else if (num_minor_ticks == null)
+      }
+    } else if (num_minor_ticks == null) {
       return 0
-    else
+    } else {
       return axis instanceof LogAxis ? 10 : 5
+    }
   }
 
   _update_legend(legend_item_label: Vector<string>, glyph_renderer: GlyphRenderer): void {
@@ -710,9 +734,9 @@ export class Figure extends BaseFigure {
   protected _handle_legend_label(value: string, legend: Legend, glyph_renderer: GlyphRenderer): void {
     const label = {value}
     const item = this._find_legend_item(label, legend)
-    if (item != null)
+    if (item != null) {
       item.renderers.push(glyph_renderer)
-    else {
+    } else {
       const new_item = new LegendItem({label, renderers: [glyph_renderer]})
       legend.items.push(new_item)
     }
@@ -721,9 +745,9 @@ export class Figure extends BaseFigure {
   protected _handle_legend_field(field: string, legend: Legend, glyph_renderer: GlyphRenderer): void {
     const label = {field}
     const item = this._find_legend_item(label, legend)
-    if (item != null)
+    if (item != null) {
       item.renderers.push(glyph_renderer)
-    else {
+    } else {
       const new_item = new LegendItem({label, renderers: [glyph_renderer]})
       legend.items.push(new_item)
     }
@@ -731,8 +755,9 @@ export class Figure extends BaseFigure {
 
   protected _handle_legend_group(name: string, legend: Legend, glyph_renderer: GlyphRenderer): void {
     const source = glyph_renderer.data_source
-    if (!(name in source.data))
+    if (!(name in source.data)) {
       throw new Error("column to be grouped does not exist in glyph data source")
+    }
 
     const column = [...source.data[name]]
     const values = uniq(column).sort()
@@ -747,8 +772,9 @@ export class Figure extends BaseFigure {
   protected _find_legend_item(label: Vector<string>, legend: Legend): LegendItem | null {
     const cmp = new Comparator()
     for (const item of legend.items) {
-      if (cmp.eq(item.label, label))
+      if (cmp.eq(item.label, label)) {
         return item
+      }
     }
     return null
   }

--- a/bokehjs/src/lib/api/gridplot.ts
+++ b/bokehjs/src/lib/api/gridplot.ts
@@ -45,8 +45,9 @@ export function group_tools(tools: ToolLike<Tool>[], merge?: MergeFn,
 
       const proto = tool.constructor.prototype
       let values = by_type.get(proto)
-      if (values == null)
+      if (values == null) {
         by_type.set(proto, values=new Set())
+      }
       values.add({tool, attrs})
     }
   }
@@ -72,9 +73,9 @@ export function group_tools(tools: ToolLike<Tool>[], merge?: MergeFn,
         }
       }
 
-      if (group.length == 1)
+      if (group.length == 1) {
         computed.push(group[0])
-      else {
+      } else {
         const merged = merge?.(cls, group)
         computed.push(merged ?? new ToolProxy({tools: group}))
       }
@@ -95,8 +96,9 @@ export function gridplot(children: (LayoutDOM | null)[][] | Matrix<LayoutDOM | n
   const toolbars: Toolbar[] = []
 
   for (const [item, row, col] of matrix) {
-    if (item == null)
+    if (item == null) {
       continue
+    }
 
     if (item instanceof Plot) {
       if (merge_tools) {
@@ -105,26 +107,29 @@ export function gridplot(children: (LayoutDOM | null)[][] | Matrix<LayoutDOM | n
       }
     }
 
-    if (options.width != null)
+    if (options.width != null) {
       item.width = options.width
-    if (options.height != null)
+    }
+    if (options.height != null) {
       item.height = options.height
+    }
 
     items.push([item, row, col])
   }
 
   function merge(_cls: typeof Tool, group: Tool[]) {
     const tool = group[0]
-    if (tool instanceof SaveTool)
+    if (tool instanceof SaveTool) {
       return new SaveTool()
-    else if (tool instanceof CopyTool)
+    } else if (tool instanceof CopyTool) {
       return new CopyTool()
-    else if (tool instanceof ExamineTool)
+    } else if (tool instanceof ExamineTool) {
       return new ExamineTool()
-    else if (tool instanceof FullscreenTool)
+    } else if (tool instanceof FullscreenTool) {
       return new FullscreenTool()
-    else
+    } else {
       return null
+    }
   }
 
   const tools = (() => {
@@ -134,10 +139,11 @@ export function gridplot(children: (LayoutDOM | null)[][] | Matrix<LayoutDOM | n
       tools.push(...toolbar.tools)
     }
 
-    if (merge_tools)
+    if (merge_tools) {
       return group_tools(tools, merge)
-    else
+    } else {
       return tools
+    }
   })()
 
   const logos = toolbars.map((toolbar) => toolbar.logo)

--- a/bokehjs/src/lib/api/io.ts
+++ b/bokehjs/src/lib/api/io.ts
@@ -24,8 +24,9 @@ export async function show(obj: Document | UIElement | UIElement[], target?: Emb
     } else {
       const doc = new Document()
 
-      for (const item of isArray(obj) ? obj : [obj])
+      for (const item of isArray(obj) ? obj : [obj]) {
         doc.add_root(item)
+      }
 
       return doc
     }
@@ -38,20 +39,23 @@ export async function show(obj: Document | UIElement | UIElement[], target?: Emb
     if (target == null) {
       if (script != null && contains(document.body, script)) {
         const parent = script.parentNode
-        if (parent instanceof HTMLElement || parent instanceof DocumentFragment)
+        if (parent instanceof HTMLElement || parent instanceof DocumentFragment) {
           return parent
+        }
       }
 
       return document.body
     } else if (isString(target)) {
       const found = document.querySelector(target)
       if (found instanceof HTMLElement) {
-        if (found.shadowRoot != null)
+        if (found.shadowRoot != null) {
           return found.shadowRoot
-        else
+        } else {
           return found
-      } else
+        }
+      } else {
         throw new Error(`'${target}' selector didn't match any elements`)
+      }
     } else if (target instanceof HTMLElement) {
       return target
     } else if (typeof $ !== "undefined" && target instanceof $) {
@@ -66,9 +70,10 @@ export async function show(obj: Document | UIElement | UIElement[], target?: Emb
   return new Promise((resolve, _reject) => {
     const views = [...view_manager]
     const result = isArray(obj) || obj instanceof Document ? views : views[0]
-    if (doc.is_idle)
+    if (doc.is_idle) {
       resolve(result)
-    else
+    } else {
       doc.idle.connect(() => resolve(result))
+    }
   })
 }

--- a/bokehjs/src/lib/api/linalg.ts
+++ b/bokehjs/src/lib/api/linalg.ts
@@ -61,84 +61,92 @@ export namespace np {
 
   export function sin<T extends Numerical>(x: T): T
   export function sin(x: Numerical): Numerical {
-    if (isNumber(x))
+    if (isNumber(x)) {
       return Math.sin(x)
-    else if (is_Floating(x))
+    } else if (is_Floating(x)) {
       return Math.sin(x[float]())
-    else
+    } else {
       return map(x, (v) => Math.sin(v))
+    }
   }
 
   export function cos<T extends Numerical>(x: T): T
   export function cos(x: Numerical): Numerical {
-    if (isNumber(x))
+    if (isNumber(x)) {
       return Math.cos(x)
-    else if (is_Floating(x))
+    } else if (is_Floating(x)) {
       return Math.cos(x[float]())
-    else
+    } else {
       return map(x, (v) => Math.cos(v))
+    }
   }
 
   export function exp<T extends Numerical>(x: T): T
   export function exp(x: Numerical): Numerical {
-    if (isNumber(x))
+    if (isNumber(x)) {
       return Math.exp(x)
-    else if (is_Floating(x))
+    } else if (is_Floating(x)) {
       return Math.exp(x[float]())
-    else
+    } else {
       return map(x, (v) => Math.exp(v))
+    }
   }
 
   export function sqrt<T extends Numerical>(x: T): T
   export function sqrt(x: Numerical): Numerical {
-    if (isNumber(x))
+    if (isNumber(x)) {
       return Math.sqrt(x)
-    else if (is_Floating(x))
+    } else if (is_Floating(x)) {
       return Math.sqrt(x[float]())
-    else
+    } else {
       return map(x, (v) => Math.sqrt(v))
+    }
   }
 
   export function factorial<T extends Numerical>(x: T): T
   export function factorial(x: Numerical): Numerical {
-    if (isNumber(x))
+    if (isNumber(x)) {
       return math.factorial(x)
-    else if (is_Floating(x))
+    } else if (is_Floating(x)) {
       return math.factorial(x[float]())
-    else
+    } else {
       return map(x, math.factorial)
+    }
   }
 
   export function hermite(n: number): (x: Numerical) => Numerical {
     const poly = math.hermite(n)
     return (x) => {
-      if (isNumber(x))
+      if (isNumber(x)) {
         return math.eval_poly(poly, x)
-      else if (is_Floating(x))
+      } else if (is_Floating(x)) {
         return math.eval_poly(poly, x[float]())
-      else
+      } else {
         return map(x, (v) => math.eval_poly(poly, v))
+      }
     }
   }
 
   export function pos<T extends Numerical>(x: T): T
   export function pos(x: Numerical): Numerical {
-    if (isNumber(x))
+    if (isNumber(x)) {
       return +x
-    else if (is_Floating(x))
+    } else if (is_Floating(x)) {
       return +x[float]()
-    else
+    } else {
       return map(x, (v) => +v)
+    }
   }
 
   export function neg<T extends Numerical>(x: T): T
   export function neg(x: Numerical): Numerical {
-    if (isNumber(x))
+    if (isNumber(x)) {
       return -x
-    else if (is_Floating(x))
+    } else if (is_Floating(x)) {
       return -x[float]()
-    else
+    } else {
       return map(x, (v) => -v)
+    }
   }
 
   export function add(x0: number, y0: number): number
@@ -150,19 +158,21 @@ export namespace np {
     const x_num = isNumber(x)
     const y_num = isNumber(y)
 
-    if (x_num && y_num)
+    if (x_num && y_num) {
       return x + y
-    else if (x_num && !y_num)
+    } else if (x_num && !y_num) {
       return map(y, (yi) => x + yi)
-    else if (!x_num && y_num)
+    } else if (!x_num && y_num) {
       return map(x, (xi) => xi + y)
-    else if (is_NDArray(x) && is_NDArray(y)) {
-      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype)
+    } else if (is_NDArray(x) && is_NDArray(y)) {
+      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype) {
         return map(x, (xi, i) => xi + y[i])
-      else
+      } else {
         throw new Error("shape or dtype mismatch")
-    } else
+      }
+    } else {
       throw new Error("not implemented")
+    }
   }
 
   export function sub(x0: number, y0: number): number
@@ -174,19 +184,21 @@ export namespace np {
     const x_num = isNumber(x)
     const y_num = isNumber(y)
 
-    if (x_num && y_num)
+    if (x_num && y_num) {
       return x - y
-    else if (x_num && !y_num)
+    } else if (x_num && !y_num) {
       return map(y, (yi) => x - yi)
-    else if (!x_num && y_num)
+    } else if (!x_num && y_num) {
       return map(x, (xi) => xi - y)
-    else if (is_NDArray(x) && is_NDArray(y)) {
-      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype)
+    } else if (is_NDArray(x) && is_NDArray(y)) {
+      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype) {
         return map(x, (xi, i) => xi - y[i])
-      else
+      } else {
         throw new Error("shape or dtype mismatch")
-    } else
+      }
+    } else {
       throw new Error("not implemented")
+    }
   }
 
   export function mul(x0: number, y0: number): number
@@ -198,19 +210,21 @@ export namespace np {
     const x_num = isNumber(x)
     const y_num = isNumber(y)
 
-    if (x_num && y_num)
+    if (x_num && y_num) {
       return x * y
-    else if (x_num && !y_num)
+    } else if (x_num && !y_num) {
       return map(y, (yi) => x * yi)
-    else if (!x_num && y_num)
+    } else if (!x_num && y_num) {
       return map(x, (xi) => xi * y)
-    else if (is_NDArray(x) && is_NDArray(y)) {
-      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype)
+    } else if (is_NDArray(x) && is_NDArray(y)) {
+      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype) {
         return map(x, (xi, i) => xi * y[i])
-      else
+      } else {
         throw new Error("shape or dtype mismatch")
-    } else
+      }
+    } else {
       throw new Error("not implemented")
+    }
   }
 
   export function div(x0: number, y0: number): number
@@ -222,19 +236,21 @@ export namespace np {
     const x_num = isNumber(x)
     const y_num = isNumber(y)
 
-    if (x_num && y_num)
+    if (x_num && y_num) {
       return x / y
-    else if (x_num && !y_num)
+    } else if (x_num && !y_num) {
       return map(y, (yi) => x / yi)
-    else if (!x_num && y_num)
+    } else if (!x_num && y_num) {
       return map(x, (xi) => xi / y)
-    else if (is_NDArray(x) && is_NDArray(y)) {
-      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype)
+    } else if (is_NDArray(x) && is_NDArray(y)) {
+      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype) {
         return map(x, (xi, i) => xi / y[i])
-      else
+      } else {
         throw new Error("shape or dtype mismatch")
-    } else
+      }
+    } else {
       throw new Error("not implemented")
+    }
   }
 
   export function pow(x0: number, y0: number): number
@@ -246,19 +262,21 @@ export namespace np {
     const x_num = isNumber(x)
     const y_num = isNumber(y)
 
-    if (x_num && y_num)
+    if (x_num && y_num) {
       return x ** y
-    else if (x_num && !y_num)
+    } else if (x_num && !y_num) {
       return map(y, (yi) => x ** yi)
-    else if (!x_num && y_num)
+    } else if (!x_num && y_num) {
       return map(x, (xi) => xi ** y)
-    else if (is_NDArray(x) && is_NDArray(y)) {
-      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype)
+    } else if (is_NDArray(x) && is_NDArray(y)) {
+      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype) {
         return map(x, (xi, i) => xi ** y[i])
-      else
+      } else {
         throw new Error("shape or dtype mismatch")
-    } else
+      }
+    } else {
       throw new Error("not implemented")
+    }
   }
 
   function cmp(x0: Numerical, y0: Numerical, op: (x: number, y: number) => boolean): Numerical {
@@ -270,19 +288,21 @@ export namespace np {
 
     const int = (v: boolean) => v ? 1 : 0
 
-    if (x_num && y_num)
+    if (x_num && y_num) {
       return int(x >= y)
-    else if (x_num && !y_num)
+    } else if (x_num && !y_num) {
       return map(y, (yi) => int(op(x, yi)))
-    else if (!x_num && y_num)
+    } else if (!x_num && y_num) {
       return map(x, (xi) => int(op(xi, y)))
-    else if (is_NDArray(x) && is_NDArray(y)) {
-      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype)
+    } else if (is_NDArray(x) && is_NDArray(y)) {
+      if (is_equal(x.shape, y.shape) && x.dtype == y.dtype) {
         return map(x, (xi, i) => int(op(xi, y[i])))
-      else
+      } else {
         throw new Error("shape or dtype mismatch")
-    } else
+      }
+    } else {
       throw new Error("not implemented")
+    }
   }
 
   export function ge(x0: number, y0: number): number
@@ -317,19 +337,21 @@ export namespace np {
     const y_num = isNumber(y)
 
     const fn = ((): (cond_i: number, i: number) => number => {
-      if (x_num && y_num)
+      if (x_num && y_num) {
         return (cond_i) => cond_i != 0 ? x : y
-      else if (x_num && !y_num)
+      } else if (x_num && !y_num) {
         return (cond_i, i) => cond_i != 0 ? x : y[i]
-      else if (!x_num && y_num)
+      } else if (!x_num && y_num) {
         return (cond_i, i) => cond_i != 0 ? x[i] : y
-      else if (is_NDArray(x) && is_NDArray(y)) {
-        if (is_equal(x.shape, y.shape) && x.dtype == y.dtype)
+      } else if (is_NDArray(x) && is_NDArray(y)) {
+        if (is_equal(x.shape, y.shape) && x.dtype == y.dtype) {
           return (cond_i, i) => cond_i != 0 ? x[i] : y[i]
-        else
+        } else {
           throw new Error("shape or dtype mismatch")
-      } else
+        }
+      } else {
         throw new Error("not implemented")
+      }
     })()
 
     return map(condition, fn) // TODO: preserve ndarrays
@@ -345,8 +367,9 @@ export namespace np {
     if (density) {
       const normed = div(div(hist, diff(edges)), sum(hist))
       return [normed, edges]
-    } else
+    } else {
       return [hist, edges]
+    }
   }
 
   export namespace random {

--- a/bokehjs/src/lib/api/palettes.ts
+++ b/bokehjs/src/lib/api/palettes.ts
@@ -1015,10 +1015,12 @@ export const colorblind = {
 
 export function interp_palette(palette: Color[], n: number): RGBA[] {
   const npalette = palette.length
-  if (npalette < 1)
+  if (npalette < 1) {
     throw new Error("palette must contain at least one color")
-  if (n < 0)
+  }
+  if (n < 0) {
     throw new Error("requested palette length cannot be negative")
+  }
 
   // Arrayable.interpolate operates on whole arrays, not slices, so need separate
   // arrays for each of the R, G, B and A components.
@@ -1047,18 +1049,21 @@ export function interp_palette(palette: Color[], n: number): RGBA[] {
 }
 
 export function linear_palette<T>(palette: T[], n: number): T[] {
-  if (n <= palette.length)
+  if (n <= palette.length) {
     return linspace(0, palette.length - 1, n).map((i) => palette[i|0])
-  else
+  } else {
     throw new Error("too many color entries requested")
+  }
 }
 
 export function varying_alpha_palette(color: Color, n: number | null = null, start_alpha: number = 0, end_alpha: number = 255): string[] {
-  if (start_alpha < 0 || start_alpha > 255)
+  if (start_alpha < 0 || start_alpha > 255) {
     throw new Error("start_alpha must be in the range 0 to 255")
+  }
 
-  if (end_alpha < 0 || end_alpha > 255)
+  if (end_alpha < 0 || end_alpha > 255) {
     throw new Error("end_alpha must be in the range 0 to 255")
+  }
 
   const rgba = color2rgba(color)
 
@@ -1076,8 +1081,9 @@ export function varying_alpha_palette(color: Color, n: number | null = null, sta
   start_alpha /= 255
 
   const palette = new Array<string>(npalette)
-  for (let i = 0; i < npalette; i++)
+  for (let i = 0; i < npalette; i++) {
     palette[i] = color2hex(rgba, start_alpha + diff_alpha*i / (npalette-1))
+  }
 
   return palette
 }

--- a/bokehjs/src/lib/api/parser.ts
+++ b/bokehjs/src/lib/api/parser.ts
@@ -212,10 +212,11 @@ export class Parser {
       const node = nodes.length == 1 ? nodes[0] : {type: COMPOUND, body: nodes} as CompoundExpression
       return node
     } catch (error) {
-      if (error instanceof ParseError)
+      if (error instanceof ParseError) {
         return {type: FAILURE, message: error.message}
-      else
+      } else {
         throw error
+      }
     }
   }
 

--- a/bokehjs/src/lib/api/themes.ts
+++ b/bokehjs/src/lib/api/themes.ts
@@ -21,8 +21,9 @@ class Theme implements p.Theme {
     const model = obj instanceof HasProps ? obj.constructor as typeof HasProps : obj
 
     for (const {type, defaults} of this.attrs) {
-      if (model == type || model.prototype instanceof type)
+      if (model == type || model.prototype instanceof type) {
         return defaults.get(attr)
+      }
     }
 
     return undefined

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -25,8 +25,9 @@ export type Token = {
 export function parse_token(token: string): Token {
   let payload = token.split(".")[0]
   const mod = payload.length % 4
-  if (mod != 0)
+  if (mod != 0) {
     payload = payload + "=".repeat(4-mod)
+  }
   return JSON.parse(atob(payload.replace(/_/g, "/").replace(/-/g, "+")))
 }
 
@@ -52,10 +53,12 @@ export class ClientConnection {
   }
 
   async connect(): Promise<ClientSession> {
-    if (this.closed_permanently)
+    if (this.closed_permanently) {
       throw new Error("Cannot connect() a closed ClientConnection")
-    if (this.socket != null)
+    }
+    if (this.socket != null) {
       throw new Error("Already connected")
+    }
 
     this._current_handler = null
     this._pending_replies.clear()
@@ -63,8 +66,9 @@ export class ClientConnection {
 
     try {
       let versioned_url = `${this.url}`
-      if (this.args_string != null && this.args_string.length > 0)
+      if (this.args_string != null && this.args_string.length > 0) {
         versioned_url += `?${this.args_string}`
+      }
 
       this.socket = new WebSocket(versioned_url, ["bokeh", this.token])
 
@@ -88,8 +92,9 @@ export class ClientConnection {
     if (!this.closed_permanently) {
       logger.debug(`Permanently closing websocket connection ${this._number}`)
       this.closed_permanently = true
-      if (this.socket != null)
+      if (this.socket != null) {
         this.socket.close(1000, `close method called on ClientConnection ${this._number}`)
+      }
       this.session!._connection_closed()
     }
   }
@@ -118,10 +123,11 @@ export class ClientConnection {
   }
 
   send(message: Message<unknown>): void {
-    if (this.socket != null)
+    if (this.socket != null) {
       message.send(this.socket)
-    else
+    } else {
       logger.error("not connected so cannot send", message)
+    }
   }
 
   async send_with_reply<T>(message: Message<unknown>): Promise<Message<T>> {
@@ -130,17 +136,19 @@ export class ClientConnection {
       this.send(message)
     })
 
-    if (reply.msgtype() == "ERROR")
+    if (reply.msgtype() == "ERROR") {
       throw new Error(`Error reply ${(reply as ErrorMsg).content.text}`)
-    else
+    } else {
       return reply as Message<T>
+    }
   }
 
   protected async _pull_doc_json(): Promise<DocJson> {
     const message = Message.create("PULL-DOC-REQ", {}, {})
     const reply = await this.send_with_reply<{doc: DocJson}>(message)
-    if (!("doc" in reply.content))
+    if (!("doc" in reply.content)) {
       throw new Error("No 'doc' field in PULL-DOC-REPLY")
+    }
     return reply.content.doc
   }
 
@@ -191,8 +199,9 @@ export class ClientConnection {
   }
 
   protected _on_message(event: MessageEvent): void {
-    if (this._current_handler == null)
+    if (this._current_handler == null) {
       logger.error("Got a message with no current handler set")
+    }
 
     try {
       this._receiver.consume(event.data)
@@ -203,8 +212,9 @@ export class ClientConnection {
     const msg = this._receiver.message
     if (msg != null) {
       const problem = msg.problem()
-      if (problem != null)
+      if (problem != null) {
         this._close_bad_protocol(problem)
+      }
 
       this._current_handler!(msg)
     }
@@ -217,8 +227,9 @@ export class ClientConnection {
     this._pending_replies.forEach((pr) => pr.reject("Disconnected"))
     this._pending_replies.clear()
 
-    if (!this.closed_permanently)
+    if (!this.closed_permanently) {
       this._schedule_reconnect(2000)
+    }
 
     reject(new Error(`Lost websocket connection, ${event.code} (${event.reason})`))
   }
@@ -232,8 +243,9 @@ export class ClientConnection {
 
   protected _close_bad_protocol(detail: string): void {
     logger.error(`Closing connection: ${detail}`)
-    if (this.socket != null)
-      this.socket.close(1002, detail) // 1002 = protocol error
+    if (this.socket != null) {
+      this.socket.close(1002, detail)
+    } // 1002 = protocol error
   }
 
   protected _awaiting_ack_handler(message: Message<unknown>, resolve: SessionResolver, reject: Rejecter): void {
@@ -242,8 +254,9 @@ export class ClientConnection {
 
       // Reload any sessions
       this._repull_session_doc(resolve, reject)
-    } else
+    } else {
       this._close_bad_protocol("First message was not an ACK")
+    }
   }
 
   protected _steady_state_handler(message: Message<unknown>): void {

--- a/bokehjs/src/lib/core/util/bbox.ts
+++ b/bokehjs/src/lib/core/util/bbox.ts
@@ -229,20 +229,42 @@ export class BBox implements Rect, Equatable {
     return x0 == 0 && x1 == 0 && y0 == 0 && y1 == 0
   }
 
-  get left(): number { return this.x0 }
-  get top(): number { return this.y0 }
-  get right(): number { return this.x1 }
-  get bottom(): number { return this.y1 }
+  get left(): number {
+    return this.x0
+  }
+  get top(): number {
+    return this.y0
+  }
+  get right(): number {
+    return this.x1
+  }
+  get bottom(): number {
+    return this.y1
+  }
 
-  get p0(): XY<number> { return {x: this.x0, y: this.y0} }
-  get p1(): XY<number> { return {x: this.x1, y: this.y1} }
+  get p0(): XY<number> {
+    return {x: this.x0, y: this.y0}
+  }
+  get p1(): XY<number> {
+    return {x: this.x1, y: this.y1}
+  }
 
-  get x(): number { return this.x0 }
-  get y(): number { return this.y0 }
-  get width(): number { return this.x1 - this.x0 }
-  get height(): number { return this.y1 - this.y0 }
+  get x(): number {
+    return this.x0
+  }
+  get y(): number {
+    return this.y0
+  }
+  get width(): number {
+    return this.x1 - this.x0
+  }
+  get height(): number {
+    return this.y1 - this.y0
+  }
 
-  get size(): Size { return {width: this.width, height: this.height} }
+  get size(): Size {
+    return {width: this.width, height: this.height}
+  }
 
   get rect(): affine.Rect {
     const {x0, y0, x1, y1} = this
@@ -264,20 +286,38 @@ export class BBox implements Rect, Equatable {
     return {left, right, top, bottom}
   }
 
-  get x_range(): Interval { return {start: this.x0, end: this.x1} }
-  get y_range(): Interval { return {start: this.y0, end: this.y1} }
+  get x_range(): Interval {
+    return {start: this.x0, end: this.x1}
+  }
+  get y_range(): Interval {
+    return {start: this.y0, end: this.y1}
+  }
 
-  get h_range(): Interval { return this.x_range }
-  get v_range(): Interval { return this.y_range }
+  get h_range(): Interval {
+    return this.x_range
+  }
+  get v_range(): Interval {
+    return this.y_range
+  }
 
-  get ranges(): [Interval, Interval] { return [this.x_range, this.y_range] }
+  get ranges(): [Interval, Interval] {
+    return [this.x_range, this.y_range]
+  }
 
-  get aspect(): number { return this.width/this.height }
+  get aspect(): number {
+    return this.width/this.height
+  }
 
-  get hcenter(): number { return (this.left + this.right)/2 }
-  get vcenter(): number { return (this.top + this.bottom)/2 }
+  get hcenter(): number {
+    return (this.left + this.right)/2
+  }
+  get vcenter(): number {
+    return (this.top + this.bottom)/2
+  }
 
-  get area(): number { return this.width*this.height }
+  get area(): number {
+    return this.width*this.height
+  }
 
   round(): BBox {
     return new BBox({

--- a/bokehjs/src/lib/document/defs.ts
+++ b/bokehjs/src/lib/document/defs.ts
@@ -98,10 +98,11 @@ export function decode_def(def: ModelDef, deserializer: Deserializer): typeof Ha
         case "Ref": {
           const [, modelref] = ref
           const model = deserializer.resolver.get(modelref.id)
-          if (model != null)
+          if (model != null) {
             return kinds.Ref(model)
-          else
+          } else {
             throw new Error(`${modelref.id} wasn't defined before referencing it`)
+          }
         }
         case "AnyRef": {
           return kinds.AnyRef()
@@ -112,13 +113,16 @@ export function decode_def(def: ModelDef, deserializer: Deserializer): typeof Ha
 
   const base: typeof HasProps = (() => {
     const name = def.extends?.id ?? "Model"
-    if (name == "Model") // TODO: support base classes in general
+    if (name == "Model") {
+      // TODO: support base classes in general
       return Model
+    }
     const base = deserializer.resolver.get(name)
-    if (base != null)
+    if (base != null) {
       return base
-    else
+    } else {
       throw new Error(`base model ${name} of ${def.name} is not defined`)
+    }
   })()
 
   const model = class extends base {
@@ -126,10 +130,11 @@ export function decode_def(def: ModelDef, deserializer: Deserializer): typeof Ha
   }
 
   function decode(value: unknown): unknown {
-    if (value === undefined)
+    if (value === undefined) {
       return value
-    else
+    } else {
       return deserializer.decode(value as AnyVal)
+    }
   }
 
   for (const prop of def.properties ?? []) {

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -51,8 +51,9 @@ export class EventManager {
 
   trigger(event: ModelEvent): void {
     for (const model of this.subscribed_models) {
-      if (event.origin != null && event.origin != model)
+      if (event.origin != null && event.origin != model) {
         continue
+      }
       model._process_event(event)
     }
   }
@@ -124,8 +125,9 @@ export class Document implements Equatable {
   get is_idle(): boolean {
     // TODO: models without views, e.g. data models
     for (const root of this._roots) {
-      if (!this._idle_roots.has(root))
+      if (!this._idle_roots.has(root)) {
         return false
+      }
     }
     return true
   }
@@ -172,10 +174,11 @@ export class Document implements Equatable {
   }
 
   interactive_duration(): number {
-    if (this._interactive_timestamp == null)
+    if (this._interactive_timestamp == null) {
       return -1
-    else
+    } else {
       return Date.now() - this._interactive_timestamp
+    }
   }
 
   destructively_move(dest_doc: Document): void {
@@ -190,8 +193,9 @@ export class Document implements Equatable {
     this.clear()
 
     for (const root of roots) {
-      if (root.document != null)
+      if (root.document != null) {
         throw new Error(`Somehow we didn't detach ${root}`)
+      }
     }
 
     if (this._all_models.size != 0) {
@@ -269,8 +273,9 @@ export class Document implements Equatable {
 
   protected _remove_root(model: HasProps): boolean {
     const i = this._roots.indexOf(model)
-    if (i < 0)
+    if (i < 0) {
       return false
+    }
 
     this._push_all_models_freeze()
     try {
@@ -284,8 +289,9 @@ export class Document implements Equatable {
 
   protected _set_title(title: string): boolean {
     const new_title = title != this._title
-    if (new_title)
+    if (new_title) {
       this._title = title
+    }
     return new_title
   }
 
@@ -324,8 +330,9 @@ export class Document implements Equatable {
   get_model_by_name(name: string): HasProps | null {
     const found = []
     for (const model of this._all_models.values()) {
-      if (model instanceof Model && model.name == name)
+      if (model instanceof Model && model.name == name) {
         found.push(model)
+      }
     }
 
     switch (found.length) {
@@ -340,10 +347,11 @@ export class Document implements Equatable {
 
   on_message(msg_type: string, callback: (msg_data: unknown) => void): void {
     const message_callbacks = this._message_callbacks.get(msg_type)
-    if (message_callbacks == null)
+    if (message_callbacks == null) {
       this._message_callbacks.set(msg_type, new Set([callback]))
-    else
+    } else {
       message_callbacks.add(callback)
+    }
   }
 
   remove_on_message(msg_type: string, callback: (msg_data: unknown) => void): void {
@@ -432,10 +440,12 @@ export class Document implements Equatable {
       if (!is_dev && pyify_version(js_version) != py_version) {
         logger.warn("JS/Python version mismatch")
         logger.warn(versions_string)
-      } else
+      } else {
         logger.debug(versions_string)
-    } else
+      }
+    } else {
       logger.warn("'version' field is missing")
+    }
   }
 
   static from_json(doc_json: DocJson, events?: Out<DocumentEvent[]>): Document {
@@ -459,10 +469,11 @@ export class Document implements Equatable {
     const roots = deserializer.decode(doc_json.roots) as Model[]
 
     const callbacks = (() => {
-      if (doc_json.callbacks != null)
+      if (doc_json.callbacks != null) {
         return deserializer.decode(doc_json.callbacks) as {[key: string]: DocumentEventCallback[]}
-      else
+      } else {
         return {}
+      }
     })()
 
     doc.remove_on_change(listener)
@@ -490,8 +501,9 @@ export class Document implements Equatable {
 
   create_json_patch(events: DocumentChangedEvent[]): Patch {
     for (const event of events) {
-      if (event.document != this)
+      if (event.document != this) {
         throw new Error("Cannot create a patch using events from a different document")
+      }
     }
 
     const references: Map<HasProps, Ref> = new Map()

--- a/bokehjs/src/lib/embed/dom.ts
+++ b/bokehjs/src/lib/embed/dom.ts
@@ -8,10 +8,12 @@ export type EmbedTarget = HTMLElement | DocumentFragment
 function _get_element(target: ID | EmbedTarget): EmbedTarget {
   let element = isString(target) ? document.getElementById(target) : target
 
-  if (element == null)
+  if (element == null) {
     throw new Error(`Error rendering Bokeh model: could not find ${isString(target) ? `#${target}` : target} HTML tag`)
-  if (!contains(document.body, element))
+  }
+  if (!contains(document.body, element)) {
     throw new Error(`Error rendering Bokeh model: element ${isString(target) ? `#${target}` : target} must be under <body>`)
+  }
 
   // If autoload script, replace script tag with div for embedding.
   if (element instanceof HTMLElement && element.tagName == "SCRIPT") {
@@ -26,18 +28,20 @@ function _get_element(target: ID | EmbedTarget): EmbedTarget {
 export function _resolve_element(item: RenderItem): EmbedTarget {
   const {elementid} = item
 
-  if (elementid != null)
+  if (elementid != null) {
     return _get_element(elementid)
-  else
+  } else {
     return document.body
+  }
 }
 
 export function _resolve_root_elements(item: RenderItem): EmbedTarget[] {
   const roots: EmbedTarget[] = []
 
   if (item.root_ids != null && item.roots != null) {
-    for (const root_id of item.root_ids)
+    for (const root_id of item.root_ids) {
       roots.push(_get_element(item.roots[root_id]))
+    }
   }
 
   return roots

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -27,8 +27,9 @@ export async function embed_item(item: JsonItem, target?: ID | EmbedTarget): Pro
   const doc_id = uuid4()
   docs_json[doc_id] = item.doc
 
-  if (target == null)
+  if (target == null) {
     target = item.target_id
+  }
 
   const roots: Roots = {[item.root_id]: target}
   const render_item: RenderItem = {roots, root_ids: [item.root_id], docid: doc_id}
@@ -49,8 +50,9 @@ export async function embed_items(docs_json: string | DocsJson, render_items: Re
 }
 
 async function _embed_items(docs_json: string | DocsJson, render_items: RenderItem[], app_path?: string, absolute_url?: string): Promise<ViewManager[]> {
-  if (isString(docs_json))
+  if (isString(docs_json)) {
     docs_json = JSON.parse(unescape(docs_json)) as DocsJson
+  }
 
   const docs: {[key: string]: Document} = {}
   for (const [docid, doc_json] of entries(docs_json)) {
@@ -72,13 +74,15 @@ async function _embed_items(docs_json: string | DocsJson, render_items: RenderIt
         views.push(await add_document_from_session(websocket_url, item.token, element, roots, item.use_for_title))
         console.log("Bokeh items were rendered successfully")
       } catch (error) {
-        if (settings.dev)
+        if (settings.dev) {
           throw error
-        else
+        } else {
           console.error("Error rendering Bokeh items:", error)
+        }
       }
-    } else
+    } else {
       throw new Error("Error rendering Bokeh items: either 'docid' or 'token' was expected.")
+    }
   }
 
   return views

--- a/bokehjs/src/lib/embed/notebook.ts
+++ b/bokehjs/src/lib/embed/notebook.ts
@@ -15,14 +15,16 @@ import {_resolve_element, _resolve_root_elements} from "./dom"
 export const kernels: {[key: string]: unknown} = {}
 
 function _handle_notebook_comms(this: Document, receiver: Receiver, comm_msg: CommMessage): void {
-  if (comm_msg.buffers.length > 0)
+  if (comm_msg.buffers.length > 0) {
     receiver.consume(comm_msg.buffers[0].buffer)
-  else
+  } else {
     receiver.consume(comm_msg.content.data)
+  }
 
   const msg = receiver.message
-  if (msg != null)
+  if (msg != null) {
     this.apply_json_patch((msg as Message<Patch>).content, msg.buffers)
+  }
 }
 
 function _init_comms(target: string, doc: Document): void {
@@ -76,14 +78,16 @@ function _init_comms(target: string, doc: Document): void {
 }
 
 export function embed_items_notebook(docs_json: DocsJson, render_items: RenderItem[]): void {
-  if (size(docs_json) != 1)
+  if (size(docs_json) != 1) {
     throw new Error("embed_items_notebook expects exactly one document in docs_json")
+  }
 
   const document = Document.from_json(values(docs_json)[0])
 
   for (const item of render_items) {
-    if (item.notebook_comms_target != null)
+    if (item.notebook_comms_target != null) {
       _init_comms(item.notebook_comms_target, document)
+    }
 
     const element = _resolve_element(item)
     const roots = _resolve_root_elements(item)

--- a/bokehjs/src/lib/embed/server.ts
+++ b/bokehjs/src/lib/embed/server.ts
@@ -9,21 +9,25 @@ import type {EmbedTarget} from "./dom"
 // @internal
 export function _get_ws_url(app_path: string | undefined, absolute_url: string | undefined): string {
   let protocol = "ws:"
-  if (window.location.protocol == "https:")
+  if (window.location.protocol == "https:") {
     protocol = "wss:"
+  }
 
   let loc: HTMLAnchorElement | Location
   if (absolute_url != null) {
     loc = document.createElement("a")
     loc.href = absolute_url
-  } else
+  } else {
     loc = window.location
+  }
 
   if (app_path != null) {
-    if (app_path == "/")
+    if (app_path == "/") {
       app_path = ""
-  } else
+    }
+  } else {
     app_path = loc.pathname.replace(/\/+$/, "")
+  }
 
   return `${protocol}//${loc.host}${app_path}/ws`
 }
@@ -35,12 +39,14 @@ const _sessions: Map<WebSocketURL, Map<SessionID, Promise<ClientSession>>> = new
 
 function _get_session(websocket_url: string, token: string, args_string: string): Promise<ClientSession> {
   const session_id = parse_token(token).session_id
-  if (!_sessions.has(websocket_url))
+  if (!_sessions.has(websocket_url)) {
     _sessions.set(websocket_url, new Map())
+  }
 
   const subsessions = _sessions.get(websocket_url)!
-  if (!subsessions.has(session_id))
+  if (!subsessions.has(session_id)) {
     subsessions.set(session_id, pull_session(websocket_url, token, args_string))
+  }
 
   return subsessions.get(session_id)!
 }

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -78,8 +78,9 @@ export class Model extends HasProps {
       execute(callback, event)
     }
 
-    if (this.document != null && this.subscribed_events.has(event.event_name))
+    if (this.document != null && this.subscribed_events.has(event.event_name)) {
       this.document.event_manager.send_event(event)
+    }
   }
 
   trigger_event(event: ModelEvent): void {
@@ -105,8 +106,9 @@ export class Model extends HasProps {
 
     for (const [event, callbacks] of this._js_callbacks) {
       const signal = signal_for(event)
-      for (const cb of callbacks)
+      for (const cb of callbacks) {
         this.disconnect(signal, cb)
+      }
     }
     this._js_callbacks.clear()
 
@@ -114,14 +116,16 @@ export class Model extends HasProps {
       const wrappers = callbacks.map((cb) => () => execute(cb, this))
       this._js_callbacks.set(event, wrappers)
       const signal = signal_for(event)
-      for (const cb of wrappers)
+      for (const cb of wrappers) {
         this.connect(signal, cb)
+      }
     }
   }
 
   protected override _doc_attached(): void {
-    if (!dict(this.js_event_callbacks).is_empty || this.subscribed_events.size != 0)
+    if (!dict(this.js_event_callbacks).is_empty || this.subscribed_events.size != 0) {
       this._update_event_callbacks()
+    }
   }
 
   protected override _doc_detached(): void {
@@ -129,14 +133,15 @@ export class Model extends HasProps {
   }
 
   select<T extends HasProps>(selector: ModelSelector<T>): T[] {
-    if (isString(selector))
+    if (isString(selector)) {
       return [...this.references()].filter((ref): ref is T => ref instanceof Model && ref.name === selector)
-    else if (isPlainObject(selector) && "type" in selector)
+    } else if (isPlainObject(selector) && "type" in selector) {
       return [...this.references()].filter((ref): ref is T => ref.type == selector.type)
-    else if (selector.prototype instanceof HasProps)
+    } else if (selector.prototype instanceof HasProps) {
       return [...this.references()].filter((ref): ref is T => ref instanceof selector)
-    else
+    } else {
       throw new Error(`invalid selector ${selector}`)
+    }
   }
 
   select_one<T extends HasProps>(selector: ModelSelector<T>): T | null {

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -74,15 +74,17 @@ export class AxisView extends GuideRendererView {
       let {sx0, sy0, sx1, sy1} = this.rule_scoords
       const {dimension, face} = this
       if (dimension == 0) {
-        if (face == "front")
+        if (face == "front") {
           sy0 -= depth
-        else
+        } else {
           sy1 += depth
+        }
       } else {
-        if (face == "front")
+        if (face == "front") {
           sx0 -= depth
-        else
+        } else {
           sx1 += depth
+        }
       }
 
       return BBox.from_lrtb({left: sx0, top: sy0, right: sx1, bottom: sy1})
@@ -93,8 +95,9 @@ export class AxisView extends GuideRendererView {
 
   override *children(): IterViews {
     yield* super.children()
-    if (this._axis_label_view != null)
+    if (this._axis_label_view != null) {
       yield this._axis_label_view
+    }
     yield* this._major_label_views.values()
   }
 
@@ -109,8 +112,9 @@ export class AxisView extends GuideRendererView {
     if (axis_label != null) {
       const _axis_label = isString(axis_label) ? parse_delimited_string(axis_label) : axis_label
       this._axis_label_view = await build_view(_axis_label, {parent: this})
-    } else
+    } else {
       this._axis_label_view = null
+    }
   }
 
   protected async _init_major_labels(): Promise<void> {
@@ -131,8 +135,9 @@ export class AxisView extends GuideRendererView {
       const {extents} = this
       const height = Math.round(extents.tick + extents.tick_label + extents.axis_label)
       return {width: 0, height}
-    } else
+    } else {
       return {width: 0, height: 0}
+    }
   }
 
   get is_renderable(): boolean {
@@ -141,8 +146,9 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _render(): void {
-    if (!this.is_renderable)
+    if (!this.is_renderable) {
       return
+    }
 
     const {tick_coords, extents} = this
 
@@ -187,8 +193,9 @@ export class AxisView extends GuideRendererView {
   // drawing sub functions -----------------------------------------------------
 
   protected _draw_background(ctx: Context2d, _extents: Extents): void {
-    if (!this.visuals.background_fill.doit)
+    if (!this.visuals.background_fill.doit) {
       return
+    }
 
     ctx.beginPath()
     const {x, y, width, height} = this.bbox
@@ -197,8 +204,9 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _draw_rule(ctx: Context2d, _extents: Extents): void {
-    if (!this.visuals.axis_line.doit)
+    if (!this.visuals.axis_line.doit) {
       return
+    }
 
     const {sx0, sy0, sx1, sy1} = this.rule_scoords
 
@@ -235,8 +243,9 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _axis_label_extent(): number {
-    if (this._axis_label_view == null)
+    if (this._axis_label_view == null) {
       return 0
+    }
 
     const axis_label_graphics = this._axis_label_view.graphics()
 
@@ -255,8 +264,9 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _draw_axis_label(ctx: Context2d, extents: Extents, _tick_coords: TickCoords): void {
-    if (this._axis_label_view == null)
+    if (this._axis_label_view == null) {
       return
+    }
 
     const [sx, sy/* TODO, x_anchor, y_anchor*/] = (() => {
       const {bbox} = this
@@ -316,8 +326,9 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _draw_ticks(ctx: Context2d, coords: Coords, tin: number, tout: number, visuals: visuals.Line): void {
-    if (!visuals.doit)
+    if (!visuals.doit) {
       return
+    }
 
     const [sxs, sys]   = this.scoords(coords)
     const [nx, ny]     = this.normals
@@ -344,8 +355,9 @@ export class AxisView extends GuideRendererView {
       ctx: Context2d, labels: GraphicsBoxes, coords: Coords,
       orient: Orient | number, standoff: number, visuals: visuals.Text,
   ): void {
-    if (!visuals.doit || labels.length == 0)
+    if (!visuals.doit || labels.length == 0) {
       return
+    }
 
     const [sxs, sys] = this.scoords(coords)
     const [xoff, yoff] = this.offsets
@@ -370,8 +382,9 @@ export class AxisView extends GuideRendererView {
         x_anchor: align,
         y_anchor: vertical_align,
       }
-      if (label instanceof TextBox)
+      if (label instanceof TextBox) {
         label.align = align
+      }
     }
 
     const n = labels.length
@@ -381,12 +394,13 @@ export class AxisView extends GuideRendererView {
     const bboxes = items.map((l) => l.bbox())
     const dist = ((): DistanceMeasure => {
       const [range] = this.ranges
-      if (!range.is_reversed)
+      if (!range.is_reversed) {
         return this.dimension == 0 ? (i, j) => bboxes[j].left - bboxes[i].right
                                    : (i, j) => bboxes[i].top - bboxes[j].bottom
-      else
+      } else {
         return this.dimension == 0 ? (i, j) => bboxes[i].left - bboxes[j].right
                                    : (i, j) => bboxes[j].top - bboxes[i].bottom
+      }
     })()
 
     const {major_label_policy} = this.model
@@ -475,8 +489,9 @@ export class AxisView extends GuideRendererView {
   }
 
   protected _oriented_labels_extent(labels: GraphicsBoxes, orient: Orient | number, standoff: number, visuals: visuals.Text): number {
-    if (labels.length == 0 || !visuals.doit)
+    if (labels.length == 0 || !visuals.doit) {
       return 0
+    }
 
     const angle = this.panel.get_label_angle_heuristic(orient)
     labels.visuals = visuals.values()
@@ -560,9 +575,9 @@ export class AxisView extends GuideRendererView {
     const user_bounds = this.model.bounds
     const range_bounds = [range.min, range.max]
 
-    if (user_bounds == "auto")
+    if (user_bounds == "auto") {
       return [range.min, range.max]
-    else {
+    } else {
       let start: number
       let end: number
 
@@ -594,8 +609,9 @@ export class AxisView extends GuideRendererView {
 
     coords[i][0] = Math.max(start, range.min)
     coords[i][1] = Math.min(end, range.max)
-    if (coords[i][0] > coords[i][1])
+    if (coords[i][0] > coords[i][1]) {
       coords[i][0] = coords[i][1] = NaN
+    }
 
     coords[j][0] = this.loc
     coords[j][1] = this.loc
@@ -634,15 +650,17 @@ export class AxisView extends GuideRendererView {
     const [range_min, range_max] = [range.min, range.max]
 
     for (let ii = 0; ii < majors.length; ii++) {
-      if (majors[ii] < range_min || majors[ii] > range_max)
+      if (majors[ii] < range_min || majors[ii] > range_max) {
         continue
+      }
       coords[i].push(majors[ii])
       coords[j].push(this.loc)
     }
 
     for (let ii = 0; ii < minors.length; ii++) {
-      if (minors[ii] < range_min || minors[ii] > range_max)
+      if (minors[ii] < range_min || minors[ii] > range_max) {
         continue
+      }
       minor_coords[i].push(minors[ii])
       minor_coords[j].push(this.loc)
     }
@@ -656,12 +674,14 @@ export class AxisView extends GuideRendererView {
   get loc(): number {
     const {fixed_location} = this.model
     if (fixed_location != null) {
-      if (isNumber(fixed_location))
+      if (isNumber(fixed_location)) {
         return fixed_location
+      }
 
       const [, cross_range] = this.ranges
-      if (cross_range instanceof FactorRange)
+      if (cross_range instanceof FactorRange) {
         return cross_range.synthetic(fixed_location)
+      }
 
       unreachable()
     }
@@ -702,17 +722,20 @@ export class AxisView extends GuideRendererView {
   }
 
   override has_finished(): boolean {
-    if (!super.has_finished())
+    if (!super.has_finished()) {
       return false
+    }
 
     if (this._axis_label_view != null) {
-      if (!this._axis_label_view.has_finished())
+      if (!this._axis_label_view.has_finished()) {
         return false
+      }
     }
 
     for (const label_view of this._major_label_views.values()) {
-      if (!label_view.has_finished())
+      if (!label_view.has_finished()) {
         return false
+      }
     }
 
     return true

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -32,8 +32,9 @@ export class CategoricalAxisView extends AxisView {
     const [range] = this.ranges as [FactorRange, FactorRange]
     const [start, end] = this.computed_bounds
 
-    if (range.tops == null || range.tops.length < 2 || !this.visuals.separator_line.doit)
+    if (range.tops == null || range.tops.length < 2 || !this.visuals.separator_line.doit) {
       return
+    }
 
     const dim = this.dimension
     const alt = 1 - dim

--- a/bokehjs/src/lib/models/callbacks/open_url.ts
+++ b/bokehjs/src/lib/models/callbacks/open_url.ts
@@ -30,27 +30,31 @@ export class OpenURL extends Callback {
   }
 
   navigate(url: string): void {
-    if (this.same_tab)
+    if (this.same_tab) {
       window.location.href = url
-    else
+    } else {
       window.open(url)
+    }
   }
 
   execute(_cb_obj: unknown, {source}: {source: ColumnarDataSource}): void {
     const open_url = (i: number) => {
       const url = replace_placeholders(this.url, source, i, undefined, undefined, encodeURI)
-      if (!isString(url))
+      if (!isString(url)) {
         throw new Error("HTML output is not supported in this context")
+      }
       this.navigate(url)
     }
 
     const {selected} = source
 
-    for (const i of selected.indices)
+    for (const i of selected.indices) {
       open_url(i)
+    }
 
-    for (const i of selected.line_indices)
+    for (const i of selected.line_indices) {
       open_url(i)
+    }
 
     // TODO: multiline_indices: {[key: string]: number[]}
   }

--- a/bokehjs/src/lib/models/callbacks/set_value.ts
+++ b/bokehjs/src/lib/models/callbacks/set_value.ts
@@ -32,9 +32,10 @@ export class SetValue extends Callback {
 
   execute(): void {
     const {obj, attr, value} = this
-    if (attr in obj.properties)
+    if (attr in obj.properties) {
       obj.setv({[attr]: value})
-    else
+    } else {
       logger.error(`${obj.type}.${attr} is not a property`)
+    }
   }
 }

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -64,10 +64,11 @@ async function init_webgl(): Promise<WebGLState | null> {
 const global_webgl: () => Promise<WebGLState | null> = (() => {
   let _global_webgl: WebGLState | null | undefined
   return async () => {
-    if (_global_webgl !== undefined)
+    if (_global_webgl !== undefined) {
       return _global_webgl
-    else
+    } else {
       return _global_webgl = await init_webgl()
+    }
   }
 })()
 
@@ -113,8 +114,9 @@ export class CanvasView extends UIElementView {
 
     if (this.model.output_backend == "webgl") {
       this.webgl = await global_webgl()
-      if (settings.force_webgl && this.webgl == null)
+      if (settings.force_webgl && this.webgl == null) {
         throw new Error("webgl is not available")
+      }
     }
   }
 

--- a/bokehjs/src/lib/models/canvas/cartesian_frame.ts
+++ b/bokehjs/src/lib/models/canvas/cartesian_frame.ts
@@ -61,8 +61,9 @@ export class CartesianFrame {
         throw new Error(`Range ${range.type} is incompatible is Scale ${scale.type}`)
       }
 
-      if (scale instanceof LogScale && range instanceof DataRange1d)
+      if (scale instanceof LogScale && range instanceof DataRange1d) {
         range.scale_hint = "log"
+      }
 
       const base_scale = in_scales.get(name) ?? scale
       const derived_scale = base_scale.clone()

--- a/bokehjs/src/lib/models/coordinates/coordinate_mapping.ts
+++ b/bokehjs/src/lib/models/coordinates/coordinate_mapping.ts
@@ -92,8 +92,9 @@ export class CoordinateMapping extends Model {
       throw new Error(`Range ${range.type} is incompatible is Scale ${scale.type}`)
     }
 
-    if (scale instanceof LogScale && range instanceof DataRange1d)
+    if (scale instanceof LogScale && range instanceof DataRange1d) {
       range.scale_hint = "log"
+    }
 
     const derived_scale = scale.clone()
     derived_scale.setv({source_range: range, target_range: target})

--- a/bokehjs/src/lib/models/dom/stylesheets.ts
+++ b/bokehjs/src/lib/models/dom/stylesheets.ts
@@ -90,8 +90,9 @@ export class GlobalInlineStyleSheet extends InlineStyleSheet {
   private _underlying: dom.StyleSheet | null = null
 
   override underlying(): dom.StyleSheet {
-    if (this._underlying == null)
+    if (this._underlying == null) {
       this._underlying = new dom.GlobalInlineStyleSheet(this.css)
+    }
     return this._underlying
   }
 }
@@ -113,8 +114,9 @@ export class GlobalImportedStyleSheet extends ImportedStyleSheet {
   private _underlying: dom.StyleSheet | null = null
 
   override underlying(): dom.StyleSheet {
-    if (this._underlying == null)
+    if (this._underlying == null) {
       this._underlying = new dom.GlobalInlineStyleSheet(this.url)
+    }
     return this._underlying
   }
 }

--- a/bokehjs/src/lib/models/dom/value_of.ts
+++ b/bokehjs/src/lib/models/dom/value_of.ts
@@ -26,8 +26,9 @@ export class ValueOfView extends DOMNodeView {
       if (attr in obj.properties) {
         const value = obj.properties[attr].get_value()
         return to_string(value)
-      } else
+      } else {
         return `<not found: ${obj.type}.${attr}>`
+      }
     })()
 
     this.el.textContent = text

--- a/bokehjs/src/lib/models/expressions/customjs_expr.ts
+++ b/bokehjs/src/lib/models/expressions/customjs_expr.ts
@@ -65,12 +65,13 @@ export class CustomJSExpr extends Expression {
     let result = generator.next()
     if ((result.done ?? false) && result.value !== undefined) {
       const {value} = result
-      if (isArray(value) || isTypedArray(value))
+      if (isArray(value) || isTypedArray(value)) {
         return value
-      else if (isIterable(value))
+      } else if (isIterable(value)) {
         return [...value]
-      else
+      } else {
         return repeat(value, source.length)
+      }
     } else {
       const array = []
 

--- a/bokehjs/src/lib/models/filters/customjs_filter.ts
+++ b/bokehjs/src/lib/models/filters/customjs_filter.ts
@@ -47,13 +47,14 @@ export class CustomJSFilter extends Filter {
   compute_indices(source: ColumnarDataSource): Indices {
     const size = source.get_length() ?? 1
     const filter = this.func(...this.values, source)
-    if (filter == null)
+    if (filter == null) {
       return Indices.all_set(size)
-    else if (isArrayOf(filter, isInteger))
+    } else if (isArrayOf(filter, isInteger)) {
       return Indices.from_indices(size, filter)
-    else if (isArrayOf(filter, isBoolean))
+    } else if (isArrayOf(filter, isBoolean)) {
       return Indices.from_booleans(size, filter)
-    else
+    } else {
       throw new Error(`expect an array of integers or booleans, or null, got ${filter}`)
+    }
   }
 }

--- a/bokehjs/src/lib/models/filters/group_filter.ts
+++ b/bokehjs/src/lib/models/filters/group_filter.ts
@@ -38,8 +38,9 @@ export class GroupFilter extends Filter {
     } else {
       const indices = new Indices(size, 0)
       for (let i = 0; i < indices.size; i++) {
-        if (column[i] === this.group)
+        if (column[i] === this.group) {
           indices.set(i)
+        }
       }
       return indices
     }

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -264,7 +264,9 @@ export abstract class GlyphView extends View {
         const base_prop = (base.model.properties as {[key: string]: p.Property<unknown> | undefined})[prop.attr]
         if (base_prop != null && is_equal(prop.get_value(), base_prop.get_value())) {
           this._configure(prop, {
-            get() { return (base as any)[`${prop.attr}`] },
+            get() {
+              return (base as any)[`${prop.attr}`]
+            },
           })
           continue
         }

--- a/bokehjs/src/lib/models/graphics/marking.ts
+++ b/bokehjs/src/lib/models/graphics/marking.ts
@@ -30,8 +30,9 @@ export abstract class MarkingView extends View implements visuals.Renderable {
   set_data(source: ColumnarDataSource, indices: Indices): void {
     const self = this as any
     for (const prop of this.model) {
-      if (!(prop instanceof p.VectorSpec || prop instanceof p.ScalarSpec))
+      if (!(prop instanceof p.VectorSpec || prop instanceof p.ScalarSpec)) {
         continue
+      }
       const uniform = prop.uniform(source).select(indices)
       self[`${prop.attr}`] = uniform
     }

--- a/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/src/lib/models/graphs/graph_hit_test_policy.ts
@@ -34,15 +34,17 @@ export abstract class GraphHitTestPolicy extends Model {
   abstract do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean
 
   protected _hit_test(geometry: Geometry, graph_view: GraphRendererView, renderer_view: GlyphRendererView): HitTestResult {
-    if (!graph_view.model.visible)
+    if (!graph_view.model.visible) {
       return null
+    }
 
     const hit_test_result = renderer_view.glyph.hit_test(geometry)
 
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return null
-    else
+    } else {
       return renderer_view.model.view.convert_selection_from_subset(hit_test_result)
+    }
   }
 }
 
@@ -66,8 +68,9 @@ export class EdgesOnly extends GraphHitTestPolicy {
   }
 
   do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const edge_selection = graph.edge_renderer.data_source.selected
     edge_selection.update(hit_test_result, final, mode)
@@ -77,8 +80,9 @@ export class EdgesOnly extends GraphHitTestPolicy {
   }
 
   do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const {edge_renderer} = graph_view.model
     const edge_inspection = edge_renderer.get_selection_manager().get_or_create_inspector(graph_view.edge_view.model)
@@ -112,8 +116,9 @@ export class NodesOnly extends GraphHitTestPolicy {
   }
 
   do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const node_selection = graph.node_renderer.data_source.selected
     node_selection.update(hit_test_result, final, mode)
@@ -123,8 +128,9 @@ export class NodesOnly extends GraphHitTestPolicy {
   }
 
   do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const  {node_renderer} = graph_view.model
     const node_inspection = node_renderer.get_selection_manager().get_or_create_inspector(graph_view.node_view.model)
@@ -167,8 +173,9 @@ export class NodesAndLinkedEdges extends GraphHitTestPolicy {
 
     const edge_indices = []
     for (let i = 0; i < edge_source.data.start.length; i++) {
-      if (contains(node_indices, edge_source.data.start[i]) || contains(node_indices, edge_source.data.end[i]))
+      if (contains(node_indices, edge_source.data.start[i]) || contains(node_indices, edge_source.data.end[i])) {
         edge_indices.push(i)
+      }
     }
 
     const linked_edges = new Selection()
@@ -181,8 +188,9 @@ export class NodesAndLinkedEdges extends GraphHitTestPolicy {
   }
 
   do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const node_selection = graph.node_renderer.data_source.selected
     node_selection.update(hit_test_result, final, mode)
@@ -197,8 +205,9 @@ export class NodesAndLinkedEdges extends GraphHitTestPolicy {
   }
 
   do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
     node_inspection.update(hit_test_result, final, mode)
@@ -254,8 +263,9 @@ export class EdgesAndLinkedNodes extends GraphHitTestPolicy {
   }
 
   do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const edge_selection = graph.edge_renderer.data_source.selected
     edge_selection.update(hit_test_result, final, mode)
@@ -270,8 +280,9 @@ export class EdgesAndLinkedNodes extends GraphHitTestPolicy {
   }
 
   do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const edge_inspection = graph_view.edge_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.edge_view.model)
     edge_inspection.update(hit_test_result, final, mode)
@@ -337,15 +348,17 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
   }
 
   do_selection(hit_test_result: HitTestResult, graph: GraphRenderer, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const node_selection = graph.node_renderer.data_source.selected
     node_selection.update(hit_test_result, final, mode)
 
     const adjacent_nodes_selection = this.get_adjacent_nodes(graph.node_renderer.data_source, graph.edge_renderer.data_source, "selection")
-    if (!adjacent_nodes_selection.is_empty())
+    if (!adjacent_nodes_selection.is_empty()) {
       node_selection.update(adjacent_nodes_selection, final, mode)
+    }
 
     graph.node_renderer.data_source._select.emit()
 
@@ -353,8 +366,9 @@ export class NodesAndAdjacentNodes extends GraphHitTestPolicy {
   }
 
   do_inspection(hit_test_result: HitTestResult, geometry: Geometry, graph_view: GraphRendererView, final: boolean, mode: SelectionMode): boolean {
-    if (hit_test_result == null)
+    if (hit_test_result == null) {
       return false
+    }
 
     const node_inspection = graph_view.node_view.model.data_source.selection_manager.get_or_create_inspector(graph_view.node_view.model)
     node_inspection.update(hit_test_result, final, mode)

--- a/bokehjs/src/lib/models/grids/grid.ts
+++ b/bokehjs/src/lib/models/grids/grid.ts
@@ -27,13 +27,15 @@ export class GridView extends GuideRendererView {
   }
 
   protected _draw_regions(ctx: Context2d): void {
-    if (!this.visuals.band_fill.doit && !this.visuals.band_hatch.doit)
+    if (!this.visuals.band_fill.doit && !this.visuals.band_hatch.doit) {
       return
+    }
 
     const [xs, ys] = this.grid_coords("major", false)
     for (let i = 0; i < xs.length-1; i++) {
-      if (i % 2 != 1)
+      if (i % 2 != 1) {
         continue
+      }
 
       const [sx0, sy0] = this.coordinates.map_to_screen(xs[i],   ys[i])
       const [sx1, sy1] = this.coordinates.map_to_screen(xs[i+1], ys[i+1])
@@ -47,15 +49,17 @@ export class GridView extends GuideRendererView {
   }
 
   protected _draw_grids(ctx: Context2d): void {
-    if (!this.visuals.grid_line.doit)
+    if (!this.visuals.grid_line.doit) {
       return
+    }
     const [xs, ys] = this.grid_coords("major")
     this._draw_grid_helper(ctx, this.visuals.grid_line, xs, ys)
   }
 
   protected _draw_minor_grids(ctx: Context2d): void {
-    if (!this.visuals.minor_grid_line.doit)
+    if (!this.visuals.minor_grid_line.doit) {
       return
+    }
     const [xs, ys] = this.grid_coords("minor")
     this._draw_grid_helper(ctx, this.visuals.minor_grid_line, xs, ys)
   }
@@ -93,14 +97,16 @@ export class GridView extends GuideRendererView {
       start = Math.min(user_bounds[0], user_bounds[1])
       end = Math.max(user_bounds[0], user_bounds[1])
 
-      if (start < range_bounds[0])
+      if (start < range_bounds[0]) {
         start = range_bounds[0]
+      }
       // XXX:
       //else if (start > range_bounds[1])
       //  start = null
 
-      if (end > range_bounds[1])
+      if (end > range_bounds[1]) {
         end = range_bounds[1]
+      }
       // XXX:
       //else if (end < range_bounds[0])
       //  end = null
@@ -146,22 +152,26 @@ export class GridView extends GuideRendererView {
 
     const [cmin, cmax] = (() => {
       const {cross_bounds} = this.model
-      if (cross_bounds == "auto")
+      if (cross_bounds == "auto") {
         return [cross_range.min, cross_range.max]
-      else
+      } else {
         return cross_bounds
+      }
     })()
 
     if (!exclude_ends) {
-      if (ticks[0] != min)
+      if (ticks[0] != min) {
         ticks.splice(0, 0, min)
-      if (ticks[ticks.length-1] != max)
+      }
+      if (ticks[ticks.length-1] != max) {
         ticks.push(max)
+      }
     }
 
     for (let ii = 0; ii < ticks.length; ii++) {
-      if ((ticks[ii] == min || ticks[ii] == max) && exclude_ends)
+      if ((ticks[ii] == min || ticks[ii] == max) && exclude_ends) {
         continue
+      }
       const dim_i: number[] = []
       const dim_j: number[] = []
       const N = 2

--- a/bokehjs/src/lib/models/layouts/css_grid_box.ts
+++ b/bokehjs/src/lib/models/layouts/css_grid_box.ts
@@ -76,36 +76,40 @@ export abstract class CSSGridBoxView extends LayoutDOMView {
     }
 
     const {_rows: rows, _cols: cols} = this
-    if (rows instanceof Map)
+    if (rows instanceof Map) {
       nrows = max(nrows, ...rows.keys())
-    else if (isArray(rows))
+    } else if (isArray(rows)) {
       nrows = max(nrows, rows.length)
+    }
 
-    if (cols instanceof Map)
+    if (cols instanceof Map) {
       ncols = max(ncols, ...cols.keys())
-    else if (isArray(cols))
+    } else if (isArray(cols)) {
       ncols = max(ncols, cols.length)
+    }
 
     function parse_sizing(tracks: TracksSizing | null, template: TrackSizing[]): void {
       if (tracks instanceof Map) {
         for (const [i, spec] of tracks.entries()) {
-          if (isString(spec))
+          if (isString(spec)) {
             template[i].size = spec
-          else
+          } else {
             template[i] = spec
+          }
         }
       } else if (isArray(tracks)) {
         for (const [spec, i] of enumerate(tracks)) {
-          if (isString(spec))
+          if (isString(spec)) {
             template[i].size = spec
-          else
+          } else {
             template[i] = spec
+          }
         }
       } else if (tracks != null) {
         for (const row of template) {
-          if (isString(tracks))
+          if (isString(tracks)) {
             row.size = tracks
-          else {
+          } else {
             row.size = tracks.size
             row.align = tracks.align
           }

--- a/bokehjs/src/lib/models/layouts/flex_box.ts
+++ b/bokehjs/src/lib/models/layouts/flex_box.ts
@@ -39,8 +39,9 @@ export abstract class FlexBoxView extends LayoutDOMView {
     let c0 = 0
 
     for (const view of this.child_views) {
-      if (!(view instanceof LayoutDOMView))
+      if (!(view instanceof LayoutDOMView)) {
         continue
+      }
 
       const sizing = view.box_sizing()
       const flex = (() => {
@@ -71,20 +72,23 @@ export abstract class FlexBoxView extends LayoutDOMView {
 
       // undo `width/height: 100%` and let `align-self: strech` do the work
       if (this._direction == "row") {
-        if (sizing.height_policy == "max")
+        if (sizing.height_policy == "max") {
           view.style.append(":host", {height: "auto"})
+        }
       } else {
-        if (sizing.width_policy == "max")
+        if (sizing.width_policy == "max") {
           view.style.append(":host", {width: "auto"})
+        }
       }
 
       if (view.layout != null) {
         layoutable.add({r0, c0, r1: r0 + 1, c1: c0 + 1}, view)
 
-        if (this._direction == "row")
+        if (this._direction == "row") {
           c0 += 1
-        else
+        } else {
           r0 += 1
+        }
       }
     }
 

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -56,8 +56,9 @@ export abstract class LayoutDOMView extends UIElementView {
       // This can happen only in pathological cases primarily in tests.
       logger.warn(`${this} wasn't built properly`)
       this.render_to(null)
-    } else
+    } else {
       this.compute_layout()
+    }
   }
 
   override async lazy_initialize(): Promise<void> {
@@ -66,8 +67,9 @@ export abstract class LayoutDOMView extends UIElementView {
   }
 
   override remove(): void {
-    for (const child_view of this.child_views)
+    for (const child_view of this.child_views) {
       child_view.remove()
+    }
     this._child_views.clear()
     super.remove()
   }
@@ -238,21 +240,25 @@ export abstract class LayoutDOMView extends UIElementView {
 
     const computed_aspect = (() => {
       if (aspect_ratio == "auto") {
-        if (width != null && height != null)
+        if (width != null && height != null) {
           return width/height
-      } else if (isNumber(aspect_ratio))
+        }
+      } else if (isNumber(aspect_ratio)) {
         return aspect_ratio
+      }
 
       return null
     })()
 
     if (aspect_ratio == "auto") {
-      if (width != null && height != null)
+      if (width != null && height != null) {
         styles.aspect_ratio = `${width} / ${height}`
-      else
+      } else {
         styles.aspect_ratio = "auto"
-    } else if (isNumber(aspect_ratio))
+      }
+    } else if (isNumber(aspect_ratio)) {
       styles.aspect_ratio = `${aspect_ratio}`
+    }
 
     const {margin} = this.model
     const margins = (() => {
@@ -280,22 +286,27 @@ export abstract class LayoutDOMView extends UIElementView {
 
       if (aspect_ratio != null) {
         if (width_policy != height_policy) {
-          if (width_policy == "fixed")
+          if (width_policy == "fixed") {
             return [css_width, "auto"]
-          if (height_policy == "fixed")
+          }
+          if (height_policy == "fixed") {
             return ["auto", css_height]
-          if (width_policy == "max")
+          }
+          if (width_policy == "max") {
             return [css_width, "auto"]
-          if (height_policy == "max")
+          }
+          if (height_policy == "max") {
             return ["auto", css_height]
+          }
           return ["auto", "auto"]
         } else {
           if (width_policy != "fixed" && height_policy != "fixed") {
             if (computed_aspect != null) {
-              if (computed_aspect >= 1)
+              if (computed_aspect >= 1) {
                 return [css_width, "auto"]
-              else
+              } else {
                 return ["auto", css_height]
+              }
             }
           }
         }
@@ -314,21 +325,25 @@ export abstract class LayoutDOMView extends UIElementView {
     styles.min_height = min_height == null ? "0px" : to_css(min_height)
 
     if (this.is_layout_root) {
-      if (max_width != null)
+      if (max_width != null) {
         styles.max_width = to_css(max_width)
+      }
 
-      if (max_height != null)
+      if (max_height != null) {
         styles.max_height = to_css(max_height)
+      }
     } else {
-      if (max_width != null)
+      if (max_width != null) {
         styles.max_width = `min(${to_css(max_width)}, 100%)`
-      else if (width_policy != "fixed")
+      } else if (width_policy != "fixed") {
         styles.max_width = "100%"
+      }
 
-      if (max_height != null)
+      if (max_height != null) {
         styles.max_height = `min(${to_css(max_height)}, 100%)`
-      else if (height_policy != "fixed")
+      } else if (height_policy != "fixed") {
         styles.max_height = "100%"
+      }
     }
 
     const {resizable} = this.model
@@ -396,10 +411,11 @@ export abstract class LayoutDOMView extends UIElementView {
       this.layout.compute(this.bbox.size)
 
       for (const child_view of this.layoutable_views) {
-        if (child_view.layout == null)
+        if (child_view.layout == null) {
           child_view._compute_layout()
-        else
+        } else {
           child_view._propagate_layout()
+        }
       }
     } else {
       for (const child_view of this.layoutable_views) {
@@ -442,12 +458,14 @@ export abstract class LayoutDOMView extends UIElementView {
 
   private _was_built: boolean = false
   override render_to(element: Node | null): void {
-    if (!this.is_layout_root)
+    if (!this.is_layout_root) {
       throw new Error(`${this.toString()} is not a root layout`)
+    }
 
     this.render()
-    if (element != null)
+    if (element != null) {
       element.appendChild(this.el)
+    }
     this.r_after_render()
     this._was_built = true
 
@@ -456,10 +474,11 @@ export abstract class LayoutDOMView extends UIElementView {
 
   r_after_render(): void {
     for (const child_view of this.child_views) {
-      if (child_view instanceof LayoutDOMView)
+      if (child_view instanceof LayoutDOMView) {
         child_view.r_after_render()
-      else
+      } else {
         child_view.after_render()
+      }
     }
 
     this.after_render()
@@ -536,20 +555,22 @@ export abstract class LayoutDOMView extends UIElementView {
           const sizing = this.parent.box_sizing()
           width_policy = sizing.width_policy
           height_policy = sizing.height_policy
-          if (aspect_ratio == null)
+          if (aspect_ratio == null) {
             aspect_ratio = sizing.aspect_ratio
+          }
         }
-      } else if (sizing_mode == "fixed")
+      } else if (sizing_mode == "fixed") {
         width_policy = height_policy = "fixed"
-      else if (sizing_mode == "stretch_both")
+      } else if (sizing_mode == "stretch_both") {
         width_policy = height_policy = "max"
-      else if (sizing_mode == "stretch_width")
+      } else if (sizing_mode == "stretch_width") {
         width_policy = "max"
-      else if (sizing_mode == "stretch_height")
+      } else if (sizing_mode == "stretch_height") {
         height_policy = "max"
-      else {
-        if (aspect_ratio == null)
+      } else {
+        if (aspect_ratio == null) {
           aspect_ratio = "auto"
+        }
 
         switch (sizing_mode) {
           case "scale_width":
@@ -570,12 +591,13 @@ export abstract class LayoutDOMView extends UIElementView {
 
     const [halign, valign] = (() => {
       const {align} = this.model
-      if (align == "auto")
+      if (align == "auto") {
         return [undefined, undefined]
-      else if (isArray(align))
+      } else if (isArray(align)) {
         return align
-      else
+      } else {
         return [align, align]
+      }
     })()
 
     const {width, height} = this.model

--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -84,8 +84,9 @@ export class TabsView extends LayoutDOMView {
     super._after_layout()
 
     const {child_views} = this
-    for (const child_view of child_views)
+    for (const child_view of child_views) {
       hide(child_view.el)
+    }
 
     const {active} = this.model
     if (active in child_views) {

--- a/bokehjs/src/lib/models/mappers/categorical_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/categorical_mapper.ts
@@ -12,8 +12,9 @@ export function _cat_equals(a: ArrayLike<unknown>, b: ArrayLike<unknown>): boole
 
   const n = a.length
   for (let i = 0; i < n; i++) {
-    if (a[i] !== b[i])
+    if (a[i] !== b[i]) {
       return false
+    }
   }
 
   return true

--- a/bokehjs/src/lib/models/mappers/color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/color_mapper.ts
@@ -21,8 +21,9 @@ export function _convert_color(color: Color): uint32 {
 // export for testing
 export function _convert_palette(palette: Color[]): Uint32Array {
   const new_palette = new Uint32Array(palette.length)
-  for (let i = 0, end = palette.length; i < end; i++)
+  for (let i = 0, end = palette.length; i < end; i++) {
     new_palette[i] = _convert_color(palette[i])
+  }
   return new_palette
 }
 

--- a/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/continuous_color_mapper.ts
@@ -77,12 +77,14 @@ export abstract class ContinuousColorMapper extends ColorMapper {
   protected *_collect(domain: [GlyphRenderer, string | string[]][]) {
     for (const [renderer, fields] of domain) {
       for (const field of isArray(fields) ? fields : [fields]) {
-        if (renderer.view.properties.indices.is_unset)
+        if (renderer.view.properties.indices.is_unset) {
           continue
+        }
 
         const column = renderer.data_source.get_column(field)
-        if (column == null)
+        if (column == null) {
           continue
+        }
 
         let array = renderer.view.indices.select(column)
 
@@ -90,12 +92,13 @@ export abstract class ContinuousColorMapper extends ColorMapper {
         const selected = renderer.data_source.selected.indices
 
         let subset: Arrayable<number> | undefined
-        if (masked != null && selected.length > 0)
+        if (masked != null && selected.length > 0) {
           subset = intersection([...masked], selected)
-        else if (masked != null)
+        } else if (masked != null) {
           subset = [...masked]
-        else if (selected.length > 0)
+        } else if (selected.length > 0) {
           subset = selected
+        }
 
         if (subset != null) {
           array = map(subset, (i) => array[i])
@@ -121,10 +124,12 @@ export abstract class ContinuousColorMapper extends ColorMapper {
 
     const {nan_color} = colors
     let {low_color, high_color} = colors
-    if (low_color == null)
+    if (low_color == null) {
       low_color = palette[0]
-    if (high_color == null)
+    }
+    if (high_color == null) {
       high_color = palette[palette.length-1]
+    }
 
     const {domain} = this
     const all_data = !is_empty(domain) ? [...this._collect(domain)] : data
@@ -134,10 +139,11 @@ export abstract class ContinuousColorMapper extends ColorMapper {
     for (let i = 0, end = data.length; i < end; i++) {
       const d = data[i]
 
-      if (isNaN(d))
+      if (isNaN(d)) {
         values[i] = nan_color
-      else
+      } else {
         values[i] = this.cmap(d, palette, low_color, high_color)
+      }
     }
   }
 
@@ -151,12 +157,13 @@ export abstract class ContinuousColorMapper extends ColorMapper {
 
   protected cmap<T>(value: number, palette: Arrayable<T>, low_color: T, high_color: T): T {
     const index = this.value_to_index(value, palette.length)
-    if (index < 0)
+    if (index < 0) {
       return low_color
-    else if (index >= palette.length)
+    } else if (index >= palette.length) {
       return high_color
-    else
+    } else {
       return palette[index]
+    }
   }
 
   abstract index_to_value(index: number): number

--- a/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/eqhist_color_mapper.ts
@@ -43,8 +43,9 @@ export class EqHistColorMapper extends ScanningColorMapper {
     // 1) Count non-zeros
     let nhist = 0
     for (let i = 0; i < nbins; i++) {
-      if (full_hist[i] != 0)
+      if (full_hist[i] != 0) {
         nhist++
+      }
     }
 
     // 2) Remove zeros, leaving extra element at beginning for rescale_discrete_levels
@@ -64,8 +65,9 @@ export class EqHistColorMapper extends ScanningColorMapper {
     const cdf = cumsum(hist)
     const lo = cdf[1]
     const diff = cdf[nhist] - lo
-    for (let i = 1; i <= nhist; i++)
+    for (let i = 1; i <= nhist; i++) {
       cdf[i] = (cdf[i] - lo) / diff
+    }
     cdf[0] = -1.0
 
     let {rescale_discrete_levels} = this
@@ -80,10 +82,11 @@ export class EqHistColorMapper extends ScanningColorMapper {
       const c = 1.5 - 2*m  // y[0] - m*x[0]
       const multiple = m*discrete_levels + c
 
-      if (multiple > 1)
+      if (multiple > 1) {
         lower_span = 1 - multiple
-      else
+      } else {
         rescale_discrete_levels = false
+      }
     }
 
     // Color bin boundaries are equally spaced in CDF
@@ -99,11 +102,13 @@ export class EqHistColorMapper extends ScanningColorMapper {
       // lowest colorbar label equals low rather than than the arbitrary value set by
       // rescale_discrete_levels. This ensures the bottom colorbar label is correct.
       // If low == binning[low_cutoff_index] then do nothing as label is already correct.
-      if (low < binning[low_cutoff_index] && low_cutoff_index > 0)
+      if (low < binning[low_cutoff_index] && low_cutoff_index > 0) {
         binning[low_cutoff_index-1] = low
+      }
       force_low_cutoff = true
-    } else
+    } else {
       binning[0] = low
+    }
     binning[binning.length-1] = high
 
     return {min: low, max: high, binning, force_low_cutoff}

--- a/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
@@ -46,8 +46,9 @@ export class LinearColorMapper extends ContinuousColorMapper {
 
     // This handles the edge case where value == high, since the code below maps
     // values exactly equal to high to palette.length when it should be one less.
-    if (value == scan_data.max)
+    if (value == scan_data.max) {
       return palette_length - 1
+    }
 
     const normed_value = (value - scan_data.min) * scan_data.norm_factor
     const index = Math.floor(normed_value / scan_data.normed_interval)

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -42,12 +42,13 @@ export class LogColorMapper extends ContinuousColorMapper {
 
     // This handles the edge case where value == high, since the code below maps
     // values exactly equal to high to palette.length when it should be one less.
-    if (value == scan_data.max)
+    if (value == scan_data.max) {
       return palette_length - 1
-    else if (value > scan_data.max)
+    } else if (value > scan_data.max) {
       return palette_length
-    else if (value < scan_data.min)
+    } else if (value < scan_data.min) {
       return -1
+    }
 
     const log = Math.log(value / scan_data.min)
     const index = Math.floor(log * scan_data.scale)

--- a/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/scanning_color_mapper.ts
@@ -35,11 +35,12 @@ export abstract class ScanningColorMapper extends ContinuousColorMapper {
   override value_to_index(value: number, palette_length: number): number {
     const scan_data = this._scan_data as ScanningScanData
 
-    if (value < scan_data.binning[0])
+    if (value < scan_data.binning[0]) {
       return -1
-    else if (value > scan_data.binning[scan_data.binning.length-1])
+    } else if (value > scan_data.binning[scan_data.binning.length-1]) {
       return palette_length
-    else
+    } else {
       return left_edge_index(value, scan_data.binning)
+    }
   }
 }

--- a/bokehjs/src/lib/models/mappers/weighted_stack_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/weighted_stack_color_mapper.ts
@@ -37,16 +37,18 @@ export class WeightedStackColorMapper extends StackColorMapper {
 
   // Weighted mix of colors.
   protected _mix_colors(colors_rgba: RGBAArray, nan_color: uint32, weights: Array<number>, total_weight: number): uint32 {
-    if (isNaN(total_weight))
+    if (isNaN(total_weight)) {
       return nan_color
+    }
 
     let r = 0.0, g = 0.0, b = 0.0, a = 0.0
     const n = weights.length
 
     if (total_weight != 0) {
       for (let i = 0; i < n; i++) {
-        if (isNaN(weights[i]))
+        if (isNaN(weights[i])) {
           continue
+        }
 
         const weight = weights[i] / total_weight
         r += colors_rgba[i*4  ]*weight
@@ -113,10 +115,11 @@ export class WeightedStackColorMapper extends StackColorMapper {
         const val = baseline == 0 ? data[index] : Math.max(data[index] - baseline, 0)
         weights[icol] = val
         if (!isNaN(val)) {
-          if (isNaN(total))
+          if (isNaN(total)) {
             total = val
-          else
+          } else {
             total += val
+          }
         }
       }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -269,7 +269,9 @@ export class PlotView extends LayoutDOMView implements Renderable {
     this._range_manager = new RangeManager(this)
     this._state_manager = new StateManager(this, this._initial_state)
 
-    this.throttled_paint = throttle(() => { if (!this._removed) this.repaint() }, 1000/60)
+    this.throttled_paint = throttle(() => {
+      if (!this._removed) this.repaint()
+    }, 1000/60)
 
     const {title_location, title} = this.model
     if (title_location != null && title != null) {
@@ -702,10 +704,14 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
     const {x_ranges, y_ranges} = this.frame
     for (const [, range] of x_ranges) {
-      this.connect(range.change, () => { this.request_paint("everything") })
+      this.connect(range.change, () => {
+        this.request_paint("everything")
+      })
     }
     for (const [, range] of y_ranges) {
-      this.connect(range.change, () => { this.request_paint("everything") })
+      this.connect(range.change, () => {
+        this.request_paint("everything")
+      })
     }
 
     this.connect(this.model.change, () => this.request_paint("everything"))

--- a/bokehjs/src/lib/models/policies/labeling.ts
+++ b/bokehjs/src/lib/models/policies/labeling.ts
@@ -70,10 +70,11 @@ export class NoOverlap extends LabelingPolicy {
     const {min_distance} = this
     let k = null
     for (const i of indices) {
-      if (k != null && distance(k, i) < min_distance)
+      if (k != null && distance(k, i) < min_distance) {
         indices.unset(i)
-      else
+      } else {
         k = i
+      }
     }
     return indices
   }
@@ -124,14 +125,15 @@ export class CustomLabelingPolicy extends LabelingPolicy {
     let result = generator.next()
     if ((result.done ?? false) && result.value !== undefined) {
       const {value} = result
-      if (value instanceof Indices)
+      if (value instanceof Indices) {
         return value
-      else if (value === undefined)
+      } else if (value === undefined) {
         return indices
-      else if (isIterable(value))
+      } else if (isIterable(value)) {
         return Indices.from_indices(indices.size, value as Iterable<number>)
-      else
+      } else {
         return Indices.all_unset(indices.size)
+      }
     } else {
       const array: number[] = []
 

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -123,10 +123,14 @@ export class DataRange1d extends DataRange {
     const result = bbox.empty()
 
     let width = bounds.x1 - bounds.x0
-    if (width <= 0) { width = 1.0 }
+    if (width <= 0) {
+      width = 1.0
+    }
 
     let height = bounds.y1 - bounds.y0
-    if (height <= 0) { height = 1.0 }
+    if (height <= 0) {
+      height = 1.0
+    }
 
     const xcenter = 0.5*(bounds.x1 + bounds.x0)
     const ycenter = 0.5*(bounds.y1 + bounds.y0)

--- a/bokehjs/src/lib/models/scales/linear_interpolation_scale.ts
+++ b/bokehjs/src/lib/models/scales/linear_interpolation_scale.ts
@@ -79,15 +79,19 @@ export class LinearInterpolationScale extends Scale<number> {
     }
 
     const vvs = map(vs, (v) => {
-      if (v < min_val)
+      if (v < min_val) {
         return min_val
-      if (v > max_val)
+      }
+      if (v > max_val) {
         return max_val
+      }
       const k = left_edge_index(v, binning)
-      if (k == -1)
+      if (k == -1) {
         return min_val
-      if (k >= n - 1)
+      }
+      if (k >= n - 1) {
         return max_val
+      }
       const b0 = binning[k]
       const b1 = binning[k+1]
       const c = (v - b0)/(b1 - b0)

--- a/bokehjs/src/lib/models/scales/log_scale.ts
+++ b/bokehjs/src/lib/models/scales/log_scale.ts
@@ -19,9 +19,9 @@ export class LogScale extends ContinuousScale {
   get s_compute(): (x: number) => number {
     const [factor, offset, inter_factor, inter_offset] = this._compute_state()
     return (x) => {
-      if (inter_factor == 0)
+      if (inter_factor == 0) {
         return 0
-      else {
+      } else {
         const _x = (Math.log(x) - inter_offset) / inter_factor
         return isFinite(_x) ? _x*factor + offset : NaN
       }
@@ -41,16 +41,17 @@ export class LogScale extends ContinuousScale {
     let end = orig_end < 0 ? 0 : orig_end
 
     if (start == end) {
-      if (start == 0)
+      if (start == 0) {
         [start, end] = [1, 10]
-      else {
+      } else {
         const log_val = Math.log10(start)
         start = 10**Math.floor(log_val)
 
-        if (Math.ceil(log_val) != Math.floor(log_val))
+        if (Math.ceil(log_val) != Math.floor(log_val)) {
           end = 10**Math.ceil(log_val)
-        else
+        } else {
           end = 10**(Math.ceil(log_val) + 1)
+        }
       }
     }
 

--- a/bokehjs/src/lib/models/scales/scale.ts
+++ b/bokehjs/src/lib/models/scales/scale.ts
@@ -62,17 +62,19 @@ export abstract class Scale<T = number> extends Transform<T, number> {
 
   r_compute(x0: T, x1: T): [number, number] {
     const {s_compute} = this
-    if (this.target_range.is_reversed)
+    if (this.target_range.is_reversed) {
       return [s_compute(x1), s_compute(x0)]
-    else
+    } else {
       return [s_compute(x0), s_compute(x1)]
+    }
   }
 
   r_invert(sx0: number, sx1: number): [number, number] {
     const {s_invert} = this
-    if (this.target_range.is_reversed)
+    if (this.target_range.is_reversed) {
       return [s_invert(sx1), s_invert(sx0)]
-    else
+    } else {
       return [s_invert(sx0), s_invert(sx1)]
+    }
   }
 }

--- a/bokehjs/src/lib/models/selections/interaction_policy.ts
+++ b/bokehjs/src/lib/models/selections/interaction_policy.ts
@@ -26,8 +26,9 @@ export class IntersectRenderers extends SelectionPolicy {
     const hit_test_result_renderers = []
     for (const r of renderer_views) {
       const result = r.hit_test(geometry)
-      if (result != null)
+      if (result != null) {
         hit_test_result_renderers.push(result)
+      }
     }
     if (hit_test_result_renderers.length > 0) {
       const hit_test_result = hit_test_result_renderers[0]
@@ -47,8 +48,9 @@ export class UnionRenderers extends SelectionPolicy {
     const hit_test_result_renderers = []
     for (const r of renderer_views) {
       const result = r.hit_test(geometry)
-      if (result != null)
+      if (result != null) {
         hit_test_result_renderers.push(result)
+      }
     }
     if (hit_test_result_renderers.length > 0) {
       const hit_test_result = hit_test_result_renderers[0]

--- a/bokehjs/src/lib/models/text/math_text.ts
+++ b/bokehjs/src/lib/models/text/math_text.ts
@@ -46,8 +46,9 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
   _base_font_size: number = 13 // the same as :host's font-size (13px)
 
   set base_font_size(v: number | null | undefined) {
-    if (v != null)
+    if (v != null) {
       this._base_font_size = v
+    }
   }
 
   get base_font_size(): number {
@@ -91,8 +92,9 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
   override async lazy_initialize() {
     await super.lazy_initialize()
 
-    if (this.provider.status == "not_started")
+    if (this.provider.status == "not_started") {
       await this.provider.fetch()
+    }
   }
 
   override connect_signals(): void {
@@ -148,9 +150,9 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
     const metrics = font_metrics(this.font)
 
     const x = sx - (() => {
-      if (isNumber(x_anchor))
+      if (isNumber(x_anchor)) {
         return x_anchor*width
-      else {
+      } else {
         switch (x_anchor) {
           case "left": return 0
           case "center": return 0.5*width
@@ -160,22 +162,25 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
     })()
 
     const y = sy - (() => {
-      if (isNumber(y_anchor))
+      if (isNumber(y_anchor)) {
         return y_anchor*height
-      else {
+      } else {
         switch (y_anchor) {
           case "top":
-            if (metrics.height > height)
+            if (metrics.height > height) {
               return (height - (-this.valign - metrics.descent) - metrics.height)
-            else
+            } else {
               return 0
+            }
           case "center": return 0.5*height
           case "bottom":
-            if (metrics.height > height)
+            if (metrics.height > height) {
               return (
                 height + metrics.descent + this.valign
               )
-            else return height
+            } else {
+              return height
+            }
           case "baseline": return 0.5*height
         }
       }
@@ -191,9 +196,9 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
     const {width, height} = this._size()
     const {angle} = this
 
-    if (angle == null || angle == 0)
+    if (angle == null || angle == 0) {
       return {width, height}
-    else {
+    } else {
       const c = Math.cos(Math.abs(angle))
       const s = Math.sin(Math.abs(angle))
 
@@ -287,9 +292,9 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
   rect(): Rect {
     const rect = this._rect()
     const {angle} = this
-    if (angle == null || angle == 0)
+    if (angle == null || angle == 0) {
       return rect
-    else {
+    } else {
       const {sx, sy} = this.position
       const tr = new AffineTransform()
       tr.translate(sx, sy)
@@ -334,8 +339,9 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
   protected abstract _process_text(): HTMLElement | undefined
 
   private async load_image(): Promise<CanvasImage | null> {
-    if (this.provider.MathJax == null)
+    if (this.provider.MathJax == null) {
       return null
+    }
 
     const mathjax_element = this._process_text()
     if (mathjax_element == null) {
@@ -363,11 +369,13 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
   */
   paint(ctx: Context2d): void {
     if (this.svg_image == null) {
-      if (this.provider.status == "not_started" || this.provider.status == "loading")
+      if (this.provider.status == "not_started" || this.provider.status == "loading") {
         this.provider.ready.connect(() => this.load_image())
+      }
 
-      if (this.provider.status == "loaded")
+      if (this.provider.status == "loaded") {
         this.load_image()
+      }
     }
 
     ctx.save()
@@ -490,8 +498,9 @@ export class MathMLView extends MathTextView {
   override get styled_text(): string {
     let styled = this.text.trim()
     let matchs = styled.match(/<math(.*?[^?])?>/s)
-    if (matchs == null)
+    if (matchs == null) {
       return this.text.trim()
+    }
 
     styled = insert_text_on_position(
       styled,
@@ -500,8 +509,9 @@ export class MathMLView extends MathTextView {
     )
 
     matchs = styled.match(/<\/[^>]*?math.*?>/s)
-    if (matchs == null)
+    if (matchs == null) {
       return this.text.trim()
+    }
 
     return insert_text_on_position(styled, styled.indexOf(matchs[0]), "</mstyle>")
   }

--- a/bokehjs/src/lib/models/tickers/categorical_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/categorical_ticker.ts
@@ -42,8 +42,9 @@ export class CategoricalTicker extends Ticker {
 
     for (const factor of factors) {
       const coord = range.synthetic(factor)
-      if (coord > start && coord < end)
+      if (coord > start && coord < end) {
         result.push(factor)
+      }
     }
 
     return result

--- a/bokehjs/src/lib/models/tickers/continuous_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/continuous_ticker.ts
@@ -64,10 +64,11 @@ export abstract class ContinuousTicker extends Ticker {
     const start_factor = Math.floor(data_low / interval)
     const end_factor   = Math.ceil(data_high / interval)
     let factors: number[]
-    if (!isFinite(start_factor) || !isFinite(end_factor))
+    if (!isFinite(start_factor) || !isFinite(end_factor)) {
       factors = []
-    else
+    } else {
       factors = range(start_factor, end_factor + 1)
+    }
     const ticks = factors
       .map((factor) => factor*interval)
       .filter((tick) => data_low <= tick && tick <= data_high)

--- a/bokehjs/src/lib/models/tickers/days_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/days_ticker.ts
@@ -21,8 +21,9 @@ function date_range_by_month(start_time: number, end_time: number): Date[] {
     dates.push(copy_date(date))
 
     date.setUTCMonth(date.getUTCMonth() + 1)
-    if (date > end_date)
+    if (date > end_date) {
       break
+    }
   }
 
   return dates
@@ -64,10 +65,11 @@ export class DaysTicker extends BaseSingleIntervalTicker {
   override initialize(): void {
     super.initialize()
     const days = this.days
-    if (days.length > 1)
+    if (days.length > 1) {
       this.interval = (days[1] - days[0])*ONE_DAY
-    else
+    } else {
       this.interval = 31*ONE_DAY
+    }
   }
 
   override get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: number, _desired_n_ticks: number): TickSpec<number> {
@@ -89,8 +91,9 @@ export class DaysTicker extends BaseSingleIntervalTicker {
         // TODO (bev) The above description does not exactly work because JS Date
         // is broken and will happily consider "Feb 28 + 3*ONE_DAY" to have month "2"
         const future_date = new Date(day_date.getTime() + (interval / 2))
-        if (future_date.getUTCMonth() == current_month)
+        if (future_date.getUTCMonth() == current_month) {
           dates.push(day_date)
+        }
       }
       return dates
     }

--- a/bokehjs/src/lib/models/tickers/mercator_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/mercator_ticker.ts
@@ -34,10 +34,11 @@ export class MercatorTicker extends BasicTicker {
 
     [data_low, data_high] = clip_mercator(data_low, data_high, this.dimension)
 
-    if (this.dimension == "lon")
+    if (this.dimension == "lon") {
       return this._get_ticks_lon(data_low, data_high, cross_loc, desired_n_ticks)
-    else
+    } else {
       return this._get_ticks_lat(data_low, data_high, cross_loc, desired_n_ticks)
+    }
   }
 
   protected _get_ticks_lon(data_low: number, data_high: number, cross_loc: number, desired_n_ticks: number): TickSpec<number> {

--- a/bokehjs/src/lib/models/tickers/months_ticker.ts
+++ b/bokehjs/src/lib/models/tickers/months_ticker.ts
@@ -18,8 +18,9 @@ function date_range_by_year(start_time: number, end_time: number): Date[] {
     dates.push(copy_date(date))
 
     date.setUTCFullYear(date.getUTCFullYear() + 1)
-    if (date > end_date)
+    if (date > end_date) {
       break
+    }
   }
 
   return dates
@@ -57,10 +58,11 @@ export class MonthsTicker extends BaseSingleIntervalTicker {
   override initialize(): void {
     super.initialize()
     const months = this.months
-    if (months.length > 1)
+    if (months.length > 1) {
       this.interval = (months[1] - months[0])*ONE_MONTH
-    else
+    } else {
       this.interval = 12*ONE_MONTH
+    }
   }
 
   override get_ticks_no_defaults(data_low: number, data_high: number, _cross_loc: number, _desired_n_ticks: number): TickSpec<number> {

--- a/bokehjs/src/lib/models/tiles/bbox_tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/bbox_tile_source.ts
@@ -28,10 +28,11 @@ export class BBoxTileSource extends MercatorTileSource {
     const image_url = this.string_lookup_replace(this.url, this.extra_url_vars)
 
     let xmax: number, xmin: number, ymax: number, ymin: number
-    if (this.use_latlon)
+    if (this.use_latlon) {
       [xmin, ymin, xmax, ymax] = this.get_tile_geographic_bounds(x, y, z)
-    else
+    } else {
       [xmin, ymin, xmax, ymax] = this.get_tile_meter_bounds(x, y, z)
+    }
 
     return image_url
       .replace("{XMIN}", xmin.toString())

--- a/bokehjs/src/lib/models/tiles/mercator_tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/mercator_tile_source.ts
@@ -43,9 +43,9 @@ export class MercatorTileSource extends TileSource {
   }
 
   protected _computed_initial_resolution(): number {
-    if (this.initial_resolution != null)
+    if (this.initial_resolution != null) {
       return this.initial_resolution
-    else {
+    } else {
       // TODO testing 2015-11-17, if this codepath is used it seems
       // to use 100% cpu and wedge Chrome
       return (2 * Math.PI * 6378137) / this.tile_size
@@ -54,12 +54,14 @@ export class MercatorTileSource extends TileSource {
 
   is_valid_tile(x: number, y: number, z: number): boolean {
     if (!this.wrap_around) {
-      if (x < 0 || x >= 2**z)
+      if (x < 0 || x >= 2**z) {
         return false
+      }
     }
 
-    if (y < 0 || y >= 2**z)
+    if (y < 0 || y >= 2**z) {
       return false
+    }
 
     return true
   }
@@ -88,10 +90,12 @@ export class MercatorTileSource extends TileSource {
     let i = 0
     for (const r of this._resolutions) {
       if (resolution > r) {
-        if (i == 0)
+        if (i == 0) {
           return 0
-        if (i > 0)
+        }
+        if (i > 0) {
           return i - 1
+        }
       }
       i += 1
     }
@@ -105,10 +109,11 @@ export class MercatorTileSource extends TileSource {
     const y_rs = (extent[3] - extent[1]) / height
     const resolution = Math.max(x_rs, y_rs)
     const closest = this._resolutions.reduce(function(previous, current) {
-      if (Math.abs(current - resolution) < Math.abs(previous - resolution))
+      if (Math.abs(current - resolution) < Math.abs(previous - resolution)) {
         return current
-      else
+      } else {
         return previous
+      }
     })
     return this._resolutions.indexOf(closest)
   }
@@ -204,8 +209,9 @@ export class MercatorTileSource extends TileSource {
     const tiles: [number, number, number, Bounds][] = []
     for (let ty = tymax; ty >= tymin; ty--) {
       for (let tx = txmin; tx <= txmax; tx++) {
-        if (this.is_valid_tile(tx, ty, level))
+        if (this.is_valid_tile(tx, ty, level)) {
           tiles.push([tx, ty, level, this.get_tile_meter_bounds(tx, ty, level)])
+        }
       }
     }
 
@@ -285,8 +291,9 @@ export class MercatorTileSource extends TileSource {
       quadkey = quadkey.substring(0, quadkey.length - 1)
       ;[x, y, z] = this.quadkey_to_tile_xyz(quadkey)
       ;[x, y, z] = this.denormalize_xyz(x, y, z, world_x)
-      if (this.tiles.has(this.tile_xyz_to_key(x, y, z)))
+      if (this.tiles.has(this.tile_xyz_to_key(x, y, z))) {
         return [x, y, z]
+      }
     }
     return [0, 0, 0]
   }

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -55,8 +55,9 @@ export class TileRendererView extends RendererView {
   }
 
   override remove(): void {
-    if (this.attribution_el != null)
+    if (this.attribution_el != null) {
       remove(this.attribution_el)
+    }
     super.remove()
   }
 
@@ -100,8 +101,9 @@ export class TileRendererView extends RendererView {
   }
 
   protected _update_attribution(): void {
-    if (this.attribution_el != null)
+    if (this.attribution_el != null) {
       remove(this.attribution_el)
+    }
 
     const {attribution} = this.model.tile_source
 
@@ -156,8 +158,9 @@ export class TileRendererView extends RendererView {
     const quadkey = this.model.tile_source.tile_xyz_to_quadkey(x, y, z)
     const cache_key = this.model.tile_source.tile_xyz_to_key(x, y, z)
 
-    if (this.model.tile_source.tiles.has(cache_key))
+    if (this.model.tile_source.tiles.has(cache_key)) {
       return
+    }
 
     const [nx, ny, nz] = this.model.tile_source.normalize_xyz(x, y, z)
     const src = this.model.tile_source.get_image_url(nx, ny, nz)
@@ -176,8 +179,9 @@ export class TileRendererView extends RendererView {
     }
 
     this.model.tile_source.tiles.set(cache_key, tile)
-    if (this._tiles == null)
+    if (this._tiles == null) {
       this._tiles = []
+    }
     this._tiles.push(tile)
 
     new ImageLoader(src, {
@@ -187,8 +191,9 @@ export class TileRendererView extends RendererView {
         if (cache_only) {
           tile.finished = true
           this.notify_finished()
-        } else
+        } else {
           this.request_render()
+        }
       },
       failed() {
         tile.finished = true
@@ -211,15 +216,18 @@ export class TileRendererView extends RendererView {
   }
 
   override has_finished(): boolean {
-    if (!super.has_finished())
+    if (!super.has_finished()) {
       return false
+    }
 
-    if (this._tiles == null)
+    if (this._tiles == null) {
       return false
+    }
 
     for (const tile of this._tiles) {
-      if (!tile.finished)
+      if (!tile.finished) {
         return false
+      }
     }
 
     return true
@@ -365,15 +373,17 @@ export class TileRendererView extends RendererView {
             for (const [cx, cy, cz] of child_tiles) {
               const child_key = tile_source.tile_xyz_to_key(cx, cy, cz)
 
-              if (tile_source.tiles.has(child_key))
+              if (tile_source.tiles.has(child_key)) {
                 children.push(child_key)
+              }
             }
           }
         }
       }
 
-      if (tile == null)
+      if (tile == null) {
         need_load.push(t)
+      }
     }
 
     // draw stand-in parents ----------

--- a/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/poly_draw_tool.ts
@@ -80,7 +80,9 @@ export class PolyDrawToolView extends PolyToolView {
   }
 
   _show_vertices(): void {
-    if (!this.model.active) { return }
+    if (!this.model.active) {
+      return
+    }
     const xs: number[] = []
     const ys: number[] = []
     for (let i=0; i<this.model.renderers.length; i++) {

--- a/bokehjs/src/lib/models/transforms/interpolator.ts
+++ b/bokehjs/src/lib/models/transforms/interpolator.ts
@@ -55,17 +55,20 @@ export abstract class Interpolator extends Transform {
   }
 
   sort(descending: boolean = false): void {
-    if (!this._sorted_dirty)
+    if (!this._sorted_dirty) {
       return
+    }
 
     let tsx: Arrayable<number>
     let tsy: Arrayable<number>
     if (isString(this.x) && isString(this.y) && this.data != null) {
       const column_names = this.data.columns()
-      if (!includes(column_names, this.x))
+      if (!includes(column_names, this.x)) {
         throw new Error("The x parameter does not correspond to a valid column name defined in the data parameter")
-      if (!includes(column_names, this.y))
+      }
+      if (!includes(column_names, this.y)) {
         throw new Error("The y parameter does not correspond to a valid column name defined in the data parameter")
+      }
 
       tsx = this.data.get_column(this.x)!
       tsy = this.data.get_column(this.y)!
@@ -76,11 +79,13 @@ export abstract class Interpolator extends Transform {
       throw new Error("parameters 'x' and 'y' must be both either string fields or arrays")
     }
 
-    if (tsx.length !== tsy.length)
+    if (tsx.length !== tsy.length) {
       throw new Error("The length for x and y do not match")
+    }
 
-    if (tsx.length < 2)
+    if (tsx.length < 2) {
       throw new Error("x and y must have at least two elements to support interpolation")
+    }
 
     const n = tsx.length
     const index = new Uint32Array(n)

--- a/bokehjs/src/lib/models/transforms/jitter.ts
+++ b/bokehjs/src/lib/models/transforms/jitter.ts
@@ -53,10 +53,11 @@ export class Jitter extends RangeTransform {
 
   override v_compute(xs0: Arrayable<number | Factor>): Arrayable<number> {
     const xs: Arrayable<number> = (() => {
-      if (this.range instanceof FactorRange)
+      if (this.range instanceof FactorRange) {
         return this.range.v_synthetic(xs0)
-      else
+      } else {
         return xs0 as Arrayable<number>
+      }
     })()
 
     const offsets = (() => {

--- a/bokehjs/src/lib/models/transforms/linear_interpolator.ts
+++ b/bokehjs/src/lib/models/transforms/linear_interpolator.ts
@@ -21,17 +21,21 @@ export class LinearInterpolator extends Interpolator {
     this.sort(false)
 
     if (this.clip) {
-      if (x < this._x_sorted[0] || x > this._x_sorted[this._x_sorted.length-1])
+      if (x < this._x_sorted[0] || x > this._x_sorted[this._x_sorted.length-1]) {
         return NaN
+      }
     } else {
-      if (x < this._x_sorted[0])
+      if (x < this._x_sorted[0]) {
         return this._y_sorted[0]
-      if (x > this._x_sorted[this._x_sorted.length-1])
+      }
+      if (x > this._x_sorted[this._x_sorted.length-1]) {
         return this._y_sorted[this._y_sorted.length-1]
+      }
     }
 
-    if (x == this._x_sorted[0])
+    if (x == this._x_sorted[0]) {
       return this._y_sorted[0]
+    }
 
     const ind = find_last_index(this._x_sorted, num => num < x)
 

--- a/bokehjs/src/lib/models/transforms/range_transform.ts
+++ b/bokehjs/src/lib/models/transforms/range_transform.ts
@@ -33,12 +33,13 @@ export abstract class RangeTransform extends Transform {
 
   v_compute(xs0: Arrayable<number | Factor>): Arrayable<number> {
     let xs: Arrayable<number>
-    if (this.range instanceof FactorRange)
+    if (this.range instanceof FactorRange) {
       xs = this.range.v_synthetic(xs0)
-    else if (isArrayableOf(xs0, isNumber))
+    } else if (isArrayableOf(xs0, isNumber)) {
       xs = xs0
-    else
+    } else {
       unreachable()
+    }
 
     const result = new (infer_type(xs))(xs.length)
     for (let i = 0; i < xs.length; i++) {
@@ -49,12 +50,13 @@ export abstract class RangeTransform extends Transform {
   }
 
   compute(x: number | Factor): number {
-    if (this.range instanceof FactorRange)
+    if (this.range instanceof FactorRange) {
       return this._compute(this.range.synthetic(x))
-    else if (isNumber(x))
+    } else if (isNumber(x)) {
       return this._compute(x)
-    else
+    } else {
       unreachable()
+    }
   }
 
   protected abstract _compute(x: number): number

--- a/bokehjs/src/lib/models/transforms/step_interpolator.ts
+++ b/bokehjs/src/lib/models/transforms/step_interpolator.ts
@@ -30,13 +30,16 @@ export class StepInterpolator extends Interpolator {
     this.sort(false)
 
     if (this.clip) {
-      if (x < this._x_sorted[0] || x > this._x_sorted[this._x_sorted.length-1])
+      if (x < this._x_sorted[0] || x > this._x_sorted[this._x_sorted.length-1]) {
         return NaN
+      }
     } else {
-      if (x < this._x_sorted[0])
+      if (x < this._x_sorted[0]) {
         return this._y_sorted[0]
-      if (x > this._x_sorted[this._x_sorted.length-1])
+      }
+      if (x > this._x_sorted[this._x_sorted.length-1]) {
         return this._y_sorted[this._y_sorted.length-1]
+      }
     }
 
     let ind: number

--- a/bokehjs/src/lib/models/ui/examiner.ts
+++ b/bokehjs/src/lib/models/ui/examiner.ts
@@ -24,34 +24,36 @@ export class HTMLPrinter {
 
   to_html(obj: unknown): HTMLElement {
     if (isObject(obj)) {
-      if (this.visited.has(obj))
+      if (this.visited.has(obj)) {
         return span("<circular>")
-      else
+      } else {
         this.visited.add(obj)
+      }
     }
 
-    if (obj == null)
+    if (obj == null) {
       return this.null()
-    else if (isBoolean(obj))
+    } else if (isBoolean(obj)) {
       return this.boolean(obj)
-    else if (isNumber(obj))
+    } else if (isNumber(obj)) {
       return this.number(obj)
-    else if (isString(obj))
+    } else if (isString(obj)) {
       return this.string(obj)
-    else if (isSymbol(obj))
+    } else if (isSymbol(obj)) {
       return this.symbol(obj)
-    else if (obj instanceof Model)
+    } else if (obj instanceof Model) {
       return this.model(obj)
-    else if (obj instanceof p.Property)
+    } else if (obj instanceof p.Property) {
       return this.property(obj)
-    else if (isPlainObject(obj))
+    } else if (isPlainObject(obj)) {
       return this.object(obj)
-    else if (isArray(obj))
+    } else if (isArray(obj)) {
       return this.array(obj)
-    else if (isIterable(obj))
+    } else if (isIterable(obj)) {
       return this.iterable(obj)
-    else
+    } else {
       return span(to_string(obj))
+    }
   }
 
   null(): HTMLElement {
@@ -75,12 +77,13 @@ export class HTMLPrinter {
     const dq = val.includes('"')
 
     const str = (() => {
-      if (sq && dq)
+      if (sq && dq) {
         return `\`${val.replace(/`/g, "\\`")}\``
-      else if (dq)
+      } else if (dq) {
         return `'${val}'`
-      else
+      } else {
         return `"${val}"`
+      }
     })()
 
     return span({class: "string"}, str)
@@ -153,8 +156,9 @@ export class ExaminerView extends UIElementView {
   override render(): void {
     super.render()
 
-    if (this.prev_listener != null)
+    if (this.prev_listener != null) {
       diagnostics.disconnect(this.prev_listener)
+    }
 
     const models_list: [HasProps, HTMLElement][] = []
     const props_list: [p.Property, HTMLElement][] = []
@@ -162,13 +166,15 @@ export class ExaminerView extends UIElementView {
 
     const animations = new WeakMap<Element, Animation>()
     const listener = (obj: unknown): void => {
-      if (!(obj instanceof p.Property))
+      if (!(obj instanceof p.Property)) {
         return
+      }
 
       function highlight(el: Element) {
         const prev = animations.get(el)
-        if (prev != null)
+        if (prev != null) {
           prev.cancel()
+        }
         const anim = el.animate([
           {backgroundColor: "#def189"},
           {backgroundColor: "initial"},
@@ -278,8 +284,9 @@ export class ExaminerView extends UIElementView {
     const examiner_el = div({class: "examiner"}, models_panel_el, column_el)
 
     function click(obj: unknown) {
-      if (obj instanceof Model)
+      if (obj instanceof Model) {
         render_props(obj)
+      }
     }
 
     function to_html(obj: unknown) {
@@ -336,8 +343,9 @@ export class ExaminerView extends UIElementView {
       const connections = receivers_for_sender.get(model) ?? []
 
       for (const [base, attrs] of bases) {
-        if (attrs.length == 0)
+        if (attrs.length == 0) {
           continue
+        }
 
         const expander_el = span({class: ["expander"]})
         const base_el = div({class: "base"}, expander_el, "inherited from", " ", span({class: "monospace"}, base.__qualified__))

--- a/bokehjs/src/lib/models/ui/pane.ts
+++ b/bokehjs/src/lib/models/ui/pane.ts
@@ -62,12 +62,14 @@ export class PaneView extends UIElementView {
   }
 
   override has_finished(): boolean {
-    if (!super.has_finished())
+    if (!super.has_finished()) {
       return false
+    }
 
     for (const child_view of this.child_views) {
-      if (!child_view.has_finished())
+      if (!child_view.has_finished()) {
         return false
+      }
     }
 
     return true

--- a/bokehjs/src/lib/models/ui/tooltip.ts
+++ b/bokehjs/src/lib/models/ui/tooltip.ts
@@ -48,9 +48,9 @@ export class TooltipView extends UIElementView {
       }
     })()
 
-    if (el instanceof Element)
+    if (el instanceof Element) {
       this._target = el
-    else {
+    } else {
       logger.warn(`unable to resolve target '${target}' for '${this}'`)
       this._target = document.body
     }
@@ -65,8 +65,9 @@ export class TooltipView extends UIElementView {
 
   override *children(): IterViews {
     yield* super.children()
-    if (this._html != null)
+    if (this._html != null) {
       yield this._html
+    }
   }
 
   override async lazy_initialize(): Promise<void> {
@@ -138,8 +139,9 @@ export class TooltipView extends UIElementView {
     } else if (content instanceof HTML) {
       assert(this._html != null)
       return this._html.el
-    } else
+    } else {
       return content
+    }
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/ui/ui_element.ts
+++ b/bokehjs/src/lib/models/ui/ui_element.ts
@@ -35,8 +35,9 @@ function* _iter_styles(styles: CSSStyles | Styles): Iterable<[string, unknown]> 
         yield [prop.attr, prop.get_value()]
       }
     }
-  } else
+  } else {
     yield* entries(styles)
+  }
 }
 
 export abstract class UIElementView extends DOMComponentView {
@@ -115,11 +116,11 @@ export abstract class UIElementView extends DOMComponentView {
     const displayed = (() => {
       // Consider using Element.checkVisibility() in the future.
       // https://w3c.github.io/csswg-drafts/cssom-view-1/#dom-element-checkvisibility
-      if (!this.el.isConnected)
+      if (!this.el.isConnected) {
         return false
-      else if (this.el.offsetParent != null)
+      } else if (this.el.offsetParent != null) {
         return true
-      else {
+      } else {
         const {position, display} = getComputedStyle(this.el)
         return position == "fixed" && display != "none"
       }
@@ -218,9 +219,9 @@ export abstract class UIElementView extends DOMComponentView {
   }
 
   protected _apply_visible(): void {
-    if (this.model.visible)
+    if (this.model.visible) {
       this._display.clear()
-    else {
+    } else {
       // in case `display` element style was set, use `!important` to work around this
       this._display.replace(":host { display: none !important; }")
     }
@@ -241,8 +242,9 @@ export abstract class UIElementView extends DOMComponentView {
       const name = attr.replace(/_/g, "-")
 
       if (!apply(name, value)) {
-        if (!apply(`-webkit-${name}`, value) && !apply(`-moz-${name}`, value))
+        if (!apply(`-webkit-${name}`, value) && !apply(`-moz-${name}`, value)) {
           logger.trace(`unknown CSS property '${name}'`)
+        }
       }
     }
   }

--- a/bokehjs/src/lib/models/widgets/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_slider.ts
@@ -118,8 +118,9 @@ abstract class AbstractBaseSliderView extends OrientedControlView {
       }
 
       tooltips = repeat(formatter, value.length)
-    } else
+    } else {
       tooltips = null
+    }
 
     if (this.slider_el == null) {
       this.slider_el = div()
@@ -139,8 +140,9 @@ abstract class AbstractBaseSliderView extends OrientedControlView {
       this._noUiSlider.on("change", (_, __, values) => this._change(values))
 
       const toggle_tooltip = (i: number, show: boolean): void => {
-        if (tooltips == null || this.slider_el == null)
+        if (tooltips == null || this.slider_el == null) {
           return
+        }
         const handle = this.slider_el.querySelectorAll(".noUi-handle")[i]
         const tooltip = handle.querySelector<HTMLElement>(".noUi-tooltip")!
         tooltip.style.display = show ? "block" : ""
@@ -161,10 +163,11 @@ abstract class AbstractBaseSliderView extends OrientedControlView {
 
     this._set_bar_color()
 
-    if (this.model.disabled)
+    if (this.model.disabled) {
       this.slider_el.setAttribute("disabled", "true")
-    else
+    } else {
       this.slider_el.removeAttribute("disabled")
+    }
 
     this.title_el = div({class: sliders.slider_title})
     this._update_title()
@@ -202,10 +205,11 @@ export abstract class AbstractSliderView extends AbstractBaseSliderView {
   }
 
   protected _calc_from([value]: number[]): number {
-    if (Number.isInteger(this.model.start) && Number.isInteger(this.model.end) && Number.isInteger(this.model.step))
+    if (Number.isInteger(this.model.start) && Number.isInteger(this.model.end) && Number.isInteger(this.model.step)) {
       return Math.round(value)
-    else
+    } else {
       return value
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -102,10 +102,11 @@ export class AutocompleteInputView extends TextInputView {
     const completions = this.compute_completions(value)
     this._update_completions(completions)
 
-    if (completions.length == 0)
+    if (completions.length == 0) {
       this._hide_menu()
-    else
+    } else {
       this._show_menu()
+    }
   }
 
   protected _show_menu(): void {

--- a/bokehjs/src/lib/models/widgets/checkbox_group.ts
+++ b/bokehjs/src/lib/models/widgets/checkbox_group.ts
@@ -38,11 +38,13 @@ export class CheckboxGroupView extends ToggleInputGroupView {
       checkbox.addEventListener("change", () => this.change_active(i))
       this._inputs.push(checkbox)
 
-      if (this.model.disabled)
+      if (this.model.disabled) {
         checkbox.disabled = true
+      }
 
-      if (includes(active, i))
+      if (includes(active, i)) {
         checkbox.checked = true
+      }
 
       const label_el = label(checkbox, span(labels[i]))
       group.appendChild(label_el)

--- a/bokehjs/src/lib/models/widgets/date_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_range_slider.ts
@@ -49,9 +49,10 @@ export class DateRangeSlider extends AbstractSlider {
   override connected = [false, true, false]
 
   protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
+    if (isString(format)) {
       return tz(value, format)
-    else
+    } else {
       return format.compute(value)
+    }
   }
 }

--- a/bokehjs/src/lib/models/widgets/date_slider.ts
+++ b/bokehjs/src/lib/models/widgets/date_slider.ts
@@ -48,9 +48,10 @@ export class DateSlider extends AbstractSlider {
   override connected = [true, false]
 
   protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
+    if (isString(format)) {
       return tz(value, format)
-    else
+    } else {
       return format.compute(value)
+    }
   }
 }

--- a/bokehjs/src/lib/models/widgets/datetime_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/datetime_range_slider.ts
@@ -38,9 +38,10 @@ export class DatetimeRangeSlider extends AbstractSlider {
   override connected = [false, true, false]
 
   protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
+    if (isString(format)) {
       return tz(value, format)
-    else
+    } else {
       return format.compute(value)
+    }
   }
 }

--- a/bokehjs/src/lib/models/widgets/div.ts
+++ b/bokehjs/src/lib/models/widgets/div.ts
@@ -6,10 +6,11 @@ export class DivView extends MarkupView {
 
   override render(): void {
     super.render()
-    if (this.model.render_as_text)
+    if (this.model.render_as_text) {
       this.markup_el.textContent = this.model.text
-    else
+    } else {
       this.markup_el.innerHTML = this.has_math_disabled() ? this.model.text : this.process_tex(this.model.text)
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/dropdown.ts
+++ b/bokehjs/src/lib/models/widgets/dropdown.ts
@@ -28,9 +28,9 @@ export class DropdownView extends AbstractButtonView {
 
     const caret = div({class: [carets.caret, carets.down]})
 
-    if (!this.model.is_split)
+    if (!this.model.is_split) {
       this.button_el.appendChild(caret)
-    else {
+    } else {
       const toggle = this._render_button(caret)
       toggle.classList.add(buttons.dropdown_toggle)
       toggle.addEventListener("click", () => this._toggle_menu())
@@ -38,9 +38,9 @@ export class DropdownView extends AbstractButtonView {
     }
 
     const items = this.model.menu.map((item, i) => {
-      if (item == null)
+      if (item == null) {
         return div({class: dropdown.divider})
-      else {
+      } else {
         const label = isString(item) ? item : item[0]
         const el = div(label)
         el.addEventListener("click", () => this._item_click(i))
@@ -76,16 +76,17 @@ export class DropdownView extends AbstractButtonView {
   }
 
   protected _toggle_menu(): void {
-    if (this._open)
+    if (this._open) {
       this._hide_menu()
-    else
+    } else {
       this._show_menu()
+    }
   }
 
   override click(): void {
-    if (!this.model.is_split)
+    if (!this.model.is_split) {
       this._toggle_menu()
-    else {
+    } else {
       this._hide_menu()
       this.model.trigger_event(new ButtonClick())
       super.click()

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -50,12 +50,13 @@ export class FileInputView extends InputWidgetView {
     }
 
     const [value, filename, mime_type] = (() =>{
-      if (this.model.multiple)
+      if (this.model.multiple) {
         return [values, filenames, mime_types]
-      else if (files.length != 0)
+      } else if (files.length != 0) {
         return [values[0], filenames[0], mime_types[0]]
-      else
+      } else {
         return ["", "", ""]
+      }
     })()
 
     this.model.setv({value, filename, mime_type})

--- a/bokehjs/src/lib/models/widgets/help_button.ts
+++ b/bokehjs/src/lib/models/widgets/help_button.ts
@@ -51,8 +51,9 @@ export class HelpButtonView extends AbstractButtonView {
       toggle(true)
     })
     this.el.addEventListener("mouseleave", () => {
-      if (!persistent)
+      if (!persistent) {
         toggle(false)
+      }
     })
     document.addEventListener("mousedown", (event) => {
       const path = event.composedPath()

--- a/bokehjs/src/lib/models/widgets/input_widget.ts
+++ b/bokehjs/src/lib/models/widgets/input_widget.ts
@@ -31,8 +31,9 @@ export abstract class InputWidgetView extends ControlView {
 
   override *children(): IterViews {
     yield* super.children()
-    if (this.description != null)
+    if (this.description != null) {
       yield this.description
+    }
   }
 
   override async lazy_initialize(): Promise<void> {
@@ -65,15 +66,15 @@ export abstract class InputWidgetView extends ControlView {
 
     const {title, description} = this.model
 
-    if (description == null)
+    if (description == null) {
       this.desc_el = null
-    else {
+    } else {
       const icon_el = div({class: inputs.icon})
       this.desc_el = div({class: inputs.description}, icon_el)
 
-      if (isString(description))
+      if (isString(description)) {
         this.desc_el.title = description
-      else {
+      } else {
         const {description} = this
         assert(description != null)
 
@@ -103,8 +104,9 @@ export abstract class InputWidgetView extends ControlView {
           toggle(true)
         })
         desc_el.addEventListener("mouseleave", () => {
-          if (!persistent)
+          if (!persistent) {
             toggle(false)
+          }
         })
         document.addEventListener("mousedown", (event) => {
           const path = event.composedPath()

--- a/bokehjs/src/lib/models/widgets/markup.ts
+++ b/bokehjs/src/lib/models/widgets/markup.ts
@@ -16,11 +16,13 @@ export abstract class MarkupView extends WidgetView {
   override async lazy_initialize() {
     await super.lazy_initialize()
 
-    if (this.provider.status == "not_started" || this.provider.status == "loading")
+    if (this.provider.status == "not_started" || this.provider.status == "loading") {
       this.provider.ready.connect(() => {
-        if (this.contains_tex_string(this.model.text))
+        if (this.contains_tex_string(this.model.text)) {
           this.rerender()
+        }
       })
+    }
   }
 
   has_math_disabled() {
@@ -47,8 +49,9 @@ export abstract class MarkupView extends WidgetView {
     this.markup_el = div({class: clearfix, style: {display: "inline-block"}})
     this.shadow_el.appendChild(this.markup_el)
 
-    if (this.provider.status == "failed" || this.provider.status == "loaded")
+    if (this.provider.status == "failed" || this.provider.status == "loaded") {
       this._has_finished = true
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/multi_choice.ts
+++ b/bokehjs/src/lib/models/widgets/multi_choice.ts
@@ -88,10 +88,11 @@ export class MultiChoiceView extends InputWidgetView {
     const selected = new Set(this.model.value)
     const choices = this.model.options.map((opt) => {
       let value, label
-      if (isString(opt))
+      if (isString(opt)) {
         value = label  = opt
-      else
+      } else {
         [value, label] = opt
+      }
       return {value, label, selected: selected.has(value)}
     })
 
@@ -117,10 +118,11 @@ export class MultiChoiceView extends InputWidgetView {
   }
 
   set_disabled(): void {
-    if (this.model.disabled)
+    if (this.model.disabled) {
       this.choice_el.disable()
-    else
+    } else {
       this.choice_el.enable()
+    }
   }
 
   protected get _current_values(): string[] {

--- a/bokehjs/src/lib/models/widgets/multiselect.ts
+++ b/bokehjs/src/lib/models/widgets/multiselect.ts
@@ -25,10 +25,11 @@ export class MultiSelectView extends InputWidgetView {
 
     const options = this.model.options.map((opt) => {
       let value, _label
-      if (isString(opt))
+      if (isString(opt)) {
         value = _label  = opt
-      else
+      } else {
         [value, _label] = opt
+      }
 
       return option({value}, _label)
     })
@@ -49,8 +50,9 @@ export class MultiSelectView extends InputWidgetView {
   render_selection(): void {
     const selected = new Set(this.model.value)
 
-    for (const el of this.shadow_el.querySelectorAll("option"))
+    for (const el of this.shadow_el.querySelectorAll("option")) {
       el.selected = selected.has(el.value)
+    }
 
     // Note that some browser implementations might not reduce
     // the number of visible options for size <= 3.
@@ -62,8 +64,9 @@ export class MultiSelectView extends InputWidgetView {
 
     const values = []
     for (const el of this.shadow_el.querySelectorAll("option")) {
-      if (el.selected)
+      if (el.selected) {
         values.push(el.value)
+      }
     }
 
     this.model.value = values
@@ -72,8 +75,9 @@ export class MultiSelectView extends InputWidgetView {
     // so that even if python on_change callback is invoked,
     // focus remains on <select> and one can seamlessly scroll
     // up/down.
-    if (is_focused)
+    if (is_focused) {
       this.input_el.focus()
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/numeric_input.ts
+++ b/bokehjs/src/lib/models/widgets/numeric_input.ts
@@ -28,17 +28,21 @@ export class NumericInputView extends InputWidgetView {
     })
     this.connect(this.model.properties.low.change, () => {
       const {value, low, high} = this.model
-      if (low != null && high != null)
+      if (low != null && high != null) {
         assert(low <= high, "Invalid bounds, low must be inferior to high")
-      if (value != null && low != null && value < low)
+      }
+      if (value != null && low != null && value < low) {
         this.model.value = low
+      }
     })
     this.connect(this.model.properties.high.change, () => {
       const {value, low, high} = this.model
-      if (low != null && high != null)
+      if (low != null && high != null) {
         assert(high >= low, "Invalid bounds, high must be superior to low")
-      if (value != null && high != null && value > high)
+      }
+      if (value != null && high != null && value > high) {
         this.model.value = high
+      }
     })
     this.connect(this.model.properties.high.change, () => this.input_el.placeholder = this.model.placeholder)
     this.connect(this.model.properties.disabled.change, () => this.input_el.disabled = this.model.disabled)
@@ -55,10 +59,12 @@ export class NumericInputView extends InputWidgetView {
       if (!inputFilter(this.input_el.value)) { // an invalid character is entered
         const difflen = this.old_value.length - this.input_el.value.length
         this.input_el.value = this.old_value
-        if (selectionStart != null && selectionEnd != null)
+        if (selectionStart != null && selectionEnd != null) {
           this.input_el.setSelectionRange(selectionStart-1, selectionEnd + difflen)
-      } else
+        }
+      } else {
         this.old_value = this.input_el.value
+      }
     })
   }
 
@@ -96,16 +102,18 @@ export class NumericInputView extends InputWidgetView {
 
   get value(): number | null {
     let value = this.input_el.value != "" ? Number(this.input_el.value) : null
-    if (value != null)
+    if (value != null) {
       value = this.bound_value(value)
+    }
     return value
   }
 
   override change_input(): void {
-    if (this.value == null)
+    if (this.value == null) {
       this.model.value = null
-    else if (!Number.isNaN(this.value))
+    } else if (!Number.isNaN(this.value)) {
       this.model.value = this.value
+    }
   }
 }
 
@@ -154,9 +162,10 @@ export class NumericInput extends InputWidget {
   }
 
   pretty(value: number): string {
-    if (this.format!=null)
+    if (this.format!=null) {
       return this._formatter(value, this.format)
-    else
+    } else {
       return `${value}`
+    }
   }
 }

--- a/bokehjs/src/lib/models/widgets/paragraph.ts
+++ b/bokehjs/src/lib/models/widgets/paragraph.ts
@@ -10,10 +10,11 @@ export class ParagraphView extends MarkupView {
     // This overrides default user-agent styling and helps layout work
     const content = paragraph({style: {margin: 0}})
 
-    if (this.has_math_disabled())
+    if (this.has_math_disabled()) {
       content.textContent = this.model.text
-    else
+    } else {
       content.innerHTML = this.process_tex(this.model.text)
+    }
 
     this.markup_el.appendChild(content)
   }

--- a/bokehjs/src/lib/models/widgets/picker_base.ts
+++ b/bokehjs/src/lib/models/widgets/picker_base.ts
@@ -103,7 +103,9 @@ export abstract class PickerBaseView extends InputWidgetView {
     self.calendarContainer.classList.toggle("arrowTop", !showOnTop)
     self.calendarContainer.classList.toggle("arrowBottom", showOnTop)
 
-    if (self.config.inline) return
+    if (self.config.inline) {
+      return
+    }
 
     let left = window.scrollX + inputBounds.left
     let isCenter = false
@@ -129,7 +131,9 @@ export abstract class PickerBaseView extends InputWidgetView {
 
     self.calendarContainer.classList.toggle("rightMost", rightMost)
 
-    if (self.config.static) return
+    if (self.config.static) {
+      return
+    }
 
     self.calendarContainer.style.top = `${top}px`
 

--- a/bokehjs/src/lib/models/widgets/radio_group.ts
+++ b/bokehjs/src/lib/models/widgets/radio_group.ts
@@ -35,10 +35,12 @@ export class RadioGroupView extends ToggleInputGroupView {
       radio.addEventListener("change", () => this.change_active(i))
       this._inputs.push(radio)
 
-      if (this.model.disabled)
+      if (this.model.disabled) {
         radio.disabled = true
-      if (i == active)
+      }
+      if (i == active) {
         radio.checked = true
+      }
 
       const label_el = label(radio, span(labels[i]))
       group.appendChild(label_el)

--- a/bokehjs/src/lib/models/widgets/range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/range_slider.ts
@@ -37,9 +37,10 @@ export class RangeSlider extends AbstractSlider {
   override connected = [false, true, false]
 
   protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
+    if (isString(format)) {
       return numbro.format(value, format)
-    else
+    } else {
       return format.compute(value)
+    }
   }
 }

--- a/bokehjs/src/lib/models/widgets/selectbox.ts
+++ b/bokehjs/src/lib/models/widgets/selectbox.ts
@@ -33,10 +33,11 @@ export class SelectView extends InputWidgetView {
     function build_options(values: (string | [string, string])[]): HTMLOptionElement[] {
       return values.map((el) => {
         let value, label
-        if (isString(el))
+        if (isString(el)) {
           value = label = el
-        else
+        } else {
           [value, label] = el
+        }
 
         _known_values.add(value)
         return option({value}, label)
@@ -44,10 +45,11 @@ export class SelectView extends InputWidgetView {
     }
 
     const {options} = this.model
-    if (isArray(options))
+    if (isArray(options)) {
       return build_options(options)
-    else
+    } else {
       return entries(options).map(([label, values]) => optgroup({label}, build_options(values)))
+    }
   }
 
   override render(): void {
@@ -73,10 +75,11 @@ export class SelectView extends InputWidgetView {
 
   protected _update_value(): void {
     const {value} = this.model
-    if (this._known_values.has(value))
+    if (this._known_values.has(value)) {
       this.input_el.value = value
-    else
+    } else {
       this.input_el.removeAttribute("value")
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/slider.ts
+++ b/bokehjs/src/lib/models/widgets/slider.ts
@@ -37,9 +37,10 @@ export class Slider extends AbstractSlider {
   override connected = [true, false]
 
   protected _formatter(value: number, format: string | TickFormatter): string {
-    if (isString(format))
+    if (isString(format)) {
       return numbro.format(value, format)
-    else
+    } else {
       return format.compute(value)
+    }
   }
 }

--- a/bokehjs/src/lib/models/widgets/spinner.ts
+++ b/bokehjs/src/lib/models/widgets/spinner.ts
@@ -196,12 +196,14 @@ export class SpinnerView extends NumericInputView {
   increment(step: number): void {
     const {low, high} = this.model
     if (this.model.value == null) {
-      if (step > 0)
+      if (step > 0) {
         this.model.value = (low!=null)? low : (high!=null)? min(0, high) : 0
-      else if (step < 0)
+      } else if (step < 0) {
         this.model.value = (high!=null)? high : (low!=null)? max(low, 0) : 0
-    } else
+      }
+    } else {
       this.model.value = this.adjust_to_precision(this.model.value + step)
+    }
   }
 
   override change_input(): void {

--- a/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_editors.ts
@@ -364,10 +364,11 @@ export class IntEditorView extends CellEditorView {
       value = Number(value)
     }
 
-    if (isInteger(value))
+    if (isInteger(value)) {
       return super.validateValue(value)
-    else
+    } else {
       return {valid: false, msg: "Please enter a valid integer"}
+    }
   }
 }
 
@@ -424,10 +425,11 @@ export class NumberEditorView extends CellEditorView {
   }
 
   override validateValue(value: any): any {
-    if (isNaN(value))
+    if (isNaN(value)) {
       return {valid: false, msg: "Please enter a valid number"}
-    else
+    } else {
       return super.validateValue(value)
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -27,10 +27,11 @@ export abstract class CellFormatter extends Model {
   }
 
   doFormat(_row: any, _cell: any, value: any, _columnDef: any, _dataContext: any): string {
-    if (value == null)
+    if (value == null) {
       return ""
-    else
+    } else {
       return `${value}`.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    }
   }
 }
 
@@ -84,8 +85,9 @@ export class StringFormatter extends CellFormatter {
 
     text.style.textAlign = text_align
 
-    if (text_color != null)
+    if (text_color != null) {
       text.style.color = color2css(text_color)
+    }
 
     return text.outerHTML
   }
@@ -136,14 +138,15 @@ export class ScientificFormatter extends StringFormatter {
       precision = 1
     }
 
-    if (value == null || isNaN(value))
+    if (value == null || isNaN(value)) {
       value = this.nan_format
-    else if (value == 0)
+    } else if (value == 0) {
       value = to_fixed(value, 1)
-    else if (need_sci)
+    } else if (need_sci) {
       value = value.toExponential(precision)
-    else
+    } else {
       value = to_fixed(value, precision)
+    }
 
     // add StringFormatter formatting
     return super.doFormat(row, cell, value, columnDef, dataContext)
@@ -187,10 +190,11 @@ export class NumberFormatter extends StringFormatter {
         case "ceil":  case "roundup":   return Math.ceil
       }
     })()
-    if (value == null || isNaN(value))
+    if (value == null || isNaN(value)) {
       value = nan_format
-    else
+    } else {
       value = Numbro.format(value, format, language, rounding)
+    }
     return super.doFormat(row, cell, value, columnDef, dataContext)
   }
 }
@@ -297,10 +301,11 @@ export class DateFormatter extends StringFormatter {
     const NaT = -9223372036854776.0
 
     const date = (() => {
-      if (epoch == null || isNaN(epoch) || epoch == NaT)
+      if (epoch == null || isNaN(epoch) || epoch == NaT) {
         return this.nan_format
-      else
+      } else {
         return tz(epoch, this.getFormat())
+      }
     })()
 
     return super.doFormat(row, cell, date, columnDef, dataContext)
@@ -332,9 +337,9 @@ export class HTMLTemplateFormatter extends CellFormatter {
 
   override doFormat(_row: any, _cell: any, value: any, _columnDef: any, dataContext: any): string {
     const {template} = this
-    if (value == null)
+    if (value == null) {
       return ""
-    else {
+    } else {
       const compiled_template = _.template(template)
       const context = {...dataContext, value}
       return compiled_template(context)

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -49,8 +49,9 @@ export class TableDataProvider implements DataProvider<Item> {
   }
 
   init(source: ColumnarDataSource, view: CDSView): void {
-    if (DTINDEX_NAME in source.data)
+    if (DTINDEX_NAME in source.data) {
       throw new Error(`special name ${DTINDEX_NAME} cannot be used as a data table column`)
+    }
 
     this.source = source
     this.view = view
@@ -118,17 +119,19 @@ export class TableDataProvider implements DataProvider<Item> {
       for (const [field, sign] of cols) {
         const v0 = records[old_index.indexOf(i0)][field!]
         const v1 = records[old_index.indexOf(i1)][field!]
-        if (v0 === v1)
+        if (v0 === v1) {
           continue
+        }
         if (isNumber(v0) && isNumber(v1)) {
           /* eslint-disable @typescript-eslint/strict-boolean-expressions */
           return sign*(v0 - v1 || +isNaN(v0) - +isNaN(v1))
         } else {
           const result = `${v0}`.localeCompare(`${v1}`)
-          if (result == 0)
+          if (result == 0) {
             continue
-          else
+          } else {
             return sign*result
+          }
         }
       }
       return 0
@@ -212,19 +215,22 @@ export class DataTableView extends WidgetView {
 
   override box_sizing(): DOMBoxSizing {
     const sizing = super.box_sizing()
-    if (this.model.autosize_mode === "fit_viewport" && this._width != null)
+    if (this.model.autosize_mode === "fit_viewport" && this._width != null) {
       sizing.width = this._width
+    }
     return sizing
   }
 
   updateLayout(initialized: boolean, rerender: boolean): void {
     const autosize = this.autosize
     if (autosize === AutosizeModes.fit_columns || autosize === AutosizeModes.force_fit) {
-      if (!initialized)
+      if (!initialized) {
         this.grid.resizeCanvas()
+      }
       this.grid.autosizeColumns()
-    } else if (initialized && rerender && autosize === AutosizeModes.fit_viewport)
+    } else if (initialized && rerender && autosize === AutosizeModes.fit_viewport) {
       this.invalidate_layout()
+    }
   }
 
   updateGrid(): void {
@@ -248,8 +254,9 @@ export class DataTableView extends WidgetView {
   }
 
   updateSelection(): void {
-    if (this.model.selectable === false || this._in_selection_update)
+    if (this.model.selectable === false || this._in_selection_update) {
       return
+    }
 
     const {indices} = this.model.source.selected
     const permuted_indices = sort_by(map(indices, (x) => this.data.index.indexOf(x)), (x) => x)
@@ -268,8 +275,9 @@ export class DataTableView extends WidgetView {
     const cur_grid_range = this.grid.getViewport()
 
     const scroll_index = this.model.get_scroll_index(cur_grid_range, permuted_indices)
-    if (scroll_index != null)
+    if (scroll_index != null) {
       this.grid.scrollRowToTop(scroll_index)
+    }
   }
 
   newIndexColumn(): ColumnType {
@@ -290,12 +298,13 @@ export class DataTableView extends WidgetView {
 
   get autosize(): AutosizeMode {
     let autosize: AutosizeMode
-    if (this.model.fit_columns === true)
+    if (this.model.fit_columns === true) {
       autosize = AutosizeModes.force_fit
-    else if (this.model.fit_columns === false)
+    } else if (this.model.fit_columns === false) {
       autosize = AutosizeModes.none
-    else
+    } else {
       autosize = AutosizeModes[this.model.autosize_mode]
+    }
     return autosize
   }
 
@@ -324,12 +333,13 @@ export class DataTableView extends WidgetView {
       const index = this.newIndexColumn()
       // This is to be able to provide negative index behaviour that
       // matches what python users will expect
-      if (index_position == -1)
+      if (index_position == -1) {
         columns.push(index)
-      else if (index_position < -1)
+      } else if (index_position < -1) {
         columns.splice(index_position+1, 0, index)
-      else
+      } else {
         columns.splice(index_position, 0, index)
+      }
     }
 
     let {reorderable} = this.model
@@ -374,17 +384,20 @@ export class DataTableView extends WidgetView {
     if (this.autosize == AutosizeModes.fit_viewport) {
       this.grid.autosizeColumns()
       let width = 0
-      for (const column of columns)
+      for (const column of columns) {
         width += column.width ?? 0
+      }
       this._width = Math.ceil(width)
     }
 
     this.grid.onSort.subscribe((_event: Event, args: OnSortEventArgs<Item>) => {
-      if (!this.model.sortable)
+      if (!this.model.sortable) {
         return
+      }
       const to_sort = args.sortCols
-      if (to_sort == null)
+      if (to_sort == null) {
         return
+      }
       this.data.sort(to_sort)
       this.grid.invalidate()
       this.updateSelection()
@@ -397,8 +410,9 @@ export class DataTableView extends WidgetView {
 
     if (this.model.selectable !== false) {
       this.grid.setSelectionModel(new RowSelectionModel({selectActiveRow: checkbox_selector == null}))
-      if (checkbox_selector != null)
+      if (checkbox_selector != null) {
         this.grid.registerPlugin(checkbox_selector)
+      }
 
       const pluginOptions = {
         dataItemColumnValueExtractor(val: Item, col: TableColumn) {
@@ -514,8 +528,9 @@ export class DataTable extends TableWidget {
   }
 
   get_scroll_index(grid_range: {top: number, bottom: number}, selected_indices: Arrayable<number>): number | null {
-    if (!this.scroll_to_selection || (selected_indices.length == 0))
+    if (!this.scroll_to_selection || (selected_indices.length == 0)) {
       return null
+    }
 
     if (!some(selected_indices, i => grid_range.top <= i && i <= grid_range.bottom)) {
       return Math.max(0, Math.min(...selected_indices) - 1)

--- a/bokehjs/src/lib/models/widgets/text_like_input.ts
+++ b/bokehjs/src/lib/models/widgets/text_like_input.ts
@@ -14,10 +14,11 @@ export abstract class TextLikeInputView extends InputWidgetView {
     this.connect(this.model.properties.placeholder.change, () => this.input_el.placeholder = this.model.placeholder)
     this.connect(this.model.properties.max_length.change, () => {
       const {max_length} = this.model
-      if (max_length != null)
+      if (max_length != null) {
         this.input_el.maxLength = max_length
-      else
+      } else {
         this.input_el.removeAttribute("maxLength")
+      }
     })
   }
 
@@ -33,8 +34,9 @@ export abstract class TextLikeInputView extends InputWidgetView {
     input_el.value = this.model.value
     input_el.disabled = this.model.disabled
     input_el.placeholder = this.model.placeholder
-    if (this.model.max_length != null)
+    if (this.model.max_length != null) {
       input_el.maxLength = this.model.max_length
+    }
 
     input_el.addEventListener("change", () => this.change_input())
     input_el.addEventListener("input",  () => this.change_input_value())

--- a/bokehjs/src/lib/models/widgets/widget.ts
+++ b/bokehjs/src/lib/models/widgets/widget.ts
@@ -18,20 +18,23 @@ export abstract class WidgetView extends LayoutDOMView {
   override async lazy_initialize() {
     await super.lazy_initialize()
 
-    if (this.provider.status == "not_started")
+    if (this.provider.status == "not_started") {
       await this.provider.fetch()
+    }
   }
 
   override _after_layout(): void {
     super._after_layout()
 
-    if (this.provider.status == "loading")
+    if (this.provider.status == "loading") {
       this._has_finished = false
+    }
   }
 
   process_tex(text: string): string {
-    if (this.provider.MathJax == null)
+    if (this.provider.MathJax == null) {
       return text
+    }
 
     const tex_parts = this.provider.MathJax.find_tex(text)
     const processed_text: string[] = []
@@ -44,15 +47,17 @@ export abstract class WidgetView extends LayoutDOMView {
       last_index = part.end.n
     }
 
-    if (last_index! < text.length)
+    if (last_index! < text.length) {
       processed_text.push(text.slice(last_index))
+    }
 
     return processed_text.join("")
   }
 
   protected contains_tex_string(text: string): boolean {
-    if (this.provider.MathJax == null)
+    if (this.provider.MathJax == null) {
       return false
+    }
 
     return this.provider.MathJax.find_tex(text).length > 0
   };

--- a/bokehjs/src/lib/protocol/message.ts
+++ b/bokehjs/src/lib/protocol/message.ts
@@ -33,8 +33,9 @@ export class Message<T> {
 
   assemble_buffer(buf_header: string, buf_payload: ArrayBuffer): void {
     const nb = this.header.num_buffers ?? 0
-    if (nb <= this._buffers.size)
+    if (nb <= this._buffers.size) {
       throw new Error(`too many buffers received, expecting ${nb}`)
+    }
     const {id} = JSON.parse(buf_header)
     this._buffers.set(id, buf_payload)
   }
@@ -65,8 +66,9 @@ export class Message<T> {
         const ref = {id: `${buffers.length}`}
         buffers.push([ref, val.buffer])
         return ref
-      } else
+      } else {
         return val
+      }
     })
 
     const num_buffers = buffers.length
@@ -101,11 +103,12 @@ export class Message<T> {
 
   // return the reason we should close on bad protocol, if there is one
   problem(): string | null {
-    if (!("msgid" in this.header))
+    if (!("msgid" in this.header)) {
       return "No msgid in header"
-    else if (!("msgtype" in this.header))
+    } else if (!("msgtype" in this.header)) {
       return "No msgtype in header"
-    else
+    } else {
       return null
+    }
   }
 }

--- a/bokehjs/src/lib/protocol/receiver.ts
+++ b/bokehjs/src/lib/protocol/receiver.ts
@@ -57,20 +57,23 @@ export class Receiver {
   }
 
   private _assume_text(fragment: Fragment): asserts fragment is string {
-    if (!isString(fragment))
+    if (!isString(fragment)) {
       throw new Error("Expected text fragment but received binary fragment")
+    }
   }
 
   private _assume_binary(fragment: Fragment): asserts fragment is ArrayBuffer {
-    if (!(fragment instanceof ArrayBuffer))
+    if (!(fragment instanceof ArrayBuffer)) {
       throw new Error("Expected binary fragment but received text fragment")
+    }
   }
 
   private _check_complete(): void {
     if (this._partial!.complete()) {
       this.message = this._partial
       this._current_consumer = this._HEADER
-    } else
+    } else {
       this._current_consumer = this._BUFFER_HEADER
+    }
   }
 }

--- a/bokehjs/src/lib/safely.ts
+++ b/bokehjs/src/lib/safely.ts
@@ -58,9 +58,10 @@ export function safely<T>(fn: () => T, silent: boolean = false): T | undefined {
   } catch (error) {
     const text = error instanceof Error && error.stack != null ? error.stack : `${error}`
     _burst_into_flames(text)
-    if (!silent)
+    if (!silent) {
       throw error
-    else
+    } else {
       return
+    }
   }
 }

--- a/bokehjs/src/server/message.ts
+++ b/bokehjs/src/server/message.ts
@@ -33,8 +33,9 @@ export class Message<T> {
 
   assemble_buffer(buf_header: string, buf_payload: ArrayBuffer): void {
     const nb = this.header.num_buffers ?? 0
-    if (nb <= this._buffers.size)
+    if (nb <= this._buffers.size) {
       throw new Error(`too many buffers received, expecting ${nb}`)
+    }
     const {id} = JSON.parse(buf_header)
     this._buffers.set(id, buf_payload)
   }
@@ -65,8 +66,9 @@ export class Message<T> {
         const ref = {id: `${buffers.length}`}
         buffers.push([ref, val.buffer])
         return ref
-      } else
+      } else {
         return val
+      }
     })
 
     const num_buffers = buffers.length
@@ -101,11 +103,12 @@ export class Message<T> {
 
   // return the reason we should close on bad protocol, if there is one
   problem(): string | null {
-    if (!("msgid" in this.header))
+    if (!("msgid" in this.header)) {
       return "No msgid in header"
-    else if (!("msgtype" in this.header))
+    } else if (!("msgtype" in this.header)) {
       return "No msgtype in header"
-    else
+    } else {
       return null
+    }
   }
 }

--- a/bokehjs/src/server/receiver.ts
+++ b/bokehjs/src/server/receiver.ts
@@ -57,20 +57,23 @@ export class Receiver {
   }
 
   private _assume_text(fragment: Fragment): asserts fragment is string {
-    if (!isString(fragment))
+    if (!isString(fragment)) {
       throw new Error("Expected text fragment but received binary fragment")
+    }
   }
 
   private _assume_binary(fragment: Fragment): asserts fragment is ArrayBuffer {
-    if (!(fragment instanceof ArrayBuffer))
+    if (!(fragment instanceof ArrayBuffer)) {
       throw new Error("Expected binary fragment but received text fragment")
+    }
   }
 
   private _check_complete(): void {
     if (this._partial!.complete()) {
       this.message = this._partial
       this._current_consumer = this._HEADER
-    } else
+    } else {
       this._current_consumer = this._BUFFER_HEADER
+    }
   }
 }

--- a/bokehjs/src/server/server.ts
+++ b/bokehjs/src/server/server.ts
@@ -30,8 +30,9 @@ type Token = {
 function parse_token(token: string): Token {
   let payload = token.split(".")[0]
   const mod = payload.length % 4
-  if (mod != 0)
+  if (mod != 0) {
     payload += "=".repeat(4-mod)
+  }
   payload = payload.replace(/_/g, "/").replace(/-/g, "+")
   const json = Buffer.from(payload, "base64").toString()
   return JSON.parse(json)
@@ -115,9 +116,9 @@ wss.on("connection", (ws, req: Request) => {
 
   const session = (() => {
     const session = sessions.get(session_id)
-    if (session != null)
+    if (session != null) {
       return session
-    else {
+    } else {
       const session = new ServerSession(session_id)
       sessions.set(session_id, session)
       return session
@@ -133,9 +134,9 @@ wss.on("connection", (ws, req: Request) => {
   ws.addEventListener("message", (event) => {
     const {data, type} = event
     log(`received: ${data} ${type}`)
-    if (isString(data) || data instanceof ArrayBuffer)
+    if (isString(data) || data instanceof ArrayBuffer) {
       receiver.consume(data)
-    else {
+    } else {
       ws.close()
       return
     }

--- a/bokehjs/test/codebase/size.ts
+++ b/bokehjs/test/codebase/size.ts
@@ -29,7 +29,9 @@ for (const [filename, limit] of LIMITS) {
   const stats = fs.existsSync(path) ? fs.statSync(path) : null
 
   const ok = stats != null && stats.size <= limit*1024
-  if (!ok) failures++
+  if (!ok) {
+    failures++
+  }
   const prefix = ok ? chalk.green("\u2713") : chalk.red("\u2717")
   const op = ok ? "<=" : "> "
   const padding = " ".repeat(n - filename.length + 1)

--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -29,14 +29,15 @@ function _resolve_defaults(_name: string, defaults: KV) {
   delete defaults.__extends__
 
   const bases = (() => {
-    if (isArray(__extends__))
+    if (isArray(__extends__)) {
       return __extends__ as string[]
-    else if (isString(__extends__))
+    } else if (isString(__extends__)) {
       return [__extends__]
-    else if (__extends__ == null)
+    } else if (__extends__ == null) {
       return []
-    else
+    } else {
       throw new Error(`invalid __extends__: ${__extends__}`)
+    }
   })()
 
   let new_defaults: KV = {}
@@ -75,10 +76,11 @@ class DefaultsSerializer extends Serializer {
 
 function get_defaults(name: string): KV {
   const defaults = all_defaults.get(name)
-  if (defaults != null)
+  if (defaults != null) {
     return defaults
-  else
+  } else {
     throw new Error(`can't find defaults for ${name}`)
+  }
 }
 
 function check_matching_defaults(context: string[], name: string, python_defaults: KV, bokehjs_defaults: KV): boolean {
@@ -90,16 +92,19 @@ function check_matching_defaults(context: string[], name: string, python_default
     console.log(`${context.join(" -> ")} ${name}.${k}`)
 
     // node_renderer/edge_renderer are configured dynamicaly in bokehjs
-    if (name == "GraphRenderer" && (k == "node_renderer" || k == "edge_renderer"))
+    if (name == "GraphRenderer" && (k == "node_renderer" || k == "edge_renderer")) {
       continue
+    }
 
     // special case for days/months/years tickers (null vs computed integer)
-    if ((name == "DaysTicker" || name == "MonthsTicker" || name == "YearsTicker") && k == "interval")
+    if ((name == "DaysTicker" || name == "MonthsTicker" || name == "YearsTicker") && k == "interval") {
       continue
+    }
 
     // if testing in dev mode, we use special platform independent "Bokeh" font, instead of the default
-    if (settings.dev && k.includes("text_font") && (js_v == "Bokeh" || (js_v as any)?.value == "Bokeh"))
+    if (settings.dev && k.includes("text_font") && (js_v == "Bokeh" || (js_v as any)?.value == "Bokeh")) {
       continue
+    }
 
     if (k in python_defaults) {
       const py_v = (() => {
@@ -128,11 +133,13 @@ function check_matching_defaults(context: string[], name: string, python_default
       }
 
       if (is_vector(py_v) && !is_vector(js_v)) {
-        if (is_equal(py_v, {type: "value", value: js_v}))
+        if (is_equal(py_v, {type: "value", value: js_v})) {
           continue
+        }
       } else if (!is_vector(py_v) && is_vector(js_v)) {
-        if (is_equal({type: "value", value: py_v}, js_v))
+        if (is_equal({type: "value", value: py_v}, js_v)) {
           continue
+        }
       }
 
       if (!is_equal(py_v, js_v)) {
@@ -140,9 +147,9 @@ function check_matching_defaults(context: string[], name: string, python_default
         if (isArray(js_v) && isArray(py_v)) {
           let equal = true
 
-          if (js_v.length != py_v.length)
+          if (js_v.length != py_v.length) {
             equal = false
-          else {
+          } else {
             for (let i = 0; i < js_v.length; i++) {
               const js_vi = js_v[i]
               const py_vi = py_v[i]
@@ -160,18 +167,21 @@ function check_matching_defaults(context: string[], name: string, python_default
             }
           }
 
-          if (equal)
+          if (equal) {
             continue
+          }
         }
 
         different.push(`${[...context, `${name}.${k}`].join(" -> ")}: bokehjs defaults to ${to_string(js_v)} but python defaults to ${to_string(py_v)}`)
       }
     } else {
       // TODO: bad class structure due to inability to override help
-      if ((name == "Range" || name == "DataRange") && (k == "bounds" || k == "min_interval" || k == "max_interval"))
+      if ((name == "Range" || name == "DataRange") && (k == "bounds" || k == "min_interval" || k == "max_interval")) {
         continue
-      if (name == "XYGlyph" && (k == "x" || k == "y"))
+      }
+      if (name == "XYGlyph" && (k == "x" || k == "y")) {
         continue
+      }
       python_missing.push(`${[...context, `${name}.${k}`].join(" -> ")}: bokehjs defaults to ${to_string(js_v)} but python has no such property`)
     }
   }
@@ -185,8 +195,9 @@ function check_matching_defaults(context: string[], name: string, python_default
   function complain(failures: string[], message: string): void {
     if (failures.length > 0) {
       console.error(message)
-      for (const f of failures)
+      for (const f of failures) {
         console.error(`    ${f}`)
+      }
     }
   }
 
@@ -199,8 +210,9 @@ function check_matching_defaults(context: string[], name: string, python_default
 
 function diff<T>(a: Set<T>, b: Set<T>): Set<T> {
   const result = new Set<T>(a)
-  for (const bi of b)
+  for (const bi of b) {
     result.delete(bi)
+  }
   return result
 }
 
@@ -222,8 +234,9 @@ describe("Defaults", () => {
     const missing_py = diff(js_models, py_models)
     //const missing_js = diff(py_models, js_models)
 
-    if (missing_py.size != 0)
+    if (missing_py.size != 0) {
       throw new ExpectationError(`expected bokeh to implement ${to_string([...missing_py])} models`)
+    }
     //if (missing_js.size != 0)
     //  throw new ExpectationError(`expected bokehjs to implement ${to_string([...missing_js])} models`)
   })

--- a/bokehjs/test/devtools/baselines.ts
+++ b/bokehjs/test/devtools/baselines.ts
@@ -17,8 +17,9 @@ export function create_baseline(items: State[]): string {
 
       baseline += "\n"
 
-      if (children != null)
+      if (children != null) {
         descend(children, level+1)
+      }
     }
   }
 
@@ -45,8 +46,9 @@ export function diff_baseline(baseline_path: string, ref: string): string {
   if (proc.status == 0) {
     const proc = git("diff", "--color", "/dev/null", baseline_path)
     return proc.stdout
-  } else
+  } else {
     return diff_highlight(proc.stdout)
+  }
 }
 
 function diff_highlight(diff: string): string {

--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -19,8 +19,9 @@ export class Random {
 
   constructor(seed: number) {
     this.seed = seed % MAX_INT32
-    if (this.seed <= 0)
+    if (this.seed <= 0) {
       this.seed += MAX_INT32 - 1
+    }
   }
 
   integer(): number {
@@ -198,9 +199,9 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
           return output
         } else {
           const {result, exceptionDetails} = output
-          if (exceptionDetails == null)
+          if (exceptionDetails == null) {
             return new Value(result.value)
-          else {
+          } else {
             const {text} = handle_exception(exceptionDetails)
             return new Failure(text)
           }
@@ -369,12 +370,13 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
 
       function state(): object {
         function format(value: number, single: string, plural?: string): string {
-          if (value == 0)
+          if (value == 0) {
             return ""
-          else if (value == 1)
+          } else if (value == 1) {
             return ` | 1 ${single}`
-          else
+          } else {
             return ` | ${value} ${plural ?? single}`
+          }
         }
         return {
           failures: format(failures, "failure", "failures"),
@@ -396,8 +398,9 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
       }
 
       async function add_datapoint(): Promise<void> {
-        if (baselines_root == null)
+        if (baselines_root == null) {
           return
+        }
         const data = await Performance.getMetrics()
         for (const {name, value} of data.metrics) {
           switch (name) {
@@ -423,8 +426,9 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
           const stream = fs.createWriteStream(report_out, {flags: "a"})
           stream.write(`Tests report output generated on ${new Date().toISOString()}:\n`)
           return stream
-        } else
+        } else {
           return null
+        }
       })()
 
       function format_output(test_case: TestItem): string | null {
@@ -487,13 +491,15 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
               const seq = JSON.stringify(to_seq(suites, test))
               const ctx_ = JSON.stringify(ctx)
               const output = await (async () => {
-                if (test.dpr != null)
+                if (test.dpr != null) {
                   override_metrics(test.dpr)
+                }
                 try {
                   return await evaluate<Result>(`Tests.run(${seq}, ${ctx_})`)
                 } finally {
-                  if (test.dpr != null)
+                  if (test.dpr != null) {
                     override_metrics()
+                  }
                 }
               })()
               await add_datapoint()
@@ -565,8 +571,9 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
                             if (existing == null) {
                               status.errors.push("missing baseline")
                             } else {
-                              if (test.retries != null)
+                              if (test.retries != null) {
                                 may_retry = true
+                              }
                             }
                             const diff = diff_baseline(baseline_file, ref)
                             status.failure = true
@@ -645,16 +652,19 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
 
               for (let i = 0; i < retries; i++) {
                 const do_retry = await run_test(i, status)
-                if (!do_retry)
+                if (!do_retry) {
                   break
+                }
               }
             }
           }
 
-          if (status.skipped ?? false)
+          if (status.skipped ?? false) {
             skipped++
-          if ((status.failure ?? false) || (status.timeout ?? false))
+          }
+          if ((status.failure ?? false) || (status.timeout ?? false)) {
             failures++
+          }
 
           append_report_out(test_case)
           progress.increment(1, state())
@@ -683,10 +693,11 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
           return [descriptions(suites, test), {failure, image, image_diff, reference}]
         })
         const json = JSON.stringify({results, metrics}, (_key, value) => {
-          if (value?.type == "Buffer")
+          if (value?.type == "Buffer") {
             return Buffer.from(value.data).toString("base64")
-          else
+          } else {
             return value
+          }
         })
         await fs.promises.writeFile(path.join(baselines_root, platform, "report.json"), json)
 

--- a/bokehjs/test/devtools/server.ts
+++ b/bokehjs/test/devtools/server.ts
@@ -86,11 +86,13 @@ app.get("/examples", async (_req, res) => {
   const dir = await fs.promises.opendir("examples")
   const entries = []
   for await (const dirent of dir) {
-    if (!dirent.isDirectory())
+    if (!dirent.isDirectory()) {
       continue
+    }
     const {name} = dirent
-    if (name.startsWith(".") || name.startsWith("_"))
+    if (name.startsWith(".") || name.startsWith("_")) {
       continue
+    }
     entries.push(name)
   }
   entries.sort()

--- a/bokehjs/test/framework.ts
+++ b/bokehjs/test/framework.ts
@@ -173,16 +173,17 @@ export async function run_all(query?: string | string[] | RegExp): Promise<void>
 
 export async function* yield_all(query?: string | string[] | RegExp): AsyncGenerator<PartialResult> {
   const matches = ((): (desc: string) => boolean => {
-    if (query == null)
+    if (query == null) {
       return () => true
-    else if (isString(query))
+    } else if (isString(query)) {
       return (desc) => desc.includes(query)
-    else if (isArray(query))
+    } else if (isArray(query)) {
       return (desc) => query.every((q) => desc.includes(q))
-    else if (query instanceof RegExp)
+    } else if (query instanceof RegExp) {
       return (desc) => desc.match(query) != null
-    else
+    } else {
       unreachable()
+    }
   })()
 
   for (const [parents, test] of iter_tests()) {
@@ -237,8 +238,9 @@ export async function get_state(seq: TestSeq): Promise<State | null> {
 
 function _get_state(test: Test): State | null {
   for (const view of test.views) {
-    if (!(view instanceof UIElementView))
+    if (!(view instanceof UIElementView)) {
       continue
+    }
     const state = _resolve_bbox(view.serializable_state()) as State
     return state
   }
@@ -297,8 +299,9 @@ async function _run_test(suites: Suite[], test: Test, ctx: TestRunContext): Prom
 
   try {
     for (const suite of suites) {
-      for (const {fn} of suite.before_each)
+      for (const {fn} of suite.before_each) {
         await fn()
+      }
     }
 
     try {
@@ -308,8 +311,9 @@ async function _run_test(suites: Suite[], test: Test, ctx: TestRunContext): Prom
       error = err instanceof Error ? err : new Error(`${err}`)
     } finally {
       for (const suite of suites) {
-        for (const {fn} of suite.after_each)
+        for (const {fn} of suite.after_each) {
           await fn()
+        }
       }
     }
   } finally {
@@ -321,14 +325,16 @@ async function _run_test(suites: Suite[], test: Test, ctx: TestRunContext): Prom
 
   if (error == null) {
     for (const view of test.views) {
-      if (!(view instanceof UIElementView))
+      if (!(view instanceof UIElementView)) {
         continue
+      }
       try {
         const {width, height} = view.bbox
         if (test.viewport != null) {
           const [vw, vh] = test.viewport
-          if (width > vw || height > vh)
+          if (width > vw || height > vh) {
             error = new Error(`viewport size exceeded [${width}, ${height}] > [${vw}, ${vh}]`)
+          }
         }
         const bbox = offset_bbox(test.el!).box
         const state = _resolve_bbox(view.serializable_state()) as State
@@ -354,14 +360,15 @@ export async function display(obj: Document | UIElement, viewport: [number, numb
 
   const margin = 50
   const size: [number, number] | null = (() => {
-    if (viewport == null)
+    if (viewport == null) {
       return null
-    else if (viewport == "auto") {
+    } else if (viewport == "auto") {
       const model = obj instanceof Document ? obj.roots()[0] : obj
       if (model instanceof LayoutDOM) {
         const {width, height} = _infer_viewport(model)
-        if (isFinite(width) && isFinite(height))
+        if (isFinite(width) && isFinite(height)) {
           return [width + margin, height + margin]
+        }
       }
     } else {
       return viewport
@@ -371,18 +378,18 @@ export async function display(obj: Document | UIElement, viewport: [number, numb
   })()
 
   const viewport_el = (() => {
-    if (size == null)
+    if (size == null) {
       return div({class: "viewport", style: {width: "max-content", height: "max-content", overflow: "visible"}}, el)
-    else {
+    } else {
       const [width, height] = size
       return div({class: "viewport", style: {width: `${width}px`, height: `${height}px`, overflow: "hidden"}}, el)
     }
   })()
 
   const doc = (() => {
-    if (obj instanceof Document)
+    if (obj instanceof Document) {
       return obj
-    else {
+    } else {
       const doc = new Document()
       doc.add_root(obj)
       return doc
@@ -397,10 +404,11 @@ export async function display(obj: Document | UIElement, viewport: [number, numb
   test.views = views
   test.el = viewport_el
   test.viewport = size ?? undefined
-  if (obj instanceof Document)
+  if (obj instanceof Document) {
     return {views: test.views, doc, el: viewport_el}
-  else
+  } else {
     return {view: test.views[0] as UIElementView, doc, el: viewport_el}
+  }
 }
 
 export async function compare_on_dom(fn: (ctx: CanvasRenderingContext2D) => void, svg: SVGSVGElement, {width, height}: {width: number, height: number}): Promise<void> {
@@ -427,10 +435,11 @@ import {GridPlot} from "@bokehjs/models/plots"
 import {Button, Div} from "@bokehjs/models/widgets"
 
 function _infer_viewport(obj: UIElement): Size {
-  if (obj instanceof LayoutDOM)
+  if (obj instanceof LayoutDOM) {
     return _infer_layoutdom_viewport(obj)
-  else
+  } else {
     return {width: Infinity, height: Infinity}
+  }
 }
 
 function _infer_layoutdom_viewport(obj: LayoutDOM): Size {

--- a/bokehjs/test/integration/annotations/color_bar.ts
+++ b/bokehjs/test/integration/annotations/color_bar.ts
@@ -217,15 +217,17 @@ describe("ColorBar annotation", () => {
 
     const [l, s] = [500, 200]
     const p = (() => {
-      if (horizontal)
+      if (horizontal) {
         return fig([l, s], {x_axis_location: side, border_fill_color: "lightgray"})
-      else
+      } else {
         return fig([s, l], {y_axis_location: side, border_fill_color: "lightgray"})
+      }
     })()
     p.circle({x, y, radius: r, fill_color: {field: "values", transform: color_mapper}, source: {values: v}})
 
-    if (color_bar.title == null)
+    if (color_bar.title == null) {
       color_bar.title = "Unspecified title"
+    }
 
     color_bar.border_line_color = "black"
 
@@ -469,8 +471,9 @@ describe("ColorBar annotation", () => {
         new ColorBar({color_mapper, title: "Reset", display_low: 3, display_high: 7}),
       ]
       const side = vertical ? "right" : "below"
-      for (const cbar of cbars)
+      for (const cbar of cbars) {
         p.add_layout(cbar, side)
+      }
       return {plot: p, cbars}
     }
 

--- a/bokehjs/test/integration/annotations/legend.ts
+++ b/bokehjs/test/integration/annotations/legend.ts
@@ -102,10 +102,11 @@ describe("Legend annotation", () => {
       }
 
       const gls = glyphs.map(({x, y, type, options}) => {
-        if (type == "line")
+        if (type == "line") {
           return p.line(x, y, options as Partial<LineArgs>)
-        else
+        } else {
           return p.circle(x, y, options)
+        }
       })
 
       if (legend_items == null) {

--- a/bokehjs/test/integration/axes.ts
+++ b/bokehjs/test/integration/axes.ts
@@ -41,8 +41,9 @@ import {radians} from "@bokehjs/core/util/math"
       })
 
       const axis = axis_type == "linear" ? new LinearAxis(attrs) : new LogAxis(attrs)
-      if (options?.num_ticks != null)
+      if (options?.num_ticks != null) {
         axis.ticker.desired_num_ticks = options.num_ticks
+      }
       p.add_layout(axis, side)
 
       await display(p)
@@ -67,8 +68,9 @@ import {radians} from "@bokehjs/core/util/math"
       })
 
       const axis = axis_type == "linear" ? new LinearAxis(attrs) : new LogAxis(attrs)
-      if (options?.num_ticks != null)
+      if (options?.num_ticks != null) {
         axis.ticker.desired_num_ticks = options.num_ticks
+      }
       p.add_layout(axis, side)
 
       await display(p)

--- a/bokehjs/test/integration/colors.ts
+++ b/bokehjs/test/integration/colors.ts
@@ -30,15 +30,17 @@ describe("Color support", () => {
       if (isArrayable(color) || nd.is_NDArray(color)) {
         source.data.fill_color = color
         return {field: "fill_color"}
-      } else
+      } else {
         return color
+      }
     })()
     const fill_alpha: Vector<number> | undefined = (() => {
       if (isArrayable(alpha) || nd.is_NDArray(alpha)) {
         source.data.fill_alpha = alpha
         return {field: "fill_alpha"}
-      } else
+      } else {
         return alpha
+      }
     })()
     const glyph = new Circle({radius: {field: "radius"}, fill_color, fill_alpha, line_color: null})
     const circle = new GlyphRenderer({data_source: source, glyph})

--- a/bokehjs/test/integration/examples/polar_subcoordinates.ts
+++ b/bokehjs/test/integration/examples/polar_subcoordinates.ts
@@ -20,9 +20,11 @@ describe("Examples", () => {
     const color_map: Map<string, Color> = new Map()
 
     const dark_colors = (function* () {
-      for (const color of values(named_colors))
-        if (brightness(color) < 0.6)
+      for (const color of values(named_colors)) {
+        if (brightness(color) < 0.6) {
           yield color
+        }
+      }
       unreachable()
     })()
 
@@ -40,8 +42,9 @@ describe("Examples", () => {
 
       // XXX: Map keys are compared by reference
       const hash = k.toString()
-      if (!color_map.has(hash))
+      if (!color_map.has(hash)) {
         color_map.set(hash, dark_colors.next().value)
+      }
 
       const color = color_map.get(hash)
       xy.line({expr: t.x}, {expr: t.y}, {line_color: color, source}) // TODO: expr convenience

--- a/bokehjs/test/integration/glyphs/images.ts
+++ b/bokehjs/test/integration/glyphs/images.ts
@@ -47,8 +47,9 @@ describe("ImageRGBA glyph", () => { // TODO: async describe
     const yf = y_flipped ? " with flipped y-axis" : ""
 
     for (const anchor of Anchor) {
-      if (!anchor.includes("_"))
+      if (!anchor.includes("_")) {
         continue
+      }
 
       it(`should support ${anchor} anchor with all origins${xf}${yf}`, async () => {
         await plot(anchor, x_flipped, y_flipped)

--- a/bokehjs/test/integration/glyphs/line.ts
+++ b/bokehjs/test/integration/glyphs/line.ts
@@ -50,12 +50,13 @@ describe("Line glyph", () => {
         for (let j = 0; j < linewidths.length; j++) {
           const x2 = X()
           const y2 = Y()
-          if (i == 0)
+          if (i == 0) {
             x2[0] = NaN
-          else if (i == 1)
+          } else if (i == 1) {
             x2[4] = NaN
-          else
+          } else {
             y2[2] = NaN
+          }
           p.line(x2, y2, {
             line_width: linewidths[j],
             line_color: colors[i],

--- a/bokehjs/test/integration/palettes.ts
+++ b/bokehjs/test/integration/palettes.ts
@@ -22,8 +22,9 @@ function plot(name: string, palettes: Color[][]) {
 
   for (const palette of palettes) {
     const k = palette.length
-    if (k == 256)
+    if (k == 256) {
       continue
+    }
     yf.push(`${k}`)
 
     x.push(...xf)

--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -325,8 +325,9 @@ describe("Bug", () => {
       })
 
       for (const axis of p.yaxis) {
-        if (axis instanceof CategoricalAxis)
+        if (axis instanceof CategoricalAxis) {
           axis.subgroup_label_orientation = 0
+        }
       }
 
       await display(p)

--- a/bokehjs/test/integration/tools/tools.ts
+++ b/bokehjs/test/integration/tools/tools.ts
@@ -35,8 +35,9 @@ describe("Tools", () => {
   ]
 
   for (const tool of tools) {
-    if (tool.menu == null)
+    if (tool.menu == null) {
       continue
+    }
 
     it(`should support ${tool.type}'s setup menu`, async () => {
       const tool_button = tool.tool_button()

--- a/bokehjs/test/unit/assertions.ts
+++ b/bokehjs/test/unit/assertions.ts
@@ -59,8 +59,9 @@ type ElementAssertions = {
 }
 
 function compare_attributes(actual: Element, expected: Element) {
-  if (actual.nodeName !== expected.nodeName)
+  if (actual.nodeName !== expected.nodeName) {
     throw new ExpectationError(`expected <${actual.nodeName}> to be equal <${expected.nodeName}>`)
+  }
 
   const names = (el: Element) => [...el.attributes].map((attr) => attr.name)
   const attrs = new Set([...names(actual), ...names(expected)])
@@ -70,20 +71,23 @@ function compare_attributes(actual: Element, expected: Element) {
     const expected_val = expected.getAttribute(attr)
 
     if (actual_val == null || expected_val == null) {
-      if (actual_val == null)
+      if (actual_val == null) {
         throw new ExpectationError(`expected attribute ${attr} missing in the actual element`)
-      else
+      } else {
         throw new ExpectationError(`actual attribute ${attr} missing in the expected element`)
-    } else if (actual_val !== expected_val)
+      }
+    } else if (actual_val !== expected_val) {
       throw new ExpectationError(`expected ${attr}="${expected_val}" to be equal ${attr}="${actual_val}"`)
+    }
   }
 }
 
 function compare_element_attributes(actual: Element, expected: Element) {
   compare_attributes(actual, expected)
 
-  if (actual.childElementCount != expected.childElementCount)
+  if (actual.childElementCount != expected.childElementCount) {
     throw new ExpectationError("elements differ on child count")
+  }
 
   for (let i = 0; i < expected.childElementCount; i++) {
     compare_element_attributes(actual.children[i], expected.children[i])
@@ -186,14 +190,15 @@ class Asserts implements Assertions<unknown> {
     const {value} = this
 
     const is_empty = (() => {
-      if (isArray(value) || isTypedArray(value))
+      if (isArray(value) || isTypedArray(value)) {
         return value.length == 0
-      else if (isPlainObject(value))
+      } else if (isPlainObject(value)) {
         return Object.keys(value).length == 0
-      else if (isIterable(value))
+      } else if (isIterable(value)) {
         return value[Symbol.iterator]().next().done
-      else
+      } else {
         return null
+      }
     })()
 
     if (is_empty == null) {
@@ -285,11 +290,13 @@ function NotThrows(fn: () => unknown) {
 
         if (pattern != null && error instanceof Error) {
           if (pattern instanceof RegExp) {
-            if (error.message.match(pattern) != null)
+            if (error.message.match(pattern) != null) {
               throw new ExpectationError(`expected ${to_string(fn)} to not throw an exception matching ${to_string(pattern)}, got ${to_string(error)}`)
+            }
           } else if (isString(pattern)) {
-            if (error.message.includes(pattern))
+            if (error.message.includes(pattern)) {
               throw new ExpectationError(`expected ${to_string(fn)} to not throw an exception including ${to_string(pattern)}, got ${to_string(error)}`)
+            }
           }
         }
       }

--- a/bokehjs/test/unit/core/logging.ts
+++ b/bokehjs/test/unit/core/logging.ts
@@ -19,8 +19,9 @@ describe("logging module", () => {
 
       let original: LogLevel | null = null
       after_each(() => {
-        if (original != null)
+        if (original != null) {
           set_log_level(original)
+        }
       })
 
       it("trace", () => {

--- a/bokehjs/test/unit/core/properties.ts
+++ b/bokehjs/test/unit/core/properties.ts
@@ -20,8 +20,9 @@ class TestTransform extends Transform {
   }
   v_compute(xs: number[]): number[] {
     const ret =  []
-    for (let i = 0; i < xs.length; i++)
+    for (let i = 0; i < xs.length; i++) {
       ret.push(xs[i] + i)
+    }
     return ret
   }
 }
@@ -333,8 +334,9 @@ describe("properties module", () => {
 
     describe("valid", () => {
       it("should return undefined on anchor input", () => {
-        for (const x of enums.Anchor)
+        for (const x of enums.Anchor) {
           expect(prop.valid(x)).to.be.true
+        }
       })
 
       it("should throw an Error on other input", () => {
@@ -354,8 +356,9 @@ describe("properties module", () => {
       })
 
       it("should accept any other value", () => {
-        for (const x of [true, null, 10, 10.2, "foo", [1, 2, 3], {}, new Some(), new X()])
+        for (const x of [true, null, 10, 10.2, "foo", [1, 2, 3], {}, new Some(), new X()]) {
           expect(prop.valid(x)).to.be.true
+        }
       })
     })
   })

--- a/bokehjs/test/unit/core/util/iterator.ts
+++ b/bokehjs/test/unit/core/util/iterator.ts
@@ -104,7 +104,9 @@ describe("core/util/iterator module", () => {
     const r0 = flat_map([1, 2, 3], (k) => Array(k).fill(k))
     expect([...r0]).to.be.equal([1, 2, 2, 3, 3, 3])
 
-    const r1 = flat_map([1, 2, 3], function* (k) { yield* Array(k).fill(k) })
+    const r1 = flat_map([1, 2, 3], function* (k) {
+      yield* Array(k).fill(k)
+    })
     expect([...r1]).to.be.equal([1, 2, 2, 3, 3, 3])
   })
 

--- a/bokehjs/test/unit/core/util/svg.tsx
+++ b/bokehjs/test/unit/core/util/svg.tsx
@@ -116,10 +116,11 @@ describe("SVGRenderingContext2d", () => {
 
           ctx.arc(x, y, radius, start_angle, end_angle, counterclockwise)
 
-          if (i > 1)
+          if (i > 1) {
             ctx.fill()
-          else
+          } else {
             ctx.stroke()
+          }
         }
       }
     }

--- a/bokehjs/test/unit/models/mappers/eqhist_color_mapper.ts
+++ b/bokehjs/test/unit/models/mappers/eqhist_color_mapper.ts
@@ -17,16 +17,18 @@ describe("EqHistColorMapper module", () => {
         // Ignore values at start of binning array up to low_cutoff_index
         const n = binning.length - low_cutoff_index
         const cutoff_binning = new Array<number>(n)
-        for (let i = 0; i < n; i++)
+        for (let i = 0; i < n; i++) {
           cutoff_binning[i] = binning[i + low_cutoff_index]
+        }
         binning = cutoff_binning
       }
 
       const sorted = values.sort()
-      if (rescale_discrete_levels)
+      if (rescale_discrete_levels) {
         expect(scan.min).to.be.similar(expected_binning[0], 1e-6)
-      else
+      } else {
         expect(scan.min).to.be.equal(sorted[0])
+      }
       expect(scan.max).to.be.equal(sorted[n-1])
 
       expect(binning).to.be.similar(expected_binning, 1e-6)

--- a/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
@@ -92,7 +92,11 @@ describe("TapTool", () => {
 
     it("and report key modifiers in a callback", async () => {
       let modifiers: Partial<KeyModifiers> | undefined
-      const callback: TapToolCallback = {execute(_, {event}) { modifiers = event.modifiers }}
+      const callback: TapToolCallback = {
+        execute(_, {event}) {
+          modifiers = event.modifiers
+        },
+      }
       const tool = new TapTool({behavior: "inspect", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 


### PR DESCRIPTION
This is part one of possibly many, to avoid conflicts with existing PRs and work. This PR makes a partial conversion of bokehjs' codebase from:
```ts
if (condition)
  statement
```
to:
```ts
if (condition) {
  statement
}
```
This is a practical change more than a stylistic one. It has been increasingly annoying to me to add those brackets when code changes and when requiring temporary changes like adding debug or print statements. One can somewhat equate this change to requiring trailing colons, as e.g. both reduce diff sizes.

I've been writing all my recent code and PRs in this style recently with good results. Though this PR doesn't enforce this style yet, I would recommend than any new submissions follow this guideline, to avoid unnecessary churn in the future. 