### PR TITLE
fix indentation in property mixins

### DIFF
--- a/src/bokeh/core/property/color.py
+++ b/src/bokeh/core/property/color.py
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import re
-from textwrap import dedent
 from typing import Any
 
 # Bokeh imports
@@ -51,6 +50,24 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
+ALPHA_DEFAULT_HELP = """\
+Acceptable values are floating-point numbers between 0 and 1 (0 being
+transparent and 1 being opaque).
+"""
+
+COLOR_DEFAULT_HELP = """\
+Acceptable values are:
+
+- any of the |named CSS colors|, e.g ``'green'``, ``'indigo'``
+- RGB(A) hex strings, e.g., ``'#FF0000'``, ``'#44444444'``
+- CSS4 color strings, e.g., ``'rgba(255, 0, 127, 0.6)'``,
+  ``'rgb(0 127 0 / 1.0)'``, or ``'hsl(60deg 100% 50% / 1.0)'``
+- a 3-tuple of integers (r, g, b) between 0 and 255
+- a 4-tuple of (r, g, b, a) where r, g, b are integers between 0 and 255,
+  and a is between 0 and 1
+- a 32-bit unsigned integer using the 0xRRGGBBAA byte order pattern
+
+"""
 
 class RGB(Property[colors.RGB]):
     """ Accept colors.RGB values.
@@ -104,20 +121,6 @@ class Color(Either):
 
     """
 
-    _default_help = """\
-    Acceptable values are:
-
-    - any of the |named CSS colors|, e.g ``'green'``, ``'indigo'``
-    - RGB(A) hex strings, e.g., ``'#FF0000'``, ``'#44444444'``
-    - CSS4 color strings, e.g., ``'rgba(255, 0, 127, 0.6)'``,
-      ``'rgb(0 127 0 / 1.0)'``, or ``'hsl(60deg 100% 50% / 1.0)'``
-    - a 3-tuple of integers (r, g, b) between 0 and 255
-    - a 4-tuple of (r, g, b, a) where r, g, b are integers between 0 and 255,
-      and a is between 0 and 1
-    - a 32-bit unsigned integer using the 0xRRGGBBAA byte order pattern
-
-    """
-
     def __init__(self, default: Init[str | tuple[int, int, int] | tuple[int, int, int, float]] = Undefined, *, help: str | None = None) -> None:
         types = (Enum(enums.NamedColor),
                  Regex(r"^#[0-9a-fA-F]{3}$"),
@@ -132,7 +135,7 @@ class Color(Either):
                  Tuple(Byte, Byte, Byte),
                  Tuple(Byte, Byte, Byte, Percent),
                  RGB)
-        help = f"{help or ''}\n{self._default_help}"
+        help = f"{help or ''}\n{COLOR_DEFAULT_HELP}"
         super().__init__(*types, default=default, help=help)
 
     def __str__(self) -> str:
@@ -170,13 +173,8 @@ class ColorHex(Color):
 
 class Alpha(Percent):
 
-    _default_help = dedent("""\
-    Acceptable values are floating-point numbers between 0 and 1 (0 being
-    transparent and 1 being opaque).
-    """)
-
     def __init__(self, default: Init[float] = 1.0, *, help: str | None = None) -> None:
-        help = f"{help or ''}\n{self._default_help}"
+        help = f"{help or ''}\n{ALPHA_DEFAULT_HELP}"
         super().__init__(default=default, help=help)
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/core/property/color.py
+++ b/src/bokeh/core/property/color.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import re
+from textwrap import dedent
 from typing import Any
 
 # Bokeh imports
@@ -169,10 +170,10 @@ class ColorHex(Color):
 
 class Alpha(Percent):
 
-    _default_help = """\
+    _default_help = dedent("""\
     Acceptable values are floating-point numbers between 0 and 1 (0 being
     transparent and 1 being opaque).
-    """
+    """)
 
     def __init__(self, default: Init[float] = 1.0, *, help: str | None = None) -> None:
         help = f"{help or ''}\n{self._default_help}"

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from textwrap import dedent
 from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
@@ -275,10 +276,10 @@ class NumberSpec(DataSpec):
 
 class AlphaSpec(NumberSpec):
 
-    _default_help = """\
+    _default_help = dedent("""\
     Acceptable values are floating-point numbers between 0 and 1 (0 being
     transparent and 1 being opaque).
-    """
+    """)
 
     def __init__(self, default=1.0, *, help: str | None = None) -> None:
         help = f"{help or ''}\n{self._default_help}"
