### PR TITLE
Fix unawaited promises and modernize interactive tests

### DIFF
--- a/bokehjs/eslint.js
+++ b/bokehjs/eslint.js
@@ -84,6 +84,7 @@ module.exports = {
       "FunctionExpression": {"body": 1, "parameters": "off"},
       "ignoredNodes": ["ConditionalExpression"],
     }],
+    "@typescript-eslint/no-floating-promises": ["error", {ignoreVoid: true}],
     "no-debugger": "error",
     "no-floating-decimal": ["error"],
     "no-multiple-empty-lines": ["error", {"max": 1, "maxBOF": 0, "maxEOF": 0}],

--- a/bokehjs/examples/anscombe/anscombe.ts
+++ b/bokehjs/examples/anscombe/anscombe.ts
@@ -75,5 +75,5 @@ export namespace Anscombe {
   doc.add_root(grid)
 
   const div = document.getElementById("plot")!
-  Bokeh.embed.add_document_standalone(doc, div)
+  void Bokeh.embed.add_document_standalone(doc, div)
 }

--- a/bokehjs/examples/burtin/burtin.ts
+++ b/bokehjs/examples/burtin/burtin.ts
@@ -151,5 +151,5 @@ export namespace Burtin {
     text_font_size: "12px", text_align: "left", text_baseline: "middle",
   })
 
-  plt.show(p)
+  void plt.show(p)
 }

--- a/bokehjs/examples/categorical/categorical.ts
+++ b/bokehjs/examples/categorical/categorical.ts
@@ -44,5 +44,5 @@ export namespace Categorical {
     return fig
   }
 
-  plt.show(new Row({children: [hm(), dot()], sizing_mode: "scale_width"}))
+  void plt.show(new Row({children: [hm(), dot()], sizing_mode: "scale_width"}))
 }

--- a/bokehjs/examples/charts/charts.ts
+++ b/bokehjs/examples/charts/charts.ts
@@ -33,5 +33,5 @@ export namespace Charts {
     [p21, p22, p23, p24],
   ]
 
-  plt.show(plt.gridplot(plots, {toolbar_location: null}))
+  void plt.show(plt.gridplot(plots, {toolbar_location: null}))
 }

--- a/bokehjs/examples/donut/donut.ts
+++ b/bokehjs/examples/donut/donut.ts
@@ -158,5 +158,5 @@ export namespace WebBrowserMarketShare {
     }
   }, 1000)
 
-  plt.show(fig)
+  void plt.show(fig)
 }

--- a/bokehjs/examples/hierarchical/hierarchical.ts
+++ b/bokehjs/examples/hierarchical/hierarchical.ts
@@ -33,5 +33,5 @@ export namespace Hierarchical {
 
   p.y_range.start = 0
 
-  show(p)
+  void show(p)
 }

--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -58,5 +58,5 @@ export namespace HoverfulScatter {
     return div
   }
 
-  plt.show(p)
+  void plt.show(p)
 }

--- a/bokehjs/examples/legends/legends.ts
+++ b/bokehjs/examples/legends/legends.ts
@@ -34,5 +34,5 @@ export namespace Legends {
   p2.square(x, y3, {legend_label: "3*sin(x)", fill_color: null, line_color: "green"})
   p2.line(x, y3, {legend_label: "3*sin(x)", line_color: "green"})
 
-  plt.show(new Bokeh.Column({children: [p1, p2]}))
+  void plt.show(new Bokeh.Column({children: [p1, p2]}))
 }

--- a/bokehjs/examples/linked/linked.ts
+++ b/bokehjs/examples/linked/linked.ts
@@ -29,5 +29,5 @@ export namespace LinkedBrushingAndPanning {
   const s3 = plt.figure({width: 350, height: 350, tools, x_range: s1.x_range})
   s3.circle(x, y3, {source, color: "olive", size: 8, alpha: 0.5})
 
-  plt.show(plt.gridplot([[s1, s2, s3]]))
+  void plt.show(plt.gridplot([[s1, s2, s3]]))
 }

--- a/bokehjs/examples/stocks/stocks.ts
+++ b/bokehjs/examples/stocks/stocks.ts
@@ -67,5 +67,5 @@ export namespace Stocks {
 
   // Create plot and attach to DOM
   const plot = make_plot("Simple stocks demo", source)
-  plt.show(plot, "#plot")
+  void plt.show(plot, "#plot")
 }

--- a/bokehjs/examples/tap/tap.ts
+++ b/bokehjs/examples/tap/tap.ts
@@ -59,5 +59,5 @@ export namespace TappyScatter {
     }
   }
 
-  plt.show(p)
+  void plt.show(p)
 }

--- a/bokehjs/make/main.ts
+++ b/bokehjs/make/main.ts
@@ -29,4 +29,4 @@ async function main(): Promise<void> {
   process.exit(0)
 }
 
-main()
+void main()

--- a/bokehjs/src/compiler/main.ts
+++ b/bokehjs/src/compiler/main.ts
@@ -79,4 +79,4 @@ async function main() {
   }
 }
 
-main()
+void main()

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -253,7 +253,7 @@ export class ClientConnection {
       this._current_handler = (message) => this._steady_state_handler(message)
 
       // Reload any sessions
-      this._repull_session_doc(resolve, reject)
+      void this._repull_session_doc(resolve, reject)
     } else {
       this._close_bad_protocol("First message was not an ACK")
     }

