### PR TITLE
Add support for function callbacks in bokehjs

### DIFF
--- a/bokehjs/src/lib/core/util/callbacks.ts
+++ b/bokehjs/src/lib/core/util/callbacks.ts
@@ -1,0 +1,20 @@
+import {isFunction} from "core/util/types"
+
+type Fn<Obj, Args extends unknown[], Ret = void> = (obj: Obj, ...args: Args) => Ret
+
+export type Callable<Obj, Args extends unknown[], Ret = void> = Fn<Obj, Args, Ret> | Fn<Obj, Args, Promise<Ret>>
+export type Executable<Obj, Args extends unknown[], Ret = void> = {execute: Callable<Obj, Args, Ret>}
+
+export type CallbackLike<Obj, Args extends unknown[], Ret = void> = Executable<Obj, Args, Ret> | Callable<Obj, Args, Ret>
+export type ExecutableOf<T extends CallbackLike<any, any, any>> = T extends Function ? never : T
+
+export type CallbackLike0<Obj, Ret = void> = CallbackLike<Obj, [], Ret>
+export type CallbackLike1<Obj, Arg, Ret = void> = CallbackLike<Obj, [Arg], Ret>
+
+export function execute<Obj, Args extends unknown[], Ret>(cb: CallbackLike<Obj, Args, Ret>, obj: Obj, ...args: Args): Ret | Promise<Ret> {
+  if (isFunction(cb)) {
+    return cb(obj, ...args)
+  } else {
+    return cb.execute(obj, ...args)
+  }
+}

--- a/bokehjs/src/lib/models/callbacks/callback.ts
+++ b/bokehjs/src/lib/models/callbacks/callback.ts
@@ -1,24 +1,15 @@
 import {Model} from "../../model"
 import type * as p from "core/properties"
-
-export type CallbackFn<Obj, Args extends any[], Ret = void> = (obj: Obj, ...args: Args) => Ret
-
-export type CallbackLike<Obj, Args extends any[], Ret = void> = {
-  execute: CallbackFn<Obj, Args, Ret> | CallbackFn<Obj, Args, Promise<Ret>>
-}
-
-export type CallbackLike0<Obj, Ret = void> = CallbackLike<Obj, [], Ret>
-export type CallbackLike1<Obj, Arg, Ret = void> = CallbackLike<Obj, [Arg], Ret>
+import type {Executable} from "core/util/callbacks"
 
 export namespace Callback {
   export type Attrs = p.AttrsOf<Props>
-
   export type Props = Model.Props
 }
 
 export interface Callback extends Callback.Attrs {}
 
