### PR TITLE
add vermin minpy version check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,12 @@ repos:
         language: conda
         pass_filenames: false
 
+      - id: run-vermin
+        name: Run vermin checks
+        entry: pytest tests/codebase/test_vermin.py
+        language: conda
+        pass_filenames: false
+
       - id: validate-json
         name: Validate JSON files
         entry: pytest tests/codebase/test_json.py

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -82,4 +82,6 @@ dependencies:
     - types-pillow
     - types-pyyaml
     - types-requests
+    - types-toml
     - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13407
+    - vermin

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -82,4 +82,6 @@ dependencies:
     - types-pillow
     - types-pyyaml
     - types-requests
+    - types-toml
     - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13407
+    - vermin

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -82,6 +82,8 @@ dependencies:
     - types-pillow
     - types-pyyaml
     - types-requests
+    - types-toml
     - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13407
+    - vermin
     # move the following back to conda sections above when python 3.12 conda-forge packages available
     - squarify

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -82,4 +82,6 @@ dependencies:
     - types-pillow
     - types-pyyaml
     - types-requests
+    - types-toml
     - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13407
+    - vermin

--- a/docs/bokeh/source/docs/first_steps.rst
+++ b/docs/bokeh/source/docs/first_steps.rst
@@ -18,7 +18,8 @@ First steps
 Installing Bokeh
 ----------------
 
-Bokeh is officially supported and tested on Python 3.9 and above (CPython).
+Bokeh is officially supported and tested on Python :bokeh-minpy:`cpython` and
+above (CPython).
 
 You can install Bokeh with either ``conda`` or ``pip``:
 

--- a/tests/codebase/test_vermin.py
+++ b/tests/codebase/test_vermin.py
@@ -1,0 +1,44 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2023, Anaconda, Inc. All rights reserved.
+#
+# Powered by the Bokeh Development Team.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from os import chdir
+from subprocess import run
+
+# External imports
+import toml
+
+# Bokeh imports
+from tests.support.util.project import TOP_PATH
+
+#-----------------------------------------------------------------------------
+# Tests
+#-----------------------------------------------------------------------------
+
+def test_vermin() -> None:
+    chdir(TOP_PATH)
+    pyproject = toml.load(TOP_PATH / "pyproject.toml")
+    minpy = pyproject["project"]["requires-python"].lstrip(">=")
+    cmd =  f"vermin --eval-annotations --no-tips  -t={minpy} -vvv --lint src/bokeh".split()
+    proc = run(cmd, capture_output=True)
+    assert proc.returncode == 0, f"vermin issues:\n{proc.stdout.decode('utf-8')}"
+
+#-----------------------------------------------------------------------------
+# Support
+#-----------------------------------------------------------------------------

--- a/tests/codebase/test_vermin.py
+++ b/tests/codebase/test_vermin.py
@@ -35,7 +35,7 @@ def test_vermin() -> None:
     chdir(TOP_PATH)
     pyproject = toml.load(TOP_PATH / "pyproject.toml")
     minpy = pyproject["project"]["requires-python"].lstrip(">=")
-    cmd =  f"vermin --eval-annotations --no-tips  -t={minpy} -vvv --lint src/bokeh".split()
+    cmd =  f"vermin --eval-annotations --no-tips -t={minpy} -vvv --lint src/bokeh".split()
     proc = run(cmd, capture_output=True)
     assert proc.returncode == 0, f"vermin issues:\n{proc.stdout.decode('utf-8')}"
 


### PR DESCRIPTION
This PR adds a and codebase test and associated pre-commit hook that runs `vermin` to validate that our advertised `minpy` version is satisfied. The check is keyed off the reported `requires-python` key in `pyproject.toml` as a single source of truth. Additionally a case of hard-coded `minpy` version in the docs was noticed and updated to use the sphinx extension for repotting `minpy`.

- [x] issues: fixes #13429
- [x] tests added / passed
- [x] release document entry (if new feature or API change)
