### PR TITLE
Convert value of `BOKEH_DEFAULT_SERVER_PORT` to `int`

### DIFF
--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -35,13 +35,13 @@ immediately supplied values
         settings.minified(minified_val)
 
     If ``minified_val`` is not None, then it will be returned, as-is.
-    Otherwise, if None is passed, then the setting will continute to look
+    Otherwise, if None is passed, then the setting will continue to look
     down the search order for a value. This is useful for passing optional
-    function paramters that are None by default. If the parameter is passed
+    function parameters that are None by default. If the parameter is passed
     to the function, then it will take precedence.
 
 previously user-set values
-    If the value is set explicity in code:
+    If the value is set explicitly in code:
 
     .. code-block:: python
 
@@ -84,7 +84,7 @@ local defaults
 
         settings.resources(default="server")
 
-    Local defaults have lower precendence than every other setting mechanism
+    Local defaults have lower precedence than every other setting mechanism
     except global defaults.
 
 global defaults
@@ -163,6 +163,11 @@ def convert_str(value: str) -> str:
     ''' Return a string as-is.
     '''
     return value
+
+def convert_int(value: int | str) -> int:
+    ''' Convert a string to an integer.
+    '''
+    return int(value)
 
 def convert_bool(value: bool | str) -> bool:
     ''' Convert a string to True or False.
@@ -492,6 +497,8 @@ class PrioritizedSetting(Generic[T]):
             return "String"
         if self._convert is convert_bool:
             return "Bool"
+        if self._convert is convert_int:
+            return "Int"
         if self._convert is convert_logging:
             return "Log Level"
         if self._convert is convert_str_seq:
@@ -698,7 +705,7 @@ class Settings:
     Allows to define the default host used by Bokeh's server and resources.
     """)
 
-    default_server_port: PrioritizedSetting[int] = PrioritizedSetting("default_server_port", "BOKEH_DEFAULT_SERVER_PORT", default=5006, help="""
+    default_server_port: PrioritizedSetting[int] = PrioritizedSetting("default_server_port", "BOKEH_DEFAULT_SERVER_PORT", default=5006, convert=convert_int, help="""
     Allows to define the default port used by Bokeh's server and resources.
     """)
 

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -80,12 +80,12 @@ class TestSettings:
         assert set(settings) == set(_expected_settings)
 
     @pytest.mark.parametrize("name", _expected_settings)
-    def test_prefix(self, name) -> None:
+    def test_prefix(self, name: str) -> None:
         ps = getattr(bs.settings, name)
         assert ps.env_var.startswith("BOKEH_")
 
     @pytest.mark.parametrize("name", _expected_settings)
-    def test_parent(self, name) -> None:
+    def test_parent(self, name: str) -> None:
         ps = getattr(bs.settings, name)
         assert ps._parent == bs.settings
 
@@ -95,6 +95,8 @@ class TestSettings:
         assert bs.settings.perform_document_validation.convert_type == "Bool"
         assert bs.settings.simple_ids.convert_type == "Bool"
         assert bs.settings.xsrf_cookies.convert_type == "Bool"
+
+        assert bs.settings.default_server_port.convert_type == "Int"
 
         assert bs.settings.py_log_level.convert_type == "Log Level"
 
@@ -108,6 +110,7 @@ class TestSettings:
             'ico_path',
             'ignore_filename',
             'minified',
+            'default_server_port',
             'perform_document_validation',
             'simple_ids',
             'validation_level',
@@ -125,15 +128,15 @@ class TestSettings:
 
 class TestConverters:
     @pytest.mark.parametrize("value", ["Yes", "YES", "yes", "1", "ON", "on", "true", "True", True])
-    def test_convert_bool(self, value) -> None:
+    def test_convert_bool(self, value: str | bool) -> None:
         assert bs.convert_bool(value)
 
     @pytest.mark.parametrize("value", ["No", "NO", "no", "0", "OFF", "off", "false", "False", False])
-    def test_convert_bool_false(self, value) -> None:
+    def test_convert_bool_false(self, value: str | bool) -> None:
         assert not bs.convert_bool(value)
 
     @pytest.mark.parametrize("value", [True, False])
-    def test_convert_bool_identity(self, value) -> None:
+    def test_convert_bool_identity(self, value: bool) -> None:
         assert bs.convert_bool(value) == value
 
     def test_convert_bool_bad(self) -> None:
@@ -141,7 +144,7 @@ class TestConverters:
             bs.convert_bool("junk")
 
     @pytest.mark.parametrize("value", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
-    def test_convert_logging_good(self, value) -> None:
+    def test_convert_logging_good(self, value: str) -> None:
         assert bs.convert_logging(value) == getattr(logging, value)
 
         # check lowercase works too
@@ -157,7 +160,7 @@ class TestConverters:
         assert bs.convert_logging(None) is None
 
     @pytest.mark.parametrize("value", ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"])
-    def test_convert_logging_identity(self, value) -> None:
+    def test_convert_logging_identity(self, value: str) -> None:
         level = getattr(logging, value)
         assert bs.convert_logging(level) == level
 
@@ -166,7 +169,7 @@ class TestConverters:
             bs.convert_logging("junk")
 
     @pytest.mark.parametrize("value", ["none", "errors", "all"])
-    def test_convert_validation_good(self, value) -> None:
+    def test_convert_validation_good(self, value: str) -> None:
         assert bs.convert_validation(value) == value
 
     def test_convert_validation_bad(self) -> None:
@@ -174,7 +177,7 @@ class TestConverters:
             bs.convert_validation("junk")
 
     @pytest.mark.parametrize("value", ["none", "NONE", "None"])
-    def test_convert_ico_path_none(self, value) -> None:
+    def test_convert_ico_path_none(self, value: str) -> None:
         assert bs.convert_ico_path(value) == "none"
 
     def test_convert_ico_path_default(self) -> None:


### PR DESCRIPTION
Previously this failed:
```py
$ BOKEH_DEV=true BOKEH_RESOURCES=server BOKEH_DEFAULT_SERVER_PORT=5778 bokeh serve examples/basic/annotations/box_annotation.py 
2023-11-04 19:54:06,457 Starting Bokeh server version 3.4.0.dev2+7.gd37c647d (running on Tornado 6.3.3)
Traceback (most recent call last):
(...)
ValueError: failed to validate _ServerOpts.port: expected a value of type Integral, got 5778 of type str
```