-export abstract class Callback extends Model implements CallbackLike<unknown, any, unknown> {
+export abstract class Callback extends Model implements Executable<unknown, any, unknown> {
   declare properties: Callback.Props
 
   constructor(attrs?: Partial<Callback.Attrs>) {

--- a/bokehjs/src/lib/models/sources/web_data_source.ts
+++ b/bokehjs/src/lib/models/sources/web_data_source.ts
@@ -1,6 +1,7 @@
 import {ColumnDataSource} from "./column_data_source"
 import {UpdateMode} from "core/enums"
-import type {CallbackLike1} from "../callbacks/callback"
+import type {CallbackLike1} from "core/util/callbacks"
+import {execute} from "core/util/callbacks"
 import type {Data} from "core/types"
 import type * as p from "core/properties"
 import type {Arrayable} from "core/types"
@@ -44,10 +45,11 @@ export abstract class WebDataSource extends ColumnDataSource {
   async load_data(raw_data: any, mode: UpdateMode, max_size?: number): Promise<void> {
     const {adapter} = this
     let data: Data
-    if (adapter != null)
-      data = await adapter.execute(this, {response: raw_data})
-    else
+    if (adapter != null) {
+      data = await execute(adapter, this, {response: raw_data})
+    } else {
       data = raw_data
+    }
 
     switch (mode) {
       case "replace": {

--- a/bokehjs/src/lib/models/tools/actions/custom_action.ts
+++ b/bokehjs/src/lib/models/tools/actions/custom_action.ts
@@ -1,5 +1,6 @@
 import {ActionTool, ActionToolView} from "./action_tool"
-import type {CallbackLike0} from "../../callbacks/callback"
+import type {CallbackLike0} from "core/util/callbacks"
+import {execute} from "core/util/callbacks"
 import type * as p from "core/properties"
 import * as icons from "styles/icons.css"
 
@@ -7,7 +8,10 @@ export class CustomActionView extends ActionToolView {
   declare model: CustomAction
 
   doit(): void {
-    this.model.callback?.execute(this.model)
+    const {callback} = this.model
+    if (callback != null) {
+      execute(callback, this.model)
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -1,5 +1,6 @@
 import {SelectTool, SelectToolView} from "./select_tool"
-import type {CallbackLike1} from "../../callbacks/callback"
+import type {CallbackLike1} from "core/util/callbacks"
+import {execute} from "core/util/callbacks"
 import type * as p from "core/properties"
 import type {TapEvent, KeyModifiers} from "core/ui_events"
 import * as events from "core/bokeh_events"
@@ -98,7 +99,7 @@ export class TapToolView extends SelectToolView {
         source,
         event: {modifiers},
       }
-      callback.execute(this.model, data)
+      execute(callback, this.model, data)
     }
   }
 }

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -12,13 +12,14 @@ import {assert} from "core/util/assert"
 import {color2css, color2hex} from "core/util/color"
 import {enumerate} from "core/util/iterator"
 import {is_empty} from "core/util/object"
+import type {CallbackLike1} from "core/util/callbacks"
+import {execute} from "core/util/callbacks"
 import type {Formatters} from "core/util/templating"
 import {FormatterType, replace_placeholders} from "core/util/templating"
 import {isFunction, isNumber, isString, is_undefined} from "core/util/types"
 import {tool_icon_hover} from "styles/icons.css"
 import * as styles from "styles/tooltips.css"
 import {Tooltip} from "../../ui/tooltip"
-import type {CallbackLike1} from "../../callbacks/callback"
 import type {TemplateView} from "../../dom/template"
 import {Template} from "../../dom/template"
 import type {GlyphView} from "../../glyphs/glyph"
@@ -495,7 +496,7 @@ export class HoverToolView extends InspectToolView {
 
       const index = renderer.data_source.inspected
 
-      callback.execute(this.model, {
+      execute(callback, this.model, {
         geometry: {x, y, ...geometry},
         renderer,
         index,

--- a/bokehjs/src/lib/models/widgets/button.ts
+++ b/bokehjs/src/lib/models/widgets/button.ts
@@ -1,6 +1,6 @@
 import {AbstractButton, AbstractButtonView} from "./abstract_button"
 import {ButtonClick} from "core/bokeh_events"
-import type {EventCallbackLike} from "model"
+import type {EventCallback} from "model"
 
 import type * as p from "core/properties"
 
@@ -37,7 +37,7 @@ export class Button extends AbstractButton {
     })
   }
 
-  on_click(callback: EventCallbackLike<ButtonClick>): void {
+  on_click(callback: EventCallback<ButtonClick>): void {
     this.on_event(ButtonClick, callback)
   }
 }

--- a/bokehjs/src/lib/models/widgets/dropdown.ts
+++ b/bokehjs/src/lib/models/widgets/dropdown.ts
@@ -1,11 +1,12 @@
 import {AbstractButton, AbstractButtonView} from "./abstract_button"
-import type {CallbackLike1} from "../callbacks/callback"
 
 import {ButtonClick, MenuItemClick} from "core/bokeh_events"
 import type {StyleSheetLike} from "core/dom"
 import {div, display, undisplay} from "core/dom"
 import type * as p from "core/properties"
 import {isString} from "core/util/types"
+import type {CallbackLike1} from "core/util/callbacks"
+import {execute} from "core/util/callbacks"
 
 import * as buttons from "styles/buttons.css"
 import dropdown_css, * as dropdown from "styles/dropdown.css"
@@ -100,7 +101,7 @@ export class DropdownView extends AbstractButtonView {
       if (isString(value_or_callback)) {
         this.model.trigger_event(new MenuItemClick(value_or_callback))
       } else {
-        value_or_callback.execute(this.model, {index: i}) // TODO
+        execute(value_or_callback, this.model, {index: i}) // TODO
       }
     }
   }

--- a/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/tap_tool.ts
@@ -49,7 +49,7 @@ describe("TapTool", () => {
   describe("should support 'tap' gesture", () => {
     it("and trigger on 'tap' event", async () => {
       let called = false
-      const callback: TapToolCallback = {execute() { called = true }}
+      const callback: TapToolCallback = () => called = true
       const tool = new TapTool({behavior: "select", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
@@ -59,7 +59,7 @@ describe("TapTool", () => {
 
     it("and not trigger on 'tap' event when didn't hit a glyph", async () => {
       let called = false
-      const callback: TapToolCallback = {execute() { called = true }}
+      const callback: TapToolCallback = () => called = true
       const tool = new TapTool({behavior: "select", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
@@ -69,7 +69,7 @@ describe("TapTool", () => {
 
     it("and not trigger on 'doubletap' event", async () => {
       let called = false
-      const callback: TapToolCallback = {execute() { called = true }}
+      const callback: TapToolCallback = () => called = true
       const tool = new TapTool({behavior: "select", gesture: "tap", callback})
       const plot_view = await test_case(tool)
 
@@ -79,7 +79,7 @@ describe("TapTool", () => {
 
     it("and allow setting key modifiers", async () => {
       let called = false
-      const callback: TapToolCallback = {execute() { called = true }}
+      const callback: TapToolCallback = () => called = true
       const tool = new TapTool({behavior: "inspect", gesture: "tap", modifiers: {shift: true, alt: true}, callback})
       const plot_view = await test_case(tool)
 
@@ -110,7 +110,7 @@ describe("TapTool", () => {
   describe("should support 'doubletap' gesture", () => {
     it("and not trigger on 'tap' event", async () => {
       let called = false
-      const callback: TapToolCallback = {execute() { called = true }}
+      const callback: TapToolCallback = () => called = true
       const tool = new TapTool({behavior: "select", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
@@ -120,7 +120,7 @@ describe("TapTool", () => {
 
     it("and trigger on 'doubletap' event", async () => {
       let called = false
-      const callback: TapToolCallback = {execute() { called = true }}
+      const callback: TapToolCallback = () => called = true
       const tool = new TapTool({behavior: "select", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 
@@ -130,7 +130,7 @@ describe("TapTool", () => {
 
     it("and not trigger on 'doubletap' event when didn't hit a glyph", async () => {
       let called = false
-      const callback: TapToolCallback = {execute() { called = true }}
+      const callback: TapToolCallback = () => called = true
       const tool = new TapTool({behavior: "select", gesture: "doubletap", callback})
       const plot_view = await test_case(tool)
 

--- a/examples/models/popup.ts
+++ b/examples/models/popup.ts
@@ -1,8 +1,10 @@
 import {Model} from "model"
-import {ColumnarDataSource} from "models/sources/columnar_data_source"
-import {TapTool, TapToolCallback} from "models/tools/gestures/tap_tool"
+import type {ColumnarDataSource} from "models/sources/columnar_data_source"
+import type {TapToolCallback} from "models/tools/gestures/tap_tool"
+import {TapTool} from "models/tools/gestures/tap_tool"
+import type {ExecutableOf} from "core/util/callbacks"
 import {replace_placeholders} from "core/util/templating"
-import * as p from "core/properties"
+import type * as p from "core/properties"
 import {popup} from "./popup_helper"
 
 export namespace Popup {
@@ -15,7 +17,7 @@ export namespace Popup {
 
 export interface Popup extends Popup.Attrs {}
 
-export class Popup extends Model implements TapToolCallback {
+export class Popup extends Model implements ExecutableOf<TapToolCallback> {
   declare properties: Popup.Props
 
   constructor(attrs?: Partial<Popup.Attrs>) {


### PR DESCRIPTION
Allows to write:
```ts
const callback: TapToolCallback = () => called = true
```
instead of:
```ts
const callback: TapToolCallback = {execute() { called = true }}
```
and generally simplifies typing situation around callbacks.