### PR TITLE
Robustify type expectations greatly reduce `!` usage in tests

### DIFF
--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -45,8 +45,8 @@ export namespace HoverfulScatter {
     source, alpha: 0.5, text_font_size: "7px", text_baseline: "middle", text_align: "center",
   })
 
-  const hover = p.toolbar.select_one(Bokeh.HoverTool)
-  hover!.tooltips = (source, info) => {
+  const hover = p.toolbar.get_one(Bokeh.HoverTool)
+  hover.tooltips = (source, info) => {
     const ds = source as Bokeh.ColumnDataSource
     const div = document.createElement("div")
     div.style.width = "200px"

--- a/bokehjs/examples/tap/tap.ts
+++ b/bokehjs/examples/tap/tap.ts
@@ -45,18 +45,17 @@ export namespace TappyScatter {
     source, alpha: 0.5, text_font_size: "7px", text_baseline: "middle", text_align: "center",
   })
 
-  const tap = p.toolbar.select_one(Bokeh.TapTool)
-  tap!.renderers = [circles]
-  tap!.callback = {
-    execute(_obj, {source}): void {
-      const indices = source.selected.indices
-      if (indices.length == 1)
-        console.log(`Selected index: ${indices[0]}`)
-      else if (indices.length > 1)
-        console.log(`Selected indices: ${[...indices].join(", ")}`)
-      else
-        console.log("Nothing selected")
-    },
+  const tap = p.toolbar.get_one(Bokeh.TapTool)
+  tap.renderers = [circles]
+  tap.callback = (_obj, {source}) => {
+    const indices = source.selected.indices
+    if (indices.length == 1) {
+      console.log(`Selected index: ${indices[0]}`)
+    } else if (indices.length > 1) {
+      console.log(`Selected indices: ${[...indices].join(", ")}`)
+    } else {
+      console.log("Nothing selected")
+    }
   }
 
   plt.show(p)

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -147,7 +147,16 @@ export class Model extends HasProps {
       case 1:
         return result[0]
       default:
-        throw new Error(`found more than one object matching given selector ${selector}`)
+        throw new Error(`found multiple objects matching the given selector ${selector}`)
+    }
+  }
+
+  get_one<T extends HasProps>(selector: ModelSelector<T>): T {
+    const result = this.select_one(selector)
+    if (result != null) {
+      return result
+    } else {
+      throw new Error(`could not find any objects matching the given selector ${selector}`)
     }
   }
 

--- a/bokehjs/test/integration/features.ts
+++ b/bokehjs/test/integration/features.ts
@@ -3,7 +3,6 @@ import {PlotActions, xy} from "../interactive"
 
 import {PanTool, SaveTool, CrosshairTool, Span, GridBox, Row, Pane, Slope, GridPlot} from "@bokehjs/models"
 import {paint} from "@bokehjs/core/util/defer"
-import {assert} from "@bokehjs/core/util/assert"
 import {range} from "@bokehjs/core/util/array"
 import {Random} from "@bokehjs/core/util/random"
 
@@ -114,8 +113,7 @@ describe("Feature", () => {
       const {view} = await display(grid)
       await paint()
 
-      const pv0 = view.owner.find_one(p0)
-      assert(pv0 != null, "view not found")
+      const pv0 = view.owner.get_one(p0)
 
       const actions = new PlotActions(pv0)
       await actions.hover(xy(1, 1), xy(4, 4))

--- a/bokehjs/test/integration/glyphs/image_stack.ts
+++ b/bokehjs/test/integration/glyphs/image_stack.ts
@@ -33,7 +33,7 @@ describe("ImageStack glyph", () => {
     const {view} = await display(row([p0, p1, p2]))
 
     function hover_at(plot_view: PlotView, r: Renderer, x: number, y: number) {
-      const crv = plot_view.renderer_views.get(r)!
+      const crv = plot_view.owner.get_one(r)
       const [[sx], [sy]] = crv.coordinates.map_to_screen([x], [y])
 
       const ui = plot_view.canvas_view.ui_event_bus

--- a/bokehjs/test/integration/glyphs/markers.ts
+++ b/bokehjs/test/integration/glyphs/markers.ts
@@ -1,10 +1,10 @@
+import {expect} from "../../unit/assertions"
 import {display, fig, row} from "../_util"
 
 import type {HatchPattern} from "@bokehjs/core/property_mixins"
 import type {LineJoin} from "@bokehjs/core/enums"
 import {MarkerType, OutputBackend} from "@bokehjs/core/enums"
 import {Random} from "@bokehjs/core/util/random"
-import {assert} from "@bokehjs/core/util/assert"
 
 describe("Marker glyph", () => {
   const random = new Random(1)
@@ -81,7 +81,7 @@ describe("Marker glyph", () => {
       p.y(X, Y(), attrs)
 
       const N = [...MarkerType].length
-      assert(p.renderers.length == N)
+      expect(p.renderers.length).to.be.equal(N)
 
       return p
     }

--- a/bokehjs/test/integration/plots.ts
+++ b/bokehjs/test/integration/plots.ts
@@ -1,11 +1,10 @@
 import * as sinon from "sinon"
 
-import {expect} from "../unit/assertions"
+import {expect, expect_not_null} from "../unit/assertions"
 import {display, fig, row} from "./_util"
 
 import {figure} from "@bokehjs/api/plotting"
 import type {Location} from "@bokehjs/core/enums"
-import {assert} from "@bokehjs/core/util/assert"
 import {Range1d, LinearScale, LinearAxis, ColumnDataSource, Pane} from "@bokehjs/models"
 import type {PlotView} from "@bokehjs/models/plots/plot"
 
@@ -84,7 +83,7 @@ describe("Plot", () => {
 
     const click = (view: PlotView) => {
       const el = view.toolbar_panel?.toolbar_view.overflow_el
-      assert(el != null)
+      expect_not_null(el)
       const ev = new MouseEvent("click", {clientX: 5, clientY: 5, bubbles: true})
       el.dispatchEvent(ev)
     }

--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -1248,7 +1248,7 @@ describe("Bug", () => {
       p.add_tools(new HoverTool({tooltips: null, renderers: [cr], mode: "vline"}))
       const {view} = await display(p)
 
-      const crv = view.renderer_views.get(cr)!
+      const crv = view.owner.get_one(cr)
       const [[sx], [sy]] = crv.coordinates.map_to_screen([2], [1.5])
 
       const ui = view.canvas_view.ui_event_bus
@@ -1303,7 +1303,7 @@ describe("Bug", () => {
       const {view} = await display(row([p0, p1, p2]))
 
       function hover_at(plot_view: PlotView, r: Renderer, x: number, y: number) {
-        const crv = plot_view.renderer_views.get(r)!
+        const crv = plot_view.owner.get_one(r)
         const [[sx], [sy]] = crv.coordinates.map_to_screen([x], [y])
 
         const ui = plot_view.canvas_view.ui_event_bus
@@ -1641,7 +1641,7 @@ describe("Bug", () => {
 
       const {view} = await display(p)
 
-      const zoom_in_tool_view = view.tool_views.get(zoom_in_tool)! as ZoomInTool["__view_type__"]
+      const zoom_in_tool_view = view.owner.get_one(zoom_in_tool)
       zoom_in_tool_view.doit()
 
       await view.ready

--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon"
 
-import {expect} from "../unit/assertions"
+import {expect, expect_condition, expect_not_null} from "../unit/assertions"
 import {display, fig, row, column, grid, DelayedInternalProvider} from "./_util"
 import {PlotActions, xy, click, press, mouseenter} from "../interactive"
 
@@ -44,7 +44,6 @@ import type {Color, Arrayable} from "@bokehjs/core/types"
 import type {LineDash, Location, OutputBackend} from "@bokehjs/core/enums"
 import {Anchor, MarkerType} from "@bokehjs/core/enums"
 import {subsets, tail} from "@bokehjs/core/util/iterator"
-import {assert} from "@bokehjs/core/util/assert"
 import {isArray, isPlainObject} from "@bokehjs/core/util/types"
 import {range, linspace} from "@bokehjs/core/util/array"
 import {ndarray} from "@bokehjs/core/util/ndarray"
@@ -727,7 +726,7 @@ describe("Bug", () => {
         (p) => p.y.bind(p),
       ]
 
-      assert(fns.length == n_marker_types)
+      expect(fns.length).to.be.equal(n_marker_types)
 
       const layout = column(fns.map((fn) => row(plots(fn))))
       await display(layout)
@@ -1672,7 +1671,7 @@ describe("Bug", () => {
       document.fonts.add(font)
     })
 
-    function assert_fonts(status: boolean) {
+    function expect_fonts(status: boolean) {
       expect(document.fonts.check("normal 12px VujahdayScript")).to.be.equal(status)
       expect(document.fonts.check("normal 22px VujahdayScript")).to.be.equal(status)
       expect(document.fonts.check("normal 26px VujahdayScript")).to.be.equal(status)
@@ -1680,7 +1679,7 @@ describe("Bug", () => {
     }
 
     it("prevents correct text rendering with lazily loaded fonts", async () => {
-      assert_fonts(false)
+      expect_fonts(false)
 
       const p = fig([200, 200], {x_range: [0, 10], y_range: [0, 3]})
 
@@ -1705,14 +1704,14 @@ describe("Bug", () => {
       const {view} = await display(p)
 
       await document.fonts.ready
-      assert_fonts(true)
+      expect_fonts(true)
 
       await view.ready
     })
 
     after_each(() => {
       const deleted = document.fonts.delete(font)
-      assert(deleted, "font cleanup failed")
+      expect_condition(deleted, "font cleanup failed")
     })
   })
 
@@ -2737,8 +2736,8 @@ describe("Bug", () => {
       const crv = view.owner.get_one(r)
       const [[sx], [sy]] = crv.coordinates.map_to_screen([pt.x], [pt.y])
 
-      // TODO: tt.position is not guarantted to be whole pixels (?)
-      assert(isArray(tt.position))
+      // TODO: tt.position is not guaranteed to be whole pixels (?)
+      expect_condition(isArray(tt.position), "tt.position must be a tuple")
       const [px, py] = tt.position
       expect([px|0, py|0]).to.be.equal([sx|0, sy|0])
     })
@@ -3074,17 +3073,17 @@ describe("Bug", () => {
       await paint()
 
       const el_D = view.shadow_el.querySelector("[data-value='D']")
-      assert(el_D != null)
+      expect_not_null(el_D)
       await click(el_D, "mousedown")
       await paint()
 
       const el_A = view.shadow_el.querySelector("[data-value='A']")
-      assert(el_A != null)
+      expect_not_null(el_A)
       await click(el_A, "mousedown")
       await paint()
 
       const el_B = view.shadow_el.querySelector("[data-value='B']")
-      assert(el_B != null)
+      expect_not_null(el_B)
       await click(el_B, "mousedown")
       await paint()
     })
@@ -3347,7 +3346,7 @@ describe("Bug", () => {
       expect(isPlainObject(doc_json)).to.be.true
 
       const {desc_el} = view.owner.get_one(widget)
-      assert(desc_el != null)
+      expect_not_null(desc_el)
       await mouseenter(desc_el)
     })
   })

--- a/bokehjs/test/integration/widgets.ts
+++ b/bokehjs/test/integration/widgets.ts
@@ -1,5 +1,6 @@
 import {display, column} from "./_util"
 import {click} from "../interactive"
+import {expect_not_null} from "../unit/assertions"
 
 import {range} from "@bokehjs/core/util/array"
 import {ButtonType} from "@bokehjs/core/enums"
@@ -44,7 +45,8 @@ export async function open_picker(view: PickerBaseView): Promise<void> {
   view.picker._input.dispatchEvent(new MouseEvent("click"))
   await view.ready
 
-  const calendar_el = view.shadow_el.querySelector(".flatpickr-calendar")!
+  const calendar_el = view.shadow_el.querySelector(".flatpickr-calendar")
+  expect_not_null(calendar_el)
   await finished_animating(calendar_el)
 }
 
@@ -79,11 +81,12 @@ describe("Widgets", () => {
     const obj = new Dropdown({label: "Dropdown 1", button_type: "primary", menu})
     const {view} = await display(obj, [500, 200])
 
-    const button = view.shadow_el.querySelector("button")!
-    const {left, top} = button.getBoundingClientRect()
+    const button_el = view.shadow_el.querySelector("button")
+    expect_not_null(button_el)
+    const {left, top} = button_el.getBoundingClientRect()
 
     const ev = new MouseEvent("click", {clientX: left + 5, clientY: top + 5})
-    button.dispatchEvent(ev)
+    button_el.dispatchEvent(ev)
 
     await view.ready
   })
@@ -99,11 +102,12 @@ describe("Widgets", () => {
     const obj = new Dropdown({label: "Dropdown 1", button_type: "primary", menu, split: true})
     const {view} = await display(obj, [500, 200])
 
-    const toggle = view.shadow_el.querySelector(".bk-dropdown-toggle")!
-    const {left, top} = toggle.getBoundingClientRect()
+    const toggle_el = view.shadow_el.querySelector(".bk-dropdown-toggle")
+    expect_not_null(toggle_el)
+    const {left, top} = toggle_el.getBoundingClientRect()
 
     const ev = new MouseEvent("click", {clientX: left + 5, clientY: top + 5})
-    toggle.dispatchEvent(ev)
+    toggle_el.dispatchEvent(ev)
 
     await view.ready
   })

--- a/bokehjs/test/unit/api/gridplot.ts
+++ b/bokehjs/test/unit/api/gridplot.ts
@@ -1,4 +1,4 @@
-import {expect} from "assertions"
+import {expect, expect_instanceof} from "assertions"
 
 import {
   PanTool, TapTool, SaveTool, BoxSelectTool, HoverTool,
@@ -7,7 +7,6 @@ import {
 
 import {gridplot, group_tools} from "@bokehjs/api/gridplot"
 import {figure} from "@bokehjs/api/figure"
-import {assert} from "@bokehjs/core/util/assert"
 
 describe("api/gridplot module", () => {
   it("should support group_tools() function", () => {
@@ -39,14 +38,14 @@ describe("api/gridplot module", () => {
     expect(tools.length).to.be.equal(8)
     const [t0, t1, t2, t3, t4, t5, t6, t7] = tools
 
-    assert(t0 instanceof ToolProxy)
-    assert(t1 instanceof ToolProxy)
-    assert(t2 instanceof PanTool)
-    assert(t3 instanceof ToolProxy)
-    assert(t4 instanceof TapTool)
-    assert(t5 instanceof SaveTool)
-    assert(t6 instanceof ToolProxy)
-    assert(t7 instanceof ToolProxy)
+    expect_instanceof(t0, ToolProxy)
+    expect_instanceof(t1, ToolProxy)
+    expect_instanceof(t2, PanTool)
+    expect_instanceof(t3, ToolProxy)
+    expect_instanceof(t4, TapTool)
+    expect_instanceof(t5, SaveTool)
+    expect_instanceof(t6, ToolProxy)
+    expect_instanceof(t7, ToolProxy)
 
     expect(t0.tools).to.be.equal([pan0, pan1])
     expect(t1.tools).to.be.equal([pan2, pan4, pan3])

--- a/bokehjs/test/unit/assertions.ts
+++ b/bokehjs/test/unit/assertions.ts
@@ -324,6 +324,20 @@ export function expect<T>(fn_or_val: (() => T) | T): ToFn<T> | ToVal<T> {
   }
 }
 
+export function expect_not_null<T>(val: T | null | undefined): asserts val is T {
+  expect(val).to.not.be.null
+}
+
+export function expect_instanceof<T>(val: unknown, constructor: Constructor<T>): asserts val is T {
+  expect(val).to.be.instanceof(constructor)
+}
+
+export function expect_condition(condition: boolean, message: string): asserts condition {
+  if (!condition) {
+    throw new ExpectationError(`unmet expectation: ${message}`)
+  }
+}
+
 export function expect_element(element: Element): ToElement {
   return {
     to: {

--- a/bokehjs/test/unit/core/has_props.ts
+++ b/bokehjs/test/unit/core/has_props.ts
@@ -1,6 +1,5 @@
-import {expect} from "assertions"
+import {expect, expect_instanceof} from "assertions"
 
-import {assert} from "@bokehjs/core/util/assert"
 import {HasProps} from "@bokehjs/core/has_props"
 import * as mixins from "@bokehjs/core/property_mixins"
 import {Serializer} from "@bokehjs/core/serialization/serializer"
@@ -189,7 +188,7 @@ describe("core/has_props module", () => {
 
       counter = 0
       const obj0_ = deserializer0.decode(serializer0.encode(obj0))
-      assert(obj0_ instanceof Some0)
+      expect_instanceof(obj0_, Some0)
       expect(obj0_.prop0).to.be.equal(0)
       expect(obj0_.prop1).to.be.equal(1)
       expect(obj0_.prop2).to.be.equal(2)
@@ -200,7 +199,7 @@ describe("core/has_props module", () => {
 
       counter = 0
       const obj1_ = deserializer1.decode(serializer1.encode(obj1))
-      assert(obj1_ instanceof Some0)
+      expect_instanceof(obj1_, Some0)
       expect(obj1_.prop0).to.be.equal(10)
       expect(obj1_.prop1).to.be.equal(0)
       expect(obj1_.prop2).to.be.equal(1)
@@ -211,7 +210,7 @@ describe("core/has_props module", () => {
 
       counter = 0
       const obj2_ = deserializer2.decode(serializer2.encode(obj2))
-      assert(obj2_ instanceof Some0)
+      expect_instanceof(obj2_, Some0)
       expect(obj2_.prop0).to.be.equal(0)
       expect(obj2_.prop1).to.be.equal(20)
       expect(obj2_.prop2).to.be.equal(1)

--- a/bokehjs/test/unit/core/properties.ts
+++ b/bokehjs/test/unit/core/properties.ts
@@ -1,8 +1,9 @@
-import {expect} from "assertions"
+import {expect, expect_not_null} from "assertions"
 
 import * as p from "@bokehjs/core/properties"
 import * as enums from "@bokehjs/core/enums"
 import {keys} from "@bokehjs/core/util/object"
+import {range} from "@bokehjs/core/util/array"
 import {ndarray} from "@bokehjs/core/util/ndarray"
 
 import type {Color} from  "@bokehjs/core/types"
@@ -27,11 +28,9 @@ class TestTransform extends Transform {
 
 class TestExpression extends Expression {
   _v_compute(source: ColumnDataSource): number[] {
-    const ret = []
-    for (let i = 0; i < source.get_length()!; i++) {
-      ret.push(i)
-    }
-    return ret
+    const n = source.get_length()
+    expect_not_null(n)
+    return range(n)
   }
 }
 

--- a/bokehjs/test/unit/document/defs.ts
+++ b/bokehjs/test/unit/document/defs.ts
@@ -1,4 +1,4 @@
-import {expect} from "assertions"
+import {expect, expect_not_null} from "assertions"
 
 import {Deserializer} from "@bokehjs/core/serialization/deserializer"
 import type {ModelDef} from "@bokehjs/document/defs"
@@ -6,7 +6,6 @@ import {Model} from "@bokehjs/model"
 import {default_resolver} from "@bokehjs/base"
 import {ModelResolver} from "@bokehjs/core/resolvers"
 import type * as p from "@bokehjs/core/properties"
-import {assert} from "@bokehjs/core/util/assert"
 import {ColumnDataSource} from "@bokehjs/models"
 
 type int = number
@@ -189,11 +188,11 @@ describe("document/defs module", () => {
       const Some3 = resolver.get<typeof _Some3>("some.Some3")
       const Some4 = resolver.get<typeof _Some4>("some.Some4")
 
-      assert(Some0 != null)
-      assert(Some1 != null)
-      assert(Some2 != null)
-      assert(Some3 != null)
-      assert(Some4 != null)
+      expect_not_null(Some0)
+      expect_not_null(Some1)
+      expect_not_null(Some2)
+      expect_not_null(Some3)
+      expect_not_null(Some4)
 
       expect(Some0.prototype).to.be.instanceof(Model)
       expect(Some1.prototype).to.be.instanceof(Model)

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -1,4 +1,4 @@
-import {expect, expect_instanceof} from "assertions"
+import {expect, expect_instanceof, expect_not_null} from "assertions"
 import * as sinon from "sinon"
 
 import {Document, DEFAULT_TITLE} from "@bokehjs/document"
@@ -282,12 +282,14 @@ describe("Document", () => {
 
   it("lets us get_model_by_name", () => {
     const d = new Document()
-    const m = new SomeModel({name: "foo"})
-    const m2 = new AnotherModel({name: "bar"})
-    m.child = m2
-    d.add_root(m)
-    expect(d.get_model_by_name(m.name!)).to.be.equal(m)
-    expect(d.get_model_by_name(m2.name!)).to.be.equal(m2)
+    const m0 = new SomeModel({name: "foo"})
+    const m1 = new AnotherModel({name: "bar"})
+    m0.child = m1
+    d.add_root(m0)
+    expect_not_null(m0.name)
+    expect_not_null(m1.name)
+    expect(d.get_model_by_name(m0.name)).to.be.equal(m0)
+    expect(d.get_model_by_name(m1.name)).to.be.equal(m1)
     expect(d.get_model_by_name("invalidid")).to.be.null
   })
 
@@ -770,9 +772,9 @@ describe("Document", () => {
     d.apply_json_patch(patch1)
 
     expect(root1.child.id).to.be.equal(child3.id)
-    expect(root1.child).to.be.instanceof(SomeModel)
-    const root1_child0 = root1.child as SomeModel
-    expect(root1_child0.child!.id).to.be.equal(child2.id)
+    expect_instanceof(root1.child, SomeModel)
+    const root1_child0 = root1.child
+    expect(root1_child0.child?.id).to.be.equal(child2.id)
     expect(d._all_models.has(child1.id)).to.be.true
     expect(d._all_models.has(child2.id)).to.be.true
     expect(d._all_models.has(child3.id)).to.be.true
@@ -783,8 +785,8 @@ describe("Document", () => {
     d.apply_json_patch(patch2)
 
     expect(root1.child.id).to.be.equal(child1.id)
-    expect(root1.child).to.be.instanceof(SomeModel)
-    const root1_child1 = root1.child as SomeModel
+    expect_instanceof(root1.child, SomeModel)
+    const root1_child1 = root1.child
     expect(root1_child1.child).to.be.null
     expect(d._all_models.has(child1.id)).to.be.true
     expect(d._all_models.has(child2.id)).to.be.false
@@ -830,15 +832,15 @@ describe("Document", () => {
     // Testing only for/against null .document is not the strongest test but it
     // should suffice.
 
-    expect(root1.document!.roots().length).to.be.equal(1)
+    expect(root1.document?.roots().length).to.be.equal(1)
     expect(root1.child).to.be.null
 
     const event1 = new ev.ModelChangedEvent(d, root1, "child", child1)
     const patch1 = d.create_json_patch([event1])
     d.apply_json_patch(patch1)
 
-    expect(root1.document!.roots().length).to.be.equal(1)
-    expect(root1.child!.document!.roots().length).to.be.equal(1)
+    expect(root1.document?.roots().length).to.be.equal(1)
+    expect(root1.child?.document?.roots().length).to.be.equal(1)
   })
 
   it("sets proper document on models added during construction", () => {
@@ -867,7 +869,7 @@ describe("Document", () => {
     expect(root1_copy.foo).to.be.equal(4)
     expect(root1_copy.child).to.be.instanceof(AnotherModel)
     expect(root1_copy.document).to.be.equal(copy)
-    expect(root1_copy.child!.document).to.be.equal(copy)
+    expect(root1_copy.child?.document).to.be.equal(copy)
   })
 
   it("can detect changes during model initialization", () => {

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -1,7 +1,6 @@
-import {expect} from "assertions"
+import {expect, expect_instanceof} from "assertions"
 import * as sinon from "sinon"
 
-import {assert} from "@bokehjs/core/util/assert"
 import {Document, DEFAULT_TITLE} from "@bokehjs/document"
 import * as ev from "@bokehjs/document/events"
 import {version as js_version} from "@bokehjs/version"
@@ -475,7 +474,7 @@ describe("Document", () => {
     expect(events1.length).to.be.equal(2)
 
     const [batch] = events0
-    assert(batch instanceof ev.DocumentEventBatch)
+    expect_instanceof(batch, ev.DocumentEventBatch)
     expect(batch.events.length).to.be.equal(2)
   })
 
@@ -696,7 +695,7 @@ describe("Document", () => {
     expect(copy.roots().length).to.be.equal(1)
     const model0 = copy.roots()[0]
     expect(model0).to.be.instanceof(SomeModel)
-    assert(model0 instanceof SomeModel)
+    expect_instanceof(model0, SomeModel)
     expect(model0.name).to.be.equal("foo")
 
     // be sure defaults were NOT included
@@ -892,7 +891,7 @@ describe("Document", () => {
     expect(events.length).to.be.equal(2)
 
     const [root0] = doc.roots()
-    assert(root0 instanceof ModelWithConstructTimeChanges)
+    expect_instanceof(root0, ModelWithConstructTimeChanges)
     expect(root0.foo).to.be.equal(4)
     expect(root0.child).to.be.instanceof(AnotherModel)
   })

--- a/bokehjs/test/unit/model.ts
+++ b/bokehjs/test/unit/model.ts
@@ -116,6 +116,6 @@ describe("Model objects", () => {
     const some1_1 = new Some1Model({p3: [some1_0, some0_1]})
 
     expect(some1_1.select({type: "Some0Model"})).to.be.equal([some0_0, some0_1])
-    expect(() => some1_1.select_one({type: "Some0Model"})).to.throw(Error, "found more than one object matching given selector")
+    expect(() => some1_1.select_one({type: "Some0Model"})).to.throw(Error, "found multiple objects matching the given selector")
   })
 })

--- a/bokehjs/test/unit/models/axes/axis.ts
+++ b/bokehjs/test/unit/models/axes/axis.ts
@@ -28,7 +28,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "below")
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
 
     const labels = axis_view.compute_labels([0, 2, 4.0, 6, 8, 10])
     expect(labels.items.map((l) => (l as TextBox).text)).to.be.equal(["zero", "2", "four", "6", "8", "ten"])
@@ -48,7 +48,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "below")
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
 
     const labels = axis_view.compute_labels([0, 2, 4, 6, 8, 10])
 
@@ -72,7 +72,7 @@ describe("Axis", () => {
     plot.add_layout(axis, "below")
 
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
 
     expect(axis_view._axis_label_view).to.be.instanceof(TeXView)
   })
@@ -95,7 +95,7 @@ describe("Axis", () => {
     plot.add_layout(axis, "below")
 
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
 
     expect(axis_view._axis_label_view).to.be.instanceof(TeXView)
   })
@@ -114,7 +114,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "below")
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
     expect(axis_view.loc).to.be.equal(10)
   })
 
@@ -132,7 +132,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "left")
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
     expect(axis_view.offsets).to.be.equal([0, 0])
   })
 
@@ -151,7 +151,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "left")
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
     expect(axis_view.offsets).to.be.equal([0, 0])
   })
 
@@ -170,7 +170,7 @@ describe("Axis", () => {
     })
     plot.add_layout(axis, "left")
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
     expect(axis_view.loc).to.be.equal(0.5)
   })
 })
@@ -197,7 +197,7 @@ describe("AxisView", () => {
     plot.add_layout(axis, "below")
 
     const {view: plot_view} = await display(plot)
-    const axis_view = plot_view.renderer_view(axis)!
+    const axis_view = plot_view.owner.get_one(axis)
 
     return {axis, axis_view}
   }

--- a/bokehjs/test/unit/models/callbacks/customjs.ts
+++ b/bokehjs/test/unit/models/callbacks/customjs.ts
@@ -1,11 +1,10 @@
 import * as sinon from "sinon"
-import {expect} from "assertions"
+import {expect, expect_instanceof} from "assertions"
 
 import {CustomJS} from "@bokehjs/models/callbacks/customjs"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import {GeneratorFunction, AsyncGeneratorFunction} from "@bokehjs/core/types"
 import {logger} from "@bokehjs/core/logging"
-import {assert} from "@bokehjs/core/util/assert"
 import {Document} from "@bokehjs/document"
 import {version as js_version} from "@bokehjs/version"
 
@@ -27,10 +26,10 @@ describe("CustomJS", () => {
       const copy = Document.from_json_string(JSON.stringify(parsed))
 
       const cb_copy = copy.get_model_by_id(cb.id)
-      assert(cb_copy instanceof CustomJS)
+      expect_instanceof(cb_copy, CustomJS)
 
       const rng_copy = copy.get_model_by_id(rng.id)
-      assert(rng_copy instanceof Range1d)
+      expect_instanceof(rng_copy, Range1d)
 
       expect(cb.args).to.be.equal({rng})
       expect(cb_copy.args).to.be.equal({rng: rng_copy})

--- a/bokehjs/test/unit/models/canvas/cartesian_frame.ts
+++ b/bokehjs/test/unit/models/canvas/cartesian_frame.ts
@@ -38,8 +38,8 @@ describe("CartesianFrame", () => {
       const ranges = new Map([["default", new Range1d()]])
       const scales = frame._get_scales(frame.x_scale, {}, ranges, frame_range)
       expect(scales.get("default")).to.be.instanceof(LinearScale)
-      expect(scales.get("default")!.source_range).to.be.instanceof(Range1d)
-      expect(scales.get("default")!.target_range).to.be.instanceof(Range1d)
+      expect(scales.get("default")?.source_range).to.be.instanceof(Range1d)
+      expect(scales.get("default")?.target_range).to.be.instanceof(Range1d)
     })
 
     it("should throw error for incompatible numeric scale and factor range", () => {

--- a/bokehjs/test/unit/models/glyphs/annular_wedge.ts
+++ b/bokehjs/test/unit/models/glyphs/annular_wedge.ts
@@ -65,8 +65,8 @@ describe("Glyph (using AnnularWedge as a concrete Glyph)", () => {
       ]
 
       for (let i = 0; i < geometries.length; i++) {
-        const result = glyph_view.hit_test(geometries[i])!
-        expect(result.indices).to.be.equal(expected_hits[i])
+        const result = glyph_view.hit_test(geometries[i])
+        expect(result?.indices).to.be.equal(expected_hits[i])
       }
 
       // Re-run hit tests with double the Y scale, keeping its center the same.
@@ -75,8 +75,8 @@ describe("Glyph (using AnnularWedge as a concrete Glyph)", () => {
       glyph_renderer.yscale.source_range.start -= 100
       glyph_renderer.yscale.source_range.end += 100
       for (let i = 0; i < geometries.length; i++) {
-        const result = glyph_view.hit_test(geometries[i])!
-        expect(result.indices).to.be.equal(expected_hits[i])
+        const result = glyph_view.hit_test(geometries[i])
+        expect(result?.indices).to.be.equal(expected_hits[i])
       }
     })
 
@@ -139,8 +139,8 @@ describe("Glyph (using AnnularWedge as a concrete Glyph)", () => {
       ]
 
       for (let i = 0; i < geometries.length; i++) {
-        const result = glyph_view.hit_test(geometries[i])!
-        expect(result.indices).to.be.equal(expected_hits[i])
+        const result = glyph_view.hit_test(geometries[i])
+        expect(result?.indices).to.be.equal(expected_hits[i])
       }
     })
   })

--- a/bokehjs/test/unit/models/glyphs/hspan.ts
+++ b/bokehjs/test/unit/models/glyphs/hspan.ts
@@ -4,7 +4,6 @@ import type {DataOf} from "./_util"
 import {create_glyph_view} from "./_util"
 import {HSpan} from "@bokehjs/models/glyphs/hspan"
 import type {Geometry} from "@bokehjs/core/geometry"
-import {assert} from "@bokehjs/core/util/assert"
 
 describe("HSpan", () => {
 
@@ -48,17 +47,11 @@ describe("HSpan", () => {
       const result3 = glyph_view.hit_test(geometry3)
       const result4 = glyph_view.hit_test(geometry4)
 
-      assert(result0 != null)
-      assert(result1 != null)
-      assert(result2 != null)
-      assert(result3 != null)
-      assert(result4 != null)
-
-      expect(result0.indices).to.be.equal([0])
-      expect(result1.indices).to.be.equal([1])
-      expect(result2.indices).to.be.equal([2])
-      expect(result3.indices).to.be.equal([3])
-      expect(result4.indices).to.be.equal([])
+      expect(result0?.indices).to.be.equal([0])
+      expect(result1?.indices).to.be.equal([1])
+      expect(result2?.indices).to.be.equal([2])
+      expect(result3?.indices).to.be.equal([3])
+      expect(result4?.indices).to.be.equal([])
     })
   })
 })

--- a/bokehjs/test/unit/models/glyphs/image_url.ts
+++ b/bokehjs/test/unit/models/glyphs/image_url.ts
@@ -1,4 +1,4 @@
-import {expect} from "assertions"
+import {expect, expect_not_null} from "assertions"
 
 import {create_glyph_view} from "./_util"
 import {ImageURL} from "@bokehjs/models/glyphs/image_url"
@@ -41,8 +41,8 @@ describe("ImageURL module", () => {
 
       // TODO await
       const image = image_url_view.image[0]
-      expect(image).to.not.be.null
-      expect(image!.src).to.be.equal("image.jpg") // XXX: null
+      expect_not_null(image)
+      expect(image.src).to.be.equal("image.jpg")
     })
 
     it("`_map_data` should correctly map data if w and h units are 'data'", async () => {

--- a/bokehjs/test/unit/models/glyphs/rect.ts
+++ b/bokehjs/test/unit/models/glyphs/rect.ts
@@ -67,13 +67,13 @@ describe("Glyph (using Rect as a concrete Glyph)", () => {
       const geometry2: Geometry = {type: "rect", sx0: 60, sy0: 210, sx1: 80,  sy1: 150}
       const geometry3: Geometry = {type: "rect", sx0: 0,  sy0:  50, sx1: 200, sy1:  59}
 
-      const result1 = glyph_view.hit_test(geometry1)!
-      const result2 = glyph_view.hit_test(geometry2)!
-      const result3 = glyph_view.hit_test(geometry3)!
+      const result1 = glyph_view.hit_test(geometry1)
+      const result2 = glyph_view.hit_test(geometry2)
+      const result3 = glyph_view.hit_test(geometry3)
 
-      expect(result1.indices).to.be.equal([0])
-      expect(result2.indices).to.be.equal([1])
-      expect(result3.indices).to.be.equal([])
+      expect(result1?.indices).to.be.equal([0])
+      expect(result2?.indices).to.be.equal([1])
+      expect(result3?.indices).to.be.equal([])
     })
   })
 })
@@ -195,13 +195,13 @@ describe("Rect", () => {
           const data = {x: [60, 100, 140], y: [60, 100, 140]}
           const glyph_view = await create_glyph_view(glyph, data, {axis_type: "linear"})
 
-          const result1 = glyph_view.hit_test(geometry1)!
-          const result2 = glyph_view.hit_test(geometry2)!
-          const result3 = glyph_view.hit_test(geometry3)!
+          const result1 = glyph_view.hit_test(geometry1)
+          const result2 = glyph_view.hit_test(geometry2)
+          const result3 = glyph_view.hit_test(geometry3)
 
-          expect(result1.indices).to.be.equal([1])
-          expect(result2.indices).to.be.equal([1])
-          expect(result3.indices).to.be.equal([])
+          expect(result1?.indices).to.be.equal([1])
+          expect(result2?.indices).to.be.equal([1])
+          expect(result3?.indices).to.be.equal([])
         })
 
         it("should work when width and height units are 'screen'", async () => {
@@ -211,13 +211,13 @@ describe("Rect", () => {
           const data = {x: [60, 100, 140], y: [60, 100, 140]}
           const glyph_view = await create_glyph_view(glyph, data, {axis_type: "linear"})
 
-          const result1 = glyph_view.hit_test(geometry1)!
-          const result2 = glyph_view.hit_test(geometry2)!
-          const result3 = glyph_view.hit_test(geometry3)!
+          const result1 = glyph_view.hit_test(geometry1)
+          const result2 = glyph_view.hit_test(geometry2)
+          const result3 = glyph_view.hit_test(geometry3)
 
-          expect(result1.indices).to.be.equal([])
-          expect(result2.indices).to.be.equal([1])
-          expect(result3.indices).to.be.equal([])
+          expect(result1?.indices).to.be.equal([])
+          expect(result2?.indices).to.be.equal([1])
+          expect(result3?.indices).to.be.equal([])
         })
 
         it("should work when rects are rotated", async () => {
@@ -232,13 +232,13 @@ describe("Rect", () => {
           const data = {x: [60, 100, 140], y: [60, 100, 140]}
           const glyph_view = await create_glyph_view(glyph, data, {axis_type: "linear"})
 
-          const result1 = glyph_view.hit_test(geometry1)!
-          const result2 = glyph_view.hit_test(geometry2)!
-          const result3 = glyph_view.hit_test(geometry3)!
+          const result1 = glyph_view.hit_test(geometry1)
+          const result2 = glyph_view.hit_test(geometry2)
+          const result3 = glyph_view.hit_test(geometry3)
 
-          expect(result1.indices).to.be.equal([])
-          expect(result2.indices).to.be.equal([])
-          expect(result3.indices).to.be.equal([1])
+          expect(result1?.indices).to.be.equal([])
+          expect(result2?.indices).to.be.equal([])
+          expect(result3?.indices).to.be.equal([1])
         })
 
         /*
@@ -269,13 +269,13 @@ describe("Rect", () => {
           glyph_view.renderer.plot_view.frame.xscales.default = xscale
           glyph_view.renderer.plot_view.frame.yscales.default = yscale
 
-          const result1 = glyph_view.hit_test({type: "point", sx: 105, sy:   0})!
-          const result2 = glyph_view.hit_test({type: "point", sx: 105, sy: -20})!
-          const result3 = glyph_view.hit_test({type: "point", sx: 91,  sy:  14})!
+          const result1 = glyph_view.hit_test({type: "point", sx: 105, sy:   0})
+          const result2 = glyph_view.hit_test({type: "point", sx: 105, sy: -20})
+          const result3 = glyph_view.hit_test({type: "point", sx: 91,  sy:  14})
 
-          expect(result1.indices).to.be.equal([1])
-          expect(result2.indices).to.be.equal([])
-          expect(result3.indices).to.be.equal([1])
+          expect(result1?.indices).to.be.equal([1])
+          expect(result2?.indices).to.be.equal([])
+          expect(result3?.indices).to.be.equal([1])
         })
         */
 
@@ -283,11 +283,11 @@ describe("Rect", () => {
           const data = {x: [1, 10, 100, 1000], y: [1, 10, 100, 1000]}
           const glyph_view = await create_glyph_view(glyph, data, {axis_type: "log"})
 
-          const result4 = glyph_view.hit_test({type: "point", sx: 66.666,  sy: 133.333})!
-          const result5 = glyph_view.hit_test({type: "point", sx: 133.333, sy:  66.666})!
+          const result4 = glyph_view.hit_test({type: "point", sx: 66.666,  sy: 133.333})
+          const result5 = glyph_view.hit_test({type: "point", sx: 133.333, sy:  66.666})
 
-          expect(result4.indices).to.be.equal([])  // XXX: this seems to be a hit if not for intermediate NaNs
-          expect(result5.indices).to.be.equal([2])
+          expect(result4?.indices).to.be.equal([])  // XXX: this seems to be a hit if not for intermediate NaNs
+          expect(result5?.indices).to.be.equal([2])
         })
       })
     })

--- a/bokehjs/test/unit/models/glyphs/vspan.ts
+++ b/bokehjs/test/unit/models/glyphs/vspan.ts
@@ -4,7 +4,6 @@ import type {DataOf} from "./_util"
 import {create_glyph_view} from "./_util"
 import {VSpan} from "@bokehjs/models/glyphs/vspan"
 import type {Geometry} from "@bokehjs/core/geometry"
-import {assert} from "@bokehjs/core/util/assert"
 
 describe("VSpan", () => {
 
@@ -48,17 +47,11 @@ describe("VSpan", () => {
       const result3 = glyph_view.hit_test(geometry3)
       const result4 = glyph_view.hit_test(geometry4)
 
-      assert(result0 != null)
-      assert(result1 != null)
-      assert(result2 != null)
-      assert(result3 != null)
-      assert(result4 != null)
-
-      expect(result0.indices).to.be.equal([0])
-      expect(result1.indices).to.be.equal([1])
-      expect(result2.indices).to.be.equal([2])
-      expect(result3.indices).to.be.equal([3])
-      expect(result4.indices).to.be.equal([])
+      expect(result0?.indices).to.be.equal([0])
+      expect(result1?.indices).to.be.equal([1])
+      expect(result2?.indices).to.be.equal([2])
+      expect(result3?.indices).to.be.equal([3])
+      expect(result4?.indices).to.be.equal([])
     })
   })
 })

--- a/bokehjs/test/unit/models/glyphs/wedge.ts
+++ b/bokehjs/test/unit/models/glyphs/wedge.ts
@@ -47,8 +47,8 @@ describe("Glyph (using Wedge as a concrete Glyph)", () => {
       ]
 
       for (let i = 0; i < geometries.length; i++) {
-        const result = glyph_view.hit_test(geometries[i])!
-        expect(result.indices).to.be.equal(expected_hits[i])
+        const result = glyph_view.hit_test(geometries[i])
+        expect(result?.indices).to.be.equal(expected_hits[i])
       }
 
       // Re-run hit tests with double the Y scale, keeping its center the same.
@@ -57,8 +57,8 @@ describe("Glyph (using Wedge as a concrete Glyph)", () => {
       glyph_renderer.yscale.source_range.start -= 100
       glyph_renderer.yscale.source_range.end += 100
       for (let i = 0; i < geometries.length; i++) {
-        const result = glyph_view.hit_test(geometries[i])!
-        expect(result.indices).to.be.equal(expected_hits[i])
+        const result = glyph_view.hit_test(geometries[i])
+        expect(result?.indices).to.be.equal(expected_hits[i])
       }
     })
 
@@ -103,8 +103,8 @@ describe("Glyph (using Wedge as a concrete Glyph)", () => {
       ]
 
       for (let i = 0; i < geometries.length; i++) {
-        const result = glyph_view.hit_test(geometries[i])!
-        expect(result.indices).to.be.equal(expected_hits[i])
+        const result = glyph_view.hit_test(geometries[i])
+        expect(result?.indices).to.be.equal(expected_hits[i])
       }
     })
   })

--- a/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
@@ -1,6 +1,6 @@
 import * as sinon from "sinon"
 
-import {expect} from "assertions"
+import {expect, expect_not_null} from "assertions"
 import {display} from "../../_util"
 
 import {Selection} from "@bokehjs/models/selections/selection"
@@ -95,8 +95,8 @@ describe("GraphHitTestPolicy", () => {
         edge_stub.returns(new Selection({indices: [1, 2]}))
         const policy = new EdgesOnly()
         const result = policy.hit_test({type: "point", sx: 0, sy: 0}, gv)
-        expect(result).to.not.be.null
-        expect(result!.indices).to.be.equal([1, 2])
+        expect_not_null(result)
+        expect(result.indices).to.be.equal([1, 2])
       })
     })
 
@@ -168,8 +168,8 @@ describe("GraphHitTestPolicy", () => {
         node_stub.returns(new Selection({indices: [1, 2, 3]}))
         const policy = new NodesOnly()
         const result = policy.hit_test({type: "point", sx: 0, sy: 0}, gv)
-        expect(result).to.not.be.null
-        expect(result!.indices).to.be.equal([1, 2, 3])
+        expect_not_null(result)
+        expect(result.indices).to.be.equal([1, 2, 3])
       })
     })
 

--- a/bokehjs/test/unit/models/grids/grid.ts
+++ b/bokehjs/test/unit/models/grids/grid.ts
@@ -23,7 +23,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker})
     plot.add_layout(grid, "center")
     const {view: plot_view} = await display(plot)
-    const grid_view = plot_view.renderer_view(grid)!
+    const grid_view = plot_view.owner.get_one(grid)
 
     expect(grid_view.computed_bounds()).to.be.equal([2, 8])
   })
@@ -40,7 +40,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker})
     plot.add_layout(grid, "center")
     const {view: plot_view} = await display(plot)
-    const grid_view = plot_view.renderer_view(grid)!
+    const grid_view = plot_view.owner.get_one(grid)
 
     expect(grid_view.computed_bounds()).to.be.equal([0, 10])
   })
@@ -57,7 +57,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker, bounds: [1, 9]})
     plot.add_layout(grid, "center")
     const {view: plot_view} = await display(plot)
-    const grid_view = plot_view.renderer_view(grid)!
+    const grid_view = plot_view.owner.get_one(grid)
 
     expect(grid_view.computed_bounds()).to.be.equal([1, 9])
   })
@@ -74,7 +74,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker})
     plot.add_layout(grid, "center")
     const {view: plot_view} = await display(plot)
-    const grid_view = plot_view.renderer_view(grid)!
+    const grid_view = plot_view.owner.get_one(grid)
 
     expect(grid_view.grid_coords("major")).to.be.equal([
       [[2, 2],     [4, 4],     [6, 6],     [8, 8]    ],
@@ -94,7 +94,7 @@ describe("Grid", () => {
     const grid = new Grid({ticker})
     plot.add_layout(grid, "center")
     const {view: plot_view} = await display(plot)
-    const grid_view = plot_view.renderer_view(grid)!
+    const grid_view = plot_view.owner.get_one(grid)
 
     expect(grid_view.grid_coords("major", false)).to.be.equal([
       [[0.1, 0.1], [2, 2],     [4, 4],     [6, 6],     [8, 8],     [9.9, 9.9]],
@@ -114,7 +114,7 @@ describe("Grid", () => {
     const grid = new Grid({axis})
     plot.add_layout(grid, "center")
     const {view: plot_view} = await display(plot)
-    const grid_view = plot_view.renderer_view(grid)!
+    const grid_view = plot_view.owner.get_one(grid)
 
     expect(grid_view.grid_coords("major", false)).to.be.equal([
       [[0.1, 0.1], [2, 2],     [4, 4],     [6, 6],     [8, 8],     [9.9, 9.9]],
@@ -137,7 +137,7 @@ describe("Grid", () => {
     const grid = new Grid({axis, ticker})
     plot.add_layout(grid, "center")
     const {view: plot_view} = await display(plot)
-    const grid_view = plot_view.renderer_view(grid)!
+    const grid_view = plot_view.owner.get_one(grid)
 
     expect(grid_view.grid_coords("major", false)).to.be.equal([
       [[0.1, 0.1], [2, 2],     [4, 4],     [6, 6],     [8, 8],     [9.9, 9.9]],

--- a/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_in_tool.ts
@@ -3,7 +3,6 @@ import {display} from "../../../_util"
 
 import type {Tool} from "@bokehjs/models/tools/tool"
 import {ZoomInTool} from "@bokehjs/models/tools/actions/zoom_in_tool"
-import type {ZoomBaseToolView} from "@bokehjs/models/tools/actions/zoom_base_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import type {PlotView} from "@bokehjs/models/plots/plot"
 import {Plot} from "@bokehjs/models/plots/plot"
@@ -49,7 +48,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool()
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomBaseToolView
+      const zoom_in_tool_view = plot_view.owner.get_one(zoom_in_tool)
 
       // perform the tool action
       zoom_in_tool_view.doit()
@@ -65,7 +64,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool({dimensions: "width"})
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomBaseToolView
+      const zoom_in_tool_view = plot_view.owner.get_one(zoom_in_tool)
 
       // perform the tool action
       zoom_in_tool_view.doit()
@@ -81,7 +80,7 @@ describe("ZoomInTool", () => {
       const zoom_in_tool = new ZoomInTool({dimensions: "height"})
       const plot_view = await mkplot(zoom_in_tool)
 
-      const zoom_in_tool_view = plot_view.tool_views.get(zoom_in_tool)! as ZoomBaseToolView
+      const zoom_in_tool_view = plot_view.owner.get_one(zoom_in_tool)
 
       // perform the tool action
       zoom_in_tool_view.doit()

--- a/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
+++ b/bokehjs/test/unit/models/tools/actions/zoom_out_tool.ts
@@ -3,7 +3,6 @@ import {display} from "../../../_util"
 
 import type {Tool} from "@bokehjs/models/tools/tool"
 import {ZoomOutTool} from "@bokehjs/models/tools/actions/zoom_out_tool"
-import type {ZoomBaseToolView} from "@bokehjs/models/tools/actions/zoom_base_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import type {PlotView} from "@bokehjs/models/plots/plot"
 import {Plot} from "@bokehjs/models/plots/plot"
@@ -49,7 +48,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool()
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomBaseToolView
+      const zoom_out_tool_view = plot_view.owner.get_one(zoom_out_tool)
 
       // perform the tool action
       zoom_out_tool_view.doit()
@@ -65,7 +64,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool({dimensions: "width"})
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomBaseToolView
+      const zoom_out_tool_view = plot_view.owner.get_one(zoom_out_tool)
 
       // perform the tool action
       zoom_out_tool_view.doit()
@@ -81,7 +80,7 @@ describe("ZoomOutTool", () => {
       const zoom_out_tool = new ZoomOutTool({dimensions: "height"})
       const plot_view = await mkplot(zoom_out_tool)
 
-      const zoom_out_tool_view = plot_view.tool_views.get(zoom_out_tool)! as ZoomBaseToolView
+      const zoom_out_tool_view = plot_view.owner.get_one(zoom_out_tool)
 
       // perform the tool action
       zoom_out_tool_view.doit()

--- a/bokehjs/test/unit/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/box_edit_tool.ts
@@ -60,7 +60,7 @@ async function make_testcase(): Promise<BoxEditTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as BoxEditToolView
+  const draw_tool_view = plot_view.owner.get_one(draw_tool)
   plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
 
   return {

--- a/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
@@ -57,7 +57,7 @@ async function make_testcase(): Promise<FreehandDrawTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as FreehandDrawToolView
+  const draw_tool_view = plot_view.owner.get_one(draw_tool)
   plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
   sinon.stub(glyph_renderer_view, "set_data")
 

--- a/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
@@ -53,7 +53,7 @@ async function make_testcase(): Promise<PointDrawTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as PointDrawToolView
+  const draw_tool_view = plot_view.owner.get_one(draw_tool)
   plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
 
   return {

--- a/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
@@ -56,7 +56,7 @@ async function make_testcase(): Promise<PolyDrawTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as PolyDrawToolView
+  const draw_tool_view = plot_view.owner.get_one(draw_tool)
   plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
   sinon.stub(glyph_renderer_view, "set_data")
 

--- a/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
@@ -73,7 +73,7 @@ async function make_testcase(): Promise<PolyEditTestCase> {
   plot.add_tools(draw_tool)
   await plot_view.ready
 
-  const draw_tool_view = plot_view.tool_views.get(draw_tool)! as PolyEditToolView
+  const draw_tool_view = plot_view.owner.get_one(draw_tool)
   plot_view.renderer_views.set(glyph_renderer, glyph_renderer_view)
   plot_view.renderer_views.set(vertex_renderer, vertex_renderer_view)
 

--- a/bokehjs/test/unit/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/box_zoom_tool.ts
@@ -3,7 +3,6 @@ import {display} from "../../../_util"
 import {click} from "../../../../interactive"
 
 import type {Tool} from "@bokehjs/models/tools/tool"
-import type {BoxZoomToolView} from "@bokehjs/models/tools/gestures/box_zoom_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import {Plot} from "@bokehjs/models/plots/plot"
 import {BoxZoomTool, PanTool, Toolbar} from "@bokehjs/models"
@@ -88,7 +87,7 @@ describe("BoxZoomTool", () => {
       const box_zoom = new BoxZoomTool()
       const {plot_view} = await mkplot(box_zoom)
 
-      const box_zoom_view = plot_view.tool_views.get(box_zoom)! as BoxZoomToolView
+      const box_zoom_view = plot_view.owner.get_one(box_zoom)
 
       // perform the tool action
       const zoom_event0 = {type: "pan" as "pan", sx: 200, sy: 100, dx: 0, dy: 0, scale: 1, modifiers: {ctrl: false, shift: false, alt: false}}
@@ -108,7 +107,7 @@ describe("BoxZoomTool", () => {
       const box_zoom = new BoxZoomTool({match_aspect: true})
       const {plot_view} = await mkplot(box_zoom)
 
-      const box_zoom_view = plot_view.tool_views.get(box_zoom)! as BoxZoomToolView
+      const box_zoom_view = plot_view.owner.get_one(box_zoom)
 
       // perform the tool action
       const zoom_event0 = {type: "pan" as "pan", sx: 200, sy: 200, dx: 0, dy: 0, scale: 1, modifiers: {ctrl: false, shift: false, alt: false}}

--- a/bokehjs/test/unit/models/tools/gestures/wheel_pan_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/wheel_pan_tool.ts
@@ -2,7 +2,6 @@ import {expect} from "assertions"
 import {display} from "../../../_util"
 
 import type {Tool} from "@bokehjs/models/tools/tool"
-import type {WheelPanToolView} from "@bokehjs/models/tools/gestures/wheel_pan_tool"
 import {WheelPanTool} from "@bokehjs/models/tools/gestures/wheel_pan_tool"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import type {PlotView} from "@bokehjs/models/plots/plot"
@@ -42,7 +41,7 @@ describe("WheelPanTool", () => {
       const x_wheel_pan_tool = new WheelPanTool()
       const plot_view = await mkplot(x_wheel_pan_tool)
 
-      const wheel_pan_tool_view = plot_view.tool_views.get(x_wheel_pan_tool)! as WheelPanToolView
+      const wheel_pan_tool_view = plot_view.owner.get_one(x_wheel_pan_tool)
 
       // negative factors move in positive x-data direction
       wheel_pan_tool_view._update_ranges(-0.5)
@@ -60,7 +59,7 @@ describe("WheelPanTool", () => {
       const x_wheel_pan_tool = new WheelPanTool({dimension: "height"})
       const plot_view = await mkplot(x_wheel_pan_tool)
 
-      const wheel_pan_tool_view = plot_view.tool_views.get(x_wheel_pan_tool)! as WheelPanToolView
+      const wheel_pan_tool_view = plot_view.owner.get_one(x_wheel_pan_tool)
 
       // positive factors move in positive y-data direction
       wheel_pan_tool_view._update_ranges(0.75)

--- a/bokehjs/test/unit/models/tools/inspectors/customjs_hover.ts
+++ b/bokehjs/test/unit/models/tools/inspectors/customjs_hover.ts
@@ -1,4 +1,4 @@
-import {expect} from "assertions"
+import {expect, expect_instanceof} from "assertions"
 
 import {CustomJSHover} from "@bokehjs/models/tools/inspectors/customjs_hover"
 
@@ -9,42 +9,44 @@ import {version as js_version} from "@bokehjs/version"
 describe("CustomJSHover", () => {
 
   describe("default constructor", () => {
-    const r = new CustomJSHover()
+    const customjs_hover = new CustomJSHover()
 
     it("should have empty args", () => {
-      expect(r.args).to.be.equal({})
+      expect(customjs_hover.args).to.be.equal({})
     })
 
     it("should have empty code", () => {
-      expect(r.code).to.be.equal("")
+      expect(customjs_hover.code).to.be.equal("")
     })
   })
 
   describe("values property", () => {
-    const rng = new Range1d()
-    const r = new CustomJSHover({args: {foo: rng}})
+    const range = new Range1d()
+    const customjs_hover = new CustomJSHover({args: {foo: range}})
 
     it("should contain the args values", () => {
-      expect(r.values).to.be.equal([rng])
+      expect(customjs_hover.values).to.be.equal([range])
     })
 
     it("should round-trip through document serialization", () => {
       const d = new Document()
-      d.add_root(r)
+      d.add_root(customjs_hover)
       const json = d.to_json_string()
       const parsed = JSON.parse(json)
       parsed.version = js_version
       const copy = Document.from_json_string(JSON.stringify(parsed))
-      const r_copy = copy.get_model_by_id(r.id)! as CustomJSHover
-      const rng_copy = copy.get_model_by_id(rng.id)! as CustomJSHover
-      expect(r.values).to.be.equal([rng])
-      expect(r_copy.values).to.be.equal([rng_copy])
+      const customjs_hover_copy = copy.get_model_by_id(customjs_hover.id)
+      const range_copy = copy.get_model_by_id(range.id)
+      expect_instanceof(customjs_hover_copy, CustomJSHover)
+      expect_instanceof(range_copy, Range1d)
+      expect(customjs_hover.values).to.be.equal([range])
+      expect(customjs_hover_copy.values).to.be.equal([range_copy])
     })
 
     it("should update when args changes", () => {
       const rng2 = new Range1d()
-      r.args = {foo: rng2}
-      expect(r.values).to.be.equal([rng2])
+      customjs_hover.args = {foo: rng2}
+      expect(customjs_hover.values).to.be.equal([rng2])
     })
   })
 

--- a/bokehjs/test/unit/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/test/unit/models/tools/inspectors/hover_tool.ts
@@ -1,7 +1,6 @@
-import {expect} from "assertions"
+import {expect, expect_not_null} from "assertions"
 import {display, fig} from "../../../_util"
 
-import {assert} from "@bokehjs/core/util/assert"
 import type {CircleView} from "@bokehjs/models/glyphs/circle"
 import {Circle} from "@bokehjs/models/glyphs/circle"
 import {Plot} from "@bokehjs/models/plots/plot"
@@ -58,21 +57,21 @@ describe("HoverTool", () => {
       }
 
       const el0 = hover_view._render_tooltips(data_source, vars)
-      assert(el0 != null)
+      expect_not_null(el0)
       expect(el0.childElementCount).to.be.equal(3)
 
       hover_view.model.tooltips = [["foo", "$x"]]
       await hover_view.ready
 
       const el1 = hover_view._render_tooltips(data_source, vars)
-      assert(el1 != null)
+      expect_not_null(el1)
       expect(el1.childElementCount).to.be.equal(1)
 
       hover_view.model.tooltips = "<b>foo</b> is <i>$x</i>"
       await hover_view.ready
 
       const el2 = hover_view._render_tooltips(data_source, vars)
-      assert(el2 != null)
+      expect_not_null(el2)
       expect(el2.childElementCount).to.be.equal(2)
     })
   })
@@ -133,7 +132,7 @@ describe("HoverTool", () => {
     }
 
     const el = hover_view._render_tooltips(r.data_source, vars)
-    assert(el != null)
+    expect_not_null(el)
 
     const html =
 `

--- a/bokehjs/test/unit/models/tools/toolbar.ts
+++ b/bokehjs/test/unit/models/tools/toolbar.ts
@@ -2,7 +2,6 @@ import {expect} from "assertions"
 import {fig, display} from "../../_util"
 
 import {Toolbar} from "@bokehjs/models/tools/toolbar"
-import {ToolbarPanelView} from "@bokehjs/models/annotations/toolbar_panel"
 import {HoverTool} from "@bokehjs/models/tools/inspectors/hover_tool"
 import {SelectTool} from "@bokehjs/models/tools/gestures/select_tool"
 import {PanTool} from "@bokehjs/models/tools/gestures/pan_tool"
@@ -65,22 +64,22 @@ describe("Toolbar", () => {
       p.rect({x: [0, 1], y: [0, 1], width: 1, height: 1, color: ["red", "blue"]})
 
       const {view} = await display(p)
-      const tpv = [...view.renderer_views.values()].find((rv): rv is ToolbarPanelView => rv instanceof ToolbarPanelView)!
+      const toolbar_view = view.owner.get_one(p.toolbar)
 
-      expect(tpv.toolbar_view.visible).to.be.false
-      expect(tpv.toolbar_view.el.classList.contains("bk-hidden")).to.be.true
+      expect(toolbar_view.visible).to.be.false
+      expect(toolbar_view.el.classList.contains("bk-hidden")).to.be.true
 
       const ev0 = new MouseEvent("mouseenter", {clientX: 0, clientY: 0})
       view.el.dispatchEvent(ev0)
 
-      expect(tpv.toolbar_view.visible).to.be.true
-      expect(tpv.toolbar_view.el.classList.contains("bk-hidden")).to.be.false
+      expect(toolbar_view.visible).to.be.true
+      expect(toolbar_view.el.classList.contains("bk-hidden")).to.be.false
 
       const ev1 = new MouseEvent("mouseleave", {clientX: 0, clientY: 0})
       view.el.dispatchEvent(ev1)
 
-      expect(tpv.toolbar_view.visible).to.be.false
-      expect(tpv.toolbar_view.el.classList.contains("bk-hidden")).to.be.true
+      expect(toolbar_view.visible).to.be.false
+      expect(toolbar_view.el.classList.contains("bk-hidden")).to.be.true
     })
 
     it("in grid plots", async () => {

--- a/bokehjs/test/unit/models/widgets/checkbox_button_group.ts
+++ b/bokehjs/test/unit/models/widgets/checkbox_button_group.ts
@@ -1,6 +1,6 @@
 import * as sinon from "sinon"
 
-import {expect} from "assertions"
+import {expect, expect_not_null} from "assertions"
 import {display} from "../../_util"
 
 import {CheckboxButtonGroup} from "@bokehjs/models/widgets/checkbox_button_group"
@@ -34,7 +34,8 @@ describe("CheckboxButtonGroup", () => {
       expect(g.active).to.be.equal([0, 1, 2])
 
       const button = view.shadow_el.querySelector<HTMLElement>(".bk-btn:nth-child(1)")
-      button!.click()
+      expect_not_null(button)
+      button.click()
 
       expect(spy.callCount).to.be.equal(1)
       expect(g.active).to.be.equal([1, 2])

--- a/bokehjs/test/unit/models/widgets/paragraph.ts
+++ b/bokehjs/test/unit/models/widgets/paragraph.ts
@@ -1,4 +1,4 @@
-import {expect} from "assertions"
+import {expect, expect_not_null} from "assertions"
 import {display} from "../../_util"
 
 import {Paragraph} from "@bokehjs/models/widgets/paragraph"
@@ -9,7 +9,8 @@ describe("Paragraph.View render", () => {
     const p = new Paragraph()
     const {view: pv} = await display(p, null)
 
-    const el = pv.shadow_el.querySelector<HTMLElement>("p")!
+    const el = pv.shadow_el.querySelector<HTMLElement>("p")
+    expect_not_null(el)
     expect(el.style.cssText.includes("margin: 0px;")).to.be.true
     // TODO: expect(getComputedStyle(el).margin).to.be.equal("0px")
   })

--- a/bokehjs/test/unit/protocol/receiver.ts
+++ b/bokehjs/test/unit/protocol/receiver.ts
@@ -1,4 +1,4 @@
-import {expect} from "assertions"
+import {expect, expect_instanceof} from "assertions"
 
 import {Message} from "@bokehjs/protocol/message"
 import {Receiver} from "@bokehjs/protocol/receiver"
@@ -49,8 +49,8 @@ describe("protocol/receiver module", () => {
         it("should should set a complete message", () => {
           const res = r.consume('{"bar": "20"}')
           expect(res).to.be.undefined
-          expect(r.message).to.be.instanceof(Message)
-          expect(r.message!.complete()).to.be.true
+          expect_instanceof(r.message, Message)
+          expect(r.message.complete()).to.be.true
         })
 
         it("should throw an error on binary data", () => {
@@ -162,9 +162,9 @@ describe("protocol/receiver module", () => {
         it("should should set a complete message", () => {
           const res = r.consume(new ArrayBuffer(20))
           expect(res).to.be.undefined
-          expect(r.message).to.be.instanceof(Message)
-          expect(r.message!.complete()).to.be.true
-          const {buffers} = r.message!
+          expect_instanceof(r.message, Message)
+          expect(r.message.complete()).to.be.true
+          const {buffers} = r.message
           expect(buffers.size).to.be.equal(2)
           const entries = [...buffers.entries()]
           expect(entries[0][0]).to.be.equal("1")

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon"
 
-import {expect} from "assertions"
+import {expect, expect_instanceof} from "assertions"
 import {display, fig, restorable} from "./_util"
 import {PlotActions, xy, click} from "../interactive"
 
@@ -38,7 +38,6 @@ import {
 import {version} from "@bokehjs/version"
 import {Model} from "@bokehjs/model"
 import * as p from "@bokehjs/core/properties"
-import {assert} from "@bokehjs/core/util/assert"
 import {is_equal} from "@bokehjs/core/util/eq"
 import {linspace} from "@bokehjs/core/util/array"
 import {ndarray} from "@bokehjs/core/util/ndarray"
@@ -214,7 +213,7 @@ describe("Bug", () => {
         plot.title = "some title"
       }
       set_title()                         // indirection to deal with type narrowing to string
-      assert(plot.title instanceof Title) // expect() can't narrow types
+      expect_instanceof(plot.title, Title) // expect() can't narrow types
       plot.title.text = "other title"
       expect(plot.title).to.be.instanceof(Title)
       expect(plot.title.text).to.be.equal("other title")
@@ -788,44 +787,34 @@ describe("Bug", () => {
       }
 
       const result0 = rv.hit_test({type: "point", ...at(2, 2)})
-      assert(result0 != null)
-      expect(result0.indices).to.be.equal([])
+      expect(result0?.indices).to.be.equal([])
 
       const result1 = rv.hit_test({type: "point", ...at(3, 3)})
-      assert(result1 != null)
-      expect(result1.indices).to.be.equal([2])
+      expect(result1?.indices).to.be.equal([2])
 
       const result2 = rv.hit_test({type: "span", direction: "h", ...at(2, 2)})
-      assert(result2 != null)
-      expect(result2.indices).to.be.equal([])
+      expect(result2?.indices).to.be.equal([])
 
       const result3 = rv.hit_test({type: "span", direction: "h", ...at(3, 3)})
-      assert(result3 != null)
-      expect(result3.indices).to.be.equal([2])
+      expect(result3?.indices).to.be.equal([2])
 
       const result4 = rv.hit_test({type: "span", direction: "v", ...at(2, 2)})
-      assert(result4 != null)
-      expect(result4.indices).to.be.equal([])
+      expect(result4?.indices).to.be.equal([])
 
       const result5 = rv.hit_test({type: "span", direction: "v", ...at(3, 3)})
-      assert(result5 != null)
-      expect(result5.indices).to.be.equal([2])
+      expect(result5?.indices).to.be.equal([2])
 
       const result6 = rv.hit_test({type: "rect", ...rect(1.5, 1.5, 2.5, 2.5)})
-      assert(result6 != null)
-      expect(result6.indices).to.be.equal([])
+      expect(result6?.indices).to.be.equal([])
 
       const result7 = rv.hit_test({type: "rect", ...rect(2.5, 2.5, 3.5, 3.5)})
-      assert(result7 != null)
-      expect(result7.indices).to.be.equal([2])
+      expect(result7?.indices).to.be.equal([2])
 
       const result8 = rv.hit_test({type: "poly", ...poly(1.5, 1.5, 2.5, 2.5)})
-      assert(result8 != null)
-      expect(result8.indices).to.be.equal([])
+      expect(result8?.indices).to.be.equal([])
 
       const result9 = rv.hit_test({type: "poly", ...poly(2.5, 2.5, 3.5, 3.5)})
-      assert(result9 != null)
-      expect(result9.indices).to.be.equal([2])
+      expect(result9?.indices).to.be.equal([2])
     })
   })
 


### PR DESCRIPTION
This mostly eliminates `!` non-null assertions and robustifies other kinds of expectations. For example, where previously either `!` or assertions were needed, write:
```ts
expect_not_null(obj)
expect(obj.attr).to.be.equal(0)
```
instead of:
```ts
assert(obj != null)
expect(obj.attr).to.be.equal(0)
```
or even worse
```ts
expect(obj!.attr).to.be.equal(0)
```