--- a/bokehjs/src/lib/core/signaling.ts
+++ b/bokehjs/src/lib/core/signaling.ts
@@ -187,8 +187,8 @@ function find_connection(conns: Connection[], signal: Signal<any, any>, slot: Sl
 const dirty_set = new Set<Connection[]>()
 
 function schedule_cleanup(connections: Connection[]): void {
-  if (dirty_set.size === 0) {
-    (async () => {
+  if (dirty_set.size == 0) {
+    void (async () => {
       await defer()
       cleanup_dirty_set()
     })()

--- a/bokehjs/src/lib/core/visuals/hatch.ts
+++ b/bokehjs/src/lib/core/visuals/hatch.ts
@@ -34,7 +34,7 @@ export class Hatch extends VisualProperties {
       const image = texture.get_pattern(color, alpha, scale, weight)
       if (image instanceof Promise) {
         const {_update_iteration} = this
-        image.then((image) => {
+        void image.then((image) => {
           if (this._update_iteration == _update_iteration) {
             finalize(image)
             this.obj.request_render()
@@ -144,7 +144,7 @@ export class HatchScalar extends VisualUniforms {
       const image = texture.get_pattern(color, alpha, scale, weight)
       if (image instanceof Promise) {
         const {_update_iteration} = this
-        image.then((image) => {
+        void image.then((image) => {
           if (this._update_iteration == _update_iteration) {
             finalize(image)
             this.obj.request_render()
@@ -250,7 +250,7 @@ export class HatchVector extends VisualUniforms {
         const image = texture.get_pattern(color, alpha, scale, weight)
         if (image instanceof Promise) {
           const {_update_iteration} = this
-          image.then((image) => {
+          void image.then((image) => {
             if (this._update_iteration == _update_iteration) {
               finalize(image)
               this.obj.request_render()

--- a/bokehjs/src/lib/core/visuals/text.ts
+++ b/bokehjs/src/lib/core/visuals/text.ts
@@ -22,7 +22,7 @@ function load_font(font: string, obj: Renderable): void {
 
   const {fonts} = document
   if (!fonts.check(font)) {
-    fonts.load(font).then(() => obj.request_render())
+    void fonts.load(font).then(() => obj.request_render())
   }
 }
 

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -396,7 +396,7 @@ export class Document implements Equatable {
     const callbacks = this._document_callbacks.get(event.event_name)
     if (callbacks != null) {
       for (const callback of callbacks) {
-        execute(callback, this, event)
+        void execute(callback, this, event)
       }
     }
   }

--- a/bokehjs/src/lib/embed/notebook.ts
+++ b/bokehjs/src/lib/embed/notebook.ts
@@ -77,7 +77,7 @@ function _init_comms(target: string, doc: Document): void {
   }
 }
 
-export function embed_items_notebook(docs_json: DocsJson, render_items: RenderItem[]): void {
+export async function embed_items_notebook(docs_json: DocsJson, render_items: RenderItem[]): Promise<void> {
   if (size(docs_json) != 1) {
     throw new Error("embed_items_notebook expects exactly one document in docs_json")
   }
@@ -92,7 +92,7 @@ export function embed_items_notebook(docs_json: DocsJson, render_items: RenderIt
     const element = _resolve_element(item)
     const roots = _resolve_root_elements(item)
 
-    add_document_standalone(document, element, roots)
+    await add_document_standalone(document, element, roots)
 
     for (const root of roots) {
       if (root instanceof HTMLElement) {

--- a/bokehjs/src/lib/embed/standalone.ts
+++ b/bokehjs/src/lib/embed/standalone.ts
@@ -94,7 +94,7 @@ export async function add_document_standalone(document: Document, element: Embed
 
   document.on_change((event) => {
     if (event instanceof RootAddedEvent) {
-      render_model(event.model)
+      void render_model(event.model)
     } else if (event instanceof RootRemovedEvent) {
       unrender_model(event.model)
     } else if (use_for_title && event instanceof TitleChangedEvent) {

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -75,7 +75,7 @@ export class Model extends HasProps {
 
   /*protected*/ _process_event(event: ModelEvent): void {
     for (const callback of dict(this.js_event_callbacks).get(event.event_name) ?? []) {
-      execute(callback, event)
+      void execute(callback, event)
     }
 
     if (this.document != null && this.subscribed_events.has(event.event_name)) {

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -497,7 +497,7 @@ export abstract class LayoutDOMView extends UIElementView {
       } else {
         // In case after_resize() wasn't called (see regression test for issue
         // #9113), then wait one macro task and consider this view finished.
-        defer().then(() => {
+        void defer().then(() => {
           if (!this._resized) {
             this.finish()
           }

--- a/bokehjs/src/lib/models/layouts/tabs.ts
+++ b/bokehjs/src/lib/models/layouts/tabs.ts
@@ -27,9 +27,9 @@ export class TabsView extends LayoutDOMView {
   override connect_signals(): void {
     super.connect_signals()
     const {tabs, active} = this.model.properties
-    this.on_change(tabs, () => {
+    this.on_change(tabs, async () => {
       this._update_headers()
-      this.update_children()
+      await this.update_children()
     })
     this.on_change(active, () => {
       this.update_active()

--- a/bokehjs/src/lib/models/plots/grid_plot.ts
+++ b/bokehjs/src/lib/models/plots/grid_plot.ts
@@ -50,12 +50,12 @@ export class GridPlotView extends LayoutDOMView {
     super.connect_signals()
 
     const {toolbar, toolbar_location, children, rows, cols, spacing} = this.model.properties
-    this.on_change(toolbar_location, () => {
+    this.on_change(toolbar_location, async () => {
       this._update_location()
-      this.rebuild()
+      await this.rebuild()
     })
-    this.on_change([toolbar, children, rows, cols, spacing], () => {
-      this.rebuild()
+    this.on_change([toolbar, children, rows, cols, spacing], async () => {
+      await this.rebuild()
     })
 
     this.on_change(this.model.toolbar.properties.tools, async () => {

--- a/bokehjs/src/lib/models/text/math_text.ts
+++ b/bokehjs/src/lib/models/text/math_text.ts
@@ -374,7 +374,7 @@ export abstract class MathTextView extends BaseTextView implements GraphicsBox {
       }
 
       if (this.provider.status == "loaded") {
-        this.load_image()
+        void this.load_image()
       }
     }
 

--- a/bokehjs/src/lib/models/tools/actions/copy_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/copy_tool.ts
@@ -12,7 +12,7 @@ export class CopyToolView extends ActionToolView {
   }
 
   doit(): void {
-    this.copy()
+    void this.copy()
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/custom_action.ts
+++ b/bokehjs/src/lib/models/tools/actions/custom_action.ts
@@ -10,7 +10,7 @@ export class CustomActionView extends ActionToolView {
   doit(): void {
     const {callback} = this.model
     if (callback != null) {
-      execute(callback, this.model)
+      void execute(callback, this.model)
     }
   }
 }

--- a/bokehjs/src/lib/models/tools/actions/fullscreen_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/fullscreen_tool.ts
@@ -13,14 +13,16 @@ const request_fullscreen = (() => {
 export class FullscreenToolView extends ActionToolView {
   declare model: FullscreenTool
 
-  doit(): void {
+  async fullscreen(): Promise<void> {
     if (document.fullscreenElement != null) {
-      document.exitFullscreen()
+      await document.exitFullscreen()
     } else {
-      (async () => {
-        await request_fullscreen(this.parent.el)
-      })()
+      await request_fullscreen(this.parent.el)
     }
+  }
+
+  doit(): void {
+    void this.fullscreen()
   }
 }
 

--- a/bokehjs/src/lib/models/tools/actions/save_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/save_tool.ts
@@ -26,12 +26,12 @@ export class SaveToolView extends ActionToolView {
       case "save": {
         const filename = this.model.filename ?? prompt("Enter filename", "bokeh_plot")
         if (filename != null) {
-          this.save(filename)
+          void this.save(filename)
         }
         break
       }
       case "copy": {
-        this.copy()
+        void this.copy()
         break
       }
     }

--- a/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/tap_tool.ts
@@ -99,7 +99,7 @@ export class TapToolView extends SelectToolView {
         source,
         event: {modifiers},
       }
-      execute(callback, this.model, data)
+      void execute(callback, this.model, data)
     }
   }
 }

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -496,7 +496,7 @@ export class HoverToolView extends InspectToolView {
 
       const index = renderer.data_source.inspected
 
-      execute(callback, this.model, {
+      void execute(callback, this.model, {
         geometry: {x, y, ...geometry},
         renderer,
         index,

--- a/bokehjs/src/lib/models/ui/pane.ts
+++ b/bokehjs/src/lib/models/ui/pane.ts
@@ -39,8 +39,8 @@ export class PaneView extends UIElementView {
   override connect_signals(): void {
     super.connect_signals()
     const {children} = this.model.properties
-    this.on_change(children, () => {
-      this._rebuild_views()
+    this.on_change(children, async () => {
+      await this._rebuild_views()
       this.render()
     })
   }

--- a/bokehjs/src/lib/models/widgets/dropdown.ts
+++ b/bokehjs/src/lib/models/widgets/dropdown.ts
@@ -102,7 +102,7 @@ export class DropdownView extends AbstractButtonView {
       if (isString(value_or_callback)) {
         this.model.trigger_event(new MenuItemClick(value_or_callback))
       } else {
-        execute(value_or_callback, this.model, {index: i}) // TODO
+        void execute(value_or_callback, this.model, {index: i})
       }
     }
   }

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -27,10 +27,10 @@ export class FileInputView extends InputWidgetView {
     this.input_el = input({type: "file", class: inputs.input, multiple, accept, disabled})
     this.group_el.appendChild(this.input_el)
 
-    this.input_el.addEventListener("change", () => {
+    this.input_el.addEventListener("change", async () => {
       const {files} = this.input_el
       if (files != null) {
-        this.load_files(files)
+        await this.load_files(files)
       }
     })
   }

--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -233,7 +233,7 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
         })
       }
 
-      override_metrics()
+      await override_metrics()
 
       await Browser.grantPermissions({
         permissions: ["clipboardReadWrite"],
@@ -492,13 +492,13 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
               const ctx_ = JSON.stringify(ctx)
               const output = await (async () => {
                 if (test.dpr != null) {
-                  override_metrics(test.dpr)
+                  await override_metrics(test.dpr)
                 }
                 try {
                   return await evaluate<Result>(`Tests.run(${seq}, ${ctx_})`)
                 } finally {
                   if (test.dpr != null) {
-                    override_metrics()
+                    await override_metrics()
                   }
                 }
               })()

--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -797,4 +797,4 @@ async function main(): Promise<void> {
   }
 }
 
-main()
+void main()

--- a/bokehjs/test/integration/_util.ts
+++ b/bokehjs/test/integration/_util.ts
@@ -31,7 +31,7 @@ export class DelayedInternalProvider extends MathJaxProvider {
 
   async fetch() {
     this.status = "loading"
-    delay(50).then(() => {
+    void delay(50).then(() => {
       this.status = "loaded"
       this.ready.emit()
     })

--- a/bokehjs/test/integration/annotations/box_annotation.ts
+++ b/bokehjs/test/integration/annotations/box_annotation.ts
@@ -1,6 +1,6 @@
 import {display, fig, row} from "../_util"
 import type {Point} from "../../interactive"
-import {PlotActions, xy} from "../../interactive"
+import {actions, xy} from "../../interactive"
 
 import {BoxAnnotation, Node} from "@bokehjs/models"
 import type {OutputBackend} from "@bokehjs/core/enums"
@@ -126,9 +126,8 @@ describe("BoxAnnotation annotation", () => {
     await display(p)
   })
 
-  async function pan(view: PlotView, xy0: Point, xy1: Point) {
-    const actions = new PlotActions(view)
-    await actions.pan_along({type: "line", xy0, xy1})
+  async function pan(pv: PlotView, xy0: Point, xy1: Point) {
+    await actions(pv).pan_along({type: "line", xy0, xy1})
     await paint()
   }
 

--- a/bokehjs/test/integration/glyphs/image_stack.ts
+++ b/bokehjs/test/integration/glyphs/image_stack.ts
@@ -1,11 +1,9 @@
 import {display, fig, row} from "../_util"
+import {actions, xy} from "../../interactive"
 
 import {EqHistColorMapper, HoverTool, WeightedStackColorMapper} from "@bokehjs/models"
-import type {Renderer} from "@bokehjs/models"
 import {varying_alpha_palette} from "@bokehjs/api/palettes"
 import {Float64NDArray} from "@bokehjs/core/util/ndarray"
-import type {PlotView} from "@bokehjs/models/plots/plot"
-import {offset_bbox} from "@bokehjs/core/dom"
 
 describe("ImageStack glyph", () => {
   it("should support hover tooltip", async () => {
@@ -23,31 +21,22 @@ describe("ImageStack glyph", () => {
         renderers: [ir],
         tooltips: [["value", "@image"]],
       }))
-      return [p, ir] as const
+      return p
     }
 
-    const [p0, r0] = plot()
-    const [p1, r1] = plot()
-    const [p2, r2] = plot()
+    const p0 = plot()
+    const p1 = plot()
+    const p2 = plot()
 
     const {view} = await display(row([p0, p1, p2]))
 
-    function hover_at(plot_view: PlotView, r: Renderer, x: number, y: number) {
-      const crv = plot_view.owner.get_one(r)
-      const [[sx], [sy]] = crv.coordinates.map_to_screen([x], [y])
+    const pv0 = view.owner.get_one(p0)
+    const pv1 = view.owner.get_one(p1)
+    const pv2 = view.owner.get_one(p2)
 
-      const ui = plot_view.canvas_view.ui_event_bus
-      const {left, top} = offset_bbox(ui.hit_area)
-
-      const ev = new MouseEvent("mousemove", {clientX: left + sx, clientY: top + sy})
-      ui.hit_area.dispatchEvent(ev)
-    }
-
-    const [pv0, pv1, pv2] = view.child_views as PlotView[]
-
-    hover_at(pv0, r0, 0.2, 0.8)
-    hover_at(pv1, r1, 0.8, 0.5)
-    hover_at(pv2, r2, 0.2, 0.2)
+    await actions(pv0).hover(xy(0.2, 0.8))
+    await actions(pv1).hover(xy(0.8, 0.5))
+    await actions(pv2).hover(xy(0.2, 0.2))
 
     await view.ready
   })

--- a/bokehjs/test/integration/layouts.ts
+++ b/bokehjs/test/integration/layouts.ts
@@ -1,5 +1,6 @@
 import {expect} from "../unit/assertions"
 import {display, fig} from "./_util"
+import {mouse_click} from "../interactive"
 
 import {Spacer, Tabs, TabPanel, GridBox, GroupBox, ScrollBox, Row, Column, HBox, VBox} from "@bokehjs/models/layouts"
 import {Pane} from "@bokehjs/models/ui"
@@ -781,7 +782,7 @@ describe("GroupBox", () => {
     })
     const {view} = await display(group_box, [400, 200])
 
-    view.checkbox_el.dispatchEvent(new MouseEvent("click"))
+    await mouse_click(view.checkbox_el)
     await view.ready
   })
 })

--- a/bokehjs/test/integration/plots.ts
+++ b/bokehjs/test/integration/plots.ts
@@ -1,12 +1,12 @@
 import * as sinon from "sinon"
 
-import {expect, expect_not_null} from "../unit/assertions"
+import {expect} from "../unit/assertions"
 import {display, fig, row} from "./_util"
+import {mouse_click} from "../interactive"
 
 import {figure} from "@bokehjs/api/plotting"
 import type {Location} from "@bokehjs/core/enums"
 import {Range1d, LinearScale, LinearAxis, ColumnDataSource, Pane} from "@bokehjs/models"
-import type {PlotView} from "@bokehjs/models/plots/plot"
 
 describe("Plot", () => {
   const f = (location: Location | null, options: {title?: string, inner?: boolean} = {}) => {
@@ -81,31 +81,28 @@ describe("Plot", () => {
       return p
     }
 
-    const click = (view: PlotView) => {
-      const el = view.toolbar_panel?.toolbar_view.overflow_el
-      expect_not_null(el)
-      const ev = new MouseEvent("click", {clientX: 5, clientY: 5, bubbles: true})
-      el.dispatchEvent(ev)
-    }
-
     it("with toolbar located above a plot", async () => {
       const {view} = await display(f("above"))
-      click(view)
+      const {overflow_el} = view.owner.get_one(view.model.toolbar)
+      await mouse_click(overflow_el)
     })
 
     it("with toolbar located below a plot", async () => {
       const {view} = await display(f("below"))
-      click(view)
+      const {overflow_el} = view.owner.get_one(view.model.toolbar)
+      await mouse_click(overflow_el)
     })
 
     it("with toolbar located left of a plot", async () => {
       const {view} = await display(f("left"))
-      click(view)
+      const {overflow_el} = view.owner.get_one(view.model.toolbar)
+      await mouse_click(overflow_el)
     })
 
     it("with toolbar located right of a plot", async () => {
       const {view} = await display(f("right"))
-      click(view)
+      const {overflow_el} = view.owner.get_one(view.model.toolbar)
+      await mouse_click(overflow_el)
     })
   })
 

--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -2,9 +2,9 @@ import sinon from "sinon"
 
 import {expect, expect_condition, expect_not_null} from "../unit/assertions"
 import {display, fig, row, column, grid, DelayedInternalProvider} from "./_util"
-import {PlotActions, xy, click, press, mouseenter} from "../interactive"
+import {PlotActions, actions, xy, click, press, mouse_enter, mouse_down, mouse_click} from "../interactive"
 
-import type {ArrowHead, Line, Renderer, BasicTickFormatter} from "@bokehjs/models"
+import type {ArrowHead, Line, BasicTickFormatter} from "@bokehjs/models"
 import {
   Arrow, NormalHead, OpenHead,
   BoxAnnotation, LabelSet, ColorBar, Slope, Whisker,
@@ -54,12 +54,11 @@ import {encode_rgba} from "@bokehjs/core/util/color"
 import {Figure, figure, show} from "@bokehjs/api/plotting"
 import type {MarkerArgs} from "@bokehjs/api/glyph_api"
 import {Spectral11, turbo, plasma} from "@bokehjs/api/palettes"
-import {div, offset_bbox} from "@bokehjs/core/dom"
+import {div} from "@bokehjs/core/dom"
 import type {XY, LRTB} from "@bokehjs/core/util/bbox"
 import {sprintf} from "@bokehjs/core/util/templating"
 
 import {MathTextView} from "@bokehjs/models/text/math_text"
-import type {PlotView} from "@bokehjs/models/plots/plot"
 import {FigureView} from "@bokehjs/models/plots/figure"
 
 import {gridplot} from "@bokehjs/api/gridplot"
@@ -1247,18 +1246,10 @@ describe("Bug", () => {
         size: 20, fill_color: "steelblue", hover_fill_color: "red", hover_alpha: 0.1,
       })
       p.add_tools(new HoverTool({tooltips: null, renderers: [cr], mode: "vline"}))
-      const {view} = await display(p)
+      const {view: pv} = await display(p)
 
-      const crv = view.owner.get_one(cr)
-      const [[sx], [sy]] = crv.coordinates.map_to_screen([2], [1.5])
-
-      const ui = view.canvas_view.ui_event_bus
-      const {left, top} = offset_bbox(ui.hit_area)
-
-      const ev = new MouseEvent("mousemove", {clientX: left + sx, clientY: top + sy})
-      ui.hit_area.dispatchEvent(ev)
-
-      await view.ready
+      await actions(pv).hover(xy(2, 1.5))
+      await pv.ready
     })
   })
 
@@ -1294,31 +1285,22 @@ describe("Bug", () => {
             ["value", "@image"],
           ],
         }))
-        return [p, ir] as const
+        return p
       }
 
-      const [p0, r0] = plot([0])
-      const [p1, r1] = plot([1])
-      const [p2, r2] = plot([0, 1])
+      const p0 = plot([0])
+      const p1 = plot([1])
+      const p2 = plot([0, 1])
 
       const {view} = await display(row([p0, p1, p2]))
 
-      function hover_at(plot_view: PlotView, r: Renderer, x: number, y: number) {
-        const crv = plot_view.owner.get_one(r)
-        const [[sx], [sy]] = crv.coordinates.map_to_screen([x], [y])
+      const pv0 = view.owner.get_one(p0)
+      const pv1 = view.owner.get_one(p1)
+      const pv2 = view.owner.get_one(p2)
 
-        const ui = plot_view.canvas_view.ui_event_bus
-        const {left, top} = offset_bbox(ui.hit_area)
-
-        const ev = new MouseEvent("mousemove", {clientX: left + sx, clientY: top + sy})
-        ui.hit_area.dispatchEvent(ev)
-      }
-
-      const [pv0, pv1, pv2] = view.child_views as PlotView[]
-
-      hover_at(pv0, r0,  2, 5)
-      hover_at(pv1, r1, 12, 5)
-      hover_at(pv2, r2,  2, 5)
+      await actions(pv0).hover(xy(2, 5))
+      await actions(pv1).hover(xy(12, 5))
+      await actions(pv2).hover(xy(2, 5))
 
       await view.ready
     })
@@ -2173,9 +2155,7 @@ describe("Bug", () => {
       const {view} = await display(layout, [300, 100])
       const button_view = view.owner.get_one(button)
 
-      const ev = new MouseEvent("click", {bubbles: true})
-      button_view.button_el.dispatchEvent(ev)
-
+      await mouse_click(button_view.button_el)
       await view.ready
       await paint()
     })
@@ -2216,8 +2196,7 @@ describe("Bug", () => {
       const button_view = view.owner.get_one(button)
 
       for (const _ of range(0, 5)) {
-        const ev = new MouseEvent("click", {bubbles: true})
-        button_view.button_el.dispatchEvent(ev)
+        await mouse_click(button_view.button_el)
         await view.ready
         await paint()
       }
@@ -2342,9 +2321,7 @@ describe("Bug", () => {
       const {view} = await display(layout, [550, 350])
       const button_view = view.owner.get_one(button)
 
-      const ev = new MouseEvent("click", {bubbles: true})
-      button_view.button_el.dispatchEvent(ev)
-
+      await mouse_click(button_view.button_el)
       await view.ready
     })
   })
@@ -2382,10 +2359,8 @@ describe("Bug", () => {
 
     it("doesn't allow to correctly display lasso select overlay in single plots", async () => {
       const p = plot("red")
-      const {view} = await display(p)
-
-      const actions = new PlotActions(view)
-      await actions.pan_along(path)
+      const {view: pv} = await display(p)
+      await actions(pv).pan_along(path)
     })
 
     it("doesn't allow to correctly display lasso select overlay in layouts", async () => {
@@ -2396,11 +2371,8 @@ describe("Bug", () => {
       const pv0 = view.owner.get_one(p0)
       const pv1 = view.owner.get_one(p1)
 
-      const actions0 = new PlotActions(pv0)
-      await actions0.pan_along(path)
-
-      const actions1 = new PlotActions(pv1)
-      await actions1.pan_along(path)
+      await actions(pv0).pan_along(path)
+      await actions(pv1).pan_along(path)
 
       await paint()
     })
@@ -2457,10 +2429,8 @@ describe("Bug", () => {
       p.add_tools(new HoverTool())
       p.circle([1, 2, 3], [1, 2, 3], {size: 20})
 
-      const {view} = await display(p)
-
-      const actions = new PlotActions(view)
-      actions.hover(xy(3, 3))
+      const {view: pv} = await display(p)
+      await actions(pv).hover(xy(3, 3))
     })
   })
 
@@ -2607,8 +2577,7 @@ describe("Bug", () => {
       const {view} = await display(layout)
 
       const pv = view.owner.get_one(p00)
-      const actions = new PlotActions(pv)
-      await actions.hover(xy(2, 1))
+      await actions(pv).hover(xy(2, 1))
     })
 
     it("allows to cut tooltips short in layouts", async () => {
@@ -2627,8 +2596,7 @@ describe("Bug", () => {
       const {view} = await display(layout)
 
       const pv = view.owner.get_one(p00)
-      const actions = new PlotActions(pv)
-      await actions.hover(xy(2, 1))
+      await actions(pv).hover(xy(2, 1))
     })
   })
 
@@ -2725,10 +2693,7 @@ describe("Bug", () => {
       const {view} = await display(p)
 
       const pt = xy(1.8, 1.5)
-
-      const actions = new PlotActions(view)
-      actions.hover(pt)
-
+      await actions(view).hover(pt)
       await view.ready
 
       const hover_view = view.owner.get_one(hover)
@@ -2830,10 +2795,8 @@ describe("Bug", () => {
       const plot = fig([200, 200], {x_range: [1, 2], y_range: [1, 2], tools: "hover"})
       plot.circle([0.9], [0.9], {radius: 0.5})
 
-      const {view} = await display(plot)
-
-      const actions = new PlotActions(view)
-      actions.hover(xy(1.1, 1.1))
+      const {view: pv} = await display(plot)
+      await actions(pv).hover(xy(1.1, 1.1))
     })
   })
 
@@ -2938,11 +2901,10 @@ describe("Bug", () => {
 
       p.add_tools(range_tool, hover_tool)
 
-      const {view} = await display(p)
+      const {view: pv} = await display(p)
       await paint()
 
-      const actions = new PlotActions(view)
-      await actions.hover({x: 3, y: 3})
+      await actions(pv).hover({x: 3, y: 3})
       await paint()
     })
   })
@@ -3060,48 +3022,40 @@ describe("Bug", () => {
   })
 
   describe("in issue #12157", () => {
-    async function click(el: Element, event: "click" | "mousedown" = "click"): Promise<void> {
-      el.dispatchEvent(new MouseEvent(event, {bubbles: true, composed: true}))
-    }
-
     it("doesn't allow MultiChoice widget's menu to persist after selection an option", async () => {
       const input = new MultiChoice({options: ["A", "B", "C", "D"], width: 200})
       const {view} = await display(input, [300, 200])
       await paint()
 
       const input_el = view.choice_el.input.element
-      await click(input_el)
+      await mouse_click(input_el)
       await paint()
 
       const el_D = view.shadow_el.querySelector("[data-value='D']")
       expect_not_null(el_D)
-      await click(el_D, "mousedown")
+      await mouse_down(el_D)
       await paint()
 
       const el_A = view.shadow_el.querySelector("[data-value='A']")
       expect_not_null(el_A)
-      await click(el_A, "mousedown")
+      await mouse_down(el_A)
       await paint()
 
       const el_B = view.shadow_el.querySelector("[data-value='B']")
       expect_not_null(el_B)
-      await click(el_B, "mousedown")
+      await mouse_down(el_B)
       await paint()
     })
   })
 
   describe("in issue #12584", () => {
-    async function click(el: Element, event: "click" | "mousedown" = "click"): Promise<void> {
-      el.dispatchEvent(new MouseEvent(event, {bubbles: true, composed: true}))
-    }
-
     it("doesn't allow auto-completion to work correctly in MultiChoice widget", async () => {
       const input = new MultiChoice({options: ["A1", "B1", "B2", "B3", "C1", "C2"], search_option_limit: 2, width: 200})
       const {view} = await display(input, [300, 300])
       await paint()
 
       const input_el = view.choice_el.input.element
-      await click(input_el)
+      await mouse_click(input_el)
       input_el.value = "B" // Can't enter value with a synthetic event.
       input_el.focus()
       await paint()
@@ -3348,7 +3302,7 @@ describe("Bug", () => {
 
       const {desc_el} = view.owner.get_one(widget)
       expect_not_null(desc_el)
-      await mouseenter(desc_el)
+      await mouse_enter(desc_el)
     })
   })
 
@@ -3688,13 +3642,11 @@ describe("Bug", () => {
       const p = fig([300, 300], {tools: "hover"})
       p.circle([0], [0], {size: 10})
 
-      const {view} = await display(p, [400, 300], box)
+      const {view: pv} = await display(p, [400, 300], box)
       box.scroll({left: 100, top: 100})
 
-      const actions = new PlotActions(view)
-      actions.hover(xy(0, 0))
-
-      await view.ready
+      await actions(pv).hover(xy(0, 0))
+      await pv.ready
     })
   })
 })

--- a/bokehjs/test/integration/tables.ts
+++ b/bokehjs/test/integration/tables.ts
@@ -1,8 +1,8 @@
 import {display} from "./_util"
+import {mouse_click} from "../interactive"
 
 import {ColumnDataSource} from "@bokehjs/models"
 import {DataTable, TableColumn} from "@bokehjs/models/widgets/tables"
-import {offset_bbox} from "@bokehjs/core/dom"
 
 describe("DataTable", () => {
 
@@ -17,10 +17,7 @@ describe("DataTable", () => {
     const {view} = await display(table, [600, 400])
 
     const el = view.shadow_el.querySelectorAll(".slick-header-column")[2]
-    const {left, top} = offset_bbox(el)
-    const ev = new MouseEvent("click", {clientX: left + 5, clientY: top + 5, bubbles: true})
-    el.dispatchEvent(ev)
-
+    await mouse_click(el)
     await view.ready
   })
 })

--- a/bokehjs/test/integration/widgets.ts
+++ b/bokehjs/test/integration/widgets.ts
@@ -1,5 +1,5 @@
 import {display, column} from "./_util"
-import {click} from "../interactive"
+import {click, mouse_click} from "../interactive"
 import {expect_not_null} from "../unit/assertions"
 
 import {range} from "@bokehjs/core/util/array"
@@ -42,7 +42,7 @@ async function finished_animating(el: Element): Promise<void> {
 }
 
 export async function open_picker(view: PickerBaseView): Promise<void> {
-  view.picker._input.dispatchEvent(new MouseEvent("click"))
+  await mouse_click(view.picker._input)
   await view.ready
 
   const calendar_el = view.shadow_el.querySelector(".flatpickr-calendar")
@@ -83,11 +83,8 @@ describe("Widgets", () => {
 
     const button_el = view.shadow_el.querySelector("button")
     expect_not_null(button_el)
-    const {left, top} = button_el.getBoundingClientRect()
 
-    const ev = new MouseEvent("click", {clientX: left + 5, clientY: top + 5})
-    button_el.dispatchEvent(ev)
-
+    await mouse_click(button_el)
     await view.ready
   })
 
@@ -104,11 +101,8 @@ describe("Widgets", () => {
 
     const toggle_el = view.shadow_el.querySelector(".bk-dropdown-toggle")
     expect_not_null(toggle_el)
-    const {left, top} = toggle_el.getBoundingClientRect()
 
-    const ev = new MouseEvent("click", {clientX: left + 5, clientY: top + 5})
-    toggle_el.dispatchEvent(ev)
-
+    await mouse_click(toggle_el)
     await view.ready
   })
 
@@ -133,7 +127,7 @@ describe("Widgets", () => {
       const obj = new ColorMap({value: "RdBu", items})
       const {view} = await display(obj, [250, 400])
 
-      click(view.input_el)
+      await click(view.input_el)
       await view.ready
     })
 
@@ -141,7 +135,7 @@ describe("Widgets", () => {
       const obj = new ColorMap({value: "Magma", items, ncols: 3})
       const {view} = await display(obj, [500, 200])
 
-      click(view.input_el)
+      await click(view.input_el)
       await view.ready
     })
 
@@ -149,7 +143,7 @@ describe("Widgets", () => {
       const obj = new ColorMap({value: "Accent", items, disabled: true})
       const {view} = await display(obj, [250, 50])
 
-      click(view.input_el)
+      await click(view.input_el)
       await view.ready
     })
   })
@@ -237,8 +231,7 @@ describe("Widgets", () => {
   it.allowing(8)("should allow PasswordInput with password visible", async () => {
     const obj = new PasswordInput({value: "foo"})
     const {view} = await display(obj, [500, 100])
-    const ev = new MouseEvent("click", {bubbles: true})
-    view.toggle_el.dispatchEvent(ev)
+    await mouse_click(view.toggle_el)
   })
 
   it.allowing(8)("should allow AutocompleteInput", async () => {

--- a/bokehjs/test/interactive.ts
+++ b/bokehjs/test/interactive.ts
@@ -22,14 +22,29 @@ const _mouse_common: Partial<MouseEventInit> = {
   altKey: false,
 }
 
-export async function mouseenter(el: Element): Promise<void> {
-  const ev0 = new PointerEvent("mouseenter", {..._mouse_common, buttons: MouseButton.Left})
-  el.dispatchEvent(ev0)
+export async function mouse_enter(el: Element): Promise<void> {
+  const ev = new PointerEvent("mouseenter", {..._mouse_common, buttons: MouseButton.Left})
+  el.dispatchEvent(ev)
 }
 
-export async function mousleave(el: Element): Promise<void> {
-  const ev0 = new PointerEvent("mousleave", {..._mouse_common, buttons: MouseButton.Left})
-  el.dispatchEvent(ev0)
+export async function mouse_leave(el: Element): Promise<void> {
+  const ev = new PointerEvent("mouseleave", {..._mouse_common, buttons: MouseButton.Left})
+  el.dispatchEvent(ev)
+}
+
+export async function mouse_down(el: Element): Promise<void> {
+  const ev = new PointerEvent("mousedown", {..._mouse_common, buttons: MouseButton.Left})
+  el.dispatchEvent(ev)
+}
+
+export async function mouse_up(el: Element): Promise<void> {
+  const ev = new PointerEvent("mouseup", {..._mouse_common, buttons: MouseButton.Left})
+  el.dispatchEvent(ev)
+}
+
+export async function mouse_click(el: Element): Promise<void> {
+  const ev = new PointerEvent("click", {..._mouse_common, buttons: MouseButton.Left})
+  el.dispatchEvent(ev)
 }
 
 const _pointer_common: Partial<PointerEventInit> = {
@@ -74,6 +89,10 @@ type Path = Line | Poly | Circle
 export type Options = {
   pause: number
   units: "data" | "screen"
+}
+
+export function actions(target: PlotView, options: Partial<Options> = {}): PlotActions {
+  return new PlotActions(target, options)
 }
 
 export class PlotActions {

--- a/bokehjs/test/unit/models/tools/toolbar.ts
+++ b/bokehjs/test/unit/models/tools/toolbar.ts
@@ -1,5 +1,6 @@
 import {expect} from "assertions"
 import {fig, display} from "../../_util"
+import {mouse_enter, mouse_leave} from "../../../interactive"
 
 import {Toolbar} from "@bokehjs/models/tools/toolbar"
 import {HoverTool} from "@bokehjs/models/tools/inspectors/hover_tool"
@@ -69,15 +70,11 @@ describe("Toolbar", () => {
       expect(toolbar_view.visible).to.be.false
       expect(toolbar_view.el.classList.contains("bk-hidden")).to.be.true
 
-      const ev0 = new MouseEvent("mouseenter", {clientX: 0, clientY: 0})
-      view.el.dispatchEvent(ev0)
-
+      await mouse_enter(view.el)
       expect(toolbar_view.visible).to.be.true
       expect(toolbar_view.el.classList.contains("bk-hidden")).to.be.false
 
-      const ev1 = new MouseEvent("mouseleave", {clientX: 0, clientY: 0})
-      view.el.dispatchEvent(ev1)
-
+      await mouse_leave(view.el)
       expect(toolbar_view.visible).to.be.false
       expect(toolbar_view.el.classList.contains("bk-hidden")).to.be.true
     })
@@ -97,15 +94,11 @@ describe("Toolbar", () => {
       expect(tbv.visible).to.be.false
       expect(tbv.el.classList.contains("bk-hidden")).to.be.true
 
-      const ev0 = new MouseEvent("mouseenter", {clientX: 0, clientY: 0})
-      view.el.dispatchEvent(ev0)
-
+      await mouse_enter(view.el)
       expect(tbv.visible).to.be.true
       expect(tbv.el.classList.contains("bk-hidden")).to.be.false
 
-      const ev1 = new MouseEvent("mouseleave", {clientX: 0, clientY: 0})
-      view.el.dispatchEvent(ev1)
-
+      await mouse_leave(view.el)
       expect(tbv.visible).to.be.false
       expect(tbv.el.classList.contains("bk-hidden")).to.be.true
     })

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -2,7 +2,7 @@ import sinon from "sinon"
 
 import {expect, expect_instanceof, expect_not_null} from "assertions"
 import {display, fig, restorable} from "./_util"
-import {PlotActions, xy, click} from "../interactive"
+import {PlotActions, actions, xy, click} from "../interactive"
 
 import {
   BooleanFilter,
@@ -221,7 +221,7 @@ describe("Bug", () => {
   })
 
   describe("in issue #11750", () => {
-    it("makes plots render uncecessarily when hover glyph wasn't defined", async () => {
+    it("makes plots render unnecessarily when hover glyph wasn't defined", async () => {
       async function test(hover_glyph: Line | null) {
         const data_source = new ColumnDataSource({data: {x: [0, 1], y: [0.1, 0.1]}})
         const glyph = new Line({line_color: "red"})
@@ -233,15 +233,8 @@ describe("Bug", () => {
 
         const lnv = view.owner.get_one(renderer)
         const ln_spy = sinon.spy(lnv, "request_render")
-        const ui = view.canvas_view.ui_event_bus
-        const {left, top} = offset_bbox(ui.hit_area)
 
-        for (let i = 0; i <= 1; i += 0.2) {
-          const [[sx], [sy]] = lnv.coordinates.map_to_screen([i], [i])
-          const ev = new MouseEvent("mousemove", {clientX: left + sx, clientY: top + sy})
-          ui.hit_area.dispatchEvent(ev)
-        }
-
+        await actions(view).hover(xy(0, 0), xy(1, 1), 6)
         return ln_spy.callCount
       }
 
@@ -251,7 +244,7 @@ describe("Bug", () => {
   })
 
   describe("in issue #11999", () => {
-    it("makes plots render uncecessarily when inspection indices don't change", async () => {
+    it("makes plots render unnecessarily when inspection indices don't change", async () => {
       const data_source = new ColumnDataSource({data: {x: [0, 0.6], y: [0.6, 0], width: [0.4, 0.4], height: [0.4, 0.4]}})
       const glyph = new Rect({line_color: "red"})
       const hover_glyph = new Rect({line_color: "blue"})
@@ -263,23 +256,11 @@ describe("Bug", () => {
 
       const gv = view.owner.get_one(renderer)
       const gv_spy = sinon.spy(gv, "request_render")
-      const ui = view.canvas_view.ui_event_bus
-      const {left, top} = offset_bbox(ui.hit_area)
 
-      for (let i = 0; i <= 1; i += 0.2) {
-        const [[sx], [sy]] = gv.coordinates.map_to_screen([i], [i])
-        const ev = new MouseEvent("mousemove", {clientX: left + sx, clientY: top + sy})
-        ui.hit_area.dispatchEvent(ev)
-      }
-
+      await actions(view).hover(xy(0, 0), xy(1, 1), 6)
       expect(gv_spy.callCount).to.be.equal(0)
 
-      for (let i = 1; i >= 0; i -= 0.2) {
-        const [[sx], [sy]] = gv.coordinates.map_to_screen([0.8], [i])
-        const ev = new MouseEvent("mousemove", {clientX: left + sx, clientY: top + sy})
-        ui.hit_area.dispatchEvent(ev)
-      }
-
+      await actions(view).hover(xy(0.8, 1), xy(0.8, 0), 6)
       expect(gv_spy.callCount).to.be.equal(1)
     })
   })
@@ -493,7 +474,7 @@ describe("Bug", () => {
           rotation: 0,
           srcEvent: ev,
         }
-        ui._tap(hev) // can't use dispatchEvent(), becuase of doubletap recognizer
+        ui._tap(hev) // can't use dispatchEvent(), because of doubletap recognizer
         await view.ready
       }
 

--- a/src/bokeh/core/_templates/doc_nb_js.js
+++ b/src/bokeh/core/_templates/doc_nb_js.js
@@ -3,5 +3,5 @@
 {% block code_to_run %}
   const docs_json = {{ docs_json }};
   const render_items = {{ render_items }};
-  root.Bokeh.embed.embed_items_notebook(docs_json, render_items);
+  void root.Bokeh.embed.embed_items_notebook(docs_json, render_items);
 {% endblock %}


### PR DESCRIPTION
This actually started as a test modernization effort, but then I realised that a lot of tests were missing `await` statements. Thus I enabled strict `await` enforcement and fixed all the issues in the codebase. If promise doesn't have to be awaited, then one can use `void expression_resulting_in_a_promise` syntax to discard the result. The modernization of tests in this PR is a preliminary effort and more will come later.