### PR TITLE
Make `ImageURL` eventually consistent to avoid blinking

### DIFF
--- a/bokehjs/src/lib/core/util/array.ts
+++ b/bokehjs/src/lib/core/util/array.ts
@@ -274,3 +274,15 @@ export function repeat<T>(value: T, n: number): T[] {
   const result: T[] = new Array(n).fill(value)
   return result
 }
+
+export function resize<T>(array: T[], new_length: number, fill_value?: T): T[] {
+  if (array.length >= new_length) {
+    return array.slice(0, new_length)
+  } else {
+    const suffix = new Array(new_length - array.length)
+    if (fill_value !== undefined) {
+      suffix.fill(fill_value)
+    }
+    return array.concat(suffix)
+  }
+}

--- a/bokehjs/src/lib/core/util/image.ts
+++ b/bokehjs/src/lib/core/util/image.ts
@@ -47,8 +47,7 @@ export class ImageLoader {
             this.image.crossOrigin = null
             retries = 0
           } else {
-            if (config.failed != null)
-              config.failed()
+            config.failed?.()
             return // XXX reject(new Error(message))
           }
         }
@@ -57,8 +56,7 @@ export class ImageLoader {
       }
       this.image.onload = () => {
         this._finished = true
-        if (config.loaded != null)
-          config.loaded(this.image)
+        config.loaded?.(this.image)
         resolve(this.image)
       }
       this.image.src = url

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -4,6 +4,7 @@ import type {Arrayable, Rect} from "core/types"
 import {ScreenArray, to_screen, Indices} from "core/types"
 import {Anchor} from "core/enums"
 import * as p from "core/properties"
+import {resize} from "core/util/array"
 import {minmax2} from "core/util/arrayable"
 import type {Context2d} from "core/util/canvas"
 import type {SpatialIndex} from "core/util/spatial"
@@ -28,9 +29,6 @@ export type ImageURLData = XYGlyphData & {
   readonly max_w: number
   readonly max_h: number
 
-  image: (CanvasImage | undefined)[]
-  rendered: Indices
-
   anchor: XY<number>
 }
 
