### PR TITLE
Log figure render count and start/end

### DIFF
--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -882,9 +882,7 @@ export class PlotView extends LayoutDOMView implements Renderable {
   }
 
   protected _actual_paint(): void {
-  //  console.log("PlotView._actual_paint", this.model.id, this._render_count, "start")
     logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} start`);
-    logger.trace('testing logger trace')
 
     const {document} = this.model
     if (document != null) {
@@ -964,7 +962,6 @@ export class PlotView extends LayoutDOMView implements Renderable {
     this._needs_paint = false
     this.repainted.emit()
 
-    // console.log("PlotView._actual_paint", this.model.id, this._render_count, "end")
     logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} end`);
     this._render_count++
   }

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -63,6 +63,9 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
   frame: CartesianFrame
 
+  //////////////// NEW CODE
+  private _render_count: number = 0
+
   canvas_view: CanvasView
   get canvas(): CanvasView {
     return this.canvas_view
@@ -880,6 +883,10 @@ export class PlotView extends LayoutDOMView implements Renderable {
   }
 
   protected _actual_paint(): void {
+
+    //////////////// NEW CODE
+    console.log("PlotView._actual_paint", this._render_count, "start")
+
     const {document} = this.model
     if (document != null) {
       const interactive_duration = document.interactive_duration()
@@ -957,6 +964,10 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
     this._needs_paint = false
     this.repainted.emit()
+
+    //////////////// NEW CODE
+    console.log("PlotView._actual_paint", this._render_count, "end")
+    this._render_count++
   }
 
   protected _paint_levels(ctx: Context2d, level: RenderLevel, clip_region: FrameBox, global_clip: boolean): void {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -882,7 +882,8 @@ export class PlotView extends LayoutDOMView implements Renderable {
   }
 
   protected _actual_paint(): void {
-    logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} start`);
+    // logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} start`)
+    logger.trace(`${this.toString()}._actual_paint ${this._render_count} start`)
 
     const {document} = this.model
     if (document != null) {
@@ -962,7 +963,8 @@ export class PlotView extends LayoutDOMView implements Renderable {
     this._needs_paint = false
     this.repainted.emit()
 
-    logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} end`);
+    // logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} end`)
+    logger.trace(`${this.toString()}._actual_paint ${this._render_count} end`)
     this._render_count++
   }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -882,7 +882,9 @@ export class PlotView extends LayoutDOMView implements Renderable {
   }
 
   protected _actual_paint(): void {
-    console.log("PlotView._actual_paint", this.model.id, this._render_count, "start")
+  //  console.log("PlotView._actual_paint", this.model.id, this._render_count, "start")
+    logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} start`);
+    logger.trace('testing logger trace')
 
     const {document} = this.model
     if (document != null) {
@@ -962,7 +964,8 @@ export class PlotView extends LayoutDOMView implements Renderable {
     this._needs_paint = false
     this.repainted.emit()
 
-    console.log("PlotView._actual_paint", this.model.id, this._render_count, "end")
+    // console.log("PlotView._actual_paint", this.model.id, this._render_count, "end")
+    logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} end`);
     this._render_count++
   }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -63,7 +63,6 @@ export class PlotView extends LayoutDOMView implements Renderable {
 
   frame: CartesianFrame
 
-  //////////////// NEW CODE
   private _render_count: number = 0
 
   canvas_view: CanvasView
@@ -883,8 +882,6 @@ export class PlotView extends LayoutDOMView implements Renderable {
   }
 
   protected _actual_paint(): void {
-
-    //////////////// NEW CODE
     console.log("PlotView._actual_paint", this.model.id, this._render_count, "start")
 
     const {document} = this.model
@@ -965,7 +962,6 @@ export class PlotView extends LayoutDOMView implements Renderable {
     this._needs_paint = false
     this.repainted.emit()
 
-    //////////////// NEW CODE
     console.log("PlotView._actual_paint", this.model.id, this._render_count, "end")
     this._render_count++
   }

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -885,7 +885,7 @@ export class PlotView extends LayoutDOMView implements Renderable {
   protected _actual_paint(): void {
 
     //////////////// NEW CODE
-    console.log("PlotView._actual_paint", this._render_count, "start")
+    console.log("PlotView._actual_paint", this.model.id, this._render_count, "start")
 
     const {document} = this.model
     if (document != null) {
@@ -966,7 +966,7 @@ export class PlotView extends LayoutDOMView implements Renderable {
     this.repainted.emit()
 
     //////////////// NEW CODE
-    console.log("PlotView._actual_paint", this._render_count, "end")
+    console.log("PlotView._actual_paint", this.model.id, this._render_count, "end")
     this._render_count++
   }
 

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -882,7 +882,6 @@ export class PlotView extends LayoutDOMView implements Renderable {
   }
 
   protected _actual_paint(): void {
-    // logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} start`)
     logger.trace(`${this.toString()}._actual_paint ${this._render_count} start`)
 
     const {document} = this.model
@@ -963,7 +962,6 @@ export class PlotView extends LayoutDOMView implements Renderable {
     this._needs_paint = false
     this.repainted.emit()
 
-    // logger.trace(`PlotView._actual_paint ${this.model.id} ${this._render_count} end`)
     logger.trace(`${this.toString()}._actual_paint ${this._render_count} end`)
     this._render_count++
   }


### PR DESCRIPTION
This branch, created by @ianthomas23 (and now rebased onto branch-3.4), addresses the need for a console log render count to measure the latency of display and interaction updates. It includes the figure id, count, and state (start, end).

As this is likely not ideal to have printed for every user, the next step is to limit the conditions under which it is emitted. I could use feedback/guidance on achieving this, maybe with an environment variable like 'BOKEH_RENDER_COUNT'.

- [x] issues: fixes #13502 
- ~~[ ] tests added / passed~~ N/A
- ~~[ ] release document entry (if new feature or API change)~~ N/A

UPDATE: I've put the console messages behind Bokeh log level "trace" as suggested.