@@ -555,17 +556,17 @@ class ColorSpec(DataSpec):
 
     """
 
-    _default_help = """\
+    _default_help = dedent("""\
     Acceptable values are:
 
     - any of the |named CSS colors|, e.g ``'green'``, ``'indigo'``
     - RGB(A) hex strings, e.g., ``'#FF0000'``, ``'#44444444'``
     - CSS4 color strings, e.g., ``'rgba(255, 0, 127, 0.6)'``, ``'rgb(0 127 0 / 1.0)'``
     - a 3-tuple of integers (r, g, b) between 0 and 255
-    - a 4-tuple of (r, g, b, a) where r, g, b are integers between 0..255 and a is between 0..1
+    - a 4-tuple of (r, g, b, a) where r, g, b are integers between 0 and 255 and a is between 0 and 1
     - a 32-bit unsiged integers using the 0xRRGGBBAA byte order pattern
 
-    """
+    """)
 
     def __init__(self, default, *, help: str | None = None) -> None:
         help = f"{help or ''}\n{self._default_help}"

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -28,7 +28,7 @@ from ...util.dataclasses import Unspecified
 from ...util.serialization import convert_datetime_type, convert_timedelta_type
 from ...util.strings import nice_join
 from .. import enums
-from .color import ALPHA_DEFAULT_HELP, Color, COLOR_DEFAULT_HELP
+from .color import ALPHA_DEFAULT_HELP, COLOR_DEFAULT_HELP, Color
 from .datetime import Datetime, TimeDelta
 from .descriptors import DataSpecPropertyDescriptor, UnitsSpecPropertyDescriptor
 from .either import Either

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -21,7 +21,6 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from textwrap import dedent
 from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
@@ -29,7 +28,7 @@ from ...util.dataclasses import Unspecified
 from ...util.serialization import convert_datetime_type, convert_timedelta_type
 from ...util.strings import nice_join
 from .. import enums
-from .color import Color
+from .color import ALPHA_DEFAULT_HELP, Color, COLOR_DEFAULT_HELP
 from .datetime import Datetime, TimeDelta
 from .descriptors import DataSpecPropertyDescriptor, UnitsSpecPropertyDescriptor
 from .either import Either
@@ -276,13 +275,8 @@ class NumberSpec(DataSpec):
 
 class AlphaSpec(NumberSpec):
 
-    _default_help = dedent("""\
-    Acceptable values are floating-point numbers between 0 and 1 (0 being
-    transparent and 1 being opaque).
-    """)
-
     def __init__(self, default=1.0, *, help: str | None = None) -> None:
-        help = f"{help or ''}\n{self._default_help}"
+        help = f"{help or ''}\n{ALPHA_DEFAULT_HELP}"
         super().__init__(default=default, help=help, accept_datetime=False, accept_timedelta=False)
 
 class NullStringSpec(DataSpec):
@@ -556,20 +550,8 @@ class ColorSpec(DataSpec):
 
     """
 
-    _default_help = dedent("""\
-    Acceptable values are:
-
-    - any of the |named CSS colors|, e.g ``'green'``, ``'indigo'``
-    - RGB(A) hex strings, e.g., ``'#FF0000'``, ``'#44444444'``
-    - CSS4 color strings, e.g., ``'rgba(255, 0, 127, 0.6)'``, ``'rgb(0 127 0 / 1.0)'``
-    - a 3-tuple of integers (r, g, b) between 0 and 255
-    - a 4-tuple of (r, g, b, a) where r, g, b are integers between 0 and 255 and a is between 0 and 1
-    - a 32-bit unsiged integers using the 0xRRGGBBAA byte order pattern
-
-    """)
-
     def __init__(self, default, *, help: str | None = None) -> None:
-        help = f"{help or ''}\n{self._default_help}"
+        help = f"{help or ''}\n{COLOR_DEFAULT_HELP}"
         super().__init__(Nullable(Color), default=default, help=help)
 
     @classmethod

--- a/src/bokeh/core/property_mixins.py
+++ b/src/bokeh/core/property_mixins.py
@@ -35,7 +35,7 @@ as shown here:
 
 This adds all the fill properties ``fill_color`` and ``fill_alpha`` to this
 model. The help string contains a placeholder `{prop}`. When docs for this class
-are rendered by the, the placeholder will be replaced with more information
+are rendered by the ``bokeh-model`` directive, the placeholder will be replaced with more information
 specific to each property.
 
 .. |Include| replace:: :class:`~bokeh.core.properties.Include`

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -1188,13 +1188,13 @@ class CustomJSHover(Model):
     The snippet will be made into the body of a function and therefore requires
     a return statement.
 
-    Example:
+    **Example**
 
-        .. code-block:: javascript
+    .. code-block:: javascript
 
-            code = '''
-            return value + " total"
-            '''
+        code = '''
+        return value + " total"
+        '''
     """)
 
 class HoverTool(InspectTool):
@@ -1241,19 +1241,19 @@ class HoverTool(InspectTool):
 
     Hover tool does not currently work with the following glyphs:
 
-        .. hlist::
-            :columns: 3
+    .. hlist::
+        :columns: 3
 
-            * annulus
-            * arc
-            * bezier
-            * image_url
-            * oval
-            * patch
-            * quadratic
-            * ray
-            * step
-            * text
+        * annulus
+        * arc
+        * bezier
+        * image_url
+        * oval
+        * patch
+        * quadratic
+        * ray
+        * step
+        * text
 
     .. |hover_icon| image:: /_images/icons/Hover.png
         :height: 24px


### PR DESCRIPTION
This pull requests is part of my list of changes for the docs.

- [ ] issues: addresses #13276 

This time the focus is on the [property mixins](https://docs.bokeh.org/en/latest/docs/reference/core/property_mixins.html) page.

|old version|suggested version|
|--|--|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/ba840787-bf94-44d8-b414-9073e4b0b451)|![porperty_mixins_new](https://github.com/bokeh/bokeh/assets/68053396/6e64ab50-cc43-4e75-86f9-4476ecaef019)|

I added `dedent` from `textwrap` because the generated rst-parte by the `BokehPropDirective` looked like below.

```
.. attribute:: fill_alpha docs/reference/core/property_mixins
    :module: bokeh.core.property_mixins
    :annotation: = 1.0

    :Type: :class:`~bokeh.core.properties.AlphaSpec`\ 
    
    
    An alpha value to use to fill paths with.

        Acceptable values are floating-point numbers between 0 and 1 (0 being
        transparent and 1 being opaque).
```

This indentation created a quote block.

I also changed 

1. A wrong indentation in HoverTools
![HoverTool](https://github.com/bokeh/bokeh/assets/68053396/0c6f3e28-4b69-4e2c-bdd9-171e9c05cda5)
2.  A not working Example code block in CustomJSHover
![CustomJSHover](https://github.com/bokeh/bokeh/assets/68053396/79d05069-1682-4cf8-a1d4-110377c57d28)
3. And a missing word in the property_mixins.py
