### PR TITLE
Enable `'use strict';`, improve error handling and update `@bokeh/slickgrid`

### DIFF
--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -161,9 +161,10 @@
       "link": true
     },
     "node_modules/@bokeh/slickgrid": {
-      "version": "2.4.4102",
+      "version": "2.4.4103",
+      "resolved": "https://registry.npmjs.org/@bokeh/slickgrid/-/slickgrid-2.4.4103.tgz",
+      "integrity": "sha512-wPitQJNUNUHw+86BPemvb1kIuV6UB4CpjEEDIXpU8G6Jges+8nx/iGHW8w9BwvICdeyhAmfX9Hmn5vRJMbe+uw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/slickgrid": "^2.1.30",
         "jquery": ">=3.4.0",
@@ -3640,7 +3641,7 @@
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@bokeh/numbro": "^1.6.2",
-        "@bokeh/slickgrid": "~2.4.4102",
+        "@bokeh/slickgrid": "~2.4.4103",
         "@types/geojson": "^7946.0.10",
         "@types/google.maps": "^3.54.0",
         "@types/hammerjs": "^2.0.41",

--- a/bokehjs/src/compiler/prelude.ts
+++ b/bokehjs/src/compiler/prelude.ts
@@ -185,6 +185,7 @@ export function plugin_postlude_esm(): string {
 
 export function prelude(): string {
   return `\
+'use strict';
 ${comment(license)}
 (function(root, factory) {
   const bokeh = factory();
@@ -211,6 +212,7 @@ export function plugin_postlude(): string {
 
 export function plugin_prelude(options?: {version?: string}): string {
   return `\
+'use strict';
 ${comment(license)}
 (function(root, factory) {
   factory(root["Bokeh"], ${str(options?.version)});

--- a/bokehjs/src/lib/core/util/modules.ts
+++ b/bokehjs/src/lib/core/util/modules.ts
@@ -7,7 +7,7 @@ export async function load_module<T>(module: Promise<T>): Promise<T | null> {
   try {
     return await module
   } catch (e) {
-    // XXX: this exposes the underyling module system and hinders
+    // XXX: this exposes the underlying module system and hinders
     // interoperability with other module systems and bundlers
     if (is_ModuleError(e) && e.code === "MODULE_NOT_FOUND")
       return null

--- a/bokehjs/src/lib/models/text/providers.ts
+++ b/bokehjs/src/lib/models/text/providers.ts
@@ -55,9 +55,8 @@ export class BundleProvider extends MathJaxProvider  {
 
     try {
       const mathjax = await load_module(import("./mathjax"))
+      this.status = mathjax == null ? "failed" : "loaded"
       this._mathjax = mathjax
-
-      this.status = "loaded"
       this.ready.emit()
     } catch (error) {
       this.status = "failed"

--- a/bokehjs/src/lib/package.json
+++ b/bokehjs/src/lib/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@bokeh/numbro": "^1.6.2",
-    "@bokeh/slickgrid": "~2.4.4102",
+    "@bokeh/slickgrid": "~2.4.4103",
     "@types/geojson": "^7946.0.10",
     "@types/google.maps": "^3.54.0",
     "@types/hammerjs": "^2.0.41",

--- a/docs/bokeh/source/docs/releases/3.4.0.rst
+++ b/docs/bokeh/source/docs/releases/3.4.0.rst
@@ -9,3 +9,4 @@ Bokeh version ``3.4.0`` (December 2023) is a minor milestone of Bokeh project.
 * Added support for interactivity (rotation) to ``Label`` when ``editable=True`` (:bokeh-pull:`12825`)
 * ``BOKEH_DEV=true`` now defaults to server development resources (:bokeh-pull:`13042`)
 * ``ColorMap`` widget was renamed to ``PaletteSelect`` (:bokeh-pull:`13537`)
+* Enabled JavaScript's strict mode (``"use strict";``) in bokehjs' bundles (:bokeh-pull:`13523`)

--- a/src/bokeh/core/_templates/autoload_js.js
+++ b/src/bokeh/core/_templates/autoload_js.js
@@ -1,3 +1,4 @@
+'use strict';
 {#
 Renders JavaScript code for "autoloading".
 

--- a/src/bokeh/core/_templates/autoload_nb_js.js
+++ b/src/bokeh/core/_templates/autoload_nb_js.js
@@ -160,7 +160,7 @@
   function display_loaded(error = null) {
     const el = document.getElementById({{ elementid|tojson }});
     if (el != null) {
-      const text = (() => {
+      const html = (() => {
         if (typeof root.Bokeh === "undefined") {
           if (error == null) {
             return "BokehJS is loading ...";
@@ -168,18 +168,28 @@
             return "BokehJS failed to load.";
           }
         } else {
-          return `BokehJS ${root.Bokeh.version} ${error == null ? "successfully" : "partially"} loaded.`
+          const prefix = `BokehJS ${root.Bokeh.version}`;
+          if (error == null) {
+            return `${prefix} successfully loaded.`;
+          } else {
+            return `${prefix} <b>encountered errors</b> while loading and may not function as expected.`;
+          }
         }
       })();
-      el.textContent = text
+      el.innerHTML = html;
 
       if (error != null) {
-        const div = document.createElement("div");
-        div.style.fontFamily = "monospace";
-        div.style.whiteSpace = "pre-wrap";
-        div.style.backgroundColor = "rgb(255, 221, 221)";
-        div.textContent = error.stack ?? error.toString();
-        el.append(div);
+        const wrapper = document.createElement("div");
+        wrapper.style.overflow = "auto";
+        wrapper.style.height = "5em";
+        wrapper.style.resize = "vertical";
+        const content = document.createElement("div");
+        content.style.fontFamily = "monospace";
+        content.style.whiteSpace = "pre-wrap";
+        content.style.backgroundColor = "rgb(255, 221, 221)";
+        content.textContent = error.stack ?? error.toString();
+        wrapper.append(content);
+        el.append(wrapper);
       }
     } else if (Date.now() < root._bokeh_timeout) {
       setTimeout(() => display_loaded(error), 100);

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -62,7 +62,7 @@ def get_html_lines(resource_mode: ResourcesMode) -> list[str]:
     html = file_html(p, resources=Resources(resource_mode))
     return html.split('\n')
 
-pinned_template_sha256 = "84b4865b21c819396814839642f629ca09fa0df1033ed1f63fa3f40acae89bb2"
+pinned_template_sha256 = "527b63a6551a6a530089318a509e498fbd4d7057d77a0c23c6270313dcc7570a"
 
 def test_autoload_template_has_changed() -> None:
     """This is not really a test but a reminder that if you change the

--- a/tests/unit/bokeh/core/test_templates.py
+++ b/tests/unit/bokeh/core/test_templates.py
@@ -62,7 +62,7 @@ def get_html_lines(resource_mode: ResourcesMode) -> list[str]:
     html = file_html(p, resources=Resources(resource_mode))
     return html.split('\n')
 
-pinned_template_sha256 = "527b63a6551a6a530089318a509e498fbd4d7057d77a0c23c6270313dcc7570a"
+pinned_template_sha256 = "6019c4cb80495c17303e1b5b05c27aac64e8ef35f41b2d2b9aabcbbe5cf5d3b1"
 
 def test_autoload_template_has_changed() -> None:
     """This is not really a test but a reminder that if you change the


### PR DESCRIPTION
In case of an exception when loading bokehjs, if partially loaded then the output will look like this:

![image](https://github.com/bokeh/bokeh/assets/27475/2a5f62c9-206e-4ef0-9620-e8b8164a63a0)

fixes #13499
fixes #13337
fixes #9684