### PR TITLE
Add support for CDS/EditTool default values and overrides

### DIFF
--- a/bokehjs/test/unit/document/defs.ts
+++ b/bokehjs/test/unit/document/defs.ts
@@ -233,6 +233,7 @@ describe("document/defs module", () => {
 
       const cds_props = [
         "selected",
+        "default_values",
         "selection_policy",
         "inspected",
         "data",

--- a/bokehjs/test/unit/models/sources/column_data_source.ts
+++ b/bokehjs/test/unit/models/sources/column_data_source.ts
@@ -4,7 +4,7 @@ import {with_log_level} from "@bokehjs/core/logging"
 
 import {keys} from "@bokehjs/core/util/object"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
-import {Int32NDArray, Float32NDArray, Float64NDArray} from "@bokehjs/core/util/ndarray"
+import {Int32NDArray, Float32NDArray, Float64NDArray, ndarray} from "@bokehjs/core/util/ndarray"
 
 import {trap} from "../../../util"
 
@@ -146,6 +146,46 @@ describe("column_data_source module", () => {
         r.clear()
         expect(r.data).to.be.equal({foo: [], bar: [], baz: new typ([])})
       }
+    })
+  })
+
+  describe("inferred_defaults getter", () => {
+    const cds = new ColumnDataSource({
+      data: {
+        d0: [],
+        d1: [null, false, 0],
+        d2: [true, false, true],
+        d3: [false, true, false],
+        d4: [0, 1, 2, 3],
+        d5: [1, 2, 3, 4],
+        d6: ["a", "b", "c"],
+        d7: ndarray([], {dtype: "bool"}),
+        d8: ndarray([], {dtype: "uint32"}),
+        d9: ndarray([], {dtype: "float64"}),
+        d10: ndarray([1, 2, 3], {dtype: "object"}),
+        d11: ndarray([1, 0, 1], {dtype: "bool"}),
+        d12: ndarray([1, 2, 3], {dtype: "uint32"}),
+        d13: ndarray([1, 2, 3], {dtype: "float64"}),
+        d14: ndarray([1, 2, 3], {dtype: "object"}),
+        // TODO d15: new Map([[0, "a"], [1, "b"], [2, "c"]]),
+      },
+    })
+    expect(cds.inferred_defaults).to.be.equal({
+      d1: null,
+      d2: false,
+      d3: false,
+      d4: 0,
+      d5: 0,
+      d6: "",
+      d7: false,
+      d8: 0,
+      d9: 0,
+      d10: null,
+      d11: false,
+      d12: 0,
+      d13: 0,
+      d14: null,
+      // TODO d15: new Map([[0, "a"], [1, "b"], [2, "c"]]),
     })
   })
 })

