### PR TITLE
Add support for deferred loading of bokehjs' bundles

### DIFF
--- a/bokehjs/src/compiler/prelude.ts
+++ b/bokehjs/src/compiler/prelude.ts
@@ -62,7 +62,7 @@ const loader = `\
     if (alias != null)
       return alias;
 
-    const trailing = name.length > 0 && name[name.lenght-1] === "/";
+    const trailing = name.length > 0 && name[name.length-1] === "/";
     const index = aliases[name + (trailing ? "" : "/") + "index"];
     if (index != null)
       return index;
@@ -104,7 +104,7 @@ const loader = `\
           });
         }
 
-        modules[id].call(mod.exports, require, mod, mod.exports, __esModule, __esExport);
+        modules[id].call(mod.exports, require, mod, mod.exports, __esModule, __esExport, base_url);
       } else {
         cache[name] = mod;
       }
@@ -195,9 +195,18 @@ ${comment(license)}
   }
   const Bokeh = root.Bokeh;
   Bokeh[bokeh.version] = bokeh;
-})(this, function() {
+})(globalThis, function() {
   let define;
-  const parent_require = typeof require === "function" && require
+  const parent_require = typeof require === "function" && require;
+  const base_url = (() => {
+    if (typeof document !== "undefined" && document.currentScript != null) {
+      const parts = document.currentScript.src.split("/");
+      parts.pop();
+      return parts.join("/");
+    } else {
+      return null
+    }
+  })()
   return ${loader}\
 `
 }
@@ -216,10 +225,10 @@ export function plugin_prelude(options?: {version?: string}): string {
 ${comment(license)}
 (function(root, factory) {
   factory(root["Bokeh"], ${str(options?.version)});
-})(this, function(Bokeh, version) {
+})(globalThis, function(Bokeh, version) {
   let define;
   return (function(modules, entry, aliases, externals) {
-    const bokeh = typeof Bokeh !== "undefined" && (version != null ? Bokeh[version] : Bokeh);
+    const bokeh = typeof Bokeh !== "undefined" ? (version != null ? Bokeh[version] : Bokeh) : null;
     if (bokeh != null) {
       return bokeh.register_plugin(modules, entry, aliases);
     } else {
@@ -233,8 +242,9 @@ export function default_prelude(options?: {global?: string}): string {
   return `\
 (function(root, factory) {
   ${options?.global != null ? `root[${str(options.global)}] = factory()` : "Object.assign(root, factory())"};
-})(this, function() {
+})(globalThis, function() {
   const parent_require = typeof require === "function" && require
+  const base_url = null
   return ${loader}
 `
 }

--- a/bokehjs/src/compiler/transforms.ts
+++ b/bokehjs/src/compiler/transforms.ts
@@ -426,7 +426,7 @@ export function wrap_in_function(module_name: string) {
   return (context: ts.TransformationContext) => (root: ts.SourceFile): ts.SourceFile => {
     const {factory} = context
     const p = (name: string) => factory.createParameterDeclaration(undefined, undefined, name)
-    const params = [p("require"), p("module"), p("exports"), p("__esModule"), p("__esExport")]
+    const params = [p("require"), p("module"), p("exports"), p("__esModule"), p("__esExport"), p("base_url")]
     const block = factory.createBlock(root.statements, true)
     const func = factory.createFunctionDeclaration(undefined, undefined, "_", undefined, params, undefined, block)
     ts.addSyntheticLeadingComment(func, ts.SyntaxKind.MultiLineCommentTrivia, ` ${module_name} `, false)

--- a/bokehjs/src/lib/client/session.ts
+++ b/bokehjs/src/lib/client/session.ts
@@ -1,13 +1,13 @@
 import {DocumentEventBatch} from "document"
 import {ConnectionLost} from "core/bokeh_events"
-import type {Patch, Document, DocumentEvent} from "document"
+import type {InboundPatch, Document, DocumentEvent} from "document"
 import {Message} from "protocol/message"
 import type {ClientConnection} from "./connection"
 import {logger} from "core/logging"
 
 export type OkMsg = Message<{}>
 export type ErrorMsg = Message<{text: string, traceback: string | null}>
-export type PatchMsg = Message<Patch>
+export type PatchMsg = Message<InboundPatch>
 
 export class ClientSession {
   protected _document_listener = (event: DocumentEvent) => {
@@ -23,12 +23,12 @@ export class ClientSession {
     return this._connection.id
   }
 
-  handle(message: Message<unknown>): void {
+  async handle(message: Message<unknown>): Promise<void> {
     const msgtype = message.msgtype()
 
     switch (msgtype) {
       case "PATCH-DOC": {
-        this._handle_patch(message as PatchMsg)
+        await this._handle_patch(message as PatchMsg)
         break
       }
       case "OK": {
@@ -96,8 +96,8 @@ export class ClientSession {
     this._connection.send(message)
   }
 
-  protected _handle_patch(message: PatchMsg): void {
-    this.document.apply_json_patch(message.content, message.buffers)
+  protected async _handle_patch(message: PatchMsg): Promise<void> {
+    await this.document.apply_json_patch(message.content, message.buffers)
   }
 
   protected _handle_ok(message: OkMsg): void {

--- a/bokehjs/src/lib/core/util/modules.ts
+++ b/bokehjs/src/lib/core/util/modules.ts
@@ -16,3 +16,9 @@ export async function load_module<T>(module: Promise<T>): Promise<T | null> {
     }
   }
 }
+
+export async function import_url(url: string): Promise<unknown> {
+  // XXX: eval() to work around transpilation to require()
+  // https://github.com/microsoft/TypeScript/issues/43329
+  return await eval(`import("${url}")`)
+}

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -1,5 +1,6 @@
 import {default_resolver} from "../base"
 import {version as js_version} from "../version"
+import {settings} from "../core/settings"
 import {logger} from "../core/logging"
 import type {Class} from "core/class"
 import type {HasProps} from "core/has_props"
@@ -20,6 +21,7 @@ import {entries, dict} from "core/util/object"
 import * as sets from "core/util/set"
 import type {CallbackLike} from "core/util/callbacks"
 import {execute} from "core/util/callbacks"
+import {assert} from "core/util/assert"
 import {Model} from "model"
 import type {ModelDef} from "./defs"
 import {decode_def} from "./defs"
@@ -28,6 +30,8 @@ import {DocumentReady, LODStart, LODEnd} from "core/bokeh_events"
 import type {DocumentEvent, DocumentChangedEvent, Decoded, DocumentChanged} from "./events"
 import {DocumentEventBatch, RootRemovedEvent, TitleChangedEvent, MessageSentEvent, RootAddedEvent} from "./events"
 import type {ViewManager} from "core/view_manager"
+
+declare const base_url: string | null | undefined
 
 Deserializer.register("model", decode_def)
 
@@ -63,6 +67,7 @@ export class EventManager {
 export type DocJson = {
   version?: string
   title?: string
+  bundles?: string[]
   defs?: ModelDef[]
   roots: ModelRep[]
   callbacks?: {[key: string]: ModelRep[]}
@@ -70,6 +75,10 @@ export type DocJson = {
 
 export type Patch = {
   events: DocumentChanged[]
+}
+
+export type InboundPatch = Patch & {
+  bundles?: string[]
 }
 
 export const documents: Document[] = []
@@ -431,9 +440,9 @@ export class Document implements Equatable {
     }
   }
 
-  static from_json_string(s: string, events?: Out<DocumentEvent[]>): Document {
+  static async from_json_string(s: string, events?: Out<DocumentEvent[]>): Promise<Document> {
     const json = JSON.parse(s)
-    return Document.from_json(json, events)
+    return await Document.from_json(json, events)
   }
 
   private static _handle_version(json: DocJson): void {
@@ -452,9 +461,64 @@ export class Document implements Equatable {
     }
   }
 
-  static from_json(doc_json: DocJson, events?: Out<DocumentEvent[]>): Document {
+  private static _known_bundles: Set<string> = new Set()
+
+  static async load_bundles(bundles: string[]): Promise<void> {
+
+    const is_absolute = (uri: string): boolean => {
+      return uri.startsWith("http://") || uri.startsWith("https://") || uri.startsWith("/")
+    }
+
+    const load_url = async (url: string): Promise<boolean> => {
+      if (this._known_bundles.has(url)) {
+        return true
+      }
+
+      const response = await fetch(url)
+      if (response.ok) {
+        this._known_bundles.add(url)
+        const module = await response.text()
+        eval(module)
+        return true
+      } else {
+        return false
+      }
+    }
+
+    const build_url = (base_name: string, version?: string): string => {
+      assert(base_url != null)
+      const name = version != null ? `${base_name}-${version}` : base_name
+      const suffix = settings.dev ? ".min.js" : ".js"
+      return `${base_url}/${name}${suffix}`
+    }
+
+    for (const bundle of bundles) {
+      if (is_absolute(bundle)) {
+        if (await load_url(bundle)) {
+          continue
+        }
+      } else {
+        const url = build_url(bundle)
+        if (await load_url(url)) {
+          continue
+        }
+        const versioned_url = build_url(bundle, pyify_version(js_version))
+        if (await load_url(versioned_url)) {
+          continue
+        }
+      }
+
+      console.error(`failed to load '${bundle}' bundle`)
+    }
+  }
+
+  static async from_json(doc_json: DocJson, events?: Out<DocumentEvent[]>): Promise<Document> {
     logger.debug("Creating Document from JSON")
     Document._handle_version(doc_json)
+
+    if (doc_json.bundles != null) {
+      await this.load_bundles(doc_json.bundles)
+    }
 
     const resolver = new ModelResolver(default_resolver)
     if (doc_json.defs != null) {
@@ -498,8 +562,8 @@ export class Document implements Equatable {
     return doc
   }
 
-  replace_with_json(json: DocJson): void {
-    const replacement = Document.from_json(json)
+  async replace_with_json(json: DocJson): Promise<void> {
+    const replacement = await Document.from_json(json)
     replacement.destructively_move(this)
   }
 
@@ -524,7 +588,11 @@ export class Document implements Equatable {
     return patch
   }
 
-  apply_json_patch(patch: Patch, buffers: Map<ID, ArrayBuffer> = new Map()): void {
+  async apply_json_patch(patch: InboundPatch, buffers: Map<ID, ArrayBuffer> = new Map()): Promise<void> {
+    if (patch.bundles != null) {
+      await Document.load_bundles(patch.bundles)
+    }
+
     this._push_all_models_freeze()
 
     const deserializer = new Deserializer(this._resolver, this._all_models, (obj) => obj.attach_document(this))

--- a/bokehjs/src/lib/embed/index.ts
+++ b/bokehjs/src/lib/embed/index.ts
@@ -56,7 +56,7 @@ async function _embed_items(docs_json: string | DocsJson, render_items: RenderIt
 
   const docs: {[key: string]: Document} = {}
   for (const [docid, doc_json] of entries(docs_json)) {
-    docs[docid] = Document.from_json(doc_json)
+    docs[docid] = await Document.from_json(doc_json)
   }
 
   const views: ViewManager[] = []

--- a/bokehjs/src/lib/models/callbacks/customjs.ts
+++ b/bokehjs/src/lib/models/callbacks/customjs.ts
@@ -7,7 +7,8 @@ import {use_strict} from "core/util/string"
 import type {Model} from "../../model"
 import {logger} from "core/logging"
 import type {Dict} from "core/types"
-import {isFunction} from "core/util/types"
+import {isPlainObject, isFunction} from "core/util/types"
+import {import_url} from "core/util/modules"
 import type {ViewManager} from "core/view_manager"
 import {index} from "embed/standalone"
 
@@ -58,10 +59,8 @@ export class CustomJS extends Callback {
   protected async _compile_module(): Promise<ESFunc> {
     const url = URL.createObjectURL(new Blob([this.code], {type: "text/javascript"}))
     try {
-      // XXX: eval() to work around transpilation to require()
-      // https://github.com/microsoft/TypeScript/issues/43329
-      const module = await eval(`import("${url}")`)
-      if (isFunction(module.default)) {
+      const module = await import_url(url)
+      if (isPlainObject(module) && isFunction(module.default)) {
         return module.default as ESFunc
       } else {
         logger.warn("custom ES module didn't export a default function")

--- a/bokehjs/test/integration/cross.ts
+++ b/bokehjs/test/integration/cross.ts
@@ -9,7 +9,7 @@ async function test(name: string) {
   const response = await fetch(`/cases/${name}`)
   const text = await response.text()
   const doc_json = json5.parse<DocJson>(text)
-  const doc = Document.from_json(doc_json)
+  const doc = await Document.from_json(doc_json)
   return await display(doc)
 }
 

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -618,7 +618,7 @@ describe("Document", () => {
     expect(d2.roots().length).to.be.equal(0)
   })
 
-  it("checks for versions matching", () => {
+  it("checks for versions matching", async () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)
     const root1 = new SomeModel()
@@ -632,38 +632,38 @@ describe("Document", () => {
       const parsed = JSON.parse(json)
       const py_version = js_version.replace(/-(dev|rc)\./, ".$1")
       parsed.version = `${py_version}`
-      const out0 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
+      const out0 = await trap(async () => await Document.from_json_string(JSON.stringify(parsed)))
       expect(out0.warn).to.be.equal("")
 
       parsed.version = "0.0.1"
-      const out1 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
+      const out1 = await trap(async () => await Document.from_json_string(JSON.stringify(parsed)))
       expect(out1.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
 
       parsed.version = `${py_version}rc123`
-      const out2 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
+      const out2 = await trap(async () => await Document.from_json_string(JSON.stringify(parsed)))
       expect(out2.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
 
       parsed.version = `${py_version}dev123`
-      const out3 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
+      const out3 = await trap(async () => await Document.from_json_string(JSON.stringify(parsed)))
       expect(out3.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
 
       parsed.version = `${py_version}-foo`
-      const out4 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
+      const out4 = await trap(async () => await Document.from_json_string(JSON.stringify(parsed)))
       expect(out4.warn).to.be.equal("")
 
       parsed.version = `${py_version}rc123-foo`
-      const out5 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
+      const out5 = await trap(async () => await Document.from_json_string(JSON.stringify(parsed)))
       expect(out5.warn).to.be.equal("")
 
       parsed.version = `${py_version}dev123-bar`
-      const out6 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
+      const out6 = await trap(async () => await Document.from_json_string(JSON.stringify(parsed)))
       expect(out6.warn).to.be.equal("")
     } finally {
       logging.set_log_level(original)
     }
   })
 
-  it("can serialize with one model in it", () => {
+  it("can serialize with one model in it", async () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)
     const root1 = new SomeModel()
@@ -674,14 +674,14 @@ describe("Document", () => {
     const json = d.to_json_string()
     const parsed = JSON.parse(json)
     parsed.version = js_version
-    const copy = Document.from_json_string(JSON.stringify(parsed))
+    const copy = await Document.from_json_string(JSON.stringify(parsed))
 
     expect(copy.roots().length).to.be.equal(1)
     expect(copy.roots()[0]).to.be.instanceof(SomeModel)
     expect(copy.title()).to.be.equal("Foo")
   })
 
-  it("can serialize excluding defaults", () => {
+  it("can serialize excluding defaults", async () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)
     const root1 = new SomeModel()
@@ -692,7 +692,7 @@ describe("Document", () => {
     const json = d.to_json_string(false)
     const parsed = JSON.parse(json)
     parsed.version = js_version
-    const copy = Document.from_json_string(JSON.stringify(parsed))
+    const copy = await Document.from_json_string(JSON.stringify(parsed))
 
     expect(copy.roots().length).to.be.equal(1)
     const model0 = copy.roots()[0]
@@ -720,7 +720,7 @@ describe("Document", () => {
   // TODO copy the following tests from test_document.py here
   // TODO(havocp) test_serialization_more_models
 
-  it("can patch an integer property", () => {
+  it("can patch an integer property", async () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)
     expect(d._all_models.size).to.be.equal(0)
@@ -736,18 +736,18 @@ describe("Document", () => {
 
     const event1 = new ev.ModelChangedEvent(d, root1, "foo", 57)
     const patch1 = d.create_json_patch([event1])
-    d.apply_json_patch(patch1)
+    await d.apply_json_patch(patch1)
 
     expect(root1.foo).to.be.equal(57)
 
     const event2 = new ev.ModelChangedEvent(d, child1, "foo", 67)
     const patch2 = d.create_json_patch([event2])
-    d.apply_json_patch(patch2)
+    await d.apply_json_patch(patch2)
 
     expect(child1.foo).to.be.equal(67)
   })
 
-  it("can patch a reference property", () => {
+  it("can patch a reference property", async () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)
     expect(d._all_models.size).to.be.equal(0)
@@ -769,7 +769,7 @@ describe("Document", () => {
 
     const event1 = new ev.ModelChangedEvent(d, root1, "child", child3)
     const patch1 = d.create_json_patch([event1])
-    d.apply_json_patch(patch1)
+    await d.apply_json_patch(patch1)
 
     expect(root1.child.id).to.be.equal(child3.id)
     expect_instanceof(root1.child, SomeModel)
@@ -782,7 +782,7 @@ describe("Document", () => {
     // put it back how it was before
     const event2 = new ev.ModelChangedEvent(d, root1, "child", child1)
     const patch2 = d.create_json_patch([event2])
-    d.apply_json_patch(patch2)
+    await d.apply_json_patch(patch2)
 
     expect(root1.child.id).to.be.equal(child1.id)
     expect_instanceof(root1.child, SomeModel)
@@ -793,7 +793,7 @@ describe("Document", () => {
     expect(d._all_models.has(child3.id)).to.be.false
   })
 
-  it("can patch two properties at once", () => {
+  it("can patch two properties at once", async () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)
     expect(d._all_models.size).to.be.equal(0)
@@ -809,7 +809,7 @@ describe("Document", () => {
     const event1 = new ev.ModelChangedEvent(d, root1, "foo", 57)
     const event2 = new ev.ModelChangedEvent(d, root1, "child", child2)
     const patch1 = d.create_json_patch([event1, event2])
-    d.apply_json_patch(patch1)
+    await d.apply_json_patch(patch1)
 
     expect(root1.foo).to.be.equal(57)
     expect(root1.child).to.be.instanceof(SomeModel)
@@ -817,7 +817,7 @@ describe("Document", () => {
     expect(root1_child0.foo).to.be.equal(44)
   })
 
-  it("sets proper document on models added during patching", () => {
+  it("sets proper document on models added during patching", async () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)
     expect(d._all_models.size).to.be.equal(0)
@@ -837,13 +837,13 @@ describe("Document", () => {
 
     const event1 = new ev.ModelChangedEvent(d, root1, "child", child1)
     const patch1 = d.create_json_patch([event1])
-    d.apply_json_patch(patch1)
+    await d.apply_json_patch(patch1)
 
     expect(root1.document?.roots().length).to.be.equal(1)
     expect(root1.child?.document?.roots().length).to.be.equal(1)
   })
 
-  it("sets proper document on models added during construction", () => {
+  it("sets proper document on models added during construction", async () => {
     const d = new Document()
     expect(d.roots().length).to.be.equal(0)
     expect(d._all_models.size).to.be.equal(0)
@@ -857,7 +857,7 @@ describe("Document", () => {
     const json = d.to_json_string()
     const parsed = JSON.parse(json)
     parsed.version = js_version
-    const copy = Document.from_json_string(JSON.stringify(parsed))
+    const copy = await Document.from_json_string(JSON.stringify(parsed))
 
     const root1_copy = copy.get_model_by_id(root1.id) as ModelWithConstructTimeChanges
 
@@ -872,7 +872,7 @@ describe("Document", () => {
     expect(root1_copy.child?.document).to.be.equal(copy)
   })
 
-  it("can detect changes during model initialization", () => {
+  it("can detect changes during model initialization", async () => {
     const doc_json = {
       version: js_version,
       title: "Bokeh Application",
@@ -887,7 +887,7 @@ describe("Document", () => {
     }
 
     const events: ev.DocumentEvent[] = []
-    const doc = Document.from_json(doc_json, events)
+    const doc = await Document.from_json(doc_json, events)
 
     expect(doc.roots().length).to.be.equal(1)
     expect(events.length).to.be.equal(2)
@@ -957,7 +957,7 @@ describe("Document", () => {
   })
 
   describe("doesn't boomerang events", () => {
-    it("when adding a new root", () => {
+    it("when adding a new root", async () => {
       const doc = new Document()
 
       const events: ev.DocumentEvent[] = []
@@ -966,7 +966,7 @@ describe("Document", () => {
       const model0 = new SomeModel({foo: 127})
       const event = new ev.RootAddedEvent(doc, model0)
       const patch = doc.create_json_patch([event])
-      doc.apply_json_patch(patch)
+      await doc.apply_json_patch(patch)
 
       expect(events.filter((e) => e.sync).length).to.be.equal(0)
       expect(events.filter((e) => !e.sync).length).to.be.equal(1)
@@ -980,7 +980,7 @@ describe("Document", () => {
       expect(doc.roots().length).to.be.equal(2)
     })
 
-    it("when removing a root", () => {
+    it("when removing a root", async () => {
       const doc = new Document()
 
       const model0 = new SomeModel({foo: 127})
@@ -994,7 +994,7 @@ describe("Document", () => {
 
       const event = new ev.RootRemovedEvent(doc, model0)
       const patch = doc.create_json_patch([event])
-      doc.apply_json_patch(patch)
+      await doc.apply_json_patch(patch)
 
       expect(events.filter((e) => e.sync).length).to.be.equal(0)
       expect(events.filter((e) => !e.sync).length).to.be.equal(1)
@@ -1007,7 +1007,7 @@ describe("Document", () => {
       expect(doc.roots().length).to.be.equal(0)
     })
 
-    it("when changing a title", () => {
+    it("when changing a title", async () => {
       const doc = new Document()
 
       const events: ev.DocumentEvent[] = []
@@ -1017,7 +1017,7 @@ describe("Document", () => {
 
       const event = new ev.TitleChangedEvent(doc, "some title")
       const patch = doc.create_json_patch([event])
-      doc.apply_json_patch(patch)
+      await doc.apply_json_patch(patch)
 
       expect(events.filter((e) => e.sync).length).to.be.equal(0)
       expect(events.filter((e) => !e.sync).length).to.be.equal(1)
@@ -1030,7 +1030,7 @@ describe("Document", () => {
       expect(doc.title()).to.be.equal("other title")
     })
 
-    it("when modifying a model", () => {
+    it("when modifying a model", async () => {
       const doc = new Document()
 
       const model = new SomeModel({foo: 127})
@@ -1043,7 +1043,7 @@ describe("Document", () => {
 
       const event = new ev.ModelChangedEvent(doc, model, "foo", 128)
       const patch = doc.create_json_patch([event])
-      doc.apply_json_patch(patch)
+      await doc.apply_json_patch(patch)
 
       expect(events.filter((e) => e.sync).length).to.be.equal(0)
       expect(events.filter((e) => !e.sync).length).to.be.equal(1)
@@ -1056,7 +1056,7 @@ describe("Document", () => {
       expect(model.foo).to.be.equal(129)
     })
 
-    it("when changing column data", () => {
+    it("when changing column data", async () => {
       const doc = new Document()
 
       const source = new ColumnDataSource({data: {col0: [1, 2, 3]}})
@@ -1067,14 +1067,14 @@ describe("Document", () => {
 
       const event = new ev.ColumnDataChangedEvent(doc, source, "data", {col1: [4, 5, 6]})
       const patch = doc.create_json_patch([event])
-      doc.apply_json_patch(patch)
+      await doc.apply_json_patch(patch)
 
       expect(events.filter((e) => e.sync).length).to.be.equal(0)
       expect(events.filter((e) => !e.sync).length).to.be.equal(1)
       expect(source.data).to.be.equal({col1: [4, 5, 6]})
     })
 
-    it("when streaming to a column", () => {
+    it("when streaming to a column", async () => {
       const doc = new Document()
 
       const source = new ColumnDataSource({data: {col0: [1, 2, 3]}})
@@ -1085,7 +1085,7 @@ describe("Document", () => {
 
       const event = new ev.ColumnsStreamedEvent(doc, source, "data", {col0: [4, 5, 6]})
       const patch = doc.create_json_patch([event])
-      doc.apply_json_patch(patch)
+      await doc.apply_json_patch(patch)
 
       expect(events.filter((e) => e.sync).length).to.be.equal(0)
       expect(events.filter((e) => !e.sync).length).to.be.equal(1)
@@ -1098,7 +1098,7 @@ describe("Document", () => {
       expect(source.data).to.be.equal({col0: [1, 2, 3, 4, 5, 6, 7, 8, 9]})
     })
 
-    it("when patching a column", () => {
+    it("when patching a column", async () => {
       const doc = new Document()
 
       const source = new ColumnDataSource({data: {col0: [1, 2, 3, 4, 5, 6]}})
@@ -1109,7 +1109,7 @@ describe("Document", () => {
 
       const event = new ev.ColumnsPatchedEvent(doc, source, "data", {col0: [[new Slice({start: 1, stop: 3}), [20, 30]]]})
       const patch = doc.create_json_patch([event])
-      doc.apply_json_patch(patch)
+      await doc.apply_json_patch(patch)
 
       expect(events.filter((e) => e.sync).length).to.be.equal(0)
       expect(events.filter((e) => !e.sync).length).to.be.equal(1)

--- a/bokehjs/test/unit/models/callbacks/customjs.ts
+++ b/bokehjs/test/unit/models/callbacks/customjs.ts
@@ -12,7 +12,7 @@ describe("CustomJS", () => {
 
   describe("args property", () => {
 
-    it("should round-trip through document serialization", () => {
+    it("should round-trip through document serialization", async () => {
       const rng = new Range1d()
       const cb = new CustomJS({code: "return 10", args: {rng}})
 
@@ -23,7 +23,7 @@ describe("CustomJS", () => {
       const parsed = JSON.parse(json)
       parsed.version = js_version
 
-      const copy = Document.from_json_string(JSON.stringify(parsed))
+      const copy = await Document.from_json_string(JSON.stringify(parsed))
 
       const cb_copy = copy.get_model_by_id(cb.id)
       expect_instanceof(cb_copy, CustomJS)

--- a/bokehjs/test/unit/models/tools/inspectors/customjs_hover.ts
+++ b/bokehjs/test/unit/models/tools/inspectors/customjs_hover.ts
@@ -28,13 +28,13 @@ describe("CustomJSHover", () => {
       expect(customjs_hover.values).to.be.equal([range])
     })
 
-    it("should round-trip through document serialization", () => {
+    it("should round-trip through document serialization", async () => {
       const d = new Document()
       d.add_root(customjs_hover)
       const json = d.to_json_string()
       const parsed = JSON.parse(json)
       parsed.version = js_version
-      const copy = Document.from_json_string(JSON.stringify(parsed))
+      const copy = await Document.from_json_string(JSON.stringify(parsed))
       const customjs_hover_copy = copy.get_model_by_id(customjs_hover.id)
       const range_copy = copy.get_model_by_id(range.id)
       expect_instanceof(customjs_hover_copy, CustomJSHover)

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -405,7 +405,7 @@ describe("Bug", () => {
       }
 
       const events0: DocumentEvent[] = []
-      const doc = Document.from_json(doc_json, events0)
+      const doc = await Document.from_json(doc_json, events0)
       expect(events0).to.be.empty
 
       expect(doc.roots().length).to.be.equal(1)

--- a/bokehjs/test/util.ts
+++ b/bokehjs/test/util.ts
@@ -10,7 +10,10 @@ export type TrapOutput = {
   error: string
 }
 
-export function trap(fn: () => void): TrapOutput {
+export function trap(fn: () => Promise<void>): Promise<TrapOutput>
+export function trap(fn: () => void): TrapOutput
+
+export function trap(fn: () => unknown): TrapOutput | Promise<TrapOutput> {
   const result = {
     log: "",
     trace: "",
@@ -22,23 +25,23 @@ export function trap(fn: () => void): TrapOutput {
   function join(args: unknown[]): string {
     return args.map((arg) => `${arg}`).join(" ") + "\n"
   }
-  // XXX: stubing both console and logger, and including logger's name manually is a hack,
+
+  // XXX: stubbing both console and logger, and including logger's name manually is a hack,
   // but that's be best we can do (at least for now) while preserving logger's ability to
   // to reference the original location from where a logging method was called.
-  const log = stub(console, "log").callsFake((...args) => {result.log += join(args)})
-  const ctrace = stub(console, "trace").callsFake((...args) => {result.trace += join(args)})
-  const ltrace = stub(logger, "trace").callsFake((...args) => {result.trace += join(["[bokeh]", ...args])})
-  const cdebug = stub(console, "debug").callsFake((...args) => {result.debug += join(args)})
-  const ldebug = stub(logger, "debug").callsFake((...args) => {result.debug += join(["[bokeh]", ...args])})
-  const cinfo = stub(console, "info").callsFake((...args) => {result.info += join(args)})
-  const linfo = stub(logger, "info").callsFake((...args) => {result.info += join(["[bokeh]", ...args])})
-  const cwarn = stub(console, "warn").callsFake((...args) => {result.warn += join(args)})
-  const lwarn = stub(logger, "warn").callsFake((...args) => {result.warn += join(["[bokeh]", ...args])})
-  const cerror = stub(console, "error").callsFake((...args) => {result.error += join(args)})
-  const lerror = stub(logger, "error").callsFake((...args) => {result.error += join(["[bokeh]", ...args])})
-  try {
-    fn()
-  } finally {
+  const log = stub(console, "log").callsFake((...args) => result.log += join(args))
+  const ctrace = stub(console, "trace").callsFake((...args) => result.trace += join(args))
+  const ltrace = stub(logger, "trace").callsFake((...args) => result.trace += join(["[bokeh]", ...args]))
+  const cdebug = stub(console, "debug").callsFake((...args) => result.debug += join(args))
+  const ldebug = stub(logger, "debug").callsFake((...args) => result.debug += join(["[bokeh]", ...args]))
+  const cinfo = stub(console, "info").callsFake((...args) => result.info += join(args))
+  const linfo = stub(logger, "info").callsFake((...args) => result.info += join(["[bokeh]", ...args]))
+  const cwarn = stub(console, "warn").callsFake((...args) => result.warn += join(args))
+  const lwarn = stub(logger, "warn").callsFake((...args) => result.warn += join(["[bokeh]", ...args]))
+  const cerror = stub(console, "error").callsFake((...args) => result.error += join(args))
+  const lerror = stub(logger, "error").callsFake((...args) => result.error += join(["[bokeh]", ...args]))
+
+  function restore(): void {
     log.restore()
     ctrace.restore()
     ltrace.restore()
@@ -51,5 +54,15 @@ export function trap(fn: () => void): TrapOutput {
     cerror.restore()
     lerror.restore()
   }
-  return result
+
+  try {
+    const ret = fn()
+    if (ret instanceof Promise) {
+      return ret.then(() => result).finally(() => restore())
+    } else {
+      return result
+    }
+  } finally {
+    restore()
+  }
 }

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -739,7 +739,7 @@ side of a communications channel while it was being removed on the other end.\
             self.callbacks.trigger_on_change(TitleChangedEvent(self, title, setter))
 
     def to_json(self, *, deferred: bool = True) -> DocJson:
-        ''' Convert this document to a JSON-serializble object.
+        ''' Convert this document to a JSON-serializable object.
 
         Return:
             DocJson
@@ -752,10 +752,14 @@ side of a communications channel while it was being removed on the other end.\
         roots = serializer.encode(self._roots)
         callbacks = serializer.encode(self.callbacks._js_event_callbacks)
 
+        from ..embed.bundle import used_bundles
+        bundles = used_bundles(self._roots).components()
+
         doc_json = DocJson(
             version=__version__,
             title=self.title,
             roots=roots,
+            bundles=bundles,
         )
 
         if data_models:

--- a/src/bokeh/document/json.py
+++ b/src/bokeh/document/json.py
@@ -113,6 +113,7 @@ DocumentChanged = DocumentPatched
 class DocJson(TypedDict):
     version: NotRequired[str]
     title: NotRequired[str]
+    bundles: NotRequired[list[str]]
     defs: NotRequired[list[ModelDef]]
     roots: list[ModelRep]
     callbacks: NotRequired[dict[str, list[ModelRep]]]

--- a/src/bokeh/embed/bundle.py
+++ b/src/bokeh/embed/bundle.py
@@ -157,17 +157,21 @@ def bundle_for_objs_and_resources(objs: Sequence[HasProps | Document] | None, re
     '''
     if objs is not None:
         all_objs    = _all_objs(objs)
-        use_widgets = _use_widgets(all_objs)
-        use_tables  = _use_tables(all_objs)
-        use_gl      = _use_gl(all_objs)
-        use_mathjax = _use_mathjax(all_objs)
+        # use_widgets = _use_widgets(all_objs)
+        # use_tables  = _use_tables(all_objs)
+        # use_gl      = _use_gl(all_objs)
+        # use_mathjax = _use_mathjax(all_objs)
     else:
-        # XXX: force all components on server and in notebook, because we don't know in advance what will be used
         all_objs    = None
-        use_widgets = True
-        use_tables  = True
-        use_gl      = True
-        use_mathjax = True
+        # use_widgets = False
+        # use_tables  = False
+        # use_gl      = False
+        # use_mathjax = False
+
+    use_widgets = False
+    use_tables  = False
+    use_gl      = False
+    use_mathjax = False
 
     js_files: list[URL] = []
     js_raw: list[str] = []
@@ -210,6 +214,34 @@ def bundle_for_objs_and_resources(objs: Sequence[HasProps | Document] | None, re
         js_raw.append(ext)
 
     return Bundle(js_files, js_raw, css_files, css_raw, resources.hashes if resources else {})
+
+@dataclass
+class UsedBundles:
+    widgets: bool
+    tables: bool
+    gl: bool
+    mathjax: bool
+
+    def components(self) -> list[str]:
+        result: list[str] = []
+        if self.widgets:
+            result.append("bokeh-widgets")
+        if self.tables:
+            result.append("bokeh-tables")
+        if self.gl:
+            result.append("bokeh-gl")
+        if self.mathjax:
+            result.append("bokeh-mathjax")
+        return result
+
+def used_bundles(objs: Sequence[Model]) -> UsedBundles:
+    all_objs = _all_objs(objs)
+    return UsedBundles(
+        widgets = _use_widgets(all_objs),
+        tables  = _use_tables(all_objs),
+        gl      = _use_gl(all_objs),
+        mathjax = _use_mathjax(all_objs),
+    )
 
 #-----------------------------------------------------------------------------
 # Private API
@@ -471,6 +503,7 @@ def _ext_use_widgets(all_objs: set[HasProps]) -> bool:
 def _ext_use_mathjax(all_objs: set[HasProps]) -> bool:
     from ..models.text import MathText
     return _query_extensions(all_objs, lambda cls: issubclass(cls, MathText))
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This is an experiment in adding support for deferred bundles. Bundles are resolved the same as previously, but instead of including them via resource management, they are included either by name or respective URL in document's serialized representation and resolved by bokehjs when needed. This work for both standalone and server embedding. Additional bundles can be requested with subsequent document patches.

In the example below we can see that only `bokeh.js` was loaded with the initial HTML page, but we can use widgets and math text:

![image](https://github.com/bokeh/bokeh/assets/27475/0c64d6a6-728a-4923-9c29-2b55445925d2)

Tentatively including in 3.4 milestone, but it may take some time before this is fully incorporated into bokeh's embed.

- [ ] fixes #10166 
