### PR TITLE
handle negative microseconds with %f format

### DIFF
--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -71,7 +71,6 @@ export function _strftime(t: number, format: string): string {
   // Python's datetime library augments the microsecond directive %f, which is not
   // supported by the javascript library timezone: http://bigeasy.github.io/timezone/.
   // Use a regular expression to replace %f directive with microseconds.
-  // TODO: what should we do for negative microsecond strings?
   const microsecond_replacement_string = sprintf("$1%06d", _us(t))
   format = format.replace(/((^|[^%])(%%)*)%f/, microsecond_replacement_string)
 
@@ -91,7 +90,13 @@ export function _us(t: number): number {
   // last second. Precision seems to run out around the hundreds of nanoseconds
   // scale, so rounding to the nearest microsecond should round to a nice
   // microsecond / millisecond tick.
-  return Math.round(((t / 1000) % 1) * 1000000)
+  // Note: for negative timestamps (pre epoch) the microsecond scale needs to be
+  // inverted as we are counting backwards.
+  let us = Math.round(((t / 1000) % 1) * 1000000)
+  if (t < 0.0) {
+    us = (1000000 + us) % 1000000
+  }
+  return us
 }
 
 export namespace DatetimeTickFormatter {

--- a/bokehjs/test/unit/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/test/unit/models/formatters/datetime_tick_formatter.ts
@@ -132,6 +132,9 @@ describe("_us", () => {
   it("should round microseconds", () => {
     expect(dttf._us(123456789.1234)).to.be.equal(789123)
   })
+  it("should handle negative microseconds (pre epoch)", () => {
+    expect(dttf._us(-123456789.1234)).to.be.equal(210877)
+  })
 })
 
 const t = 1655945719752  // Thu, 23 Jun 2022 00:55:19 GMT


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: partial fix of #13067
- [x] tests added / passed

Note: The main bug of #13067 is within the external timezone library
