### PR TITLE
Fix scoping issue for box edit tool coordinates

### DIFF
--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -97,8 +97,8 @@ export class BoxEditToolView extends EditToolView {
         if (isField(left) && isField(y) && isField(height) && isField(right)) {
           return {
             [left.field]:   dx0,
-            [y.field]:      dy1,
-            [height.field]: 2 * (dy1 - dy0),
+            [y.field]:      (dy0 + dy1)/2.0,
+            [height.field]: dy1 - dy0,
             [right.field]:  dx1,
           }
         }
@@ -106,9 +106,9 @@ export class BoxEditToolView extends EditToolView {
         const {x, bottom, width, top} = glyph
         if (isField(x) && isField(bottom) && isField(width) && isField(top)) {
           return {
-            [x.field]:      dx0,
+            [x.field]:      (dx0 + dx1)/2.0,
             [bottom.field]: dy0,
-            [width.field]:  2 * (dx1 - dx0),
+            [width.field]:  dx1 - dx0,
             [top.field]:    dy1,
           }
         }

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -59,73 +59,73 @@ export class BoxEditToolView extends EditToolView {
       return
     const {glyph} = renderer
     const cds = renderer.data_source
-    const [x0, x1] = renderer_view.coordinates.x_scale.r_invert(sx0, sx1)
-    const [y0, y1] = renderer_view.coordinates.y_scale.r_invert(sy0, sy1)
+    const [rx0, rx1] = renderer_view.coordinates.x_scale.r_invert(sx0, sx1)
+    const [ry0, ry1] = renderer_view.coordinates.y_scale.r_invert(sy0, sy1)
     const fields = (() => {
       if (glyph instanceof Rect) {
         const {x, y, width, height} = glyph
         if (isField(x) && isField(y) && isField(width) && isField(height)) {
           return {
-            [x.field]: (x0 + x1)/2,
-            [y.field]: (y0 + y1)/2,
-            [width.field]:  x1 - x0,
-            [height.field]: y1 - y0,
+            [x.field]: (rx0 + rx1)/2,
+            [y.field]: (ry0 + ry1)/2,
+            [width.field]:  rx1 - rx0,
+            [height.field]: ry1 - ry0,
           }
         }
       } else if (glyph instanceof Block) {
         const {x, y, width, height} = glyph
         if (isField(x) && isField(y) && isField(width) && isField(height)) {
           return {
-            [x.field]:      x0,
-            [y.field]:      y0,
-            [width.field]:  x1 - x0,
-            [height.field]: y1 - y0,
+            [x.field]:      rx0,
+            [y.field]:      ry0,
+            [width.field]:  rx1 - rx0,
+            [height.field]: ry1 - ry0,
           }
         }
       } else if (glyph instanceof Quad) {
         const {right, bottom, left, top} = glyph
         if (isField(right) && isField(bottom) && isField(left) && isField(top)) {
           return {
-            [right.field]:  x1,
-            [bottom.field]: y0,
-            [left.field]:   x0,
-            [top.field]:    y1,
+            [right.field]:  rx1,
+            [bottom.field]: ry0,
+            [left.field]:   rx0,
+            [top.field]:    ry1,
           }
         }
       } else if (glyph instanceof HBar) {
         const {left, y, height, right} = glyph
         if (isField(left) && isField(y) && isField(height) && isField(right)) {
           return {
-            [left.field]:   x0,
-            [y.field]:      y1,
-            [height.field]: y1 - y0,
-            [right.field]:  x1,
+            [left.field]:   rx0,
+            [y.field]:      ry1,
+            [height.field]: ry1 - ry0,
+            [right.field]:  rx1,
           }
         }
       } else if (glyph instanceof VBar) {
         const {x, bottom, width, top} = glyph
         if (isField(x) && isField(bottom) && isField(width) && isField(top)) {
           return {
-            [x.field]:      x0,
-            [bottom.field]: y0,
-            [width.field]:  x1 - x0,
-            [top.field]:    y1,
+            [x.field]:      rx0,
+            [bottom.field]: ry0,
+            [width.field]:  rx1 - rx0,
+            [top.field]:    ry1,
           }
         }
       } else if (glyph instanceof HStrip) {
         const {y0, y1} = glyph
         if (isField(y0) && isField(y1)) {
           return {
-            [y0.field]: y0,
-            [y1.field]: y1,
+            [y0.field]: ry0,
+            [y1.field]: ry1,
           }
         }
       } else if (glyph instanceof VStrip) {
         const {x0, x1} = glyph
         if (isField(x0) && isField(x1)) {
           return {
-            [x0.field]: x0,
-            [x1.field]: x1,
+            [x0.field]: rx0,
+            [x1.field]: rx1,
           }
         }
       } else {

--- a/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/box_edit_tool.ts
@@ -59,73 +59,73 @@ export class BoxEditToolView extends EditToolView {
       return
     const {glyph} = renderer
     const cds = renderer.data_source
-    const [rx0, rx1] = renderer_view.coordinates.x_scale.r_invert(sx0, sx1)
-    const [ry0, ry1] = renderer_view.coordinates.y_scale.r_invert(sy0, sy1)
-    const fields = (() => {
+    const [dx0, dx1] = renderer_view.coordinates.x_scale.r_invert(sx0, sx1)
+    const [dy0, dy1] = renderer_view.coordinates.y_scale.r_invert(sy0, sy1)
+    const fields: {[key: string]: number} | null = (() => {
       if (glyph instanceof Rect) {
         const {x, y, width, height} = glyph
         if (isField(x) && isField(y) && isField(width) && isField(height)) {
           return {
-            [x.field]: (rx0 + rx1)/2,
-            [y.field]: (ry0 + ry1)/2,
-            [width.field]:  rx1 - rx0,
-            [height.field]: ry1 - ry0,
+            [x.field]: (dx0 + dx1)/2,
+            [y.field]: (dy0 + dy1)/2,
+            [width.field]:  dx1 - dx0,
+            [height.field]: dy1 - dy0,
           }
         }
       } else if (glyph instanceof Block) {
         const {x, y, width, height} = glyph
         if (isField(x) && isField(y) && isField(width) && isField(height)) {
           return {
-            [x.field]:      rx0,
-            [y.field]:      ry0,
-            [width.field]:  rx1 - rx0,
-            [height.field]: ry1 - ry0,
+            [x.field]:      dx0,
+            [y.field]:      dy0,
+            [width.field]:  dx1 - dx0,
+            [height.field]: dy1 - dy0,
           }
         }
       } else if (glyph instanceof Quad) {
         const {right, bottom, left, top} = glyph
         if (isField(right) && isField(bottom) && isField(left) && isField(top)) {
           return {
-            [right.field]:  rx1,
-            [bottom.field]: ry0,
-            [left.field]:   rx0,
-            [top.field]:    ry1,
+            [right.field]:  dx1,
+            [bottom.field]: dy0,
+            [left.field]:   dx0,
+            [top.field]:    dy1,
           }
         }
       } else if (glyph instanceof HBar) {
         const {left, y, height, right} = glyph
         if (isField(left) && isField(y) && isField(height) && isField(right)) {
           return {
-            [left.field]:   rx0,
-            [y.field]:      ry1,
-            [height.field]: ry1 - ry0,
-            [right.field]:  rx1,
+            [left.field]:   dx0,
+            [y.field]:      dy1,
+            [height.field]: 2 * (dy1 - dy0),
+            [right.field]:  dx1,
           }
         }
       } else if (glyph instanceof VBar) {
         const {x, bottom, width, top} = glyph
         if (isField(x) && isField(bottom) && isField(width) && isField(top)) {
           return {
-            [x.field]:      rx0,
-            [bottom.field]: ry0,
-            [width.field]:  rx1 - rx0,
-            [top.field]:    ry1,
+            [x.field]:      dx0,
+            [bottom.field]: dy0,
+            [width.field]:  2 * (dx1 - dx0),
+            [top.field]:    dy1,
           }
         }
       } else if (glyph instanceof HStrip) {
         const {y0, y1} = glyph
         if (isField(y0) && isField(y1)) {
           return {
-            [y0.field]: ry0,
-            [y1.field]: ry1,
+            [y0.field]: dy0,
+            [y1.field]: dy1,
           }
         }
       } else if (glyph instanceof VStrip) {
         const {x0, x1} = glyph
         if (isField(x0) && isField(x1)) {
           return {
-            [x0.field]: rx0,
-            [x1.field]: rx1,
+            [x0.field]: dx0,
+            [x1.field]: dx1,
           }
         }
       } else {

--- a/bokehjs/test/interactive.ts
+++ b/bokehjs/test/interactive.ts
@@ -110,7 +110,10 @@ export class PlotActions {
   readonly options: Options
 
   constructor(readonly target: PlotView, options: Partial<Options> = {}) {
-    this.options = {pause: 5, units: "data", ...options}
+    // The default pause between emitted events is longer than the
+    // throttling threshold. This allows for predictable number of
+    // paints and thus predictable and repeatable images.
+    this.options = {pause: 20/*ms*/, units: "data", ...options}
   }
 
   protected get el(): Element {


### PR DESCRIPTION
This commit modifies the name of the x & y coordinates that use the box edit tool, as the original name collided with a few glyph types.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #13500 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