@@ -41,6 +39,10 @@ export class ImageURLView extends XYGlyphView {
   declare visuals: ImageURL.Visuals
 
   protected _images_rendered = false
+
+  /*protected*/ image: (CanvasImage | null)[] = new Array(0)
+  loaders: (ImageLoader | null)[]
+  protected resolved: Indices
 
   override connect_signals(): void {
     super.connect_signals()
@@ -59,36 +61,48 @@ export class ImageURLView extends XYGlyphView {
   private _set_data_iteration: number = 0
 
   protected override _set_data(): void {
-    // TODO: cache by url, to reuse images between iterations
     this._set_data_iteration++
 
-    const n_urls = this.url.length
-    this.image = new Array(n_urls)
-    this.rendered = new Indices(n_urls)
+    const {url} = this
+    const n_url = url.length
+
+    this.image = resize(this.image, n_url, null)
+    this.loaders = new Array(n_url).fill(null)
+    this.resolved = new Indices(n_url)
 
     const {retry_attempts, retry_timeout} = this.model
     const {_set_data_iteration} = this
 
-    for (let i = 0; i < n_urls; i++) {
-      const url = this.url.get(i)
-      if (url == "")
+    for (let i = 0; i < n_url; i++) {
+      const url_i = url.get(i)
+      if (url_i == "") {
         continue
+      }
 
-      const loader = new ImageLoader(url, {
-        loaded: () => {
-          if (this._set_data_iteration == _set_data_iteration && !this.rendered.get(i)) {
+      const loader = new ImageLoader(url_i, {
+        loaded: (image_i) => {
+          if (this._set_data_iteration == _set_data_iteration && !this.resolved.get(i)) {
+            this.resolved.set(i)
+            this.image[i] = image_i
+            this.loaders[i] = null
             this.renderer.request_render()
           }
         },
         failed: () => {
           if (this._set_data_iteration == _set_data_iteration) {
-            this.image[i] = undefined
+            this.resolved.set(i)
+            this.loaders[i] = null
+            const image_i = this.image[i]
+            if (image_i != null) {
+              this.image[i] = null
+              this.renderer.request_render()
+            }
           }
         },
         attempts: retry_attempts + 1,
         timeout: retry_timeout,
       })
-      this.image[i] = loader.image
+      this.loaders[i] = loader
     }
 
     const w_data = this.model.properties.w.units == "data"
@@ -147,7 +161,8 @@ export class ImageURLView extends XYGlyphView {
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: ImageURLData): void {
-    const {image, sx, sy, sw, sh, angle, global_alpha} = data ?? this
+    const {sx, sy, sw, sh, angle, global_alpha} = data ?? this
+    const {image, loaders, resolved} = this
 
     // TODO (bev): take actual border width into account when clipping
     const {frame} = this.renderer.plot_view
@@ -159,19 +174,31 @@ export class ImageURLView extends XYGlyphView {
     let finished = true
 
     for (const i of indices) {
-      const img = image[i]
+      const loader_i = loaders[i]
 
-      if (!isFinite(sx[i] + sy[i] + angle.get(i) + global_alpha.get(i)) || img == null)
-        continue
-
-      if (!img.complete) {
-        finished = false
-        continue
-      } else if (img.naturalWidth == 0 && img.naturalHeight == 0) { // dumb way of detecting broken images
+      if (!isFinite(sx[i] + sy[i] + angle.get(i) + global_alpha.get(i))) {
         continue
       }
 
-      this._render_image(ctx, i, img, sx, sy, sw, sh, angle, global_alpha)
+      if (!resolved.get(i)) {
+        if (loader_i != null && loader_i.image.complete) {
+          image[i] = loader_i.image
+          loaders[i] = null
+          resolved.set(i)
+        } else {
+          finished = false
+        }
+      }
+
+      const image_i = image[i]
+      if (image_i == null) {
+        continue
+      }
+      if (image_i.naturalWidth == 0 && image_i.naturalHeight == 0) { // dumb way of detecting broken images
+        continue
+      }
+
+      this._render_image(ctx, i, image_i, sx, sy, sw, sh, angle, global_alpha)
     }
 
     if (finished && !this._images_rendered) {
@@ -224,8 +251,6 @@ export class ImageURLView extends XYGlyphView {
       ctx.drawImage(image, sx_i, sy_i, sw_i, sh_i)
 
     ctx.restore()
-
-    this.rendered.set(i)
   }
 
   override bounds(): Rect {

--- a/bokehjs/test/unit/core/util/array.ts
+++ b/bokehjs/test/unit/core/util/array.ts
@@ -160,8 +160,25 @@ describe("core/util/array module", () => {
     expect(array.argmin([4, 3, 2, 1])).to.be.equal(3)
   })
 
-  it("argmax should return the index of the highest  value along an axis", () => {
+  it("argmax should return the index of the highest value along an axis", () => {
     expect(array.argmax([1, 2, 3, 4])).to.be.equal(3)
     expect(array.argmax([4, 3, 2, 1])).to.be.equal(0)
+  })
+
+  it("should support resize() function", () => {
+    expect(array.resize([1, 2, 3], 0, 0)).to.be.equal([])
+    expect(array.resize([1, 2, 3], 1, 0)).to.be.equal([1])
+    expect(array.resize([1, 2, 3], 2, 0)).to.be.equal([1, 2])
+    expect(array.resize([1, 2, 3], 3, 0)).to.be.equal([1, 2, 3])
+    expect(array.resize([1, 2, 3], 4, 0)).to.be.equal([1, 2, 3, 0])
+    expect(array.resize([1, 2, 3], 5, 0)).to.be.equal([1, 2, 3, 0, 0])
+    expect(array.resize([1, 2, 3], 5, null)).to.be.equal([1, 2, 3, null, null])
+    expect(array.resize([1, 2, 3], 5)).to.be.equal((() => {
+      const array = new Array(5)
+      array[0] = 1
+      array[1] = 2
+      array[2] = 3
+      return array
+    })())
   })
 })


### PR DESCRIPTION
Avoids blinking while keeping efficient rendering of data URL images. The implementation could perhaphs be simplified.

fixes #13157
