### PR TITLE
Update contour line calculations to use ContourPy's LineType.ChunkCombinedNan

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
 
   # runtime
-  - contourpy >=1
+  - contourpy >=1.2
   - jinja2 >=2.7
   - numpy >=1.20.0
   - packaging >=16.8

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.11
 
   # runtime
-  - contourpy >=1
+  - contourpy >=1.2
   - jinja2 >=2.7
   - numpy >=1.20.0
   - packaging >=16.8

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.12
 
   # runtime
-  - contourpy >=1
+  - contourpy >=1.2
   - jinja2 >=2.7
   - numpy >=1.20.0
   - packaging >=16.8

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
 
   # runtime
-  - contourpy >=1
+  - contourpy >=1.2
   - jinja2 >=2.7
   - numpy >=1.20.0
   - packaging >=16.8

--- a/conda/environment-test-downstream.yml
+++ b/conda/environment-test-downstream.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
 
   # runtime
-  - contourpy >=1
+  - contourpy >=1.2
   - jinja2 >=2.7
   - numpy >=1.16
   - packaging >=16.8

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
 
   # runtime
-  - contourpy >=1
+  - contourpy >=1.2
   - jinja2 >=2.7
   - numpy <1.25
   - packaging >=16.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "Jinja2 >=2.9",
-    "contourpy >=1",
+    "contourpy >=1.2",
     "numpy >=1.16",
     "packaging >=16.8",
     "pandas >=1.2",

--- a/src/bokeh/plotting/contour.py
+++ b/src/bokeh/plotting/contour.py
@@ -18,7 +18,12 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Sequence, Union
+from typing import (
+    TYPE_CHECKING,
+    Sequence,
+    Union,
+    cast,
+)
 
 # External imports
 import numpy as np
@@ -33,6 +38,7 @@ from ..plotting._renderer import _process_sequence_literals
 from ..util.dataclasses import dataclass, entries
 
 if TYPE_CHECKING:
+    from contourpy._contourpy import FillReturn_OuterOffset, LineReturn_ChunkCombinedNan
     from numpy.typing import ArrayLike, NDArray
     from typing_extensions import TypeAlias
 
