### PR TITLE
fix indentation in sphinx extentions

### DIFF
--- a/src/bokeh/sphinxext/bokeh_color.py
+++ b/src/bokeh/sphinxext/bokeh_color.py
@@ -14,7 +14,11 @@ The ``bokeh-color`` directive accepts a named color as its argument:
 
 and generates a labeled color swatch as output.
 
-    .. bokeh-color:: aliceblue
+======
+
+.. bokeh-color:: aliceblue
+
+======
 
 The ``bokeh-color`` direction may be used explicitly, but it can also be used
 in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.

--- a/src/bokeh/sphinxext/bokeh_dataframe.py
+++ b/src/bokeh/sphinxext/bokeh_dataframe.py
@@ -17,7 +17,7 @@ For example:
 
 Will generate the output:
 
-    :bokeh-dataframe:`bokeh.sampledata.sprint.sprint`
+:bokeh-dataframe:`bokeh.sampledata.sprint.sprint`
 
 To enable this extension, add `"bokeh.sphinxext.bokeh_dataframe"` to the
 extensions list in your Sphinx configuration module.

--- a/src/bokeh/sphinxext/bokeh_enum.py
+++ b/src/bokeh/sphinxext/bokeh_enum.py
@@ -25,10 +25,14 @@ Examples
 
 The directive above will generate the following output:
 
-    .. bokeh-enum:: baz
-        :module: bokeh.sphinxext.sample
+=====
 
-        Specify a baz style
+.. bokeh-enum:: baz
+    :module: bokeh.sphinxext.sample
+
+    Specify a baz style
+
+=====
 
 Although ``bokeh-enum`` may be used explicitly, it is more often convenient in
 conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension. Together,

--- a/src/bokeh/sphinxext/bokeh_jinja.py
+++ b/src/bokeh/sphinxext/bokeh_jinja.py
@@ -17,8 +17,12 @@ Any template parameters will be displayed and the template source code will
 be rendered in a collapsible code block. For example, the usage above will
 generate the following output:
 
-    .. bokeh-jinja:: bokeh.core.templates.FILE
-        :noindex:
+=====
+
+.. bokeh-jinja:: bokeh.core.templates.FILE
+    :noindex:
+
+=====
 
 To enable this extension, add `"bokeh.sphinxext.bokeh_jinja"` to the
 extensions list in your Sphinx configuration module.

--- a/src/bokeh/sphinxext/bokeh_model.py
+++ b/src/bokeh/sphinxext/bokeh_model.py
@@ -32,8 +32,12 @@ For the following definition of ``bokeh.sphinxext.sample.Foo``:
 
 usage yields the output:
 
-    .. bokeh-model:: Foo
-        :module: bokeh.sphinxext.sample
+=====
+
+.. bokeh-model:: Foo
+    :module: bokeh.sphinxext.sample
+
+=====
 
 The ``bokeh-model`` direction may be used explicitly, but it can also be used
 in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.

--- a/src/bokeh/sphinxext/bokeh_options.py
+++ b/src/bokeh/sphinxext/bokeh_options.py
@@ -32,8 +32,12 @@ For the following definition of ``bokeh.sphinxext.sample.Opts``:
 
 the above usage yields the output:
 
-    .. bokeh-options:: Opts
-        :module: bokeh.sphinxext.sample
+=====
+
+.. bokeh-options:: Opts
+    :module: bokeh.sphinxext.sample
+
+=====
 
 To enable this extension, add `"bokeh.sphinxext.bokeh_options"` to the
 extensions list in your Sphinx configuration module.

