### PR TITLE
fix comment end strings in some jinja templates

### DIFF
--- a/src/bokeh/core/_templates/autoload_request_tag.html
+++ b/src/bokeh/core/_templates/autoload_request_tag.html
@@ -23,7 +23,7 @@ ID is not specified, the entire document will be rendered.
 .. note::
     This script injects a ``<div>`` in place, so must be placed under ``<body>``.
 
--#}
+#}
 <script id="{{ elementid }}">
   (function() {
     const xhr = new XMLHttpRequest()

--- a/src/bokeh/core/_templates/autoload_tag.html
+++ b/src/bokeh/core/_templates/autoload_tag.html
@@ -20,5 +20,5 @@ ID is not specified, the entire document will be rendered.
 .. note::
     This script injects a ``<div>`` in place, so must be placed under ``<body>``.
 
--#}
+#}
 <script src="{{ src_path }}" id="{{ elementid }}"></script>

--- a/src/bokeh/core/_templates/css_resources.html
+++ b/src/bokeh/core/_templates/css_resources.html
@@ -8,7 +8,7 @@ Resources object.
 :param css_raw: a list of raw CSS snippets to put between ``<style>`` tags
 :type css_raw: list[str]
 
--#}
+#}
 {% for file in css_files %}
     <link rel="stylesheet" href="{{ file }}" type="text/css" />
 {% endfor %}

--- a/src/bokeh/core/_templates/file.html
+++ b/src/bokeh/core/_templates/file.html
@@ -13,7 +13,7 @@ Renders Bokeh models into a basic .html file.
 Users can customize the file output by providing their own Jinja2 template
 that accepts these same parameters.
 
--#}
+#}
 {% from macros import embed %}
 <!DOCTYPE html>
 <html lang="en">

--- a/src/bokeh/core/_templates/js_resources.html
+++ b/src/bokeh/core/_templates/js_resources.html
@@ -11,7 +11,7 @@ configuration in a Resources object.
 :param js_raw: a list of raw JS snippets to put between ``<style>`` tags
 :type js_raw: list[str]
 
--#}
+#}
 {% for file in js_files %}
     <script type="text/javascript" src="{{ file }}"></script>
 {% endfor %}

--- a/src/bokeh/core/_templates/notebook_load.html
+++ b/src/bokeh/core/_templates/notebook_load.html
@@ -20,7 +20,7 @@ Notebook according to a Resources object.
 :param warnings: a list of warnings to display to user
 :type warnings: list[str]
 
--#}
+#}
     <style>
         .bk-notebook-logo {
             display: block;

--- a/src/bokeh/core/_templates/plot_div.html
+++ b/src/bokeh/core/_templates/plot_div.html
@@ -5,7 +5,7 @@ Renders a basic plot div, that can be used in conjunction with PLOT_JS.
     template should be configured with the same ``elementid``
 :type elementid: str
 
--#}
+#}
 {% from macros import embed %}
 {{ embed(doc) if doc.elementid }}
 {% for root in doc.roots %}


### PR DESCRIPTION
The suggested change will remove some empty bullet points from the docs in the [templates](https://docs.bokeh.org/en/latest/docs/reference/core/templates.html) section.

I removed some `-` characters from some jinja templates. Reading about the "comment end string" syntax [here](https://jinja.palletsprojects.com/en/3.1.x/api/#basics)  and [here](https://documentation.bloomreach.com/engagement/docs/jinja-syntax#delimiters) this seems to be correct. The correct syntax was already used in `bokeh/src/bokeh/core/_templates/script_tag.html`.

- [ ] issues: fixes #13306

|current page|suggestion|
|--|--|
|![current_webpage](https://github.com/bokeh/bokeh/assets/68053396/057573dc-e67b-495a-979e-532b0a267a4b)|![suggestion](https://github.com/bokeh/bokeh/assets/68053396/646dfda8-8eb9-43c5-8e46-71dac31603f8)|