@@ -326,6 +332,9 @@ def _contour_coords(
         all_ys = []
         for i in range(len(levels)-1):
             filled = cont_gen.filled(levels[i], levels[i+1])
+            if TYPE_CHECKING:
+                # This is guaranteed by use of fill_type=FillType.OuterOffset in contour_generator call.
+                filled = cast(FillReturn_OuterOffset, filled)
             coords = _filled_to_coords(filled)
             all_xs.append(coords.xs)
             all_ys.append(coords.ys)
@@ -337,6 +346,9 @@ def _contour_coords(
         all_ys = []
         for level in levels:
             lines = cont_gen.lines(level)
+            if TYPE_CHECKING:
+                # This is guaranteed by use of line_type=LineType.ChunkCombinedNan in contour_generator call.
+                lines = cast(LineReturn_ChunkCombinedNan, lines)
             coords = _lines_to_coords(lines)
             all_xs.append(coords.xs)
             all_ys.append(coords.ys)
@@ -344,11 +356,10 @@ def _contour_coords(
 
     return ContourCoords(fill_coords, line_coords)
 
-def _filled_to_coords(filled) -> SingleFillCoords:
+def _filled_to_coords(filled: FillReturn_OuterOffset) -> SingleFillCoords:
     # Processes polygon data returned from a single call to
     # contourpy.ContourGenerator.filled(lower_level, upper_level)
     # ContourPy filled data format is FillType.OuterOffset.
-    # 'filled' type awaits type annotations in contourpy.
     xs = []
     ys = []
     for points, offsets in zip(*filled):
@@ -358,11 +369,10 @@ def _filled_to_coords(filled) -> SingleFillCoords:
         ys.append([points[offsets[i]:offsets[i+1], 1] for i in range(n)])
     return SingleFillCoords(xs, ys)
 
-def _lines_to_coords(lines) -> SingleLineCoords:
+def _lines_to_coords(lines: LineReturn_ChunkCombinedNan) -> SingleLineCoords:
     # Processes line data returned from a single call to
     # contourpy.ContourGenerator.lines(level).
     # ContourPy line data format is LineType.ChunkCombinedNan.
-    # 'lines' type awaits type annotations in contourpy.
     points = lines[0][0]
     if points is None:
         empty = np.empty(0)

--- a/src/bokeh/plotting/contour.py
+++ b/src/bokeh/plotting/contour.py
@@ -318,7 +318,7 @@ def _contour_coords(
         raise RuntimeError("Neither fill nor line requested in _contour_coords")
 
     from contourpy import FillType, LineType, contour_generator
-    cont_gen = contour_generator(x, y, z, line_type=LineType.ChunkCombinedOffset, fill_type=FillType.OuterOffset)
+    cont_gen = contour_generator(x, y, z, line_type=LineType.ChunkCombinedNan, fill_type=FillType.OuterOffset)
 
     fill_coords = None
     if want_fill:
@@ -361,27 +361,15 @@ def _filled_to_coords(filled) -> SingleFillCoords:
 def _lines_to_coords(lines) -> SingleLineCoords:
     # Processes line data returned from a single call to
     # contourpy.ContourGenerator.lines(level).
-    # ContourPy line data format is LineType.ChunkCombinedOffset.
+    # ContourPy line data format is LineType.ChunkCombinedNan.
     # 'lines' type awaits type annotations in contourpy.
     points = lines[0][0]
     if points is None:
         empty = np.empty(0)
         return SingleLineCoords(empty, empty)
 
-    offsets = lines[1][0]
-    npoints = len(points)
-    nlines = len(offsets) - 1
-
-    xs = np.empty(npoints + nlines-1)
-    ys = np.empty(npoints + nlines-1)
-    for i in range(nlines):
-        start = offsets[i]
-        end = offsets[i+1]
-        if i > 0:
-            xs[start+i-1] = np.nan
-            ys[start+i-1] = np.nan
-        xs[start+i:end+i] = points[start:end, 0]
-        ys[start+i:end+i] = points[start:end, 1]
+    xs = points[:, 0]
+    ys = points[:, 1]
     return SingleLineCoords(xs, ys)
 
 def _palette_from_collection(collection: PaletteCollection, n: int) -> Palette:

--- a/src/bokeh/plotting/contour.py
+++ b/src/bokeh/plotting/contour.py
@@ -332,9 +332,8 @@ def _contour_coords(
         all_ys = []
         for i in range(len(levels)-1):
             filled = cont_gen.filled(levels[i], levels[i+1])
-            if TYPE_CHECKING:
-                # This is guaranteed by use of fill_type=FillType.OuterOffset in contour_generator call.
-                filled = cast(FillReturn_OuterOffset, filled)
+            # This is guaranteed by use of fill_type=FillType.OuterOffset in contour_generator call.
+            filled = cast("FillReturn_OuterOffset", filled)
             coords = _filled_to_coords(filled)
             all_xs.append(coords.xs)
             all_ys.append(coords.ys)
@@ -346,9 +345,8 @@ def _contour_coords(
         all_ys = []
         for level in levels:
             lines = cont_gen.lines(level)
-            if TYPE_CHECKING:
-                # This is guaranteed by use of line_type=LineType.ChunkCombinedNan in contour_generator call.
-                lines = cast(LineReturn_ChunkCombinedNan, lines)
+            # This is guaranteed by use of line_type=LineType.ChunkCombinedNan in contour_generator call.
+            lines = cast("LineReturn_ChunkCombinedNan", lines)
             coords = _lines_to_coords(lines)
             all_xs.append(coords.xs)
             all_ys.append(coords.ys)


### PR DESCRIPTION
This updates contour line calculations to use the new functionality available in ContourPy 1.2.0 which is the new `LineType.ChunkCombinedNan`. This makes the Bokeh code simpler and faster as it no longer needs to create a new set of NumPy arrays with `nan` used to separate different contour lines as it is now performed within ContourPy when the contour point coordinates are calculated.

Minimum ContourPy version is now 1.2. Packages for 1.2.0 have been available on PyPI and conda-forge for the last two weeks without any reported problems.

I have also added type annotations for the data returned from ContourPy to Bokeh.

- [x] issues: fixes #13485
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
