### PR TITLE
Improve `DataRangePicker`'s calendar click behavior

### DIFF
--- a/bokehjs/src/lib/models/widgets/date_picker.ts
+++ b/bokehjs/src/lib/models/widgets/date_picker.ts
@@ -15,21 +15,16 @@ export class DatePickerView extends BaseDatePickerView {
   }
 
   protected override _on_change(selected: Date[]): void {
-    switch (selected.length) {
-      case 0: {
-        this.model.value = null
-        break
-      }
-      case 1: {
+    assert(selected.length <= 1)
+    this.model.value = (() => {
+      if (selected.length == 0) {
+        return null
+      } else {
         const [datetime] = selected
         const date = this._format_date(datetime)
-        this.model.value = date
-        break
+        return date
       }
-      default: {
-        assert(false, "invalid length")
-      }
-    }
+    })()
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/date_range_picker.ts
+++ b/bokehjs/src/lib/models/widgets/date_range_picker.ts
@@ -20,9 +20,9 @@ export class DateRangePickerView extends BaseDatePickerView {
         this.model.value = null
         break
       case 1: {
-        const [datetime] = selected
-        const date = this._format_date(datetime)
-        this.model.value = [date, date]
+        // Selection in progress, so do nothing and wait for two selected
+        // dates. Single date selection is still possible and represented
+        // by [date, date] tuple.
         break
       }
       case 2: {

--- a/bokehjs/src/lib/models/widgets/datetime_picker.ts
+++ b/bokehjs/src/lib/models/widgets/datetime_picker.ts
@@ -16,21 +16,15 @@ export class DatetimePickerView extends BaseDatetimePickerView {
   }
 
   protected override _on_change(selected: Date[]): void {
-    switch (selected.length) {
-      case 0: {
-        this.model.value = null
-        break
-      }
-      case 1: {
+    assert(selected.length <= 1)
+    this.model.value = (() => {
+      if (selected.length == 0) {
+        return null
+      } else {
         const [datetime] = selected
-        const date = this._format_date(datetime)
-        this.model.value = date
-        break
+        return this._format_date(datetime)
       }
-      default: {
-        assert(false, "invalid length")
-      }
-    }
+    })()
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/datetime_range_picker.ts
+++ b/bokehjs/src/lib/models/widgets/datetime_range_picker.ts
@@ -21,9 +21,9 @@ export class DatetimeRangePickerView extends BaseDatetimePickerView {
         this.model.value = null
         break
       case 1: {
-        const [datetime] = selected
-        const date = this._format_date(datetime)
-        this.model.value = [date, date]
+        // Selection in progress, so do nothing and wait for two selected
+        // datetimes. Single datetime selection is still possible and represented
+        // by [datetime, datetime] tuple.
         break
       }
       case 2: {

--- a/bokehjs/src/lib/models/widgets/time_picker.ts
+++ b/bokehjs/src/lib/models/widgets/time_picker.ts
@@ -84,21 +84,15 @@ export class TimePickerView extends PickerBaseView {
   }
 
   protected _on_change(selected: Date[]): void {
-    switch (selected.length) {
-      case 0: {
-        this.model.value = null
-        break
-      }
-      case 1: {
+    assert(selected.length <= 1)
+    this.model.value = (() => {
+      if (selected.length == 0) {
+        return null
+      } else {
         const [datetime] = selected
-        const time = this._format_time(datetime)
-        this.model.value = time
-        break
+        return this._format_time(datetime)
       }
-      default: {
-        assert(false, "invalid length")
-      }
-    }
+    })()
   }
 }
 


### PR DESCRIPTION
I currently can't capture screencasts after a system upgrade. The behaviour is as one would expect from pure flatpickr, i.e. calendar click starts a range selection. To select a single date one needs to click a date twice.

TODO:

- [ ] tests

fixes #13462