--- a/src/bokeh/sphinxext/bokeh_palette.py
+++ b/src/bokeh/sphinxext/bokeh_palette.py
@@ -6,7 +6,7 @@
 # -----------------------------------------------------------------------------
 """ Generate an inline visual representations of a single color palette.
 
-The ``:bokeh-palette:`` role can be used with by providing any of the
+The ``:bokeh-palette:`` role can be used by providing any of the
 following:
 
 * a palette name from ``bokeh.palettes``, e.g. ``Spectral9``
@@ -15,23 +15,39 @@ following:
 
 * An explicit list of colors: ``['#000000', '#333333', '#666666', '#999999', '#cccccc', '#ffffff']``
 
-The following usage of the the directive:
+The following usage of the the directive is valid:
+
+-----
+
+* by name
 
 .. code-block:: rest
 
-    * by name: :bokeh-palette:`Spectral9`
+    :bokeh-palette:`Spectral9`
 
-    * by function: :bokeh-palette:`viridis(12)`
+:bokeh-palette:`Spectral9`
 
-    * by list: :bokeh-palette:`['#000000', '#333333', '#666666', '#999999', '#cccccc', '#ffffff']`
+-----
 
-Generates the output:
+* by function
 
-    * by name: :bokeh-palette:`Spectral9`
+.. code-block:: rest
 
-    * by function: :bokeh-palette:`viridis(12)`
+    :bokeh-palette:`viridis(12)`
 
-    * by list: :bokeh-palette:`['#000000', '#333333', '#666666', '#999999', '#cccccc', '#ffffff']`
+:bokeh-palette:`viridis(12)`
+
+-----
+
+* by list
+
+.. code-block:: rest
+
+    :bokeh-palette:`['#000000', '#333333', '#666666', '#999999', '#cccccc', '#ffffff']`
+
+:bokeh-palette:`['#000000', '#333333', '#666666', '#999999', '#cccccc', '#ffffff']`
+
+-----
 
 Palette swatches are 20 pixels in height. For palettes short than 20 colors,
 the default width for the swatches is 20 pixels. If larger palettes are given,
@@ -44,7 +60,11 @@ pixel. For instance displaying the full Viridis palette with the expression
 
 Will generate the output:
 
-    :bokeh-palette:`viridis(256)`
+-----
+
+:bokeh-palette:`viridis(256)`
+
+-----
 
 To enable this extension, add `"bokeh.sphinxext.bokeh_palette"` to the
 extensions list in your Sphinx configuration module.

--- a/src/bokeh/sphinxext/bokeh_palette_group.py
+++ b/src/bokeh/sphinxext/bokeh_palette_group.py
@@ -19,7 +19,11 @@ As an example, the following usage of the the directive:
 
 Generates the output:
 
-    .. bokeh-palette-group:: mpl
+-----
+
+.. bokeh-palette-group:: mpl
+
+-----
 
 .. note::
    This extension assumes both Bootstrap and JQuery are present (which is the

--- a/src/bokeh/sphinxext/bokeh_prop.py
+++ b/src/bokeh/sphinxext/bokeh_prop.py
@@ -31,9 +31,12 @@ For the following definition of ``bokeh.sphinxext.sample.Bar``:
 
 the above usage yields the output:
 
-    .. bokeh-prop:: Bar.thing
-        :module: bokeh.sphinxext.sample
+-----
 
+.. bokeh-prop:: Bar.thing
+    :module: bokeh.sphinxext.sample
+
+-----
 
 The ``bokeh-prop`` direction may be used explicitly, but it can also be used
 in conjunction with the :ref:`bokeh.sphinxext.bokeh_autodoc` extension.


### PR DESCRIPTION
This is the last task in a list of tasks which will fix some indentations in the docs. This time the focus is on the [sphinxext](https://docs.bokeh.org/en/latest/docs/reference/sphinxext.html) page.

- [ ] issues: fixes #13276

|**old**|**new**|
|--|--|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/dbe51529-4336-44d7-91fc-79f78b8b4c8a)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/ff118898-1eaf-43ba-a984-cd5e17780a84)|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/9f5e80e3-92df-4160-80fb-481d9801ede5)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/61720b95-9c3b-4b69-9297-2861dc6a3a61)|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/75c9e9b7-2e8c-4e7b-9311-1a50d4c1973d)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/5d93941b-be3a-4711-8925-75919ed93065)|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/2e8c57e1-3557-4430-a55b-29f86bd811cb)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/cf89532b-6ffe-423f-99fc-b1f3c3939494)|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/c28d079a-40d2-4a3a-aafe-0e304b56cfab)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/844d56fc-1e00-49af-893a-e42f0ac1e27f)|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/d125b61b-db26-4436-8d90-cf8f23d6c49f)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/e4d70ab5-9d56-4d0e-8d5b-0bdfb319ab2e)|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/a34004aa-a5d3-43b4-8aa2-5d7b5e86d543)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/6631903b-5b55-4e4e-ac7e-bcb86cc667df)|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/b440819b-9c7a-46f0-b222-2fd21dd5b296)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/683f20bd-8952-4f9b-9363-b566a050172e)|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/3718f1ba-0a51-4efd-a0e0-9662e9c7d0c4)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/600e5a57-afd4-4293-98e0-10653523c5b3)|

Please not the thin gray lines I added to have a separation between generated blocks and the explanations.