--- a/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/freehand_draw_tool.ts
@@ -51,7 +51,7 @@ async function make_testcase(): Promise<FreehandDrawTestCase> {
 
   const draw_tool = new FreehandDrawTool({
     active: true,
-    empty_value: "Test",
+    default_overrides: {z: "Test"},
     renderers: [glyph_renderer as GlyphRenderer & HasXYGlyph],
   })
   plot.add_tools(draw_tool)
@@ -177,7 +177,7 @@ describe("FreehandDrawTool", () => {
       expect(testcase.data_source.data.ys).to.be.equal(ydata)
     })
 
-    it("should insert empty_value on other columns", async () => {
+    it("should insert default_overrides on other columns", async () => {
       const testcase = await make_testcase()
       const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test")
 

--- a/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/point_draw_tool.ts
@@ -33,7 +33,11 @@ async function make_testcase(): Promise<PointDrawTestCase> {
 
   const {view: plot_view} = await display(plot)
 
-  const data = {x: [0, 0.5, 1], y: [0, 0.5, 1], z: [null, null, null]}
+  const data = {
+    x: [0, 0.5, 1],
+    y: [0, 0.5, 1],
+    z: [null, null, null],
+  }
   const data_source = new ColumnDataSource({data})
 
   const glyph = new Scatter({
@@ -47,7 +51,7 @@ async function make_testcase(): Promise<PointDrawTestCase> {
 
   const draw_tool = new PointDrawTool({
     active: true,
-    empty_value: "Test",
+    default_overrides: {z: "Test"},
     renderers: [glyph_renderer as any],
   })
   plot.add_tools(draw_tool)
@@ -131,7 +135,7 @@ describe("PointDrawTool", (): void => {
       expect(testcase.data_source.data.y).to.be.equal([0.5, 1, 0.3389830508474576])
     })
 
-    it("should insert empty_value on other columns", async () => {
+    it("should insert default_overrides on other columns", async () => {
       const testcase = await make_testcase()
       const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test")
 

--- a/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_draw_tool.ts
@@ -50,7 +50,7 @@ async function make_testcase(): Promise<PolyDrawTestCase> {
 
   const draw_tool = new PolyDrawTool({
     active: true,
-    empty_value: "Test",
+    default_overrides: {z: "Test"},
     renderers: [glyph_renderer as any],
   })
   plot.add_tools(draw_tool)
@@ -256,7 +256,7 @@ describe("PolyDrawTool", (): void => {
       expect(testcase.data_source.data.ys).to.be.equal(ydata)
     })
 
-    it("should insert empty_value on other columns", async () => {
+    it("should insert default_overrides on other columns", async () => {
       const testcase = await make_testcase()
       const hit_test_stub = sinon.stub(testcase.glyph_view, "hit_test")
 

--- a/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
@@ -66,7 +66,7 @@ async function make_testcase(): Promise<PolyEditTestCase> {
 
   const draw_tool = new PolyEditTool({
     active: true,
-    empty_value: "Test",
+    default_overrides: {z: "Test"},
     renderers: [glyph_renderer as any],
     vertex_renderer: vertex_renderer as GlyphRenderer & HasXYGlyph,
   })

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -1011,7 +1011,7 @@ describe("Bug", () => {
         const {x, y, width, height, color} = fields(data)
         const renderer = p.rect({x, y, width, height, color, source})
 
-        const edit_tool = new BoxEditTool({renderers: [renderer], empty_value: "green"})
+        const edit_tool = new BoxEditTool({renderers: [renderer], default_overrides: {color: "green"}})
         p.add_tools(edit_tool)
         p.toolbar.active_drag = edit_tool
 
@@ -1047,7 +1047,7 @@ describe("Bug", () => {
         const {x, y, width, height, color} = fields(data)
         const renderer = p.rect({x, y, width, height, color, source})
 
-        const edit_tool = new BoxEditTool({renderers: [renderer], empty_value: "green"})
+        const edit_tool = new BoxEditTool({renderers: [renderer], default_overrides: {color: "green"}})
         p.add_tools(edit_tool)
         p.toolbar.active_drag = edit_tool
 
@@ -1083,7 +1083,7 @@ describe("Bug", () => {
         const {left, right, top, bottom, color} = fields(data)
         const renderer = p.quad({left, right, top, bottom, color, source})
 
-        const edit_tool = new BoxEditTool({renderers: [renderer], empty_value: "green"})
+        const edit_tool = new BoxEditTool({renderers: [renderer], default_overrides: {color: "green"}})
         p.add_tools(edit_tool)
         p.toolbar.active_drag = edit_tool
 
@@ -1119,7 +1119,7 @@ describe("Bug", () => {
         const {y, height, left, right, color} = fields(data)
         const renderer = p.hbar({y, height, left, right, color, source})
 
-        const edit_tool = new BoxEditTool({renderers: [renderer], empty_value: "green"})
+        const edit_tool = new BoxEditTool({renderers: [renderer], default_overrides: {color: "green"}})
         p.add_tools(edit_tool)
         p.toolbar.active_drag = edit_tool
 
@@ -1155,7 +1155,7 @@ describe("Bug", () => {
         const {x, width, top, bottom, color} = fields(data)
         const renderer = p.vbar({x, width, top, bottom, color, source})
 
-        const edit_tool = new BoxEditTool({renderers: [renderer], empty_value: "green"})
+        const edit_tool = new BoxEditTool({renderers: [renderer], default_overrides: {color: "green"}})
         p.add_tools(edit_tool)
         p.toolbar.active_drag = edit_tool
 
@@ -1189,7 +1189,7 @@ describe("Bug", () => {
         const {y0, y1, color} = fields(data)
         const renderer = p.hstrip({y0, y1, color, source})
 
-        const edit_tool = new BoxEditTool({renderers: [renderer], empty_value: "green"})
+        const edit_tool = new BoxEditTool({renderers: [renderer], default_overrides: {color: "green"}})
         p.add_tools(edit_tool)
         p.toolbar.active_drag = edit_tool
 
@@ -1221,7 +1221,7 @@ describe("Bug", () => {
         const {x0, x1, color} = fields(data)
         const renderer = p.vstrip({x0, x1, color, source})
 
-        const edit_tool = new BoxEditTool({renderers: [renderer], empty_value: "green"})
+        const edit_tool = new BoxEditTool({renderers: [renderer], default_overrides: {color: "green"}})
         p.add_tools(edit_tool)
         p.toolbar.active_drag = edit_tool
 

--- a/docs/bokeh/source/docs/user_guide/interaction/tools.rst
+++ b/docs/bokeh/source/docs/user_guide/interaction/tools.rst
@@ -810,9 +810,21 @@ as a list:
 The tool automatically modifies the columns of the data source
 corresponding to the ``x``, ``y``, ``width``, and ``height`` values of
 the glyph. Any additional columns in the data source will be padded with
-the declared ``empty_value`` when adding a new point. Any newly added
+their respective default values when adding a new point. Any newly added
 points will be inserted in the ``ColumnDataSource`` of the first supplied
 renderer.
+
+.. _ug_interaction_tools_default_values:
+
+Columns' default values are computed based on (in order):
+
+1. Tool's ``default_overrides``, which are user provided.
+2. Data source's ``default_values``, which are user provided.
+3. Data source's inferred default values, which are computed by the data
+   source based on column's ``dtype`` or contents.
+4. Tool's ``empty_value``, which is user provided and is the measure of
+   last resort when a sensible value can't be determined in the previous
+   steps.
 
 It is often useful to limit the number of elements that can be
 drawn. For example, when specifying a certain number of regions of interest.
@@ -876,10 +888,10 @@ you must pass the renderers to be edited as a list:
 
 The tool automatically modifies the columns on the data source
 corresponding to the ``xs`` and ``ys`` values of the glyph. Any
-additional columns in the data source will be padded with the declared
-``empty_value`` when adding a new point. Any newly added points will
-be inserted in the ``ColumnDataSource`` of the first supplied
-renderer.
+additional columns in the data source will be padded in accordance
+to :ref:`ug_interaction_tools_default_values` procedure when adding
+a new point.  Any newly added points will be inserted in the
+``ColumnDataSource`` of the first supplied renderer.
 
 It is also often useful to limit the number of elements that can be
 drawn. For example, when specifying a specific number of regions of interest.
@@ -930,10 +942,10 @@ you must pass the renderers to be edited as a list:
 
 The tool automatically modifies the columns on the data source
 corresponding to the ``x`` and ``y`` values of the glyph. Any
-additional columns in the data source will be padded with the declared
-``empty_value`` when adding a new point. Any newly added points will
-be inserted in the ``ColumnDataSource`` of the first supplied
-renderer.
+additional columns in the data source will be padded in accordance
+to :ref:`ug_interaction_tools_default_values` procedure when adding
+a new point. Any newly added points will be inserted in the
+``ColumnDataSource`` of the first supplied renderer.
 
 It is also often useful to limit the number of elements that can be
 drawn. Using the ``num_objects`` property, you can ensure that once the
@@ -989,10 +1001,10 @@ you must pass the renderers to be edited as a list.
 
 The tool automatically modifies the columns on the data source
 corresponding to the ``xs`` and ``ys`` values of the glyph. Any
-additional columns in the data source will be padded with the declared
-``empty_value``, when adding a new point. Any newly added patch or
-multi-line will be inserted on the ``ColumnDataSource`` of the first
-supplied renderer.
+additional columns in the data source will be padded in accordance
+to :ref:`ug_interaction_tools_default_values` procedure when adding
+a new point. Any newly added patch or multi-line will be inserted in
+the ``ColumnDataSource`` of the first supplied renderer.
 
 It is also often useful to limit the number of elements that can be
 drawn. For example, when specifying a specific number of regions of interest.
@@ -1046,8 +1058,9 @@ render a point-like Glyph (of ``XYGlyph`` type).
 
 The tool automatically modifies the columns on the data source
 corresponding to the ``xs`` and ``ys`` values of the glyph. Any
-additional columns in the data source will be padded with the declared
-``empty_value``, when adding a new point.
+additional columns in the data source will be padded in accordance
+to :ref:`ug_interaction_tools_default_values` procedure when adding
+a new point.
 
 .. raw:: html
 

--- a/examples/interaction/tools/box_edit.py
+++ b/examples/interaction/tools/box_edit.py
@@ -2,16 +2,26 @@ from bokeh.models import BoxEditTool, ColumnDataSource
 from bokeh.plotting import figure, show
 
 p = figure(x_range=(0, 10), y_range=(0, 10), width=400, height=400,
-           title='Box Edit Tool')
+           title="Box Edit Tool")
 
-src = ColumnDataSource({
-    'x': [5, 2, 8], 'y': [5, 7, 8], 'width': [2, 1, 2],
-    'height': [2, 1, 1.5], 'alpha': [0.5, 0.5, 0.5],
-})
+source = ColumnDataSource(
+    data=dict(
+        x=[5, 2, 8],
+        y=[5, 7, 8],
+        width=[2, 1, 2],
+        height=[2, 1, 1.5],
+        color=["red", "red", "red"],
+        alpha=[0.3, 0.3, 0.3],
+    ),
+    default_values = dict(
+        color="green",
+        alpha=0.5,
+    ),
+)
 
-r = p.rect('x', 'y', 'width', 'height', source=src, alpha='alpha')
+r = p.rect("x", "y", "width", "height", color="color", alpha="alpha", source=source)
 
-draw_tool = BoxEditTool(renderers=[r], empty_value=1)
+draw_tool = BoxEditTool(renderers=[r], default_overrides=dict(alpha=0.8))
 p.add_tools(draw_tool)
 p.toolbar.active_drag = draw_tool
 

--- a/examples/interaction/tools/point_draw.py
+++ b/examples/interaction/tools/point_draw.py
@@ -5,18 +5,23 @@ p = figure(x_range=(0, 10), y_range=(0, 10), tools=[],
            title='Point Draw Tool')
 p.background_fill_color = 'lightgrey'
 
-source = ColumnDataSource({
-    'x': [1, 5, 9], 'y': [1, 5, 9], 'color': ['red', 'green', 'yellow'],
-})
+source = ColumnDataSource(dict(
+    x=[1, 5, 9],
+    y=[1, 5, 9],
+    color=['red', 'green', 'yellow'],
+))
+source.default_values["color"] = "purple"
 
 r = p.scatter(x='x', y='y', source=source, color='color', size=10)
 
-columns = [TableColumn(field="x", title="x"),
-           TableColumn(field="y", title="y"),
-           TableColumn(field='color', title='color')]
+columns = [
+    TableColumn(field="x", title="x"),
+    TableColumn(field="y", title="y"),
+    TableColumn(field='color', title='color'),
+]
 table = DataTable(source=source, columns=columns, editable=True, height=200)
 
-draw_tool = PointDrawTool(renderers=[r], empty_value='black')
+draw_tool = PointDrawTool(renderers=[r])
 p.add_tools(draw_tool)
 p.toolbar.active_tap = draw_tool
 

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -117,6 +117,15 @@ class ColumnarDataSource(DataSource):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
+    default_values = Dict(String, Any, default={}, help="""
+    Defines the default value for each column.
+
+    This is used when inserting rows into a data source, e.g. by edit tools,
+    when a value for a given column is not explicitly provided. If a default
+    value is missing, a tool will defer to its own configuration or will try
+    to let the data source to infer a sensible default value.
+    """)
+
     selection_policy = Instance(SelectionPolicy, default=InstanceDefault(UnionRenderers), help="""
     An instance of a ``SelectionPolicy`` that determines how selections are set.
     """)

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -58,6 +58,7 @@ from ..core.enums import (
 from ..core.has_props import abstract
 from ..core.properties import (
     Alpha,
+    Any,
     AnyRef,
     Auto,
     Bool,
@@ -1507,12 +1508,27 @@ class EditTool(GestureTool):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
+    default_overrides = Dict(String, Any, default={}, help="""
+    Padding values overriding ``ColumnarDataSource.default_values``.
+
+    Defines values to insert into non-coordinate columns when a new glyph is
+    inserted into the ``ColumnDataSource`` columns, e.g. when a circle glyph
+    defines ``"x"``, ``"y"`` and ``"color"`` columns, adding a new point will
+    add the x and y-coordinates to ``"x"`` and ``"y"`` columns and the color
+    column will be filled with the defined default value.
+    """)
+
     empty_value = Either(Bool, Int, Float, Date, Datetime, Color, String, default=0, help="""
-    Defines the value to insert on non-coordinate columns when a new
-    glyph is inserted into the ``ColumnDataSource`` columns, e.g. when a
-    circle glyph defines 'x', 'y' and 'color' columns, adding a new
-    point will add the x and y-coordinates to 'x' and 'y' columns and
-    the color column will be filled with the defined empty value.
+    The "last resort" padding value.
+
+    This is used the same as ``default_values``, when the tool was unable
+    to figure out a default value otherwise. The tool will try the following
+    alternatives in order:
+
+    1. ``EditTool.default_overrides``
+    2. ``ColumnarDataSource.default_values``
+    3. ``ColumnarDataSource``'s inferred default values
+    4. ``EditTool.empty_value``
     """)
 
     # TODO abstract renderers = List(Instance(GlyphRenderer & ...))

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -288,6 +288,9 @@
   },
   ColumnarDataSource: {
     __extends__: "DataSource",
+    default_values: {
+      type: "map",
+    },
     selection_policy: {
       type: "object",
       name: "UnionRenderers",
@@ -5978,6 +5981,9 @@
   },
   EditTool: {
     __extends__: "GestureTool",
+    default_overrides: {
+      type: "map",
+    },
     empty_value: 0,
   },
   PolyTool: {


### PR DESCRIPTION
This generalizes `EditTool.empty_value`, by adding the following:

1. `EditTool.default_overrides` (column -> value mapping)
2. `ColumnarDataSource.default_values` (column -> value mapping)
3. Default value inference by `ColumnarDataSource` (based on `dtype` and/or contents).

Values are resolved in the above order and `EditTool.empty_value` is used as a fallback.

If value inference could be made sensible and robust then perhaps `empty_value` could be deprecated and removed at some point, because it really doesn't make much sense to have single value for a data source, unless there's only one extra column.

fixes #10583 
