### PR TITLE
Allow to override non-visual glyph data properties

### DIFF
--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -70,7 +70,7 @@ export type MaxAttrsOf<Props> = {
 }
 
 export type CoordsAttrsOf<Props> = {
-  [Key in keyof Props & string as Props[Key] extends BaseCoordinateSpec<any> ? `_${Key}` : never]:
+  [Key in keyof Props & string as Props[Key] extends BaseCoordinateSpec<any> ? Key : never]:
     Props[Key] extends CoordinateSpec          ? Arrayable<number> :
     Props[Key] extends CoordinateSeqSpec       ? RaggedArray<FloatArray> :
     Props[Key] extends CoordinateSeqSeqSeqSpec ? Arrayable<Arrayable<Arrayable<Arrayable<number>>>> : never

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -96,7 +96,7 @@ export type InheritedOf<Props> = InheritedAttrsOf<Props> & InheritedScreenOf<Pro
 
 export type Expanded<T> = T extends infer Obj ? {[K in keyof Obj]: Obj[K]} : never
 
-export type GlyphDataOf<Props> = Expanded<CoordsAttrsOf<Props> & ScreenAttrsOf<Props> & MaxAttrsOf<Props> & UniformsOf<Props> & InheritedOf<Props>>
+export type GlyphDataOf<Props> = Expanded<Readonly<CoordsAttrsOf<Props> & ScreenAttrsOf<Props> & MaxAttrsOf<Props> & UniformsOf<Props> & InheritedOf<Props>>>
 
 export type AttrsOf<P> = {
   [K in keyof P]: P[K] extends Property<infer T> ? T : never

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -82,10 +82,21 @@ export type ScreenAttrsOf<Props> = {
     Props[Key] extends CoordinateSeqSpec             ? RaggedArray<FloatArray> :
     Props[Key] extends CoordinateSeqSeqSeqSpec       ? Arrayable<Arrayable<Arrayable<Arrayable<number>>>> : never
 }
+export type InheritedAttrsOf<Props> = {
+  [Key in keyof Props & string as
+    Props[Key] extends VectorSpec<any, any> ? `inherited_${Key}` :
+    Props[Key] extends ScalarSpec<any, any> ? `inherited_${Key}` : never]: boolean
+}
+
+export type InheritedScreenOf<Props> = {
+  [Key in keyof Props & string as Props[Key] extends BaseCoordinateSpec<any> | DistanceSpec ? `inherited_s${Key}` : never]: boolean
+}
+
+export type InheritedOf<Props> = InheritedAttrsOf<Props> & InheritedScreenOf<Props>
 
 export type Expanded<T> = T extends infer Obj ? {[K in keyof Obj]: Obj[K]} : never
 
-export type GlyphDataOf<Props> = Expanded<CoordsAttrsOf<Props> & ScreenAttrsOf<Props> & MaxAttrsOf<Props> & UniformsOf<Props>>
+export type GlyphDataOf<Props> = Expanded<CoordsAttrsOf<Props> & ScreenAttrsOf<Props> & MaxAttrsOf<Props> & UniformsOf<Props> & InheritedOf<Props>>
 
 export type AttrsOf<P> = {
   [K in keyof P]: P[K] extends Property<infer T> ? T : never

--- a/bokehjs/src/lib/core/uniforms.ts
+++ b/bokehjs/src/lib/core/uniforms.ts
@@ -10,6 +10,7 @@ export abstract class Uniform<T = number> implements Equatable {
   abstract [Symbol.iterator](): Generator<T, void, undefined>
   abstract select(indices: Indices): Uniform<T>
   abstract [equals](that: this, cmp: Comparator): boolean
+  abstract map<U>(fn: (v: T) => U): Uniform<U>
 
   is_Scalar(): this is UniformScalar<T> { return this.is_scalar }
   is_Vector(): this is UniformVector<T> { return !this.is_scalar }
@@ -40,6 +41,10 @@ export class UniformScalar<T> extends Uniform<T> {
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.length, that.length) && cmp.eq(this.value, that.value)
   }
+
+  map<U>(fn: (v: T) => U): UniformScalar<U> {
+    return new UniformScalar(fn(this.value), this.length)
+  }
 }
 
 export class UniformVector<T> extends Uniform<T> {
@@ -66,6 +71,10 @@ export class UniformVector<T> extends Uniform<T> {
 
   [equals](that: this, cmp: Comparator): boolean {
     return cmp.eq(this.length, that.length) && cmp.eq(this.array, that.array)
+  }
+
+  map<U>(fn: (v: T) => U): UniformVector<U> {
+    return new UniformVector(arrayable.map(this.array, fn))
   }
 }
 

--- a/bokehjs/src/lib/core/util/array.ts
+++ b/bokehjs/src/lib/core/util/array.ts
@@ -278,6 +278,15 @@ export function pairwise<T, U>(array: T[], fn: (prev: T, next: T) => U): U[] {
   return result
 }
 
+export function elementwise<T, U>(array0: Arrayable<T>, array1: Arrayable<T>, fn: (a: T, b: T) => U): U[] {
+  const n = Math.min(array0.length, array1.length)
+  const result: U[] = Array(n)
+  for (let i = 0; i < n; i++) {
+    result[i] = fn(array0[i], array1[i])
+  }
+  return result
+}
+
 export function reversed<T>(array: T[]): T[] {
   const n = array.length
   const result: T[] = new Array(n)

--- a/bokehjs/src/lib/core/util/eq.ts
+++ b/bokehjs/src/lib/core/util/eq.ts
@@ -19,6 +19,8 @@ export const wildcard: any = Symbol("wildcard")
 
 const toString = Object.prototype.toString
 
+export class EqNotImplemented extends Error {}
+
 export class Comparator {
   private readonly a_stack: unknown[] = []
   private readonly b_stack: unknown[] = []
@@ -110,7 +112,7 @@ export class Comparator {
         return this.nodes(a, b)
       }
 
-      throw Error(`can't compare objects of type ${class_name}`)
+      throw new EqNotImplemented(`can't compare objects of type ${class_name}`)
     })()
 
     a_stack.pop()

--- a/bokehjs/src/lib/core/util/interpolation.ts
+++ b/bokehjs/src/lib/core/util/interpolation.ts
@@ -1,9 +1,9 @@
-import type {FloatArray} from "../types"
+import type {Arrayable} from "../types"
 import {infer_type} from "../types"
 import {assert} from "./assert"
 
-export function catmullrom_spline(x: FloatArray, y: FloatArray,
-    T: number = 10, tension: number = 0.5, closed: boolean = false): [FloatArray, FloatArray] {
+export function catmullrom_spline(x: Arrayable<number>, y: Arrayable<number>,
+    T: number = 10, tension: number = 0.5, closed: boolean = false): [Arrayable<number>, Arrayable<number>] {
   /** Centripetal Catmull-Rom spline. */
   assert(x.length == y.length)
 

--- a/bokehjs/src/lib/core/util/ragged_array.ts
+++ b/bokehjs/src/lib/core/util/ragged_array.ts
@@ -6,13 +6,13 @@ import {assert} from "./assert"
 
 type OffsetArray = Uint8Array | Uint16Array | Uint32Array
 
-export class RaggedArray<ArrayType extends TypedArray> implements Equatable {
+export class RaggedArray<ArrayType extends TypedArray = Float64Array> implements Equatable {
   static [Symbol.toStringTag] = "RaggedArray"
 
-  constructor(readonly offsets: OffsetArray, readonly array: ArrayType) {}
+  constructor(readonly offsets: OffsetArray, readonly data: ArrayType) {}
 
   [equals](that: this, cmp: Comparator): boolean {
-    return cmp.arrays(this.offsets, that.offsets) && cmp.arrays(this.array, that.array)
+    return cmp.arrays(this.offsets, that.offsets) && cmp.arrays(this.data, that.data)
   }
 
   get length(): number {
@@ -20,7 +20,7 @@ export class RaggedArray<ArrayType extends TypedArray> implements Equatable {
   }
 
   clone(): RaggedArray<ArrayType> {
-    return new RaggedArray<ArrayType>(this.offsets.slice(), this.array.slice() as ArrayType)
+    return new RaggedArray<ArrayType>(this.offsets.slice(), this.data.slice() as ArrayType)
   }
 
   static from<ArrayType extends TypedArray>(items: Arrayable<Arrayable<number>>, ctor: Constructor<ArrayType>): RaggedArray<ArrayType> {
@@ -50,7 +50,7 @@ export class RaggedArray<ArrayType extends TypedArray> implements Equatable {
   *[Symbol.iterator](): IterableIterator<ArrayType> {
     const {offsets, length} = this
     for (let i = 0; i < length; i++) {
-      yield this.array.subarray(offsets[i], offsets[i + 1]) as ArrayType
+      yield this.data.subarray(offsets[i], offsets[i + 1]) as ArrayType
     }
   }
 
@@ -61,11 +61,11 @@ export class RaggedArray<ArrayType extends TypedArray> implements Equatable {
   get(i: number): ArrayType {
     this._check_bounds(i)
     const {offsets} = this
-    return this.array.subarray(offsets[i], offsets[i + 1]) as ArrayType
+    return this.data.subarray(offsets[i], offsets[i + 1]) as ArrayType
   }
 
   set(i: number, array: ArrayLike<number>): void {
     this._check_bounds(i)
-    this.array.set(array, this.offsets[i])
+    this.data.set(array, this.offsets[i])
   }
 }

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -1,9 +1,8 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {generic_area_vector_legend} from "./utils"
 import type {PointGeometry} from "core/geometry"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
-import type {Rect, ScreenArray} from "core/types"
+import type {Rect} from "core/types"
 import {to_screen} from "core/types"
 import type * as visuals from "core/visuals"
 import {Direction} from "core/enums"
@@ -14,19 +13,8 @@ import {Selection} from "../selections/selection"
 import {max} from "../../core/util/arrayable"
 import type {AnnularWedgeGL} from "./webgl/annular_wedge"
 
-export type AnnularWedgeData = XYGlyphData & p.UniformsOf<AnnularWedge.Mixins> & {
-  readonly inner_radius: p.Uniform<number>
-  readonly outer_radius: p.Uniform<number>
-
-  readonly start_angle: p.Uniform<number>
-  readonly end_angle: p.Uniform<number>
-
-  sinner_radius: ScreenArray
-  souter_radius: ScreenArray
+export type AnnularWedgeData = p.GlyphDataOf<AnnularWedge.Props> & {
   max_souter_radius: number
-
-  readonly max_inner_radius: number
-  readonly max_outer_radius: number
 }
 
 export interface AnnularWedgeView extends AnnularWedgeData {}

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -29,12 +29,12 @@ export class AnnularWedgeView extends XYGlyphView {
 
   protected override _map_data(): void {
     if (this.model.properties.inner_radius.units == "data")
-      this.sinner_radius = this.sdist(this.renderer.xscale, this._x, this.inner_radius)
+      this.sinner_radius = this.sdist(this.renderer.xscale, this.x, this.inner_radius)
     else
       this.sinner_radius = to_screen(this.inner_radius)
 
     if (this.model.properties.outer_radius.units == "data")
-      this.souter_radius = this.sdist(this.renderer.xscale, this._x, this.outer_radius)
+      this.souter_radius = this.sdist(this.renderer.xscale, this.x, this.outer_radius)
     else
       this.souter_radius = to_screen(this.outer_radius)
     this.max_souter_radius = max(this.souter_radius)
@@ -95,8 +95,8 @@ export class AnnularWedgeView extends XYGlyphView {
     for (const i of this.index.indices({x0, x1, y0, y1})) {
       const or2 = this.souter_radius[i]**2
       const ir2 = this.sinner_radius[i]**2
-      const [sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
-      const [sy0, sy1] = this.renderer.yscale.r_compute(y, this._y[i])
+      const [sx0, sx1] = this.renderer.xscale.r_compute(x, this.x[i])
+      const [sy0, sy1] = this.renderer.yscale.r_compute(y, this.y[i])
       const dist = (sx0-sx1)**2 + (sy0-sy1)**2
       if (dist <= or2 && dist >= ir2)
         candidates.push(i)

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -13,11 +13,7 @@ import {Selection} from "../selections/selection"
 import {max} from "../../core/util/arrayable"
 import type {AnnularWedgeGL} from "./webgl/annular_wedge"
 
-export type AnnularWedgeData = p.GlyphDataOf<AnnularWedge.Props> & {
-  max_souter_radius: number
-}
-
-export interface AnnularWedgeView extends AnnularWedgeData {}
+export interface AnnularWedgeView extends AnnularWedge.Data {}
 
 export class AnnularWedgeView extends XYGlyphView {
   declare model: AnnularWedge
@@ -44,7 +40,7 @@ export class AnnularWedgeView extends XYGlyphView {
     this.max_souter_radius = max(this.souter_radius)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: AnnularWedgeData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: AnnularWedge.Data): void {
     const {sx, sy, start_angle, end_angle, sinner_radius, souter_radius} = data ?? this
     const anticlock = this.model.direction == "anticlock"
 
@@ -147,6 +143,10 @@ export namespace AnnularWedge {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    max_souter_radius: number
+  }
 }
 
 export interface AnnularWedge extends AnnularWedge.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -40,8 +40,8 @@ export class AnnularWedgeView extends XYGlyphView {
     this.max_souter_radius = max(this.souter_radius)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: AnnularWedge.Data): void {
-    const {sx, sy, start_angle, end_angle, sinner_radius, souter_radius} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<AnnularWedge.Data>): void {
+    const {sx, sy, start_angle, end_angle, sinner_radius, souter_radius} = {...this, ...data}
     const anticlock = this.model.direction == "anticlock"
 
     for (const i of indices) {

--- a/bokehjs/src/lib/models/glyphs/annular_wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/annular_wedge.ts
@@ -1,4 +1,5 @@
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
+import {inherit} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import type {PointGeometry} from "core/geometry"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -28,16 +29,31 @@ export class AnnularWedgeView extends XYGlyphView {
   }
 
   protected override _map_data(): void {
-    if (this.model.properties.inner_radius.units == "data")
-      this.sinner_radius = this.sdist(this.renderer.xscale, this.x, this.inner_radius)
-    else
-      this.sinner_radius = to_screen(this.inner_radius)
+    this._define_or_inherit_attr<AnnularWedge.Data>("sinner_radius", () => {
+      if (this.model.properties.inner_radius.units == "data") {
+        if (this.inherited_x && this.inherited_inner_radius) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.inner_radius)
+        }
+      } else {
+        return this.inherited_inner_radius ? inherit : to_screen(this.inner_radius)
+      }
+    })
 
-    if (this.model.properties.outer_radius.units == "data")
-      this.souter_radius = this.sdist(this.renderer.xscale, this.x, this.outer_radius)
-    else
-      this.souter_radius = to_screen(this.outer_radius)
-    this.max_souter_radius = max(this.souter_radius)
+    this._define_or_inherit_attr<AnnularWedge.Data>("souter_radius", () => {
+      if (this.model.properties.outer_radius.units == "data") {
+        if (this.inherited_x && this.inherited_outer_radius) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.outer_radius)
+        }
+      } else {
+        return this.inherited_outer_radius ? inherit : to_screen(this.outer_radius)
+      }
+    })
+
+    this._define_or_inherit_attr<AnnularWedge.Data>("max_souter_radius", () => max(this.souter_radius))
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: Partial<AnnularWedge.Data>): void {
@@ -145,7 +161,7 @@ export namespace AnnularWedge {
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
 
   export type Data = p.GlyphDataOf<Props> & {
-    max_souter_radius: number
+    readonly max_souter_radius: number
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -1,6 +1,5 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
-import type {Rect, ScreenArray} from "core/types"
+import type {Rect} from "core/types"
 import {to_screen} from "core/types"
 import type {PointGeometry} from "core/geometry"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -10,16 +9,7 @@ import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import type {AnnulusGL} from "./webgl/annulus"
 
-export type AnnulusData = XYGlyphData & p.UniformsOf<Annulus.Mixins> & {
-  readonly inner_radius: p.Uniform<number>
-  readonly outer_radius: p.Uniform<number>
-
-  sinner_radius: ScreenArray
-  souter_radius: ScreenArray
-
-  readonly max_inner_radius: number
-  readonly max_outer_radius: number
-}
+export type AnnulusData = p.GlyphDataOf<Annulus.Props>
 
 export interface AnnulusView extends AnnulusData {}
 

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -25,12 +25,12 @@ export class AnnulusView extends XYGlyphView {
 
   protected override _map_data(): void {
     if (this.model.properties.inner_radius.units == "data")
-      this.sinner_radius = this.sdist(this.renderer.xscale, this._x, this.inner_radius)
+      this.sinner_radius = this.sdist(this.renderer.xscale, this.x, this.inner_radius)
     else
       this.sinner_radius = to_screen(this.inner_radius)
 
     if (this.model.properties.outer_radius.units == "data")
-      this.souter_radius = this.sdist(this.renderer.xscale, this._x, this.outer_radius)
+      this.souter_radius = this.sdist(this.renderer.xscale, this.x, this.outer_radius)
     else
       this.souter_radius = to_screen(this.outer_radius)
   }
@@ -85,8 +85,8 @@ export class AnnulusView extends XYGlyphView {
     for (const i of this.index.indices({x0, x1, y0, y1})) {
       const or2 = this.souter_radius[i]**2
       const ir2 = this.sinner_radius[i]**2
-      const [sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
-      const [sy0, sy1] = this.renderer.yscale.r_compute(y, this._y[i])
+      const [sx0, sx1] = this.renderer.xscale.r_compute(x, this.x[i])
+      const [sy0, sy1] = this.renderer.yscale.r_compute(y, this.y[i])
       const dist = (sx0 - sx1)**2 + (sy0 - sy1)**2
       if (dist <= or2 && dist >= ir2)
         indices.push(i)

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -9,9 +9,7 @@ import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import type {AnnulusGL} from "./webgl/annulus"
 
-export type AnnulusData = p.GlyphDataOf<Annulus.Props>
-
-export interface AnnulusView extends AnnulusData {}
+export interface AnnulusView extends Annulus.Data {}
 
 export class AnnulusView extends XYGlyphView {
   declare model: Annulus
@@ -37,7 +35,7 @@ export class AnnulusView extends XYGlyphView {
       this.souter_radius = to_screen(this.outer_radius)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: AnnulusData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Annulus.Data): void {
     const {sx, sy, sinner_radius, souter_radius} = data ?? this
 
     for (const i of indices) {
@@ -127,6 +125,8 @@ export namespace Annulus {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Annulus extends Annulus.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -1,4 +1,5 @@
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
+import {inherit} from "./glyph"
 import type {Rect} from "core/types"
 import {to_screen} from "core/types"
 import type {PointGeometry} from "core/geometry"
@@ -24,15 +25,29 @@ export class AnnulusView extends XYGlyphView {
   }
 
   protected override _map_data(): void {
-    if (this.model.properties.inner_radius.units == "data")
-      this.sinner_radius = this.sdist(this.renderer.xscale, this.x, this.inner_radius)
-    else
-      this.sinner_radius = to_screen(this.inner_radius)
+    this._define_or_inherit_attr<Annulus.Data>("sinner_radius", () => {
+      if (this.model.properties.inner_radius.units == "data") {
+        if (this.inherited_x && this.inherited_inner_radius) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.inner_radius)
+        }
+      } else {
+        return this.inherited_inner_radius ? inherit : to_screen(this.inner_radius)
+      }
+    })
 
-    if (this.model.properties.outer_radius.units == "data")
-      this.souter_radius = this.sdist(this.renderer.xscale, this.x, this.outer_radius)
-    else
-      this.souter_radius = to_screen(this.outer_radius)
+    this._define_or_inherit_attr<Annulus.Data>("souter_radius", () => {
+      if (this.model.properties.outer_radius.units == "data") {
+        if (this.inherited_x && this.inherited_outer_radius) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.outer_radius)
+        }
+      } else {
+        return this.inherited_outer_radius ? inherit : to_screen(this.outer_radius)
+      }
+    })
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: Partial<Annulus.Data>): void {

--- a/bokehjs/src/lib/models/glyphs/annulus.ts
+++ b/bokehjs/src/lib/models/glyphs/annulus.ts
@@ -35,8 +35,8 @@ export class AnnulusView extends XYGlyphView {
       this.souter_radius = to_screen(this.outer_radius)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Annulus.Data): void {
-    const {sx, sy, sinner_radius, souter_radius} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Annulus.Data>): void {
+    const {sx, sy, sinner_radius, souter_radius} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]
@@ -110,7 +110,7 @@ export class AnnulusView extends XYGlyphView {
     const souter_radius: number[] = new Array(len)
     souter_radius[index] = r*0.8
 
-    this._render(ctx, [index], {sx, sy, sinner_radius, souter_radius} as any) // XXX
+    this._render(ctx, [index], {sx, sy, sinner_radius, souter_radius})
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -8,9 +8,7 @@ import {Direction} from "core/enums"
 import * as p from "core/properties"
 import type {Context2d} from "core/util/canvas"
 
-export type ArcData = p.GlyphDataOf<Arc.Props>
-
-export interface ArcView extends ArcData {}
+export interface ArcView extends Arc.Data {}
 
 export class ArcView extends XYGlyphView {
   declare model: Arc
@@ -23,7 +21,7 @@ export class ArcView extends XYGlyphView {
       this.sradius = to_screen(this.radius)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: ArcData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Arc.Data): void {
     if (!this.visuals.line.doit)
       return
 
@@ -92,6 +90,8 @@ export namespace Arc {
   export type Mixins = LineVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Arc extends Arc.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -21,11 +21,11 @@ export class ArcView extends XYGlyphView {
       this.sradius = to_screen(this.radius)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Arc.Data): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Arc.Data>): void {
     if (!this.visuals.line.doit)
       return
 
-    const {sx, sy, sradius, start_angle, end_angle} = data ?? this
+    const {sx, sy, sradius, start_angle, end_angle} = {...this, ...data}
     const anticlock = this.model.direction == "anticlock"
 
     for (const i of indices) {

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -1,4 +1,5 @@
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
+import {inherit} from "./glyph"
 import {generic_line_vector_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
@@ -15,10 +16,17 @@ export class ArcView extends XYGlyphView {
   declare visuals: Arc.Visuals
 
   protected override _map_data(): void {
-    if (this.model.properties.radius.units == "data")
-      this.sradius = this.sdist(this.renderer.xscale, this.x, this.radius)
-    else
-      this.sradius = to_screen(this.radius)
+    this._define_or_inherit_attr<Arc.Data>("sradius", () => {
+      if (this.model.properties.radius.units == "data") {
+        if (this.inherited_x && this.inherited_radius) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.radius)
+        }
+      } else {
+        return this.inherited_radius ? inherit : to_screen(this.radius)
+      }
+    })
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: Partial<Arc.Data>): void {

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -1,22 +1,14 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {generic_line_vector_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {Rect, ScreenArray} from "core/types"
+import type {Rect} from "core/types"
 import {to_screen} from "core/types"
 import {Direction} from "core/enums"
 import * as p from "core/properties"
 import type {Context2d} from "core/util/canvas"
 
-export type ArcData = XYGlyphData & p.UniformsOf<Arc.Mixins> & {
-  readonly radius: p.Uniform<number>
-  sradius: ScreenArray
-  readonly max_radius: number
-
-  readonly start_angle: p.Uniform<number>
-  readonly end_angle: p.Uniform<number>
-}
+export type ArcData = p.GlyphDataOf<Arc.Props>
 
 export interface ArcView extends ArcData {}
 

--- a/bokehjs/src/lib/models/glyphs/arc.ts
+++ b/bokehjs/src/lib/models/glyphs/arc.ts
@@ -16,7 +16,7 @@ export class ArcView extends XYGlyphView {
 
   protected override _map_data(): void {
     if (this.model.properties.radius.units == "data")
-      this.sradius = this.sdist(this.renderer.xscale, this._x, this.radius)
+      this.sradius = this.sdist(this.renderer.xscale, this.x, this.radius)
     else
       this.sradius = to_screen(this.radius)
   }

--- a/bokehjs/src/lib/models/glyphs/area.ts
+++ b/bokehjs/src/lib/models/glyphs/area.ts
@@ -1,4 +1,3 @@
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_area_scalar_legend} from "./utils"
 import type * as visuals from "core/visuals"
@@ -7,7 +6,7 @@ import type {Context2d} from "core/util/canvas"
 import type * as p from "core/properties"
 import * as mixins from "core/property_mixins"
 
-export type AreaData = GlyphData & p.UniformsOf<Area.Mixins>
+export type AreaData = p.GlyphDataOf<Area.Props>
 
 export interface AreaView extends AreaData {}
 

--- a/bokehjs/src/lib/models/glyphs/area.ts
+++ b/bokehjs/src/lib/models/glyphs/area.ts
@@ -6,9 +6,7 @@ import type {Context2d} from "core/util/canvas"
 import type * as p from "core/properties"
 import * as mixins from "core/property_mixins"
 
-export type AreaData = p.GlyphDataOf<Area.Props>
-
-export interface AreaView extends AreaData {}
+export interface AreaView extends Area.Data {}
 
 export abstract class AreaView extends GlyphView {
   declare model: Area
@@ -27,6 +25,8 @@ export namespace Area {
   export type Mixins = mixins.FillScalar & mixins.HatchScalar
 
   export type Visuals = Glyph.Visuals & {fill: visuals.FillScalar, hatch: visuals.HatchScalar}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Area extends Area.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -1,34 +1,15 @@
 import {LineVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {Rect, FloatArray, ScreenArray} from "core/types"
+import type {Rect} from "core/types"
 import type {SpatialIndex} from "core/util/spatial"
 import type {Context2d} from "core/util/canvas"
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_line_vector_legend} from "./utils"
 import {inplace} from "core/util/projections"
 import {cbb} from "core/util/algorithms"
 import * as p from "core/properties"
 
-export type BezierData = GlyphData & p.UniformsOf<Bezier.Mixins> & {
-  _x0: FloatArray
-  _y0: FloatArray
-  _x1: FloatArray
-  _y1: FloatArray
-  _cx0: FloatArray
-  _cy0: FloatArray
-  _cx1: FloatArray
-  _cy1: FloatArray
-
-  sx0: ScreenArray
-  sy0: ScreenArray
-  sx1: ScreenArray
-  sy1: ScreenArray
-  scx0: ScreenArray
-  scy0: ScreenArray
-  scx1: ScreenArray
-  scy1: ScreenArray
-}
+export type BezierData = p.GlyphDataOf<Bezier.Props>
 
 export interface BezierView extends BezierData {}
 

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -46,7 +46,7 @@ export class BezierView extends GlyphView {
     if (!this.visuals.line.doit)
       return
 
-    const {sx0, sy0, sx1, sy1, scx0, scy0, scx1, scy1} = data ?? this
+    const {sx0, sy0, sx1, sy1, scx0, scy0, scx1, scy1} = {...this, ...data}
 
     for (const i of indices) {
       const sx0_i = sx0[i]

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -16,22 +16,22 @@ export class BezierView extends GlyphView {
   declare visuals: Bezier.Visuals
 
   protected override _project_data(): void {
-    inplace.project_xy(this._x0, this._y0)
-    inplace.project_xy(this._x1, this._y1)
+    inplace.project_xy(this.x0, this.y0)
+    inplace.project_xy(this.x1, this.y1)
   }
 
   protected _index_data(index: SpatialIndex): void {
-    const {data_size, _x0, _y0, _x1, _y1, _cx0, _cy0, _cx1, _cy1} = this
+    const {data_size, x0, y0, x1, y1, cx0, cy0, cx1, cy1} = this
 
     for (let i = 0; i < data_size; i++) {
-      const x0_i = _x0[i]
-      const y0_i = _y0[i]
-      const x1_i = _x1[i]
-      const y1_i = _y1[i]
-      const cx0_i = _cx0[i]
-      const cy0_i = _cy0[i]
-      const cx1_i = _cx1[i]
-      const cy1_i = _cy1[i]
+      const x0_i = x0[i]
+      const y0_i = y0[i]
+      const x1_i = x1[i]
+      const y1_i = y1[i]
+      const cx0_i = cx0[i]
+      const cy0_i = cy0[i]
+      const cx1_i = cx1[i]
+      const cy1_i = cy1[i]
 
       if (!isFinite(x0_i + x1_i + y0_i + y1_i + cx0_i + cy0_i + cx1_i + cy1_i))
         index.add_empty()

--- a/bokehjs/src/lib/models/glyphs/bezier.ts
+++ b/bokehjs/src/lib/models/glyphs/bezier.ts
@@ -9,9 +9,7 @@ import {inplace} from "core/util/projections"
 import {cbb} from "core/util/algorithms"
 import * as p from "core/properties"
 
-export type BezierData = p.GlyphDataOf<Bezier.Props>
-
-export interface BezierView extends BezierData {}
+export interface BezierView extends Bezier.Data {}
 
 export class BezierView extends GlyphView {
   declare model: Bezier
@@ -44,7 +42,7 @@ export class BezierView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: BezierData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Bezier.Data): void {
     if (!this.visuals.line.doit)
       return
 
@@ -97,6 +95,8 @@ export namespace Bezier {
   export type Mixins = LineVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Bezier extends Bezier.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/block.ts
+++ b/bokehjs/src/lib/models/glyphs/block.ts
@@ -1,4 +1,6 @@
 import {LRTB, LRTBView} from "./lrtb"
+import type {LRTBRect} from "./lrtb"
+import {minmax} from "core/util/math"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
@@ -14,40 +16,59 @@ export class BlockView extends LRTBView {
     return [scx, scy]
   }
 
-  protected _lrtb(i: number): [number, number, number, number] {
+  protected _lrtb(i: number): LRTBRect {
     const x_i = this.x[i]
     const y_i = this.y[i]
     const width_i = this.width.get(i)
     const height_i = this.height.get(i)
 
-    const l = Math.min(x_i, x_i + width_i)
-    const r = Math.max(x_i, x_i + width_i)
-    const t = Math.max(y_i, y_i + height_i)
-    const b = Math.min(y_i, y_i + height_i)
+    const [l, r] = minmax(x_i, x_i + width_i)
+    const [b, t] = minmax(y_i, y_i + height_i)
 
-    return [l, r, t, b]
+    return {l, r, t, b}
   }
 
   protected override _map_data(): void {
-    const sx = this.renderer.xscale.v_compute(this.x)
-    const sy = this.renderer.yscale.v_compute(this.y)
-    const sw = this.sdist(this.renderer.xscale, this.x, this.width, "edge")
-    const sh = this.sdist(this.renderer.yscale, this.y, this.height, "edge")
-
+    const {sx, sy} = this
     const n = sx.length
 
-    this.stop = new ScreenArray(n)
-    this.sbottom = new ScreenArray(n)
-    this.sleft = new ScreenArray(n)
-    this.sright = new ScreenArray(n)
-    for (let i = 0; i < n; i++) {
-      this.stop[i] = sy[i] - sh[i]
-      this.sbottom[i] = sy[i]
-      this.sleft[i] = sx[i]
-      this.sright[i] = sx[i] + sw[i]
+    if (this.inherited_x && this.inherited_width) {
+      this._inherit_attr<Block.Data>("sleft")
+      this._inherit_attr<Block.Data>("sright")
+    } else {
+      const sw = this.sdist(this.renderer.xscale, this.x, this.width, "edge")
+
+      const sleft = new ScreenArray(n)
+      const sright = new ScreenArray(n)
+
+      for (let i = 0; i < n; i++) {
+        sleft[i] = sx[i]
+        sright[i] = sx[i] + sw[i]
+      }
+
+      this._define_attr<Block.Data>("sleft", sleft)
+      this._define_attr<Block.Data>("sright", sright)
     }
 
-    this._clamp_viewport()
+    if (this.inherited_y && this.inherited_height) {
+      this._inherit_attr<Block.Data>("stop")
+      this._inherit_attr<Block.Data>("sbottom")
+    } else {
+      const sh = this.sdist(this.renderer.yscale, this.y, this.height, "edge")
+
+      const stop = new ScreenArray(n)
+      const sbottom = new ScreenArray(n)
+
+      for (let i = 0; i < n; i++) {
+        stop[i] = sy[i] - sh[i]
+        sbottom[i] = sy[i]
+      }
+
+      this._define_attr<Block.Data>("stop", stop)
+      this._define_attr<Block.Data>("sbottom", sbottom)
+    }
+
+    this._clamp_to_viewport()
   }
 }
 
@@ -57,14 +78,14 @@ export namespace Block {
   export type Props = LRTB.Props & {
     x: p.CoordinateSpec
     y: p.CoordinateSpec
-    width: p.NumberSpec
-    height: p.NumberSpec
+    width: p.DistanceSpec
+    height: p.DistanceSpec
   }
 
   export type Visuals = LRTB.Visuals
 
   export type Data = LRTB.Data & p.GlyphDataOf<Props> & {
-    max_width: number
+    readonly max_width: number
   }
 }
 
@@ -84,8 +105,8 @@ export class Block extends LRTB {
     this.define<Block.Props>(({}) => ({
       x:      [ p.XCoordinateSpec, {field: "x"} ],
       y:      [ p.YCoordinateSpec, {field: "y"} ],
-      width:  [ p.NumberSpec,      {value: 1}   ],
-      height: [ p.NumberSpec,      {value: 1}   ],
+      width:  [ p.DistanceSpec,    {value: 1}   ],
+      height: [ p.DistanceSpec,    {value: 1}   ],
     }))
   }
 }

--- a/bokehjs/src/lib/models/glyphs/block.ts
+++ b/bokehjs/src/lib/models/glyphs/block.ts
@@ -1,21 +1,10 @@
 import type {LRTBData} from "./lrtb"
 import {LRTB, LRTBView} from "./lrtb"
-import type {FloatArray} from "core/types"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
-export type BlockData = LRTBData & {
-  _x: FloatArray
-  _y: FloatArray
-  readonly width: p.Uniform<number>
-  readonly height: p.Uniform<number>
-
-  stop: ScreenArray
-  sbottom: ScreenArray
-  sleft: ScreenArray
-  sright: ScreenArray
-
-  readonly max_width: number
+export type BlockData = LRTBData & p.GlyphDataOf<Block.Props> & {
+  max_width: number
 }
 
 export interface BlockView extends BlockData {}

--- a/bokehjs/src/lib/models/glyphs/block.ts
+++ b/bokehjs/src/lib/models/glyphs/block.ts
@@ -15,8 +15,8 @@ export class BlockView extends LRTBView {
   }
 
   protected _lrtb(i: number): [number, number, number, number] {
-    const x_i = this._x[i]
-    const y_i = this._y[i]
+    const x_i = this.x[i]
+    const y_i = this.y[i]
     const width_i = this.width.get(i)
     const height_i = this.height.get(i)
 
@@ -29,10 +29,10 @@ export class BlockView extends LRTBView {
   }
 
   protected override _map_data(): void {
-    const sx = this.renderer.xscale.v_compute(this._x)
-    const sy = this.renderer.yscale.v_compute(this._y)
-    const sw = this.sdist(this.renderer.xscale, this._x, this.width, "edge")
-    const sh = this.sdist(this.renderer.yscale, this._y, this.height, "edge")
+    const sx = this.renderer.xscale.v_compute(this.x)
+    const sy = this.renderer.yscale.v_compute(this.y)
+    const sw = this.sdist(this.renderer.xscale, this.x, this.width, "edge")
+    const sh = this.sdist(this.renderer.yscale, this.y, this.height, "edge")
 
     const n = sx.length
 

--- a/bokehjs/src/lib/models/glyphs/block.ts
+++ b/bokehjs/src/lib/models/glyphs/block.ts
@@ -1,13 +1,8 @@
-import type {LRTBData} from "./lrtb"
 import {LRTB, LRTBView} from "./lrtb"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
-export type BlockData = LRTBData & p.GlyphDataOf<Block.Props> & {
-  max_width: number
-}
-
-export interface BlockView extends BlockData {}
+export interface BlockView extends Block.Data {}
 
 export class BlockView extends LRTBView {
   declare model: Block
@@ -67,6 +62,10 @@ export namespace Block {
   }
 
   export type Visuals = LRTB.Visuals
+
+  export type Data = LRTB.Data & p.GlyphDataOf<Props> & {
+    max_width: number
+  }
 }
 
 export interface Block extends Block.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/center_rotatable.ts
+++ b/bokehjs/src/lib/models/glyphs/center_rotatable.ts
@@ -1,22 +1,10 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {ScreenArray, Rect} from "core/types"
+import type {Rect} from "core/types"
 import * as p from "core/properties"
 
-export type CenterRotatableData = XYGlyphData & p.UniformsOf<CenterRotatable.Mixins> & {
-  readonly angle: p.Uniform<number>
-
-  readonly width: p.Uniform<number>
-  readonly height: p.Uniform<number>
-
-  sw: ScreenArray
-  sh: ScreenArray
-
-  readonly max_width: number
-  readonly max_height: number
-}
+export type CenterRotatableData = p.GlyphDataOf<CenterRotatable.Props>
 
 export interface CenterRotatableView extends CenterRotatableData {}
 

--- a/bokehjs/src/lib/models/glyphs/center_rotatable.ts
+++ b/bokehjs/src/lib/models/glyphs/center_rotatable.ts
@@ -4,9 +4,7 @@ import type * as visuals from "core/visuals"
 import type {Rect} from "core/types"
 import * as p from "core/properties"
 
-export type CenterRotatableData = p.GlyphDataOf<CenterRotatable.Props>
-
-export interface CenterRotatableView extends CenterRotatableData {}
+export interface CenterRotatableView extends CenterRotatable.Data {}
 
 export abstract class CenterRotatableView extends XYGlyphView {
   declare model: CenterRotatable
@@ -43,6 +41,8 @@ export namespace CenterRotatable {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface CenterRotatable extends CenterRotatable.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -30,20 +30,20 @@ export class CircleView extends XYGlyphView {
   }
 
   protected override _index_data(index: SpatialIndex): void {
-    const {_x, _y, radius, data_size} = this
+    const {x, y, radius, data_size} = this
     for (let i = 0; i < data_size; i++) {
-      const x = _x[i]
-      const y = _y[i]
-      const r = radius.get(i)
-      index.add_rect(x - r, y - r, x + r, y + r)
+      const x_i = x[i]
+      const y_i = y[i]
+      const r_i = radius.get(i)
+      index.add_rect(x_i - r_i, y_i - r_i, x_i + r_i, y_i + r_i)
     }
   }
 
   protected override _map_data(): void {
     this.sradius = (() => {
       if (this.model.properties.radius.units == "data") {
-        const sradius_x = () => this.sdist(this.renderer.xscale, this._x, this.radius)
-        const sradius_y = () => this.sdist(this.renderer.yscale, this._y, this.radius)
+        const sradius_x = () => this.sdist(this.renderer.xscale, this.x, this.radius)
+        const sradius_y = () => this.sdist(this.renderer.yscale, this.y, this.radius)
 
         switch (this.model.radius_dimension) {
           case "x":   return sradius_x()
@@ -131,8 +131,8 @@ export class CircleView extends XYGlyphView {
     if (this.model.properties.radius.units == "data") {
       for (const i of candidates) {
         const r2 = (this.sradius[i]*hit_dilation)**2
-        const [sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
-        const [sy0, sy1] = this.renderer.yscale.r_compute(y, this._y[i])
+        const [sx0, sx1] = this.renderer.xscale.r_compute(x, this.x[i])
+        const [sy0, sy1] = this.renderer.yscale.r_compute(y, this.y[i])
         const dist = (sx0 - sx1)**2 + (sy0 - sy1)**2
         if (dist <= r2) {
           indices.push(i)

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -79,8 +79,8 @@ export class CircleView extends XYGlyphView {
     })
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Circle.Data): void {
-    const {sx, sy, sradius} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Circle.Data>): void {
+    const {sx, sy, sradius} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]
@@ -235,7 +235,7 @@ export class CircleView extends XYGlyphView {
     const sradius: number[] = new Array(len)
     sradius[index] = Math.min(Math.abs(x1 - x0), Math.abs(y1 - y0))*0.2
 
-    this._render(ctx, [index], {sx, sy, sradius} as any) // XXX
+    this._render(ctx, [index], {sx, sy, sradius})
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -15,9 +15,7 @@ import {Selection} from "../selections/selection"
 import type {Range1d} from "../ranges/range1d"
 import type {CircleGL} from "./webgl/circle"
 
-export type CircleData = p.GlyphDataOf<Circle.Props>
-
-export interface CircleView extends CircleData {}
+export interface CircleView extends Circle.Data {}
 
 export class CircleView extends XYGlyphView {
   declare model: Circle
@@ -81,7 +79,7 @@ export class CircleView extends XYGlyphView {
     })
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: CircleData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Circle.Data): void {
     const {sx, sy, sradius} = data ?? this
 
     for (const i of indices) {
@@ -253,6 +251,8 @@ export namespace Circle {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Circle extends Circle.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -1,11 +1,9 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import type {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
 import type {Rect, Indices} from "core/types"
 import {to_screen} from "core/types"
-import type {Arrayable} from "core/types"
 import {RadiusDimension} from "core/enums"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
@@ -17,12 +15,7 @@ import {Selection} from "../selections/selection"
 import type {Range1d} from "../ranges/range1d"
 import type {CircleGL} from "./webgl/circle"
 
-export type CircleData = XYGlyphData & p.UniformsOf<Circle.Mixins> & {
-  readonly angle: p.Uniform<number>
-  readonly radius: p.Uniform<number>
-  readonly max_radius: number
-  sradius: Arrayable<number>
-}
+export type CircleData = p.GlyphDataOf<Circle.Props>
 
 export interface CircleView extends CircleData {}
 

--- a/bokehjs/src/lib/models/glyphs/ellipse.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse.ts
@@ -15,12 +15,12 @@ export class EllipseView extends CenterRotatableView  {
 
   protected override _map_data(): void {
     if (this.model.properties.width.units == "data")
-      this.swidth = this.sdist(this.renderer.xscale, this._x, this.width, "center")
+      this.swidth = this.sdist(this.renderer.xscale, this.x, this.width, "center")
     else
       this.swidth = to_screen(this.width)
 
     if (this.model.properties.height.units == "data")
-      this.sheight = this.sdist(this.renderer.yscale, this._y, this.height, "center")
+      this.sheight = this.sdist(this.renderer.yscale, this.y, this.height, "center")
     else
       this.sheight = to_screen(this.height)
   }

--- a/bokehjs/src/lib/models/glyphs/ellipse.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse.ts
@@ -1,4 +1,5 @@
 import {CenterRotatable, CenterRotatableView} from "./center_rotatable"
+import {inherit} from "./glyph"
 import type {PointGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
 import type {Rect} from "core/types"
@@ -14,15 +15,29 @@ export class EllipseView extends CenterRotatableView  {
   declare visuals: Ellipse.Visuals
 
   protected override _map_data(): void {
-    if (this.model.properties.width.units == "data")
-      this.swidth = this.sdist(this.renderer.xscale, this.x, this.width, "center")
-    else
-      this.swidth = to_screen(this.width)
+    this._define_or_inherit_attr<Ellipse.Data>("swidth", () => {
+      if (this.model.properties.width.units == "data") {
+        if (this.inherited_x && this.inherited_width) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.width, "center")
+        }
+      } else {
+        return this.inherited_width ? inherit : to_screen(this.width)
+      }
+    })
 
-    if (this.model.properties.height.units == "data")
-      this.sheight = this.sdist(this.renderer.yscale, this.y, this.height, "center")
-    else
-      this.sheight = to_screen(this.height)
+    this._define_or_inherit_attr<Ellipse.Data>("sheight", () => {
+      if (this.model.properties.height.units == "data") {
+        if (this.inherited_y && this.inherited_height) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.yscale, this.y, this.height, "center")
+        }
+      } else {
+        return this.inherited_height ? inherit : to_screen(this.height)
+      }
+    })
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: Partial<Ellipse.Data>): void {

--- a/bokehjs/src/lib/models/glyphs/ellipse.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse.ts
@@ -1,4 +1,3 @@
-import type {CenterRotatableData} from "./center_rotatable"
 import {CenterRotatable, CenterRotatableView} from "./center_rotatable"
 import type {PointGeometry} from "core/geometry"
 import * as hittest from "core/hittest"
@@ -8,7 +7,7 @@ import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import * as p from "core/properties"
 
-export type EllipseData = CenterRotatableData
+export type EllipseData = p.GlyphDataOf<Ellipse.Props>
 
 export interface EllipseView extends EllipseData {}
 
@@ -18,31 +17,31 @@ export class EllipseView extends CenterRotatableView  {
 
   protected override _map_data(): void {
     if (this.model.properties.width.units == "data")
-      this.sw = this.sdist(this.renderer.xscale, this._x, this.width, "center")
+      this.swidth = this.sdist(this.renderer.xscale, this._x, this.width, "center")
     else
-      this.sw = to_screen(this.width)
+      this.swidth = to_screen(this.width)
 
     if (this.model.properties.height.units == "data")
-      this.sh = this.sdist(this.renderer.yscale, this._y, this.height, "center")
+      this.sheight = this.sdist(this.renderer.yscale, this._y, this.height, "center")
     else
-      this.sh = to_screen(this.height)
+      this.sheight = to_screen(this.height)
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: EllipseData): void {
-    const {sx, sy, sw, sh, angle} = data ?? this
+    const {sx, sy, swidth, sheight, angle} = data ?? this
 
     for (const i of indices) {
       const sx_i = sx[i]
       const sy_i = sy[i]
-      const sw_i = sw[i]
-      const sh_i = sh[i]
+      const swidth_i = swidth[i]
+      const sheight_i = sheight[i]
       const angle_i = angle.get(i)
 
-      if (!isFinite(sx_i + sy_i + sw_i + sh_i + angle_i))
+      if (!isFinite(sx_i + sy_i + swidth_i + sheight_i + angle_i))
         continue
 
       ctx.beginPath()
-      ctx.ellipse(sx_i, sy_i, sw_i/2, sh_i/2, angle_i, 0, 2*Math.PI)
+      ctx.ellipse(sx_i, sy_i, swidth_i/2, sheight_i/2, angle_i, 0, 2*Math.PI)
 
       this.visuals.fill.apply(ctx, i)
       this.visuals.hatch.apply(ctx, i)
@@ -79,7 +78,7 @@ export class EllipseView extends CenterRotatableView  {
     const indices: number[] = []
 
     for (const i of candidates) {
-      cond = hittest.point_in_ellipse(sx, sy, this.angle.get(i), this.sh[i]/2, this.sw[i]/2, this.sx[i], this.sy[i])
+      cond = hittest.point_in_ellipse(sx, sy, this.angle.get(i), this.sheight[i]/2, this.swidth[i]/2, this.sx[i], this.sy[i])
       if (cond) {
         indices.push(i)
       }
@@ -96,22 +95,22 @@ export class EllipseView extends CenterRotatableView  {
     const sy: number[] = new Array(n)
     sy[index] = (y0 + y1)/2
 
-    const scale = this.sw[index] / this.sh[index]
+    const scale = this.swidth[index] / this.sheight[index]
     const d = Math.min(Math.abs(x1 - x0), Math.abs(y1 - y0))*0.8
 
-    const sw: number[] = new Array(n)
-    const sh: number[] = new Array(n)
+    const swidth: number[] = new Array(n)
+    const sheight: number[] = new Array(n)
     if (scale > 1) {
-      sw[index] = d
-      sh[index] = d/scale
+      swidth[index] = d
+      sheight[index] = d/scale
     } else {
-      sw[index] = d*scale
-      sh[index] = d
+      swidth[index] = d*scale
+      sheight[index] = d
     }
 
     const angle = new p.UniformScalar(0, n) // don't attempt to match glyph angle
 
-    this._render(ctx, [index], {sx, sy, sw, sh, angle} as any) // XXX
+    this._render(ctx, [index], {sx, sy, swidth, sheight, angle} as any) // XXX
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/ellipse.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse.ts
@@ -25,8 +25,8 @@ export class EllipseView extends CenterRotatableView  {
       this.sheight = to_screen(this.height)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Ellipse.Data): void {
-    const {sx, sy, swidth, sheight, angle} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Ellipse.Data>): void {
+    const {sx, sy, swidth, sheight, angle} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]
@@ -108,7 +108,7 @@ export class EllipseView extends CenterRotatableView  {
 
     const angle = new p.UniformScalar(0, n) // don't attempt to match glyph angle
 
-    this._render(ctx, [index], {sx, sy, swidth, sheight, angle} as any) // XXX
+    this._render(ctx, [index], {sx, sy, swidth, sheight, angle})
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/ellipse.ts
+++ b/bokehjs/src/lib/models/glyphs/ellipse.ts
@@ -7,9 +7,7 @@ import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import * as p from "core/properties"
 
-export type EllipseData = p.GlyphDataOf<Ellipse.Props>
-
-export interface EllipseView extends EllipseData {}
+export interface EllipseView extends Ellipse.Data {}
 
 export class EllipseView extends CenterRotatableView  {
   declare model: Ellipse
@@ -27,7 +25,7 @@ export class EllipseView extends CenterRotatableView  {
       this.sheight = to_screen(this.height)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: EllipseData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Ellipse.Data): void {
     const {sx, sy, swidth, sheight, angle} = data ?? this
 
     for (const i of indices) {
@@ -120,6 +118,8 @@ export namespace Ellipse {
   export type Props = CenterRotatable.Props
 
   export type Visuals = CenterRotatable.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Ellipse extends Ellipse.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -18,6 +18,7 @@ import {RaggedArray} from "core/util/ragged_array"
 import {inplace_map} from "core/util/arrayable"
 import {is_equal} from "core/util/eq"
 import {SpatialIndex} from "core/util/spatial"
+import {assert} from "core/util/assert"
 import type {Scale} from "../scales/scale"
 import type {Factor} from "../ranges/factor_range"
 import {FactorRange} from "../ranges/factor_range"
@@ -256,6 +257,12 @@ export abstract class GlyphView extends View {
       value,
     })
     this._define_inherited(attr, false)
+  }
+
+  protected _inherit_attr(attr: string): void {
+    const {base} = this
+    assert(base != null)
+    this._inherit_from(attr, base)
   }
 
   protected _inherit_from(attr: string, base: this): void {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -325,7 +325,7 @@ export abstract class GlyphView extends View {
         } else
           final_array = array
 
-        this._configure(`_${prop.attr}`, {value: final_array})
+        this._configure(prop.attr, {value: final_array})
       } else {
         const uniform = prop.uniform(source).select(indices)
         this._configure(prop, {value: uniform})
@@ -389,7 +389,7 @@ export abstract class GlyphView extends View {
     for (const prop of this.model) {
       if (prop instanceof p.BaseCoordinateSpec) {
         const scale = prop.dimension == "x" ? x_scale : y_scale
-        let array = self[`_${prop.attr}`] as FloatArray | RaggedArray<FloatArray>
+        let array = self[prop.attr] as FloatArray | RaggedArray<FloatArray>
         if (array instanceof RaggedArray) {
           const screen = scale.v_compute(array.array)
           array = new RaggedArray(array.offsets, screen)

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -109,13 +109,13 @@ export abstract class GlyphView extends View {
     return this.renderer.parent.canvas_view
   }
 
-  render(ctx: Context2d, indices: number[], data?: Glyph.Data): void {
+  render(ctx: Context2d, indices: number[], data?: Partial<Glyph.Data>): void {
     if (this.glglyph != null) {
       this.glglyph.render(ctx, indices, this.base ?? this)
     } else if (this.canvas.webgl != null && settings.force_webgl) {
       throw new Error(`${this} doesn't support webgl rendering`)
     } else {
-      this._render(ctx, indices, data ?? this.base)
+      this._render(ctx, indices, data ?? this.base ?? undefined)
     }
   }
 
@@ -242,10 +242,18 @@ export abstract class GlyphView extends View {
     }
   }
 
-  protected base?: this
+  protected _base: this | null = null
+
+  get base(): this | null {
+    return this._base
+  }
+
   set_base<T extends this>(base: T): void {
-    if (base != this && base instanceof this.constructor)
-      this.base = base
+    if (base != this && base instanceof this.constructor) {
+      this._base = base
+    } else {
+      this._base = null
+    }
   }
 
   protected _configure(prop: string | p.Property<unknown>, descriptor: PropertyDescriptor): void {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -16,7 +16,7 @@ import type {Arrayable, Rect, FloatArray} from "core/types"
 import {ScreenArray, Indices} from "core/types"
 import {RaggedArray} from "core/util/ragged_array"
 import {inplace_map} from "core/util/arrayable"
-import {is_equal} from "core/util/eq"
+import {is_equal, EqNotImplemented} from "core/util/eq"
 import {SpatialIndex} from "core/util/spatial"
 import {assert} from "core/util/assert"
 import type {Scale} from "../scales/scale"
@@ -286,7 +286,19 @@ export abstract class GlyphView extends View {
 
   protected _can_inherit_from<T>(prop: p.Property<T>, base: this): boolean {
     const base_prop = base.model.property(prop.attr)
-    return is_equal(prop.get_value(), base_prop.get_value())
+
+    const value = prop.get_value()
+    const base_value = base_prop.get_value()
+
+    try {
+      return is_equal(value, base_value)
+    } catch (error) {
+      if (error instanceof EqNotImplemented) {
+        return false
+      } else {
+        throw error
+      }
+    }
   }
 
   protected _is_inherited<T>(prop: p.Property<T>): boolean {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -30,9 +30,7 @@ import type {BaseGLGlyph, BaseGLGlyphConstructor} from "./webgl/base"
 
 const {abs, ceil} = Math
 
-export type GlyphData = p.GlyphDataOf<Glyph.Props>
-
-export interface GlyphView extends GlyphData {}
+export interface GlyphView extends Glyph.Data {}
 
 export abstract class GlyphView extends View {
   declare model: Glyph
@@ -111,7 +109,7 @@ export abstract class GlyphView extends View {
     return this.renderer.parent.canvas_view
   }
 
-  render(ctx: Context2d, indices: number[], data?: GlyphData): void {
+  render(ctx: Context2d, indices: number[], data?: Glyph.Data): void {
     if (this.glglyph != null) {
       this.glglyph.render(ctx, indices, this.base ?? this)
     } else if (this.canvas.webgl != null && settings.force_webgl) {
@@ -121,7 +119,7 @@ export abstract class GlyphView extends View {
     }
   }
 
-  protected abstract _render(ctx: Context2d, indices: number[], data?: GlyphData): void
+  protected abstract _render(ctx: Context2d, indices: number[], data?: Glyph.Data): void
 
   override has_finished(): boolean {
     return true
@@ -410,6 +408,8 @@ export namespace Glyph {
   }
 
   export type Visuals = visuals.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Glyph extends Glyph.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -2,6 +2,7 @@ import type {HitTestResult} from "core/hittest"
 import * as p from "core/properties"
 import * as bbox from "core/util/bbox"
 import * as visuals from "core/visuals"
+import * as uniforms from "core/uniforms"
 import type * as geometry from "core/geometry"
 import {settings} from "core/settings"
 import type {Context2d} from "core/util/canvas"
@@ -15,7 +16,7 @@ import type {Arrayable, Rect, FloatArray} from "core/types"
 import {ScreenArray, Indices} from "core/types"
 import {isString} from "core/util/types"
 import {RaggedArray} from "core/util/ragged_array"
-import {inplace_map, max} from "core/util/arrayable"
+import {inplace_map} from "core/util/arrayable"
 import {is_equal} from "core/util/eq"
 import {SpatialIndex} from "core/util/spatial"
 import type {Scale} from "../scales/scale"
@@ -323,8 +324,8 @@ export abstract class GlyphView extends View {
         const uniform = prop.uniform(source).select(indices)
         this._configure(prop, {value: uniform})
 
-        if (prop instanceof p.DistanceSpec) {
-          const max_value = uniform.is_Scalar() ? uniform.value : max((uniform as any).array)
+        if (prop instanceof p.DistanceSpec || prop instanceof p.ScreenSizeSpec) {
+          const max_value = uniforms.max(uniform)
           this._configure(`max_${prop.attr}`, {value: max_value})
         }
       }

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -250,7 +250,7 @@ export abstract class GlyphView extends View {
     }
   }
 
-  protected _define_attr(attr: string, value: number | uniforms.Uniform<unknown> | Arrayable<unknown> | RaggedArray<any>): void {
+  protected _define_attr<Props>(attr: keyof Props, value: number | uniforms.Uniform<unknown> | Arrayable<unknown> | RaggedArray<any>): void {
     Object.defineProperty(this, attr, {
       configurable: true,
       enumerable: true,
@@ -259,13 +259,13 @@ export abstract class GlyphView extends View {
     this._define_inherited(attr, false)
   }
 
-  protected _inherit_attr(attr: string): void {
+  protected _inherit_attr<Props>(attr: keyof Props): void {
     const {base} = this
     assert(base != null)
     this._inherit_from(attr, base)
   }
 
-  protected _inherit_from(attr: string, base: this): void {
+  protected _inherit_from<Props>(attr: keyof Props, base: this): void {
     Object.defineProperty(this, attr, {
       configurable: true,
       enumerable: true,
@@ -276,8 +276,8 @@ export abstract class GlyphView extends View {
     this._define_inherited(attr, true)
   }
 
-  protected _define_inherited(attr: string, value: boolean): void {
-    Object.defineProperty(this, `inherited_${attr}`, {
+  protected _define_inherited<Props>(attr: keyof Props, value: boolean): void {
+    Object.defineProperty(this, `inherited_${attr as string}`, {
       configurable: true,
       enumerable: true,
       value,

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -30,7 +30,7 @@ import type {BaseGLGlyph, BaseGLGlyphConstructor} from "./webgl/base"
 
 const {abs, ceil} = Math
 
-export type GlyphData = {}
+export type GlyphData = p.GlyphDataOf<Glyph.Props>
 
 export interface GlyphView extends GlyphData {}
 

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -1,6 +1,4 @@
 import type {PointGeometry} from "core/geometry"
-import type {FloatArray, ScreenArray} from "core/types"
-import type {AreaData} from "./area"
 import {Area, AreaView} from "./area"
 import type {Context2d} from "core/util/canvas"
 import type {SpatialIndex} from "core/util/spatial"
@@ -8,15 +6,7 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
 
-export type HAreaData = AreaData & {
-  _x1: FloatArray
-  _x2: FloatArray
-  _y: FloatArray
-
-  sx1: ScreenArray
-  sx2: ScreenArray
-  sy: ScreenArray
-}
+export type HAreaData = p.GlyphDataOf<HArea.Props>
 
 export interface HAreaView extends HAreaData {}
 

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -17,10 +17,10 @@ export class HAreaView extends AreaView {
     const {data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const x1 = this._x1[i]
-      const x2 = this._x2[i]
-      const y = this._y[i]
-      index.add_rect(min(x1, x2), y, max(x1, x2), y)
+      const x1_i = this.x1[i]
+      const x2_i = this.x2[i]
+      const y_i = this.y[i]
+      index.add_rect(min(x1_i, x2_i), y_i, max(x1_i, x2_i), y_i)
     }
   }
 
@@ -67,9 +67,9 @@ export class HAreaView extends AreaView {
   }
 
   protected override _map_data(): void {
-    this.sx1 = this.renderer.xscale.v_compute(this._x1)
-    this.sx2 = this.renderer.xscale.v_compute(this._x2)
-    this.sy  = this.renderer.yscale.v_compute(this._y)
+    this.sx1 = this.renderer.xscale.v_compute(this.x1)
+    this.sx2 = this.renderer.xscale.v_compute(this.x2)
+    this.sy  = this.renderer.yscale.v_compute(this.y)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -6,9 +6,7 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
 
-export type HAreaData = p.GlyphDataOf<HArea.Props>
-
-export interface HAreaView extends HAreaData {}
+export interface HAreaView extends HArea.Data {}
 
 export class HAreaView extends AreaView {
   declare model: HArea
@@ -26,7 +24,7 @@ export class HAreaView extends AreaView {
     }
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: HAreaData): void {
+  protected _render(ctx: Context2d, _indices: number[], data?: HArea.Data): void {
     const {sx1, sx2, sy} = data ?? this
 
     ctx.beginPath()
@@ -85,6 +83,8 @@ export namespace HArea {
   }
 
   export type Visuals = Area.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface HArea extends HArea.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -24,8 +24,8 @@ export class HAreaView extends AreaView {
     }
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: HArea.Data): void {
-    const {sx1, sx2, sy} = data ?? this
+  protected _render(ctx: Context2d, _indices: number[], data?: Partial<HArea.Data>): void {
+    const {sx1, sx2, sy} = {...this, ...data}
 
     ctx.beginPath()
     for (let i = 0, end = sx1.length; i < end; i++) {

--- a/bokehjs/src/lib/models/glyphs/harea.ts
+++ b/bokehjs/src/lib/models/glyphs/harea.ts
@@ -65,21 +65,15 @@ export class HAreaView extends AreaView {
     const scy = this.sy[i]
     return [scx, scy]
   }
-
-  protected override _map_data(): void {
-    this.sx1 = this.renderer.xscale.v_compute(this.x1)
-    this.sx2 = this.renderer.xscale.v_compute(this.x2)
-    this.sy  = this.renderer.yscale.v_compute(this.y)
-  }
 }
 
 export namespace HArea {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Area.Props & {
-    x1: p.CoordinateSpec
-    x2: p.CoordinateSpec
-    y: p.CoordinateSpec
+    x1: p.XCoordinateSpec
+    x2: p.XCoordinateSpec
+    y: p.YCoordinateSpec
   }
 
   export type Visuals = Area.Visuals

--- a/bokehjs/src/lib/models/glyphs/harea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/harea_step.ts
@@ -116,21 +116,15 @@ export class HAreaStepView extends AreaView {
 
     return new Selection()
   }
-
-  protected override _map_data(): void {
-    this.sx1  = this.renderer.xscale.v_compute(this.x1)
-    this.sx2 = this.renderer.xscale.v_compute(this.x2)
-    this.sy = this.renderer.yscale.v_compute(this.y)
-  }
 }
 
 export namespace HAreaStep {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Area.Props & {
-    x1: p.CoordinateSpec
-    x2: p.CoordinateSpec
-    y: p.CoordinateSpec
+    x1: p.XCoordinateSpec
+    x2: p.XCoordinateSpec
+    y: p.YCoordinateSpec
     step_mode: p.Property<StepMode>
   }
 

--- a/bokehjs/src/lib/models/glyphs/harea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/harea_step.ts
@@ -1,6 +1,5 @@
 import type {PointGeometry} from "core/geometry"
-import type {FloatArray, ScreenArray} from "core/types"
-import type {AreaData} from "./area"
+import type {Arrayable} from "core/types"
 import {Area, AreaView} from "./area"
 import type {Context2d} from "core/util/canvas"
 import type {SpatialIndex} from "core/util/spatial"
@@ -10,15 +9,7 @@ import {StepMode} from "core/enums"
 import {flip_step_mode} from "core/util/flip_step_mode"
 import {Selection} from "../selections/selection"
 
-export type HAreaStepData = AreaData & {
-  _x1: FloatArray
-  _x2: FloatArray
-  _y: FloatArray
-
-  sx1: ScreenArray
-  sx2: ScreenArray
-  sy: ScreenArray
-}
+export type HAreaStepData = p.GlyphDataOf<HAreaStep.Props>
 
 export interface HAreaStepView extends HAreaStepData {}
 
@@ -37,23 +28,24 @@ export class HAreaStepView extends AreaView {
     }
   }
 
-  protected _step_path(ctx: Context2d, mode: StepMode, sx: ScreenArray, sy: ScreenArray, from_i: number, to_i: number): void {
+  protected _step_path(ctx: Context2d, mode: StepMode, sx: Arrayable<number>, sy: Arrayable<number>, from_i: number, to_i: number): void {
     // Assume the path was already moved to the first point
     let prev_x = sx[from_i]
     let prev_y = sy[from_i]
     const idx_dir = from_i < to_i ? 1 : -1
     for (let i = from_i + idx_dir; i != to_i; i += idx_dir) {
       switch (mode) {
-        case "before":
+        case "before": {
           ctx.lineTo(sx[i], prev_y)
           ctx.lineTo(sx[i], sy[i])
           break
-        case "after":
+        }
+        case "after": {
           ctx.lineTo(prev_x, sy[i])
           ctx.lineTo(sx[i], sy[i])
           break
-        case "center":
-        {
+        }
+        case "center": {
           const mid_y = (prev_y + sy[i]) / 2
           ctx.lineTo(prev_x, mid_y)
           ctx.lineTo(sx[i], mid_y)

--- a/bokehjs/src/lib/models/glyphs/harea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/harea_step.ts
@@ -56,8 +56,8 @@ export class HAreaStepView extends AreaView {
     }
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: HAreaStep.Data): void {
-    const {sx1, sx2, sy} = data ?? this
+  protected _render(ctx: Context2d, _indices: number[], data?: Partial<HAreaStep.Data>): void {
+    const {sx1, sx2, sy} = {...this, ...data}
 
     const forward_mode = this.model.step_mode
     const backward_mode = flip_step_mode(this.model.step_mode)

--- a/bokehjs/src/lib/models/glyphs/harea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/harea_step.ts
@@ -17,11 +17,12 @@ export class HAreaStepView extends AreaView {
 
   protected _index_data(index: SpatialIndex): void {
     const {min, max} = Math
+    const {x1, x2, y} = this
 
     for (let i = 0; i < this.data_size; i++) {
-      const x1_i = this.x1[i]
-      const x2_i = this.x2[i]
-      const y_i = this.y[i]
+      const x1_i = x1[i]
+      const x2_i = x2[i]
+      const y_i = y[i]
       index.add_rect(min(x1_i, x2_i), y_i, max(x1_i, x2_i), y_i)
     }
   }
@@ -88,16 +89,17 @@ export class HAreaStepView extends AreaView {
       let py: number[]
 
       switch (this.model.step_mode) {
-        case "before":
+        case "before": {
           px = [sy[i], sy[i+1], sy[i+1], sy[i]]
           py = [sx1[i+1], sx1[i+1], sx2[i+1], sx2[i+1]]
           break
-        case "after":
+        }
+        case "after": {
           px = [sy[i], sy[i+1], sy[i+1], sy[i]]
           py = [sx1[i], sx1[i], sx2[i], sx2[i]]
           break
-        case "center":
-        {
+        }
+        case "center": {
           const mid_y = (sy[i] + sy[i+1]) / 2
           px = [sy[i], mid_y, mid_y, sy[i+1], sy[i+1], mid_y, mid_y, sy[i]]
           py = [sx1[i], sx1[i], sx1[i+1], sx1[i+1], sx2[i+1], sx2[i+1], sx2[i], sx2[i]]

--- a/bokehjs/src/lib/models/glyphs/harea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/harea_step.ts
@@ -9,9 +9,7 @@ import {StepMode} from "core/enums"
 import {flip_step_mode} from "core/util/flip_step_mode"
 import {Selection} from "../selections/selection"
 
-export type HAreaStepData = p.GlyphDataOf<HAreaStep.Props>
-
-export interface HAreaStepView extends HAreaStepData {}
+export interface HAreaStepView extends HAreaStep.Data {}
 
 export class HAreaStepView extends AreaView {
   declare model: HAreaStep
@@ -58,7 +56,7 @@ export class HAreaStepView extends AreaView {
     }
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: HAreaStepData): void {
+  protected _render(ctx: Context2d, _indices: number[], data?: HAreaStep.Data): void {
     const {sx1, sx2, sy} = data ?? this
 
     const forward_mode = this.model.step_mode
@@ -137,6 +135,8 @@ export namespace HAreaStep {
   }
 
   export type Visuals = Area.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface HAreaStep extends HAreaStep.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/harea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/harea_step.ts
@@ -150,7 +150,7 @@ export class HAreaStep extends Area {
 
     this.define<HAreaStep.Props>(({}) => ({
       x1:        [ p.XCoordinateSpec, {field: "x1"} ],
-      x2:        [ p.YCoordinateSpec, {field: "x2"} ],
+      x2:        [ p.XCoordinateSpec, {field: "x2"} ],
       y:         [ p.YCoordinateSpec, {field: "y"} ],
       step_mode: [ StepMode, "before" ],
     }))

--- a/bokehjs/src/lib/models/glyphs/harea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/harea_step.ts
@@ -19,10 +19,10 @@ export class HAreaStepView extends AreaView {
     const {min, max} = Math
 
     for (let i = 0; i < this.data_size; i++) {
-      const x1 = this._x1[i]
-      const x2 = this._x2[i]
-      const y = this._y[i]
-      index.add_rect(min(x1, x2), y, max(x1, x2), y)
+      const x1_i = this.x1[i]
+      const x2_i = this.x2[i]
+      const y_i = this.y[i]
+      index.add_rect(min(x1_i, x2_i), y_i, max(x1_i, x2_i), y_i)
     }
   }
 
@@ -118,9 +118,9 @@ export class HAreaStepView extends AreaView {
   }
 
   protected override _map_data(): void {
-    this.sx1  = this.renderer.xscale.v_compute(this._x1)
-    this.sx2 = this.renderer.xscale.v_compute(this._x2)
-    this.sy = this.renderer.yscale.v_compute(this._y)
+    this.sx1  = this.renderer.xscale.v_compute(this.x1)
+    this.sx2 = this.renderer.xscale.v_compute(this.x2)
+    this.sy = this.renderer.yscale.v_compute(this.y)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -1,4 +1,5 @@
 import {LRTB, LRTBView} from "./lrtb"
+import type {LRTBRect} from "./lrtb"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
@@ -14,7 +15,7 @@ export class HBarView extends LRTBView {
     return [scx, scy]
   }
 
-  protected _lrtb(i: number): [number, number, number, number] {
+  protected _lrtb(i: number): LRTBRect {
     const left_i = this.left[i]
     const right_i = this.right[i]
     const y_i = this.y[i]
@@ -25,26 +26,35 @@ export class HBarView extends LRTBView {
     const t = y_i + half_height_i
     const b = y_i - half_height_i
 
-    return [l, r, t, b]
+    return {l, r, t, b}
   }
 
   protected override _map_data(): void {
     if (this.inherited_y && this.inherited_height) {
-      this._inherit_attr("sheight")
+      this._inherit_attr<HBar.Data>("sheight")
+      this._inherit_attr<HBar.Data>("stop")
+      this._inherit_attr<HBar.Data>("sbottom")
     } else {
       const sheight = this.sdist(this.renderer.yscale, this.y, this.height, "center")
-      this._define_attr("sheight", sheight)
+
+      const {sy} = this
+      const n = this.sy.length
+      const stop = new ScreenArray(n)
+      const sbottom = new ScreenArray(n)
+
+      for (let i = 0; i < n; i++) {
+        const sy_i = sy[i]
+        const sheight_i = sheight[i]
+        stop[i] = sy_i - sheight_i/2
+        sbottom[i] = sy_i + sheight_i/2
+      }
+
+      this._define_attr<HBar.Data>("sheight", sheight)
+      this._define_attr<HBar.Data>("stop", stop)
+      this._define_attr<HBar.Data>("sbottom", sbottom)
     }
 
-    const n = this.sy.length
-    this.stop = new ScreenArray(n)
-    this.sbottom = new ScreenArray(n)
-    for (let i = 0; i < n; i++) {
-      this.stop[i] = this.sy[i] - this.sheight[i]/2
-      this.sbottom[i] = this.sy[i] + this.sheight[i]/2
-    }
-
-    this._clamp_viewport()
+    this._clamp_to_viewport()
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -29,10 +29,7 @@ export class HBarView extends LRTBView {
   }
 
   protected override _map_data(): void {
-    this.sy = this.renderer.yscale.v_compute(this.y)
     this.sheight = this.sdist(this.renderer.yscale, this.y, this.height, "center")
-    this.sleft = this.renderer.xscale.v_compute(this.left)
-    this.sright = this.renderer.xscale.v_compute(this.right)
 
     const n = this.sy.length
     this.stop = new ScreenArray(n)
@@ -50,10 +47,10 @@ export namespace HBar {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = LRTB.Props & {
-    left: p.CoordinateSpec
-    y: p.CoordinateSpec
+    left: p.XCoordinateSpec
+    y: p.YCoordinateSpec
     height: p.DistanceSpec
-    right: p.CoordinateSpec
+    right: p.XCoordinateSpec
   }
 
   export type Visuals = LRTB.Visuals

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -1,18 +1,9 @@
-import type {LRTBData} from "./lrtb"
 import {LRTB, LRTBView} from "./lrtb"
 import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
-export type HBarData = LRTBData & p.GlyphDataOf<HBar.Props> & {
-  _y: Arrayable<number>
-  height: p.Uniform<number>
-
-  sy: Arrayable<number>
-  swidth: Arrayable<number>
-}
-
-export interface HBarView extends HBarData {}
+export interface HBarView extends HBar.Data {}
 
 export class HBarView extends LRTBView {
   declare model: HBar
@@ -67,6 +58,14 @@ export namespace HBar {
   }
 
   export type Visuals = LRTB.Visuals
+
+  export type Data = LRTB.Data & p.GlyphDataOf<Props> & {
+    _y: Arrayable<number>
+    height: p.Uniform<number>
+
+    sy: Arrayable<number>
+    swidth: Arrayable<number>
+  }
 }
 
 export interface HBar extends HBar.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -1,21 +1,15 @@
 import type {LRTBData} from "./lrtb"
 import {LRTB, LRTBView} from "./lrtb"
-import type {FloatArray} from "core/types"
+import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
-export type HBarData = LRTBData & {
-  _left: FloatArray
-  _y: FloatArray
-  readonly height: p.Uniform<number>
-  _right: FloatArray
+export type HBarData = LRTBData & p.GlyphDataOf<HBar.Props> & {
+  _y: Arrayable<number>
+  height: p.Uniform<number>
 
-  sy: ScreenArray
-  sh: ScreenArray
-  sleft: ScreenArray
-  sright: ScreenArray
-  stop: ScreenArray
-  sbottom: ScreenArray
+  sy: Arrayable<number>
+  swidth: Arrayable<number>
 }
 
 export interface HBarView extends HBarData {}
@@ -46,7 +40,7 @@ export class HBarView extends LRTBView {
 
   protected override _map_data(): void {
     this.sy = this.renderer.yscale.v_compute(this._y)
-    this.sh = this.sdist(this.renderer.yscale, this._y, this.height, "center")
+    this.swidth = this.sdist(this.renderer.yscale, this._y, this.height, "center")
     this.sleft = this.renderer.xscale.v_compute(this._left)
     this.sright = this.renderer.xscale.v_compute(this._right)
 
@@ -54,8 +48,8 @@ export class HBarView extends LRTBView {
     this.stop = new ScreenArray(n)
     this.sbottom = new ScreenArray(n)
     for (let i = 0; i < n; i++) {
-      this.stop[i] = this.sy[i] - this.sh[i]/2
-      this.sbottom[i] = this.sy[i] + this.sh[i]/2
+      this.stop[i] = this.sy[i] - this.swidth[i]/2
+      this.sbottom[i] = this.sy[i] + this.swidth[i]/2
     }
 
     this._clamp_viewport()

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -1,5 +1,4 @@
 import {LRTB, LRTBView} from "./lrtb"
-import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
@@ -16,9 +15,9 @@ export class HBarView extends LRTBView {
   }
 
   protected _lrtb(i: number): [number, number, number, number] {
-    const left_i = this._left[i]
-    const right_i = this._right[i]
-    const y_i = this._y[i]
+    const left_i = this.left[i]
+    const right_i = this.right[i]
+    const y_i = this.y[i]
     const half_height_i = this.height.get(i)/2
 
     const l = Math.min(left_i, right_i)
@@ -30,17 +29,17 @@ export class HBarView extends LRTBView {
   }
 
   protected override _map_data(): void {
-    this.sy = this.renderer.yscale.v_compute(this._y)
-    this.swidth = this.sdist(this.renderer.yscale, this._y, this.height, "center")
-    this.sleft = this.renderer.xscale.v_compute(this._left)
-    this.sright = this.renderer.xscale.v_compute(this._right)
+    this.sy = this.renderer.yscale.v_compute(this.y)
+    this.sheight = this.sdist(this.renderer.yscale, this.y, this.height, "center")
+    this.sleft = this.renderer.xscale.v_compute(this.left)
+    this.sright = this.renderer.xscale.v_compute(this.right)
 
     const n = this.sy.length
     this.stop = new ScreenArray(n)
     this.sbottom = new ScreenArray(n)
     for (let i = 0; i < n; i++) {
-      this.stop[i] = this.sy[i] - this.swidth[i]/2
-      this.sbottom[i] = this.sy[i] + this.swidth[i]/2
+      this.stop[i] = this.sy[i] - this.sheight[i]/2
+      this.sbottom[i] = this.sy[i] + this.sheight[i]/2
     }
 
     this._clamp_viewport()
@@ -53,19 +52,13 @@ export namespace HBar {
   export type Props = LRTB.Props & {
     left: p.CoordinateSpec
     y: p.CoordinateSpec
-    height: p.NumberSpec
+    height: p.DistanceSpec
     right: p.CoordinateSpec
   }
 
   export type Visuals = LRTB.Visuals
 
-  export type Data = LRTB.Data & p.GlyphDataOf<Props> & {
-    _y: Arrayable<number>
-    height: p.Uniform<number>
-
-    sy: Arrayable<number>
-    swidth: Arrayable<number>
-  }
+  export type Data = LRTB.Data & p.GlyphDataOf<Props>
 }
 
 export interface HBar extends HBar.Attrs {}
@@ -84,7 +77,7 @@ export class HBar extends LRTB {
     this.define<HBar.Props>(({}) => ({
       left:   [ p.XCoordinateSpec, {value: 0} ],
       y:      [ p.YCoordinateSpec, {field: "y"} ],
-      height: [ p.NumberSpec,      {value: 1} ],
+      height: [ p.DistanceSpec,    {value: 1} ],
       right:  [ p.XCoordinateSpec, {field: "right"} ],
     }))
   }

--- a/bokehjs/src/lib/models/glyphs/hbar.ts
+++ b/bokehjs/src/lib/models/glyphs/hbar.ts
@@ -29,7 +29,12 @@ export class HBarView extends LRTBView {
   }
 
   protected override _map_data(): void {
-    this.sheight = this.sdist(this.renderer.yscale, this.y, this.height, "center")
+    if (this.inherited_y && this.inherited_height) {
+      this._inherit_attr("sheight")
+    } else {
+      const sheight = this.sdist(this.renderer.yscale, this.y, this.height, "center")
+      this._define_attr("sheight", sheight)
+    }
 
     const n = this.sy.length
     this.stop = new ScreenArray(n)

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -1,4 +1,3 @@
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 
 import type {PointGeometry, RectGeometry, SpanGeometry} from "core/geometry"
@@ -18,14 +17,9 @@ import type {HexTileGL} from "./webgl/hex_tile"
 
 export type Vertices = [number, number, number, number, number, number]
 
-export type HexTileData = GlyphData & p.UniformsOf<HexTile.Mixins> & {
-  readonly q: p.Uniform<number>
-  readonly r: p.Uniform<number>
-
+export type HexTileData = p.GlyphDataOf<HexTile.Props> & {
   _x: FloatArray
   _y: FloatArray
-
-  readonly scale: p.Uniform<number>
 
   sx: ScreenArray
   sy: ScreenArray

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -128,8 +128,8 @@ export class HexTileView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: HexTile.Data): void {
-    const {sx, sy, svx, svy, scale} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<HexTile.Data>): void {
+    const {sx, sy, svx, svy, scale} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]

--- a/bokehjs/src/lib/models/glyphs/hex_tile.ts
+++ b/bokehjs/src/lib/models/glyphs/hex_tile.ts
@@ -17,18 +17,7 @@ import type {HexTileGL} from "./webgl/hex_tile"
 
 export type Vertices = [number, number, number, number, number, number]
 
-export type HexTileData = p.GlyphDataOf<HexTile.Props> & {
-  _x: FloatArray
-  _y: FloatArray
-
-  sx: ScreenArray
-  sy: ScreenArray
-
-  svx: Vertices
-  svy: Vertices
-}
-
-export interface HexTileView extends HexTileData {}
+export interface HexTileView extends HexTile.Data {}
 
 export class HexTileView extends GlyphView {
   declare model: HexTile
@@ -139,7 +128,7 @@ export class HexTileView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: HexTileData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: HexTile.Data): void {
     const {sx, sy, svx, svy, scale} = data ?? this
 
     for (const i of indices) {
@@ -228,6 +217,17 @@ export namespace HexTile {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    _x: FloatArray
+    _y: FloatArray
+
+    sx: ScreenArray
+    sy: ScreenArray
+
+    svx: Vertices
+    svy: Vertices
+  }
 }
 
 export interface HexTile extends HexTile.Attrs { }

--- a/bokehjs/src/lib/models/glyphs/hspan.ts
+++ b/bokehjs/src/lib/models/glyphs/hspan.ts
@@ -16,11 +16,7 @@ const {abs, max} = Math
 
 const UNUSED = 0
 
-export type HSpanData = p.GlyphDataOf<HSpan.Props> & {
-  max_line_width: number
-}
-
-export interface HSpanView extends HSpanData {}
+export interface HSpanView extends HSpan.Data {}
 
 export class HSpanView extends GlyphView {
   declare model: HSpan
@@ -53,7 +49,7 @@ export class HSpanView extends GlyphView {
     return [hcenter, this.sy[i]]
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: HSpanData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: HSpan.Data): void {
     const {sy} = data ?? this
     const {left, right} = this.renderer.plot_view.frame.bbox
 
@@ -142,6 +138,10 @@ export namespace HSpan {
   export type Mixins = LineVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    max_line_width: number
+  }
 }
 
 export interface HSpan extends HSpan.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/hspan.ts
+++ b/bokehjs/src/lib/models/glyphs/hspan.ts
@@ -49,8 +49,8 @@ export class HSpanView extends GlyphView {
     return [hcenter, this.sy[i]]
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: HSpan.Data): void {
-    const {sy} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<HSpan.Data>): void {
+    const {sy} = {...this, ...data}
     const {left, right} = this.renderer.plot_view.frame.bbox
 
     for (const i of indices) {

--- a/bokehjs/src/lib/models/glyphs/hspan.ts
+++ b/bokehjs/src/lib/models/glyphs/hspan.ts
@@ -28,7 +28,7 @@ export class HSpanView extends GlyphView {
   }
 
   protected override _index_data(index: SpatialIndex): void {
-    for (const y_i of this._y) {
+    for (const y_i of this.y) {
       index.add_point(UNUSED, y_i)
     }
   }

--- a/bokehjs/src/lib/models/glyphs/hspan.ts
+++ b/bokehjs/src/lib/models/glyphs/hspan.ts
@@ -1,10 +1,9 @@
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_line_vector_legend} from "./utils"
 import {Selection} from "../selections/selection"
 import {LineVector} from "core/property_mixins"
 import type {PointGeometry, SpanGeometry, RectGeometry} from "core/geometry"
-import type {FloatArray, ScreenArray, Rect} from "core/types"
+import type {Rect} from "core/types"
 import type * as visuals from "core/visuals"
 import * as uniforms from "core/uniforms"
 import type {Context2d} from "core/util/canvas"
@@ -17,10 +16,7 @@ const {abs, max} = Math
 
 const UNUSED = 0
 
-export type HSpanData = GlyphData & p.UniformsOf<HSpan.Mixins> & {
-  _y: FloatArray
-  sy: ScreenArray
-
+export type HSpanData = p.GlyphDataOf<HSpan.Props> & {
   max_line_width: number
 }
 

--- a/bokehjs/src/lib/models/glyphs/hspan.ts
+++ b/bokehjs/src/lib/models/glyphs/hspan.ts
@@ -41,7 +41,10 @@ export class HSpanView extends GlyphView {
   protected override _map_data(): void {
     super._map_data()
     const {round} = Math
-    this.sy = map(this.sy, (yi) => round(yi))
+    if (!this.inherited_sy) {
+      const sy = map(this.sy, (yi) => round(yi))
+      this._define_attr("sy", sy)
+    }
   }
 
   scenterxy(i: number): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/hstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/hstrip.ts
@@ -65,16 +65,16 @@ export class HStripView extends GlyphView {
     const {abs} = Math
     const {max, map, zip} = iter
 
-    const {_y0, _y1} = this
-    this.max_height = max(map(zip(_y0, _y1), ([y0_i, y1_i]) => abs(y0_i - y1_i)))
+    const {y0, y1} = this
+    this.max_height = max(map(zip(y0, y1), ([y0_i, y1_i]) => abs(y0_i - y1_i)))
   }
 
   protected override _index_data(index: SpatialIndex): void {
-    const {_y0, _y1, data_size} = this
+    const {y0, y1, data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const y0_i = _y0[i]
-      const y1_i = _y1[i]
+      const y0_i = y0[i]
+      const y1_i = y1[i]
       index.add_rect(UNUSED, y0_i, UNUSED, y1_i)
     }
   }

--- a/bokehjs/src/lib/models/glyphs/hstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/hstrip.ts
@@ -96,8 +96,8 @@ export class HStripView extends GlyphView {
     return [hcenter, (this.sy0[i] + this.sy1[i])/2]
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: HStrip.Data): void {
-    const {sy0, sy1} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<HStrip.Data>): void {
+    const {sy0, sy1} = {...this, ...data}
     const {left, right, width} = this.renderer.plot_view.frame.bbox
 
     for (const i of indices) {

--- a/bokehjs/src/lib/models/glyphs/hstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/hstrip.ts
@@ -1,10 +1,9 @@
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import {Selection} from "../selections/selection"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import type {PointGeometry, SpanGeometry, RectGeometry} from "core/geometry"
-import type {FloatArray, Rect} from "core/types"
+import type {Arrayable, Rect} from "core/types"
 import {ScreenArray} from "core/types"
 import type * as visuals from "core/visuals"
 import type {Context2d} from "core/util/canvas"
@@ -17,13 +16,7 @@ import type {LRTBGL} from "./webgl/lrtb"
 
 const UNUSED = 0
 
-export type HStripData = GlyphData & p.UniformsOf<HStrip.Mixins> & {
-  _y0: FloatArray
-  _y1: FloatArray
-
-  sy0: ScreenArray
-  sy1: ScreenArray
-
+export type HStripData = p.GlyphDataOf<HStrip.Props> & {
   max_height: number
 }
 
@@ -46,7 +39,7 @@ export class HStripView extends GlyphView {
     }
   }
 
-  get sleft(): ScreenArray {
+  get sleft(): Arrayable<number> {
     const {left} = this.renderer.plot_view.frame.bbox
     const n = this.data_size
     const sleft = new ScreenArray(n)
@@ -54,7 +47,7 @@ export class HStripView extends GlyphView {
     return sleft
   }
 
-  get sright(): ScreenArray {
+  get sright(): Arrayable<number> {
     const {right} = this.renderer.plot_view.frame.bbox
     const n = this.data_size
     const sright = new ScreenArray(n)
@@ -62,11 +55,11 @@ export class HStripView extends GlyphView {
     return sright
   }
 
-  get stop(): ScreenArray {
+  get stop(): Arrayable<number> {
     return this.sy0
   }
 
-  get sbottom(): ScreenArray {
+  get sbottom(): Arrayable<number> {
     return this.sy1
   }
 

--- a/bokehjs/src/lib/models/glyphs/hstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/hstrip.ts
@@ -16,11 +16,7 @@ import type {LRTBGL} from "./webgl/lrtb"
 
 const UNUSED = 0
 
-export type HStripData = p.GlyphDataOf<HStrip.Props> & {
-  max_height: number
-}
-
-export interface HStripView extends HStripData {}
+export interface HStripView extends HStrip.Data {}
 
 export class HStripView extends GlyphView {
   declare model: HStrip
@@ -100,7 +96,7 @@ export class HStripView extends GlyphView {
     return [hcenter, (this.sy0[i] + this.sy1[i])/2]
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: HStripData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: HStrip.Data): void {
     const {sy0, sy1} = data ?? this
     const {left, right, width} = this.renderer.plot_view.frame.bbox
 
@@ -201,6 +197,10 @@ export namespace HStrip {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    max_height: number
+  }
 }
 
 export interface HStrip extends HStrip.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/hstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/hstrip.ts
@@ -66,7 +66,12 @@ export class HStripView extends GlyphView {
     const {max, map, zip} = iter
 
     const {y0, y1} = this
-    this.max_height = max(map(zip(y0, y1), ([y0_i, y1_i]) => abs(y0_i - y1_i)))
+    if (this.inherited_y0 && this.inherited_y1) {
+      this._inherit_attr("max_height")
+    } else {
+      const max_height = max(map(zip(y0, y1), ([y0_i, y1_i]) => abs(y0_i - y1_i)))
+      this._define_attr("max_height", max_height)
+    }
   }
 
   protected override _index_data(index: SpatialIndex): void {
@@ -87,8 +92,14 @@ export class HStripView extends GlyphView {
   protected override _map_data(): void {
     super._map_data()
     const {round} = Math
-    this.sy0 = map(this.sy0, (yi) => round(yi))
-    this.sy1 = map(this.sy1, (yi) => round(yi))
+    if (!this.inherited_sy0) {
+      const sy0 = map(this.sy0, (yi) => round(yi))
+      this._define_attr("sy0", sy0)
+    }
+    if (!this.inherited_sy1) {
+      const sy1 = map(this.sy1, (yi) => round(yi))
+      this._define_attr("sy1", sy1)
+    }
   }
 
   scenterxy(i: number): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -1,4 +1,3 @@
-import type {ImageDataBase} from "./image_base"
 import {ImageBase, ImageBaseView} from "./image_base"
 import {ColorMapper} from "../mappers/color_mapper"
 import {LinearColorMapper} from "../mappers/linear_color_mapper"
@@ -6,7 +5,7 @@ import type {NDArrayType} from "core/util/ndarray"
 import type * as p from "core/properties"
 import type {ImageGL} from "./webgl/image"
 
-export type ImageData = ImageDataBase
+export type ImageData = p.GlyphDataOf<Image.Props>
 
 export interface ImageView extends ImageData {}
 

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -5,9 +5,7 @@ import type {NDArrayType} from "core/util/ndarray"
 import type * as p from "core/properties"
 import type {ImageGL} from "./webgl/image"
 
-export type ImageData = p.GlyphDataOf<Image.Props>
-
-export interface ImageView extends ImageData {}
+export interface ImageView extends Image.Data {}
 
 export class ImageView extends ImageBaseView {
   declare model: Image
@@ -55,6 +53,8 @@ export namespace Image {
   }
 
   export type Visuals = ImageBase.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Image extends Image.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -30,7 +30,7 @@ export class ImageView extends ImageBaseView {
     }
 
     // Only reset image_data if already initialized
-    if (this._image_data != null) {
+    if (this.image_data != null) {
       this._set_data(null)
       this.renderer.request_render()
     }

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -24,8 +24,6 @@ export abstract class ImageBaseView extends XYGlyphView {
   declare model: ImageBase
   declare visuals: ImageBase.Visuals
 
-  image_data: Arrayable<ImageData>
-
   protected _width: Uint32Array
   protected _height: Uint32Array
 
@@ -145,8 +143,8 @@ export abstract class ImageBaseView extends XYGlyphView {
     const dw_i = this.dw.get(i)
     const dh_i = this.dh.get(i)
 
-    const x_i = this._x[i]
-    const y_i = this._y[i]
+    const x_i = this.x[i]
+    const y_i = this.y[i]
 
     const {xy_anchor} = this
 
@@ -182,12 +180,12 @@ export abstract class ImageBaseView extends XYGlyphView {
 
   protected override _map_data(): void {
     if (this.model.properties.dw.units == "data")
-      this.sdw = this.sdist(this.renderer.xscale, this._x, this.dw, "edge", this.model.dilate)
+      this.sdw = this.sdist(this.renderer.xscale, this.x, this.dw, "edge", this.model.dilate)
     else
       this.sdw = to_screen(this.dw)
 
     if (this.model.properties.dh.units == "data")
-      this.sdh = this.sdist(this.renderer.yscale, this._y, this.dh, "edge", this.model.dilate)
+      this.sdh = this.sdist(this.renderer.yscale, this.y, this.dh, "edge", this.model.dilate)
     else
       this.sdh = to_screen(this.dh)
   }

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -18,11 +18,7 @@ import {anchor} from "../common/resolve"
 
 type ImageData = HTMLCanvasElement | null
 
-export type ImageBaseData = p.GlyphDataOf<ImageBase.Props> & {
-  image_data: Arrayable<ImageData>
-}
-
-export interface ImageBaseView extends ImageBaseData {}
+export interface ImageBaseView extends ImageBase.Data {}
 
 export abstract class ImageBaseView extends XYGlyphView {
   declare model: ImageBase
@@ -79,7 +75,7 @@ export abstract class ImageBaseView extends XYGlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: ImageBaseData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: ImageBase.Data): void {
     const {image_data, sx, sy, sdw, sdh} = data ?? this
     const {xy_sign, xy_scale, xy_offset, xy_anchor} = this
 
@@ -252,6 +248,10 @@ export namespace ImageBase {
   export type Mixins = mixins.ImageVector
 
   export type Visuals = XYGlyph.Visuals & {image: visuals.ImageVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    image_data: Arrayable<ImageData>
+  }
 }
 
 export interface ImageBase extends ImageBase.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -24,12 +24,7 @@ export abstract class ImageBaseView extends XYGlyphView {
   declare model: ImageBase
   declare visuals: ImageBase.Visuals
 
-  protected _image_data: Arrayable<ImageData> | null = null
-
-  get image_data(): Arrayable<ImageData> {
-    assert(this._image_data != null, "data not set")
-    return this._image_data
-  }
+  image_data: Arrayable<ImageData>
 
   protected _width: Uint32Array
   protected _height: Uint32Array
@@ -75,8 +70,8 @@ export abstract class ImageBaseView extends XYGlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: ImageBase.Data): void {
-    const {image_data, sx, sy, sdw, sdh} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<ImageBase.Data>): void {
+    const {image_data, sx, sy, sdw, sdh} = {...this, ...data}
     const {xy_sign, xy_scale, xy_offset, xy_anchor} = this
 
     ctx.save()
@@ -113,8 +108,8 @@ export abstract class ImageBaseView extends XYGlyphView {
   protected override _set_data(indices: number[] | null): void {
     const n = this.data_size
 
-    if (this._image_data == null || this._image_data.length != n) {
-      this._image_data = new Array(n).fill(null)
+    if (typeof this.image_data == "undefined" || this.image_data.length != n) {
+      this.image_data = new Array(n).fill(null)
       this._width = new Uint32Array(n)
       this._height = new Uint32Array(n)
     }

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -1,4 +1,5 @@
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
+import {inherit} from "./glyph"
 import type {Arrayable} from "core/types"
 import {to_screen} from "core/types"
 import {ImageOrigin} from "core/enums"
@@ -183,15 +184,29 @@ export abstract class ImageBaseView extends XYGlyphView {
   }
 
   protected override _map_data(): void {
-    if (this.model.properties.dw.units == "data")
-      this.sdw = this.sdist(this.renderer.xscale, this.x, this.dw, "edge", this.model.dilate)
-    else
-      this.sdw = to_screen(this.dw)
+    this._define_or_inherit_attr<ImageBase.Data>("sdw", () => {
+      if (this.model.properties.dw.units == "data") {
+        if (this.inherited_x && this.inherited_dw) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.dw, "edge", this.model.dilate)
+        }
+      } else {
+        return this.inherited_dw ? inherit : to_screen(this.dw)
+      }
+    })
 
-    if (this.model.properties.dh.units == "data")
-      this.sdh = this.sdist(this.renderer.yscale, this.y, this.dh, "edge", this.model.dilate)
-    else
-      this.sdh = to_screen(this.dh)
+    this._define_or_inherit_attr<ImageBase.Data>("sdh", () => {
+      if (this.model.properties.dh.units == "data") {
+        if (this.inherited_y && this.inherited_dh) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.yscale, this.y, this.dh, "edge", this.model.dilate)
+        }
+      } else {
+        return this.inherited_dh ? inherit : to_screen(this.dh)
+      }
+    })
   }
 
   _image_index(index: number, x: number, y: number): ImageIndex {

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -72,6 +72,8 @@ export abstract class ImageBaseView extends XYGlyphView {
     const {image_data, sx, sy, sdw, sdh} = {...this, ...data}
     const {xy_sign, xy_scale, xy_offset, xy_anchor} = this
 
+    assert(image_data != null)
+
     ctx.save()
     ctx.imageSmoothingEnabled = false
 
@@ -106,7 +108,7 @@ export abstract class ImageBaseView extends XYGlyphView {
   protected override _set_data(indices: number[] | null): void {
     const n = this.data_size
 
-    if (typeof this.image_data == "undefined" || this.image_data.length != n) {
+    if (this.image_data == null || this.image_data.length != n) {
       this.image_data = new Array(n).fill(null)
       this._width = new Uint32Array(n)
       this._height = new Uint32Array(n)
@@ -157,6 +159,7 @@ export abstract class ImageBaseView extends XYGlyphView {
   }
 
   protected _get_or_create_canvas(i: number): HTMLCanvasElement {
+    assert(this.image_data != null)
     const image_data_i = this.image_data[i]
     if (image_data_i != null && image_data_i.width  == this._width[i]
                              && image_data_i.height == this._height[i])
@@ -170,6 +173,7 @@ export abstract class ImageBaseView extends XYGlyphView {
   }
 
   protected _set_image_data_from_buffer(i: number, buf8: Uint8ClampedArray): void {
+    assert(this.image_data != null)
     const canvas = this._get_or_create_canvas(i)
     const ctx = canvas.getContext("2d")!
     const image_data = ctx.getImageData(0, 0, this._width[i], this._height[i])
@@ -243,7 +247,7 @@ export namespace ImageBase {
   export type Visuals = XYGlyph.Visuals & {image: visuals.ImageVector}
 
   export type Data = p.GlyphDataOf<Props> & {
-    image_data: Arrayable<ImageData>
+    image_data: Arrayable<ImageData> | null
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/image_rgba.ts
+++ b/bokehjs/src/lib/models/glyphs/image_rgba.ts
@@ -4,9 +4,7 @@ import {isTypedArray} from "core/util/types"
 import type * as p from "core/properties"
 import type {ImageGL} from "./webgl/image"
 
-export type ImageRGBAData = p.GlyphDataOf<ImageRGBA.Props>
-
-export interface ImageRGBAView extends ImageRGBAData {}
+export interface ImageRGBAView extends ImageRGBA.Data {}
 
 export class ImageRGBAView extends ImageBaseView {
   declare model: ImageRGBA
@@ -32,6 +30,8 @@ export namespace ImageRGBA {
   export type Props = ImageBase.Props
 
   export type Visuals = ImageBase.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface ImageRGBA extends ImageRGBA.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/image_rgba.ts
+++ b/bokehjs/src/lib/models/glyphs/image_rgba.ts
@@ -1,11 +1,10 @@
-import type {ImageDataBase} from "./image_base"
 import {ImageBase, ImageBaseView} from "./image_base"
 import type {NDArrayType} from "core/util/ndarray"
 import {isTypedArray} from "core/util/types"
 import type * as p from "core/properties"
 import type {ImageGL} from "./webgl/image"
 
-export type ImageRGBAData = ImageDataBase
+export type ImageRGBAData = p.GlyphDataOf<ImageRGBA.Props>
 
 export interface ImageRGBAView extends ImageRGBAData {}
 

--- a/bokehjs/src/lib/models/glyphs/image_stack.ts
+++ b/bokehjs/src/lib/models/glyphs/image_stack.ts
@@ -1,11 +1,10 @@
-import type {ImageDataBase} from "./image_base"
 import {ImageBase, ImageBaseView} from "./image_base"
 import {StackColorMapper} from "../mappers/stack_color_mapper"
 import type {NDArrayType} from "core/util/ndarray"
 import type * as p from "core/properties"
 import type {ImageGL} from "./webgl/image"
 
-export type ImageStackData = ImageDataBase
+export type ImageStackData = p.GlyphDataOf<ImageStack.Props>
 
 export interface ImageStackView extends ImageData {}
 

--- a/bokehjs/src/lib/models/glyphs/image_stack.ts
+++ b/bokehjs/src/lib/models/glyphs/image_stack.ts
@@ -4,9 +4,7 @@ import type {NDArrayType} from "core/util/ndarray"
 import type * as p from "core/properties"
 import type {ImageGL} from "./webgl/image"
 
-export type ImageStackData = p.GlyphDataOf<ImageStack.Props>
-
-export interface ImageStackView extends ImageData {}
+export interface ImageStackView extends Image.Data {}
 
 export class ImageStackView extends ImageBaseView {
   declare model: ImageStack
@@ -55,6 +53,8 @@ export namespace ImageStack {
   }
 
   export type Visuals = ImageBase.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface ImageStack extends ImageStack.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/image_stack.ts
+++ b/bokehjs/src/lib/models/glyphs/image_stack.ts
@@ -4,7 +4,7 @@ import type {NDArrayType} from "core/util/ndarray"
 import type * as p from "core/properties"
 import type {ImageGL} from "./webgl/image"
 
-export interface ImageStackView extends Image.Data {}
+export interface ImageStackView extends ImageBase.Data {}
 
 export class ImageStackView extends ImageBaseView {
   declare model: ImageStack
@@ -33,7 +33,7 @@ export class ImageStackView extends ImageBaseView {
     }
 
     // Only reset image_data if already initialized
-    if (this._image_data != null) {
+    if (this.image_data != null) {
       this._set_data(null)
       this.renderer.request_render()
     }

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -112,17 +112,17 @@ export class ImageURLView extends XYGlyphView {
     // if the width/height are in screen units, don't try to include them in bounds
     if (w_data) {
       for (let i = 0; i < n; i++) {
-        [xs[i], xs[n + i]] = x0x1(this._x[i], this.w.get(i) ?? 0)
+        [xs[i], xs[n + i]] = x0x1(this.x[i], this.w.get(i) ?? 0)
       }
     } else
-      xs.set(this._x, 0)
+      xs.set(this.x, 0)
 
     if (h_data) {
       for (let i = 0; i < n; i++) {
-        [ys[i], ys[n + i]] = y0y1(this._y[i], this.h.get(i) ?? 0)
+        [ys[i], ys[n + i]] = y0y1(this.y[i], this.h.get(i) ?? 0)
       }
     } else
-      ys.set(this._y, 0)
+      ys.set(this.y, 0)
 
     const [x0, x1, y0, y1] = minmax2(xs, ys)
     this._bounds_rect = {x0, x1, y0, y1}
@@ -137,12 +137,12 @@ export class ImageURLView extends XYGlyphView {
     const h = this.h.map((h_i) => h_i ?? NaN)
 
     if (this.model.properties.w.units == "data")
-      this.sw = this.sdist(this.renderer.xscale, this._x, w, "edge", this.model.dilate)
+      this.sw = this.sdist(this.renderer.xscale, this.x, w, "edge", this.model.dilate)
     else
       this.sw = to_screen(w)
 
     if (this.model.properties.h.units == "data")
-      this.sh = this.sdist(this.renderer.yscale, this._y, h, "edge", this.model.dilate)
+      this.sh = this.sdist(this.renderer.yscale, this.y, h, "edge", this.model.dilate)
     else
       this.sh = to_screen(h)
   }

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -1,4 +1,3 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import type {Arrayable, Rect} from "core/types"
 import {ScreenArray, to_screen, Indices} from "core/types"
@@ -14,23 +13,7 @@ import * as resolve from "../common/resolve"
 
 export type CanvasImage = HTMLImageElement
 
-export type ImageURLData = XYGlyphData & {
-  readonly url: p.Uniform<string | ArrayBuffer>
-  readonly angle: p.Uniform<number>
-  readonly w: p.Uniform<number>
-  readonly h: p.Uniform<number>
-  readonly global_alpha: p.Uniform<number>
-
-  _bounds_rect: Rect
-
-  sw: ScreenArray
-  sh: ScreenArray
-
-  readonly max_w: number
-  readonly max_h: number
-
-  anchor: XY<number>
-}
+export type ImageURLData = p.GlyphDataOf<ImageURL.Props>
 
 export interface ImageURLView extends ImageURLData {}
 
@@ -39,6 +22,9 @@ export class ImageURLView extends XYGlyphView {
   declare visuals: ImageURL.Visuals
 
   protected _images_rendered = false
+  protected _bounds_rect: Rect
+
+  anchor: XY<number>
 
   /*protected*/ image: (CanvasImage | null)[] = new Array(0)
   loaders: (ImageLoader | null)[]
@@ -128,14 +114,14 @@ export class ImageURLView extends XYGlyphView {
     // if the width/height are in screen units, don't try to include them in bounds
     if (w_data) {
       for (let i = 0; i < n; i++) {
-        [xs[i], xs[n + i]] = x0x1(this._x[i], this.w.get(i))
+        [xs[i], xs[n + i]] = x0x1(this._x[i], this.w.get(i) ?? 0)
       }
     } else
       xs.set(this._x, 0)
 
     if (h_data) {
       for (let i = 0; i < n; i++) {
-        [ys[i], ys[n + i]] = y0y1(this._y[i], this.h.get(i))
+        [ys[i], ys[n + i]] = y0y1(this._y[i], this.h.get(i) ?? 0)
       }
     } else
       ys.set(this._y, 0)
@@ -149,15 +135,18 @@ export class ImageURLView extends XYGlyphView {
   }
 
   protected override _map_data(): void {
+    const w = this.w.map((w_i) => w_i ?? NaN)
+    const h = this.h.map((h_i) => h_i ?? NaN)
+
     if (this.model.properties.w.units == "data")
-      this.sw = this.sdist(this.renderer.xscale, this._x, this.w, "edge", this.model.dilate)
+      this.sw = this.sdist(this.renderer.xscale, this._x, w, "edge", this.model.dilate)
     else
-      this.sw = to_screen(this.w)
+      this.sw = to_screen(w)
 
     if (this.model.properties.h.units == "data")
-      this.sh = this.sdist(this.renderer.yscale, this._y, this.h, "edge", this.model.dilate)
+      this.sh = this.sdist(this.renderer.yscale, this._y, h, "edge", this.model.dilate)
     else
-      this.sh = to_screen(this.h)
+      this.sh = to_screen(h)
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: ImageURLData): void {

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -13,9 +13,7 @@ import * as resolve from "../common/resolve"
 
 export type CanvasImage = HTMLImageElement
 
-export type ImageURLData = p.GlyphDataOf<ImageURL.Props>
-
-export interface ImageURLView extends ImageURLData {}
+export interface ImageURLView extends ImageURL.Data {}
 
 export class ImageURLView extends XYGlyphView {
   declare model: ImageURL
@@ -149,7 +147,7 @@ export class ImageURLView extends XYGlyphView {
       this.sh = to_screen(h)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: ImageURLData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: ImageURL.Data): void {
     const {sx, sy, sw, sh, angle, global_alpha} = data ?? this
     const {image, loaders, resolved} = this
 
@@ -263,6 +261,8 @@ export namespace ImageURL {
   }
 
   export type Visuals = XYGlyph.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface ImageURL extends ImageURL.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -147,8 +147,8 @@ export class ImageURLView extends XYGlyphView {
       this.sh = to_screen(h)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: ImageURL.Data): void {
-    const {sx, sy, sw, sh, angle, global_alpha} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<ImageURL.Data>): void {
+    const {sx, sy, sw, sh, angle, global_alpha} = {...this, ...data}
     const {image, loaders, resolved} = this
 
     // TODO (bev): take actual border width into account when clipping

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -1,4 +1,3 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {generic_line_scalar_legend, line_interpolation} from "./utils"
 import type {PointGeometry, SpanGeometry} from "core/geometry"
@@ -11,7 +10,7 @@ import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import type {LineGL} from "./webgl/line_gl"
 
-export type LineData = XYGlyphData & p.UniformsOf<Line.Mixins>
+export type LineData = p.GlyphDataOf<Line.Props>
 
 export interface LineView extends LineData {}
 

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -10,9 +10,7 @@ import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import type {LineGL} from "./webgl/line_gl"
 
-export type LineData = p.GlyphDataOf<Line.Props>
-
-export interface LineView extends LineData {}
+export interface LineView extends Line.Data {}
 
 export class LineView extends XYGlyphView {
   declare model: Line
@@ -26,7 +24,7 @@ export class LineView extends XYGlyphView {
     return LineGL
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: LineData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Line.Data): void {
     const {sx, sy} = data ?? this
     const nonselection = this.parent.nonselection_glyph == this
 
@@ -150,6 +148,8 @@ export namespace Line {
   export type Mixins = mixins.LineScalar
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineScalar}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Line extends Line.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -105,10 +105,10 @@ export class LineView extends XYGlyphView {
     let values: Arrayable<number>
     if (geometry.direction == "v") {
       val = this.renderer.yscale.invert(sy)
-      values = this._y
+      values = this.y
     } else {
       val = this.renderer.xscale.invert(sx)
-      values = this._x
+      values = this.x
     }
 
     const indices = []
@@ -131,7 +131,7 @@ export class LineView extends XYGlyphView {
   }
 
   get_interpolation_hit(i: number, geometry: PointGeometry | SpanGeometry): [number, number] {
-    const [x2, y2, x3, y3] = [this._x[i], this._y[i], this._x[i+1], this._y[i+1]]
+    const [x2, y2, x3, y3] = [this.x[i], this.y[i], this.x[i+1], this.y[i+1]]
     return line_interpolation(this.renderer, geometry, x2, y2, x3, y3)
   }
 

--- a/bokehjs/src/lib/models/glyphs/line.ts
+++ b/bokehjs/src/lib/models/glyphs/line.ts
@@ -24,8 +24,8 @@ export class LineView extends XYGlyphView {
     return LineGL
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Line.Data): void {
-    const {sx, sy} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Line.Data>): void {
+    const {sx, sy} = {...this, ...data}
     const nonselection = this.parent.nonselection_glyph == this
 
     let iprev: number | null = null

--- a/bokehjs/src/lib/models/glyphs/lrtb.ts
+++ b/bokehjs/src/lib/models/glyphs/lrtb.ts
@@ -19,21 +19,7 @@ import type {LRTBGL} from "./webgl/lrtb"
 // This class is intended to be a private implementation detail that can
 // be re-used by various rect, bar, box, quad, etc. glyphs.
 
-export type LRTBData = p.GlyphDataOf<LRTB.Props> & {
-  _right: Arrayable<number>
-  _bottom: Arrayable<number>
-  _left: Arrayable<number>
-  _top: Arrayable<number>
-
-  sright: Arrayable<number>
-  sbottom: Arrayable<number>
-  sleft: Arrayable<number>
-  stop: Arrayable<number>
-
-  border_radius: Corners<number>
-}
-
-export interface LRTBView extends LRTBData {}
+export interface LRTBView extends LRTB.Data {}
 
 export abstract class LRTBView extends GlyphView {
   declare model: LRTB
@@ -88,7 +74,7 @@ export abstract class LRTBView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: LRTBData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: LRTB.Data): void {
     const {sleft, sright, stop, sbottom, border_radius} = data ?? this
 
     for (const i of indices) {
@@ -171,6 +157,20 @@ export namespace LRTB {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    _right: Arrayable<number>
+    _bottom: Arrayable<number>
+    _left: Arrayable<number>
+    _top: Arrayable<number>
+
+    sright: Arrayable<number>
+    sbottom: Arrayable<number>
+    sleft: Arrayable<number>
+    stop: Arrayable<number>
+
+    border_radius: Corners<number>
+  }
 }
 
 export interface LRTB extends LRTB.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/lrtb.ts
+++ b/bokehjs/src/lib/models/glyphs/lrtb.ts
@@ -159,10 +159,10 @@ export namespace LRTB {
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
 
   export type Data = p.GlyphDataOf<Props> & {
-    _right: Arrayable<number>
-    _bottom: Arrayable<number>
-    _left: Arrayable<number>
-    _top: Arrayable<number>
+    right: Arrayable<number>
+    bottom: Arrayable<number>
+    left: Arrayable<number>
+    top: Arrayable<number>
 
     sright: Arrayable<number>
     sbottom: Arrayable<number>

--- a/bokehjs/src/lib/models/glyphs/lrtb.ts
+++ b/bokehjs/src/lib/models/glyphs/lrtb.ts
@@ -1,10 +1,9 @@
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
-import type {Rect, FloatArray, ScreenArray} from "core/types"
+import type {Rect, Arrayable} from "core/types"
 import type {Anchor} from "core/enums"
 import type * as visuals from "core/visuals"
 import type {SpatialIndex} from "core/util/spatial"
 import type {Context2d} from "core/util/canvas"
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import type {PointGeometry, SpanGeometry, RectGeometry} from "core/geometry"
@@ -20,16 +19,16 @@ import type {LRTBGL} from "./webgl/lrtb"
 // This class is intended to be a private implementation detail that can
 // be re-used by various rect, bar, box, quad, etc. glyphs.
 
-export type LRTBData = GlyphData & p.UniformsOf<LRTB.Mixins> & {
-  _right: FloatArray
-  _bottom: FloatArray
-  _left: FloatArray
-  _top: FloatArray
+export type LRTBData = p.GlyphDataOf<LRTB.Props> & {
+  _right: Arrayable<number>
+  _bottom: Arrayable<number>
+  _left: Arrayable<number>
+  _top: Arrayable<number>
 
-  sright: ScreenArray
-  sbottom: ScreenArray
-  sleft: ScreenArray
-  stop: ScreenArray
+  sright: Arrayable<number>
+  sbottom: Arrayable<number>
+  sleft: Arrayable<number>
+  stop: Arrayable<number>
 
   border_radius: Corners<number>
 }

--- a/bokehjs/src/lib/models/glyphs/lrtb.ts
+++ b/bokehjs/src/lib/models/glyphs/lrtb.ts
@@ -74,8 +74,8 @@ export abstract class LRTBView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: LRTB.Data): void {
-    const {sleft, sright, stop, sbottom, border_radius} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<LRTB.Data>): void {
+    const {sleft, sright, stop, sbottom, border_radius} = {...this, ...data}
 
     for (const i of indices) {
       const sleft_i = sleft[i]

--- a/bokehjs/src/lib/models/glyphs/marker.ts
+++ b/bokehjs/src/lib/models/glyphs/marker.ts
@@ -10,9 +10,7 @@ import type {Context2d} from "core/util/canvas"
 import {minmax2} from "core/util/arrayable"
 import {Selection} from "../selections/selection"
 
-export type MarkerData = p.GlyphDataOf<Marker.Props>
-
-export interface MarkerView extends MarkerData {}
+export interface MarkerView extends Marker.Data {}
 
 export abstract class MarkerView extends XYGlyphView {
   declare model: Marker
@@ -20,7 +18,7 @@ export abstract class MarkerView extends XYGlyphView {
 
   protected _render_one: RenderOne
 
-  protected _render(ctx: Context2d, indices: number[], data?: MarkerData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Marker.Data): void {
     const {sx, sy, size, angle} = data ?? this
 
     for (const i of indices) {
@@ -144,7 +142,7 @@ export abstract class MarkerView extends XYGlyphView {
     return new Selection({indices})
   }
 
-  _get_legend_args({x0, x1, y0, y1}: Rect, index: number): MarkerData {
+  _get_legend_args({x0, x1, y0, y1}: Rect, index: number): Marker.Data {
     // using objects like this seems a little wonky, since the keys are coerced to strings, but it works
     const n = index + 1
 
@@ -180,6 +178,8 @@ export namespace Marker {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Marker extends Marker.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/marker.ts
+++ b/bokehjs/src/lib/models/glyphs/marker.ts
@@ -1,5 +1,4 @@
 import type {RenderOne} from "./defs"
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import type {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "core/geometry"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -11,12 +10,7 @@ import type {Context2d} from "core/util/canvas"
 import {minmax2} from "core/util/arrayable"
 import {Selection} from "../selections/selection"
 
-export type MarkerData = XYGlyphData & p.UniformsOf<Marker.Mixins> & {
-  readonly size: p.Uniform<number>
-  readonly angle: p.Uniform<number>
-
-  readonly max_size: number
-}
+export type MarkerData = p.GlyphDataOf<Marker.Props>
 
 export interface MarkerView extends MarkerData {}
 

--- a/bokehjs/src/lib/models/glyphs/marker.ts
+++ b/bokehjs/src/lib/models/glyphs/marker.ts
@@ -18,8 +18,8 @@ export abstract class MarkerView extends XYGlyphView {
 
   protected _render_one: RenderOne
 
-  protected _render(ctx: Context2d, indices: number[], data?: Marker.Data): void {
-    const {sx, sy, size, angle} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Marker.Data>): void {
+    const {sx, sy, size, angle} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]
@@ -142,7 +142,7 @@ export abstract class MarkerView extends XYGlyphView {
     return new Selection({indices})
   }
 
-  _get_legend_args({x0, x1, y0, y1}: Rect, index: number): Marker.Data {
+  _get_legend_args({x0, x1, y0, y1}: Rect, index: number): Partial<Marker.Data> {
     // using objects like this seems a little wonky, since the keys are coerced to strings, but it works
     const n = index + 1
 
@@ -157,12 +157,12 @@ export abstract class MarkerView extends XYGlyphView {
 
     const angle = new p.UniformScalar(0, n) // don't attempt to match glyph angle
 
-    return {sx, sy, size, angle} as any
+    return {sx, sy, size, angle}
   }
 
   override draw_legend_for_index(ctx: Context2d, {x0, x1, y0, y1}: Rect, index: number): void {
     const args = this._get_legend_args({x0, x1, y0, y1}, index)
-    this._render(ctx, [index], args) // XXX
+    this._render(ctx, [index], args)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/marker.ts
+++ b/bokehjs/src/lib/models/glyphs/marker.ts
@@ -7,7 +7,6 @@ import type * as visuals from "core/visuals"
 import type {Rect, Indices} from "core/types"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
-import * as uniforms from "core/uniforms"
 import type {Context2d} from "core/util/canvas"
 import {minmax2} from "core/util/arrayable"
 import {Selection} from "../selections/selection"
@@ -149,13 +148,6 @@ export abstract class MarkerView extends XYGlyphView {
     }
 
     return new Selection({indices})
-  }
-
-  override _set_data(indices: number[] | null): void {
-    super._set_data(indices)
-
-    const max_size = uniforms.max(this.size)
-    this._configure("max_size", {value: max_size})
   }
 
   _get_legend_args({x0, x1, y0, y1}: Rect, index: number): MarkerData {

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -29,7 +29,7 @@ export class MultiLineView extends GlyphView {
   }
 
   protected override _project_data(): void {
-    inplace.project_xy(this.xs.array, this.ys.array)
+    inplace.project_xy(this.xs.data, this.ys.data)
   }
 
   protected _index_data(index: SpatialIndex): void {

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -3,25 +3,18 @@ import {inplace} from "core/util/projections"
 import type {PointGeometry, SpanGeometry} from "core/geometry"
 import {LineVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {Rect, RaggedArray, FloatArray, ScreenArray} from "core/types"
+import type {Rect, RaggedArray, FloatArray} from "core/types"
 import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {minmax2} from "core/util/arrayable"
 import {to_object} from "core/util/object"
 import type {Context2d} from "core/util/canvas"
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_line_vector_legend, line_interpolation} from "./utils"
 import {Selection} from "../selections/selection"
 import type {MultiLineGL} from "./webgl/multi_line"
 
-export type MultiLineData = GlyphData & p.UniformsOf<MultiLine.Mixins> & {
-  _xs: RaggedArray<FloatArray>
-  _ys: RaggedArray<FloatArray>
-
-  sxs: RaggedArray<ScreenArray>
-  sys: RaggedArray<ScreenArray>
-}
+export type MultiLineData = p.GlyphDataOf<MultiLine.Props>
 
 export interface MultiLineView extends MultiLineData {}
 

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -14,9 +14,7 @@ import {generic_line_vector_legend, line_interpolation} from "./utils"
 import {Selection} from "../selections/selection"
 import type {MultiLineGL} from "./webgl/multi_line"
 
-export type MultiLineData = p.GlyphDataOf<MultiLine.Props>
-
-export interface MultiLineView extends MultiLineData {}
+export interface MultiLineView extends MultiLine.Data {}
 
 export class MultiLineView extends GlyphView {
   declare model: MultiLine
@@ -46,7 +44,7 @@ export class MultiLineView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: MultiLineData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: MultiLine.Data): void {
     const {sxs, sys} = data ?? this
 
     for (const i of indices) {
@@ -172,6 +170,8 @@ export namespace MultiLine {
   export type Mixins = LineVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface MultiLine extends MultiLine.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -44,8 +44,8 @@ export class MultiLineView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: MultiLine.Data): void {
-    const {sxs, sys} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<MultiLine.Data>): void {
+    const {sxs, sys} = {...this, ...data}
 
     for (const i of indices) {
       const sx = sxs.get(i)

--- a/bokehjs/src/lib/models/glyphs/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_line.ts
@@ -29,15 +29,15 @@ export class MultiLineView extends GlyphView {
   }
 
   protected override _project_data(): void {
-    inplace.project_xy(this._xs.array, this._ys.array)
+    inplace.project_xy(this.xs.array, this.ys.array)
   }
 
   protected _index_data(index: SpatialIndex): void {
     const {data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const xsi = this._xs.get(i)
-      const ysi = this._ys.get(i)
+      const xsi = this.xs.get(i)
+      const ysi = this.ys.get(i)
 
       const [x0, x1, y0, y1] = minmax2(xsi, ysi)
       index.add_rect(x0, y0, x1, y1)
@@ -115,10 +115,10 @@ export class MultiLineView extends GlyphView {
     let vs: RaggedArray<FloatArray>
     if (geometry.direction == "v") {
       val = this.renderer.yscale.invert(sy)
-      vs = this._ys
+      vs = this.ys
     } else {
       val = this.renderer.xscale.invert(sx)
-      vs = this._xs
+      vs = this.xs
     }
 
     const hits: Map<number, number[]> = new Map()
@@ -141,8 +141,8 @@ export class MultiLineView extends GlyphView {
   }
 
   get_interpolation_hit(i: number, point_i: number, geometry: PointGeometry | SpanGeometry): [number, number] {
-    const xsi = this._xs.get(i)
-    const ysi = this._ys.get(i)
+    const xsi = this.xs.get(i)
+    const ysi = this.ys.get(i)
     const x2 = xsi[point_i]
     const y2 = ysi[point_i]
     const x3 = xsi[point_i + 1]

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -13,9 +13,7 @@ import * as p from "core/properties"
 import {Selection} from "../selections/selection"
 import {unreachable} from "core/util/assert"
 
-export type MultiPolygonsData = p.GlyphDataOf<MultiPolygons.Props>
-
-export interface MultiPolygonsView extends MultiPolygonsData {}
+export interface MultiPolygonsView extends MultiPolygons.Data {}
 
 export class MultiPolygonsView extends GlyphView {
   declare model: MultiPolygons
@@ -114,7 +112,7 @@ export class MultiPolygonsView extends GlyphView {
     })
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: MultiPolygonsData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: MultiPolygons.Data): void {
     if (!this.visuals.fill.doit && !this.visuals.line.doit)
       return
 
@@ -328,6 +326,8 @@ export namespace MultiPolygons {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface MultiPolygons extends MultiPolygons.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -112,11 +112,11 @@ export class MultiPolygonsView extends GlyphView {
     })
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: MultiPolygons.Data): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<MultiPolygons.Data>): void {
     if (!this.visuals.fill.doit && !this.visuals.line.doit)
       return
 
-    const {sxs, sys} = data ?? this
+    const {sxs, sys} = {...this, ...data}
 
     for (const i of indices) {
       ctx.beginPath()

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -1,10 +1,9 @@
 import {SpatialIndex} from "core/util/spatial"
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import {minmax2} from "core/util/arrayable"
 import {sum} from "core/util/arrayable"
-import type {Arrayable, Rect, FloatArray, ScreenArray, Indices} from "core/types"
+import type {Arrayable, Rect, Indices} from "core/types"
 import type {HitTestPoint, HitTestRect, HitTestPoly} from "core/geometry"
 import type {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -14,13 +13,7 @@ import * as p from "core/properties"
 import {Selection} from "../selections/selection"
 import {unreachable} from "core/util/assert"
 
-export type MultiPolygonsData = GlyphData & p.UniformsOf<MultiPolygons.Mixins> & {
-  _xs: FloatArray[][][]
-  _ys: FloatArray[][][]
-
-  sxs: ScreenArray[][][]
-  sys: ScreenArray[][][]
-}
+export type MultiPolygonsData = p.GlyphDataOf<MultiPolygons.Props>
 
 export interface MultiPolygonsView extends MultiPolygonsData {}
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -290,23 +290,31 @@ export class MultiPolygonsView extends GlyphView {
   }
 
   override map_data(): void {
-    const n_i = this.xs.length
-    this.sxs = new Array(n_i)
-    this.sys = new Array(n_i)
-    for (let i = 0; i < n_i; i++) {
-      const n_j = this.xs[i].length
-      this.sxs[i] = new Array(n_j)
-      this.sys[i] = new Array(n_j)
-      for (let j = 0; j < n_j; j++) {
-        const n_k = this.xs[i][j].length
-        this.sxs[i][j] = new Array(n_k)
-        this.sys[i][j] = new Array(n_k)
-        for (let k = 0; k < n_k; k++) {
-          const [sx, sy] = this.renderer.coordinates.map_to_screen(this.xs[i][j][k], this.ys[i][j][k])
-          this.sxs[i][j][k] = sx
-          this.sys[i][j][k] = sy
+    if (this.inherited_xs && this.inherited_ys) {
+      this._inherit_attr<MultiPolygons.Data>("sxs")
+      this._inherit_attr<MultiPolygons.Data>("sys")
+    } else {
+      const {xs, ys} = this
+      const n_i = xs.length
+      const sxs = new Array(n_i)
+      const sys = new Array(n_i)
+      for (let i = 0; i < n_i; i++) {
+        const n_j = xs[i].length
+        sxs[i] = new Array(n_j)
+        sys[i] = new Array(n_j)
+        for (let j = 0; j < n_j; j++) {
+          const n_k = xs[i][j].length
+          sxs[i][j] = new Array(n_k)
+          sys[i][j] = new Array(n_k)
+          for (let k = 0; k < n_k; k++) {
+            const [sx, sy] = this.renderer.coordinates.map_to_screen(xs[i][j][k], ys[i][j][k])
+            sxs[i][j][k] = sx
+            sys[i][j][k] = sy
+          }
         }
       }
+      this._define_attr<MultiPolygons.Data>("sxs", sxs)
+      this._define_attr<MultiPolygons.Data>("sys", sys)
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/multi_polygons.ts
+++ b/bokehjs/src/lib/models/glyphs/multi_polygons.ts
@@ -30,8 +30,8 @@ export class MultiPolygonsView extends GlyphView {
     const {data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const xsi = this._xs[i]
-      const ysi = this._ys[i]
+      const xsi = this.xs[i]
+      const ysi = this.ys[i]
 
       if (xsi.length == 0 || ysi.length == 0) {
         index.add_empty()
@@ -69,8 +69,8 @@ export class MultiPolygonsView extends GlyphView {
     const index = new SpatialIndex(data_size)
 
     for (let i = 0; i < data_size; i++) {
-      const xsi = this._xs[i]
-      const ysi = this._ys[i]
+      const xsi = this.xs[i]
+      const ysi = this.ys[i]
 
       if (xsi.length == 0 || ysi.length == 0) {
         index.add_empty()
@@ -290,19 +290,19 @@ export class MultiPolygonsView extends GlyphView {
   }
 
   override map_data(): void {
-    const n_i = this._xs.length
+    const n_i = this.xs.length
     this.sxs = new Array(n_i)
     this.sys = new Array(n_i)
     for (let i = 0; i < n_i; i++) {
-      const n_j = this._xs[i].length
+      const n_j = this.xs[i].length
       this.sxs[i] = new Array(n_j)
       this.sys[i] = new Array(n_j)
       for (let j = 0; j < n_j; j++) {
-        const n_k = this._xs[i][j].length
+        const n_k = this.xs[i][j].length
         this.sxs[i][j] = new Array(n_k)
         this.sys[i][j] = new Array(n_k)
         for (let k = 0; k < n_k; k++) {
-          const [sx, sy] = this.renderer.coordinates.map_to_screen(this._xs[i][j][k], this._ys[i][j][k])
+          const [sx, sy] = this.renderer.coordinates.map_to_screen(this.xs[i][j][k], this.ys[i][j][k])
           this.sxs[i][j][k] = sx
           this.sys[i][j][k] = sy
         }

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -9,15 +9,13 @@ import * as mixins from "core/property_mixins"
 import type * as p from "core/properties"
 import {Selection} from "../selections/selection"
 
-export type PatchData = p.GlyphDataOf<Patch.Props>
-
-export interface PatchView extends PatchData {}
+export interface PatchView extends Patch.Data {}
 
 export class PatchView extends XYGlyphView {
   declare model: Patch
   declare visuals: Patch.Visuals
 
-  protected _render(ctx: Context2d, indices: number[], data?: PatchData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Patch.Data): void {
     const {sx, sy} = data ?? this
 
     let move = true
@@ -70,6 +68,8 @@ export namespace Patch {
   export type Mixins = mixins.LineScalar & mixins.FillScalar & mixins.HatchScalar
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineScalar, fill: visuals.FillScalar, hatch: visuals.HatchScalar}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Patch extends Patch.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -15,8 +15,8 @@ export class PatchView extends XYGlyphView {
   declare model: Patch
   declare visuals: Patch.Visuals
 
-  protected _render(ctx: Context2d, indices: number[], data?: Patch.Data): void {
-    const {sx, sy} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Patch.Data>): void {
+    const {sx, sy} = {...this, ...data}
 
     let move = true
     ctx.beginPath()

--- a/bokehjs/src/lib/models/glyphs/patch.ts
+++ b/bokehjs/src/lib/models/glyphs/patch.ts
@@ -1,4 +1,3 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {generic_area_scalar_legend} from "./utils"
 import type {PointGeometry} from "core/geometry"
@@ -10,7 +9,7 @@ import * as mixins from "core/property_mixins"
 import type * as p from "core/properties"
 import {Selection} from "../selections/selection"
 
-export type PatchData = XYGlyphData & p.UniformsOf<Patch.Mixins>
+export type PatchData = p.GlyphDataOf<Patch.Props>
 
 export interface PatchView extends PatchData {}
 

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -1,9 +1,8 @@
 import type {SpatialIndex} from "core/util/spatial"
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import {minmax2, sum} from "core/util/arrayable"
-import type {Arrayable, Rect, RaggedArray, FloatArray, ScreenArray, Indices} from "core/types"
+import type {Arrayable, Rect, Indices} from "core/types"
 import type {HitTestPoint, HitTestRect, HitTestPoly} from "core/geometry"
 import type {Context2d} from "core/util/canvas"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -14,13 +13,7 @@ import {Selection} from "../selections/selection"
 import {unreachable} from "core/util/assert"
 import {inplace} from "core/util/projections"
 
-export type PatchesData = GlyphData & p.UniformsOf<Patches.Mixins> & {
-  _xs: RaggedArray<FloatArray>
-  _ys: RaggedArray<FloatArray>
-
-  sxs: RaggedArray<ScreenArray>
-  sys: RaggedArray<ScreenArray>
-}
+export type PatchesData = p.GlyphDataOf<Patches.Props>
 
 export interface PatchesView extends PatchesData {}
 

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -20,15 +20,15 @@ export class PatchesView extends GlyphView {
   declare visuals: Patches.Visuals
 
   protected override _project_data(): void {
-    inplace.project_xy(this._xs.array, this._ys.array)
+    inplace.project_xy(this.xs.array, this.ys.array)
   }
 
   protected _index_data(index: SpatialIndex): void {
     const {data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const xsi = this._xs.get(i)
-      const ysi = this._ys.get(i)
+      const xsi = this.xs.get(i)
+      const ysi = this.ys.get(i)
 
       const [x0, x1, y0, y1] = minmax2(xsi, ysi)
       index.add_rect(x0, y0, x1, y1)

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -43,8 +43,8 @@ export class PatchesView extends GlyphView {
     })
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Patches.Data): void {
-    const {sxs, sys} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Patches.Data>): void {
+    const {sxs, sys} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sxs.get(i)

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -20,7 +20,7 @@ export class PatchesView extends GlyphView {
   declare visuals: Patches.Visuals
 
   protected override _project_data(): void {
-    inplace.project_xy(this.xs.array, this.ys.array)
+    inplace.project_xy(this.xs.data, this.ys.data)
   }
 
   protected _index_data(index: SpatialIndex): void {

--- a/bokehjs/src/lib/models/glyphs/patches.ts
+++ b/bokehjs/src/lib/models/glyphs/patches.ts
@@ -13,9 +13,7 @@ import {Selection} from "../selections/selection"
 import {unreachable} from "core/util/assert"
 import {inplace} from "core/util/projections"
 
-export type PatchesData = p.GlyphDataOf<Patches.Props>
-
-export interface PatchesView extends PatchesData {}
+export interface PatchesView extends Patches.Data {}
 
 export class PatchesView extends GlyphView {
   declare model: Patches
@@ -45,7 +43,7 @@ export class PatchesView extends GlyphView {
     })
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: PatchesData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Patches.Data): void {
     const {sxs, sys} = data ?? this
 
     for (const i of indices) {
@@ -216,6 +214,8 @@ export namespace Patches {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Patches extends Patches.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/quad.ts
+++ b/bokehjs/src/lib/models/glyphs/quad.ts
@@ -1,19 +1,8 @@
 import type {LRTBData} from "./lrtb"
 import {LRTB, LRTBView} from "./lrtb"
-import type {FloatArray, ScreenArray} from "core/types"
 import * as p from "core/properties"
 
-export type QuadData = LRTBData & {
-  _right: FloatArray
-  _bottom: FloatArray
-  _left: FloatArray
-  _top: FloatArray
-
-  sright: ScreenArray
-  sbottom: ScreenArray
-  sleft: ScreenArray
-  stop: ScreenArray
-}
+export type QuadData = LRTBData & p.GlyphDataOf<Quad.Props>
 
 export interface QuadView extends QuadData {}
 

--- a/bokehjs/src/lib/models/glyphs/quad.ts
+++ b/bokehjs/src/lib/models/glyphs/quad.ts
@@ -14,10 +14,10 @@ export class QuadView extends LRTBView {
   }
 
   protected _lrtb(i: number): [number, number, number, number] {
-    const l = this._left[i]
-    const r = this._right[i]
-    const t = this._top[i]
-    const b = this._bottom[i]
+    const l = this.left[i]
+    const r = this.right[i]
+    const t = this.top[i]
+    const b = this.bottom[i]
     return [l, r, t, b]
   }
 }

--- a/bokehjs/src/lib/models/glyphs/quad.ts
+++ b/bokehjs/src/lib/models/glyphs/quad.ts
@@ -1,10 +1,7 @@
-import type {LRTBData} from "./lrtb"
 import {LRTB, LRTBView} from "./lrtb"
 import * as p from "core/properties"
 
-export type QuadData = LRTBData & p.GlyphDataOf<Quad.Props>
-
-export interface QuadView extends QuadData {}
+export interface QuadView extends Quad.Data {}
 
 export class QuadView extends LRTBView {
   declare model: Quad
@@ -36,6 +33,8 @@ export namespace Quad {
   }
 
   export type Visuals = LRTB.Visuals
+
+  export type Data = LRTB.Data & p.GlyphDataOf<Props>
 }
 
 export interface Quad extends Quad.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/quad.ts
+++ b/bokehjs/src/lib/models/glyphs/quad.ts
@@ -1,4 +1,5 @@
 import {LRTB, LRTBView} from "./lrtb"
+import type {LRTBRect} from "./lrtb"
 import * as p from "core/properties"
 
 export interface QuadView extends Quad.Data {}
@@ -13,12 +14,12 @@ export class QuadView extends LRTBView {
     return [scx, scy]
   }
 
-  protected _lrtb(i: number): [number, number, number, number] {
+  protected _lrtb(i: number): LRTBRect {
     const l = this.left[i]
     const r = this.right[i]
     const t = this.top[i]
     const b = this.bottom[i]
-    return [l, r, t, b]
+    return {l, r, t, b}
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -9,9 +9,7 @@ import {generic_line_vector_legend} from "./utils"
 import {qbb} from "core/util/algorithms"
 import * as p from "core/properties"
 
-export type QuadraticData = p.GlyphDataOf<Quadratic.Props>
-
-export interface QuadraticView extends QuadraticData {}
+export interface QuadraticView extends Quadratic.Data {}
 
 export class QuadraticView extends GlyphView {
   declare model: Quadratic
@@ -42,7 +40,7 @@ export class QuadraticView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: QuadraticData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Quadratic.Data): void {
     if (!this.visuals.line.doit)
       return
 
@@ -91,6 +89,8 @@ export namespace Quadratic {
   export type Mixins = LineVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Quadratic extends Quadratic.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -1,30 +1,15 @@
 import {LineVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {Rect, FloatArray, ScreenArray} from "core/types"
+import type {Rect} from "core/types"
 import type {SpatialIndex} from "core/util/spatial"
 import {inplace} from "core/util/projections"
 import type {Context2d} from "core/util/canvas"
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_line_vector_legend} from "./utils"
 import {qbb} from "core/util/algorithms"
 import * as p from "core/properties"
 
-export type QuadraticData = GlyphData & p.UniformsOf<Quadratic.Mixins> & {
-  _x0: FloatArray
-  _y0: FloatArray
-  _x1: FloatArray
-  _y1: FloatArray
-  _cx: FloatArray
-  _cy: FloatArray
-
-  sx0: ScreenArray
-  sy0: ScreenArray
-  sx1: ScreenArray
-  sy1: ScreenArray
-  scx: ScreenArray
-  scy: ScreenArray
-}
+export type QuadraticData = p.GlyphDataOf<Quadratic.Props>
 
 export interface QuadraticView extends QuadraticData {}
 

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -16,20 +16,20 @@ export class QuadraticView extends GlyphView {
   declare visuals: Quadratic.Visuals
 
   protected override _project_data(): void {
-    inplace.project_xy(this._x0, this._y0)
-    inplace.project_xy(this._x1, this._y1)
+    inplace.project_xy(this.x0, this.y0)
+    inplace.project_xy(this.x1, this.y1)
   }
 
   protected _index_data(index: SpatialIndex): void {
-    const {_x0, _x1, _y0, _y1, _cx, _cy, data_size} = this
+    const {x0, x1, y0, y1, cx, cy, data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const x0_i = _x0[i]
-      const x1_i = _x1[i]
-      const y0_i = _y0[i]
-      const y1_i = _y1[i]
-      const cx_i = _cx[i]
-      const cy_i = _cy[i]
+      const x0_i = x0[i]
+      const x1_i = x1[i]
+      const y0_i = y0[i]
+      const y1_i = y1[i]
+      const cx_i = cx[i]
+      const cy_i = cy[i]
 
       if (!isFinite(x0_i + x1_i + y0_i + y1_i + cx_i + cy_i))
         index.add_empty()

--- a/bokehjs/src/lib/models/glyphs/quadratic.ts
+++ b/bokehjs/src/lib/models/glyphs/quadratic.ts
@@ -40,11 +40,11 @@ export class QuadraticView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Quadratic.Data): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Quadratic.Data>): void {
     if (!this.visuals.line.doit)
       return
 
-    const {sx0, sy0, sx1, sy1, scx, scy} = data ?? this
+    const {sx0, sy0, sx1, sy1, scx, scy} = {...this, ...data}
 
     for (const i of indices) {
       const sx0_i = sx0[i]

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -1,19 +1,13 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {generic_line_vector_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {Rect, ScreenArray} from "core/types"
+import type {Rect} from "core/types"
 import {to_screen} from "core/types"
 import * as p from "core/properties"
 import type {Context2d} from "core/util/canvas"
 
-export type RayData = XYGlyphData & p.UniformsOf<Ray.Mixins> & {
-  readonly length: p.Uniform<number>
-  readonly angle: p.Uniform<number>
-
-  slength: ScreenArray
-}
+export type RayData = p.GlyphDataOf<Ray.Props>
 
 export interface RayView extends RayData {}
 

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -15,7 +15,7 @@ export class RayView extends XYGlyphView {
 
   protected override _map_data(): void {
     if (this.model.properties.length.units == "data")
-      this.slength = this.sdist(this.renderer.xscale, this._x, this.length)
+      this.slength = this.sdist(this.renderer.xscale, this.x, this.length)
     else
       this.slength = to_screen(this.length)
 

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -29,11 +29,11 @@ export class RayView extends XYGlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Ray.Data): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Ray.Data>): void {
     if (!this.visuals.line.doit)
       return
 
-    const {sx, sy, slength, angle} = data ?? this
+    const {sx, sy, slength, angle} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -1,4 +1,5 @@
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
+import {inherit} from "./glyph"
 import {generic_line_vector_legend} from "./utils"
 import {LineVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
@@ -14,18 +15,29 @@ export class RayView extends XYGlyphView {
   declare visuals: Ray.Visuals
 
   protected override _map_data(): void {
-    if (this.model.properties.length.units == "data")
-      this.slength = this.sdist(this.renderer.xscale, this.x, this.length)
-    else
-      this.slength = to_screen(this.length)
+    this._define_or_inherit_attr<Ray.Data>("slength", () => {
+      if (this.model.properties.length.units == "data") {
+        if (this.inherited_x && this.inherited_length) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.length)
+        }
+      } else {
+        return this.inherited_length ? inherit : to_screen(this.length)
+      }
+    })
 
-    const {width, height} = this.renderer.plot_view.frame.bbox
-    const inf_len = 2*(width + height)
+    if (!this.inherited_slength) {
+      const {width, height} = this.renderer.plot_view.frame.bbox
+      const inf_len = 2*(width + height)
 
-    const {slength} = this
-    for (let i = 0, end = slength.length; i < end; i++) {
-      if (slength[i] == 0)
-        slength[i] = inf_len
+      const {slength} = this
+      const n = slength.length
+      for (let i = 0; i < n; i++) {
+        if (slength[i] == 0) {
+          slength[i] = inf_len
+        }
+      }
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -7,9 +7,7 @@ import {to_screen} from "core/types"
 import * as p from "core/properties"
 import type {Context2d} from "core/util/canvas"
 
-export type RayData = p.GlyphDataOf<Ray.Props>
-
-export interface RayView extends RayData {}
+export interface RayView extends Ray.Data {}
 
 export class RayView extends XYGlyphView {
   declare model: Ray
@@ -31,7 +29,7 @@ export class RayView extends XYGlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: RayData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Ray.Data): void {
     if (!this.visuals.line.doit)
       return
 
@@ -76,6 +74,8 @@ export namespace Ray {
   export type Mixins = LineVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Ray extends Ray.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -42,7 +42,7 @@ export class RectView extends CenterRotatableView {
     const n = this.data_size
 
     if (this.model.properties.width.units == "data")
-      [this.swidth, this.sx0] = this._map_dist_corner_for_data_side_length(this._x, this.width, this.renderer.xscale)
+      [this.swidth, this.sx0] = this._map_dist_corner_for_data_side_length(this.x, this.width, this.renderer.xscale)
     else {
       this.swidth = to_screen(this.width)
 
@@ -53,7 +53,7 @@ export class RectView extends CenterRotatableView {
     }
 
     if (this.model.properties.height.units == "data")
-      [this.sheight, this.sy1] = this._map_dist_corner_for_data_side_length(this._y, this.height, this.renderer.yscale)
+      [this.sheight, this.sy1] = this._map_dist_corner_for_data_side_length(this.y, this.height, this.renderer.yscale)
     else {
       this.sheight = to_screen(this.height)
 

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -41,9 +41,9 @@ export class RectView extends CenterRotatableView {
   protected override _map_data(): void {
     const n = this.data_size
 
-    if (this.model.properties.width.units == "data")
+    if (this.model.properties.width.units == "data") {
       [this.swidth, this.sx0] = this._map_dist_corner_for_data_side_length(this.x, this.width, this.renderer.xscale)
-    else {
+    } else {
       this.swidth = to_screen(this.width)
 
       this.sx0 = new ScreenArray(n)
@@ -52,9 +52,9 @@ export class RectView extends CenterRotatableView {
       }
     }
 
-    if (this.model.properties.height.units == "data")
+    if (this.model.properties.height.units == "data") {
       [this.sheight, this.sy1] = this._map_dist_corner_for_data_side_length(this.y, this.height, this.renderer.yscale)
-    else {
+    } else {
       this.sheight = to_screen(this.height)
 
       this.sy1 = new ScreenArray(n)

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -1,4 +1,3 @@
-import type {CenterRotatableData} from "./center_rotatable"
 import {CenterRotatable, CenterRotatableView} from "./center_rotatable"
 import {generic_area_vector_legend} from "./utils"
 import type {PointGeometry, RectGeometry} from "core/geometry"
@@ -20,7 +19,7 @@ import type {RectGL} from "./webgl/rect"
 
 const {abs, sqrt} = Math
 
-export type RectData = CenterRotatableData & {
+export type RectData = p.GlyphDataOf<Rect.Props> & {
   sx0: ScreenArray
   sy1: ScreenArray
   ssemi_diag: ScreenArray
@@ -52,28 +51,28 @@ export class RectView extends CenterRotatableView {
     const n = this.data_size
 
     if (this.model.properties.width.units == "data")
-      [this.sw, this.sx0] = this._map_dist_corner_for_data_side_length(this._x, this.width, this.renderer.xscale)
+      [this.swidth, this.sx0] = this._map_dist_corner_for_data_side_length(this._x, this.width, this.renderer.xscale)
     else {
-      this.sw = to_screen(this.width)
+      this.swidth = to_screen(this.width)
 
       this.sx0 = new ScreenArray(n)
       for (let i = 0; i < n; i++) {
-        this.sx0[i] = this.sx[i] - this.sw[i]/2
+        this.sx0[i] = this.sx[i] - this.swidth[i]/2
       }
     }
 
     if (this.model.properties.height.units == "data")
-      [this.sh, this.sy1] = this._map_dist_corner_for_data_side_length(this._y, this.height, this.renderer.yscale)
+      [this.sheight, this.sy1] = this._map_dist_corner_for_data_side_length(this._y, this.height, this.renderer.yscale)
     else {
-      this.sh = to_screen(this.height)
+      this.sheight = to_screen(this.height)
 
       this.sy1 = new ScreenArray(n)
       for (let i = 0; i < n; i++) {
-        this.sy1[i] = this.sy[i] - this.sh[i]/2
+        this.sy1[i] = this.sy[i] - this.sheight[i]/2
       }
     }
 
-    const {sw, sh} = this
+    const {swidth: sw, sheight: sh} = this
     this.ssemi_diag = new ScreenArray(n)
 
     for (let i = 0; i < n; i++) {
@@ -86,8 +85,8 @@ export class RectView extends CenterRotatableView {
     const scenter_y = new ScreenArray(n)
 
     for (let i = 0; i < n; i++) {
-      scenter_x[i] = this.sx0[i] + this.sw[i]/2
-      scenter_y[i] = this.sy1[i] + this.sh[i]/2
+      scenter_x[i] = this.sx0[i] + this.swidth[i]/2
+      scenter_y[i] = this.sy1[i] + this.sheight[i]/2
     }
 
     this.max_x2_ddist = max(this._ddist(0, scenter_x, this.ssemi_diag))
@@ -95,33 +94,33 @@ export class RectView extends CenterRotatableView {
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: RectData): void {
-    const {sx, sy, sx0, sy1, sw, sh, angle, border_radius} = data ?? this
+    const {sx, sy, sx0, sy1, swidth, sheight, angle, border_radius} = data ?? this
 
     for (const i of indices) {
       const sx_i = sx[i]
       const sy_i = sy[i]
       const sx0_i = sx0[i]
       const sy1_i = sy1[i]
-      const sw_i = sw[i]
-      const sh_i = sh[i]
+      const swidth_i = swidth[i]
+      const sheight_i = sheight[i]
       const angle_i = angle.get(i)
 
-      if (!isFinite(sx_i + sy_i + sx0_i + sy1_i + sw_i + sh_i + angle_i))
+      if (!isFinite(sx_i + sy_i + sx0_i + sy1_i + swidth_i + sheight_i + angle_i))
         continue
 
-      if (sw_i == 0 || sh_i == 0)
+      if (swidth_i == 0 || sheight_i == 0)
         continue
 
       ctx.beginPath()
       if (angle_i != 0) {
         ctx.translate(sx_i, sy_i)
         ctx.rotate(angle_i)
-        const box = new BBox({x: -sw_i/2, y: -sh_i/2, width: sw_i, height: sh_i})
+        const box = new BBox({x: -swidth_i/2, y: -sheight_i/2, width: swidth_i, height: sheight_i})
         round_rect(ctx, box, border_radius)
         ctx.rotate(-angle_i)
         ctx.translate(-sx_i, -sy_i)
       } else {
-        const box = new BBox({x: sx0_i, y: sy1_i, width: sw_i, height: sh_i})
+        const box = new BBox({x: sx0_i, y: sy1_i, width: swidth_i, height: sheight_i})
         round_rect(ctx, box, border_radius)
       }
 
@@ -148,7 +147,7 @@ export class RectView extends CenterRotatableView {
       y1: y + this.max_y2_ddist,
     })
 
-    const {sx, sy, sx0, sy1, sw, sh, angle} = this
+    const {sx, sy, sx0, sy1, swidth: sw, sheight: sh, angle} = this
     const indices = []
 
     for (const i of candidates) {

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -19,16 +19,7 @@ import type {RectGL} from "./webgl/rect"
 
 const {abs, sqrt} = Math
 
-export type RectData = p.GlyphDataOf<Rect.Props> & {
-  sx0: ScreenArray
-  sy1: ScreenArray
-  ssemi_diag: ScreenArray
-  max_x2_ddist: number
-  max_y2_ddist: number
-  border_radius: Corners<number>
-}
-
-export interface RectView extends RectData {}
+export interface RectView extends Rect.Data {}
 
 export class RectView extends CenterRotatableView {
   declare model: Rect
@@ -93,7 +84,7 @@ export class RectView extends CenterRotatableView {
     this.max_y2_ddist = max(this._ddist(1, scenter_y, this.ssemi_diag))
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: RectData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Rect.Data): void {
     const {sx, sy, sx0, sy1, swidth, sheight, angle, border_radius} = data ?? this
 
     for (const i of indices) {
@@ -240,6 +231,15 @@ export namespace Rect {
   }
 
   export type Visuals = CenterRotatable.Visuals
+
+  export type Data = p.GlyphDataOf<Props> & {
+    sx0: ScreenArray
+    sy1: ScreenArray
+    ssemi_diag: ScreenArray
+    max_x2_ddist: number
+    max_y2_ddist: number
+    border_radius: Corners<number>
+  }
 }
 
 export interface Rect extends Rect.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/rect.ts
@@ -84,8 +84,8 @@ export class RectView extends CenterRotatableView {
     this.max_y2_ddist = max(this._ddist(1, scenter_y, this.ssemi_diag))
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Rect.Data): void {
-    const {sx, sy, sx0, sy1, swidth, sheight, angle, border_radius} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Rect.Data>): void {
+    const {sx, sy, sx0, sy1, swidth, sheight, angle, border_radius} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]

--- a/bokehjs/src/lib/models/glyphs/scatter.ts
+++ b/bokehjs/src/lib/models/glyphs/scatter.ts
@@ -18,8 +18,8 @@ export class ScatterView extends MarkerView {
     return MultiMarkerGL
   }
 
-  protected override _render(ctx: Context2d, indices: number[], data?: Scatter.Data): void {
-    const {sx, sy, size, angle, marker} = data ?? this
+  protected override _render(ctx: Context2d, indices: number[], data?: Partial<Scatter.Data>): void {
+    const {sx, sy, size, angle, marker} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]

--- a/bokehjs/src/lib/models/glyphs/scatter.ts
+++ b/bokehjs/src/lib/models/glyphs/scatter.ts
@@ -1,15 +1,11 @@
-import type {MarkerData} from "./marker"
 import {Marker, MarkerView} from "./marker"
 import {marker_funcs} from "./defs"
-import type {MarkerType} from "core/enums"
 import type {Rect} from "core/types"
 import * as p from "core/properties"
 import type {Context2d} from "core/util/canvas"
 import type {MultiMarkerGL} from "./webgl/multi_marker"
 
-export type ScatterData = MarkerData & {
-  readonly marker: p.Uniform<MarkerType | null>
-}
+export type ScatterData = p.GlyphDataOf<Scatter.Props>
 
 export interface ScatterView extends ScatterData {}
 

--- a/bokehjs/src/lib/models/glyphs/scatter.ts
+++ b/bokehjs/src/lib/models/glyphs/scatter.ts
@@ -5,9 +5,7 @@ import * as p from "core/properties"
 import type {Context2d} from "core/util/canvas"
 import type {MultiMarkerGL} from "./webgl/multi_marker"
 
-export type ScatterData = p.GlyphDataOf<Scatter.Props>
-
-export interface ScatterView extends ScatterData {}
+export interface ScatterView extends Scatter.Data {}
 
 export class ScatterView extends MarkerView {
   declare model: Scatter
@@ -20,7 +18,7 @@ export class ScatterView extends MarkerView {
     return MultiMarkerGL
   }
 
-  protected override _render(ctx: Context2d, indices: number[], data?: ScatterData): void {
+  protected override _render(ctx: Context2d, indices: number[], data?: Scatter.Data): void {
     const {sx, sy, size, angle, marker} = data ?? this
 
     for (const i of indices) {
@@ -71,6 +69,10 @@ export namespace Scatter {
   export type Props = Marker.Props & {
     marker: p.MarkerSpec
   }
+
+  export type Visuals = Marker.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Scatter extends Scatter.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -12,9 +12,7 @@ import {Glyph, GlyphView} from "./glyph"
 import {generic_line_vector_legend} from "./utils"
 import {Selection} from "../selections/selection"
 
-export type SegmentData = p.GlyphDataOf<Segment.Props>
-
-export interface SegmentView extends SegmentData {}
+export interface SegmentView extends Segment.Data {}
 
 export class SegmentView extends GlyphView {
   declare model: Segment
@@ -38,7 +36,7 @@ export class SegmentView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: SegmentData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Segment.Data): void {
     if (!this.visuals.line.doit)
       return
 
@@ -175,6 +173,8 @@ export namespace Segment {
   export type Mixins = LineVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Segment extends Segment.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -3,27 +3,16 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {LineVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {Arrayable, Rect, FloatArray, ScreenArray} from "core/types"
+import type {Arrayable, Rect} from "core/types"
 import type {SpatialIndex} from "core/util/spatial"
 import {inplace} from "core/util/projections"
 import type {Context2d} from "core/util/canvas"
 import {atan2} from "core/util/math"
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_line_vector_legend} from "./utils"
 import {Selection} from "../selections/selection"
 
-export type SegmentData = GlyphData & p.UniformsOf<Segment.Mixins> & {
-  _x0: FloatArray
-  _y0: FloatArray
-  _x1: FloatArray
-  _y1: FloatArray
-
-  sx0: ScreenArray
-  sy0: ScreenArray
-  sx1: ScreenArray
-  sy1: ScreenArray
-}
+export type SegmentData = p.GlyphDataOf<Segment.Props>
 
 export interface SegmentView extends SegmentData {}
 

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -19,20 +19,20 @@ export class SegmentView extends GlyphView {
   declare visuals: Segment.Visuals
 
   protected override _project_data(): void {
-    inplace.project_xy(this._x0, this._y0)
-    inplace.project_xy(this._x1, this._y1)
+    inplace.project_xy(this.x0, this.y0)
+    inplace.project_xy(this.x1, this.y1)
   }
 
   protected _index_data(index: SpatialIndex): void {
     const {min, max} = Math
-    const {_x0, _x1, _y0, _y1, data_size} = this
+    const {x0, x1, y0, y1, data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const x0 = _x0[i]
-      const x1 = _x1[i]
-      const y0 = _y0[i]
-      const y1 = _y1[i]
-      index.add_rect(min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
+      const x0_i = x0[i]
+      const x1_i = x1[i]
+      const y0_i = y0[i]
+      const y1_i = y1[i]
+      index.add_rect(min(x0_i, x1_i), min(y0_i, y1_i), max(x0_i, x1_i), max(y0_i, y1_i))
     }
   }
 
@@ -115,10 +115,10 @@ export class SegmentView extends GlyphView {
     let val: number
     if (geometry.direction == "v") {
       val = this.renderer.yscale.invert(sy)
-      ;[v0, v1] = [this._y0, this._y1]
+      ;[v0, v1] = [this.y0, this.y1]
     } else {
       val = this.renderer.xscale.invert(sx)
-      ;[v0, v1] = [this._x0, this._x1]
+      ;[v0, v1] = [this.x0, this.x1]
     }
 
     const indices = []

--- a/bokehjs/src/lib/models/glyphs/segment.ts
+++ b/bokehjs/src/lib/models/glyphs/segment.ts
@@ -36,11 +36,11 @@ export class SegmentView extends GlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Segment.Data): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Segment.Data>): void {
     if (!this.visuals.line.doit)
       return
 
-    const {sx0, sy0, sx1, sy1} = data ?? this
+    const {sx0, sy0, sx1, sy1} = {...this, ...data}
 
     for (const i of indices) {
       const sx0_i = sx0[i]

--- a/bokehjs/src/lib/models/glyphs/spline.ts
+++ b/bokehjs/src/lib/models/glyphs/spline.ts
@@ -1,15 +1,14 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import type * as p from "core/properties"
 import * as mixins from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {FloatArray, ScreenArray} from "core/types"
+import type {Arrayable, ScreenArray} from "core/types"
 import type {Context2d} from "core/util/canvas"
 import {catmullrom_spline} from "core/util/interpolation"
 
-export type SplineData = XYGlyphData & {
-  _xt: FloatArray
-  _yt: FloatArray
+export type SplineData = p.GlyphDataOf<Spline.Props> & {
+  _xt: Arrayable<number>
+  _yt: Arrayable<number>
   sxt: ScreenArray
   syt: ScreenArray
 }

--- a/bokehjs/src/lib/models/glyphs/spline.ts
+++ b/bokehjs/src/lib/models/glyphs/spline.ts
@@ -6,14 +6,7 @@ import type {Arrayable, ScreenArray} from "core/types"
 import type {Context2d} from "core/util/canvas"
 import {catmullrom_spline} from "core/util/interpolation"
 
-export type SplineData = p.GlyphDataOf<Spline.Props> & {
-  _xt: Arrayable<number>
-  _yt: Arrayable<number>
-  sxt: ScreenArray
-  syt: ScreenArray
-}
-
-export interface SplineView extends SplineData {}
+export interface SplineView extends Spline.Data {}
 
 export class SplineView extends XYGlyphView {
   declare model: Spline
@@ -30,7 +23,7 @@ export class SplineView extends XYGlyphView {
     this.syt = y_scale.v_compute(this._yt)
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: SplineData): void {
+  protected _render(ctx: Context2d, _indices: number[], data?: Spline.Data): void {
     const {sxt: sx, syt: sy} = data ?? this
 
     let move = true
@@ -68,6 +61,13 @@ export namespace Spline {
   export type Mixins = mixins.LineScalar
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineScalar}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    _xt: Arrayable<number>
+    _yt: Arrayable<number>
+    sxt: ScreenArray
+    syt: ScreenArray
+  }
 }
 
 export interface Spline extends Spline.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/spline.ts
+++ b/bokehjs/src/lib/models/glyphs/spline.ts
@@ -23,8 +23,8 @@ export class SplineView extends XYGlyphView {
     this.syt = y_scale.v_compute(this._yt)
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: Spline.Data): void {
-    const {sxt: sx, syt: sy} = data ?? this
+  protected _render(ctx: Context2d, _indices: number[], data?: Partial<Spline.Data>): void {
+    const {sxt: sx, syt: sy} = {...this, ...data}
 
     let move = true
     ctx.beginPath()

--- a/bokehjs/src/lib/models/glyphs/spline.ts
+++ b/bokehjs/src/lib/models/glyphs/spline.ts
@@ -14,7 +14,7 @@ export class SplineView extends XYGlyphView {
 
   protected override _set_data(): void {
     const {tension, closed} = this.model
-    ;[this._xt, this._yt] = catmullrom_spline(this._x, this._y, 20, tension, closed)
+    ;[this._xt, this._yt] = catmullrom_spline(this.x, this.y, 20, tension, closed)
   }
 
   protected override _map_data(): void {

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -1,4 +1,3 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {generic_line_scalar_legend} from "./utils"
 import * as mixins from "core/property_mixins"
@@ -10,7 +9,7 @@ import type {Context2d} from "core/util/canvas"
 import {unreachable} from "core/util/assert"
 import type {StepGL} from "./webgl/step"
 
-export type StepData = XYGlyphData
+export type StepData = p.GlyphDataOf<Step.Props>
 
 export interface StepView extends StepData {}
 

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -9,9 +9,7 @@ import type {Context2d} from "core/util/canvas"
 import {unreachable} from "core/util/assert"
 import type {StepGL} from "./webgl/step"
 
-export type StepData = p.GlyphDataOf<Step.Props>
-
-export interface StepView extends StepData {}
+export interface StepView extends Step.Data {}
 
 export class StepView extends XYGlyphView {
   declare model: Step
@@ -25,7 +23,7 @@ export class StepView extends XYGlyphView {
     return StepGL
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: StepData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Step.Data): void {
     const npoints = indices.length
     if (npoints < 2)
       return
@@ -113,6 +111,8 @@ export namespace Step {
   export type Mixins = mixins.LineScalar
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineScalar}
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface Step extends Step.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/step.ts
+++ b/bokehjs/src/lib/models/glyphs/step.ts
@@ -23,12 +23,12 @@ export class StepView extends XYGlyphView {
     return StepGL
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Step.Data): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Step.Data>): void {
     const npoints = indices.length
     if (npoints < 2)
       return
 
-    const {sx, sy} = data ?? this
+    const {sx, sy} = {...this, ...data}
     const mode = this.model.mode
 
     this.visuals.line.set_value(ctx)

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -83,8 +83,8 @@ export class TextView extends XYGlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Text.Data): void {
-    const {sx, sy, x_offset, y_offset, angle} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Text.Data>): void {
+    const {sx, sy, x_offset, y_offset, angle} = {...this, ...data}
     const {text, background_fill, background_hatch, border_line} = this.visuals
     const {anchor_: anchor, border_radius, padding} = this
     const {labels, swidth, sheight} = this

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -1,4 +1,3 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import type {PointGeometry} from "core/geometry"
 import * as mixins from "core/property_mixins"
@@ -20,13 +19,7 @@ import {round_rect} from "../common/painting"
 
 class TextAnchorSpec extends p.DataSpec<TextAnchor> {}
 
-export type TextData = XYGlyphData & p.UniformsOf<Text.Mixins> & {
-  readonly text: p.Uniform<string | null>
-  readonly angle: p.Uniform<number>
-  readonly x_offset: p.Uniform<number>
-  readonly y_offset: p.Uniform<number>
-  readonly anchor: p.Uniform<TextAnchor>
-
+export type TextData = p.GlyphDataOf<Text.Props> & {
   labels: (TextBox | null)[]
 
   swidth: Float32Array

--- a/bokehjs/src/lib/models/glyphs/text.ts
+++ b/bokehjs/src/lib/models/glyphs/text.ts
@@ -19,18 +19,7 @@ import {round_rect} from "../common/painting"
 
 class TextAnchorSpec extends p.DataSpec<TextAnchor> {}
 
-export type TextData = p.GlyphDataOf<Text.Props> & {
-  labels: (TextBox | null)[]
-
-  swidth: Float32Array
-  sheight: Float32Array
-
-  anchor_: p.Uniform<XY<number>> // can't resolve in v_materialize() due to dependency on other properties
-  padding: LRTB<number>
-  border_radius: Corners<number>
-}
-
-export interface TextView extends TextData {}
+export interface TextView extends Text.Data {}
 
 export class TextView extends XYGlyphView {
   declare model: Text
@@ -94,7 +83,7 @@ export class TextView extends XYGlyphView {
     }
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: TextData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Text.Data): void {
     const {sx, sy, x_offset, y_offset, angle} = data ?? this
     const {text, background_fill, background_hatch, border_line} = this.visuals
     const {anchor_: anchor, border_radius, padding} = this
@@ -258,6 +247,17 @@ export namespace Text {
     border_line: visuals.LineVector
     background_fill: visuals.FillVector
     background_hatch: visuals.HatchVector
+  }
+
+  export type Data = p.GlyphDataOf<Props> & {
+    labels: (TextBox | null)[]
+
+    swidth: Float32Array
+    sheight: Float32Array
+
+    anchor_: p.Uniform<XY<number>> // can't resolve in v_materialize() due to dependency on other properties
+    padding: LRTB<number>
+    border_radius: Corners<number>
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -65,21 +65,15 @@ export class VAreaView extends AreaView {
 
     return result
   }
-
-  protected override _map_data(): void {
-    this.sx  = this.renderer.xscale.v_compute(this.x)
-    this.sy1 = this.renderer.yscale.v_compute(this.y1)
-    this.sy2 = this.renderer.yscale.v_compute(this.y2)
-  }
 }
 
 export namespace VArea {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Area.Props & {
-    x: p.CoordinateSpec
-    y1: p.CoordinateSpec
-    y2: p.CoordinateSpec
+    x: p.XCoordinateSpec
+    y1: p.YCoordinateSpec
+    y2: p.YCoordinateSpec
   }
 
   export type Visuals = Area.Visuals

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -24,8 +24,8 @@ export class VAreaView extends AreaView {
     }
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: VArea.Data): void {
-    const {sx, sy1, sy2} = data ?? this
+  protected _render(ctx: Context2d, _indices: number[], data?: Partial<VArea.Data>): void {
+    const {sx, sy1, sy2} = {...this, ...data}
 
     ctx.beginPath()
     for (let i = 0, end = sy1.length; i < end; i++) {

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -6,9 +6,7 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
 
-export type VAreaData = p.GlyphDataOf<VArea.Props>
-
-export interface VAreaView extends VAreaData {}
+export interface VAreaView extends VArea.Data {}
 
 export class VAreaView extends AreaView {
   declare model: VArea
@@ -26,7 +24,7 @@ export class VAreaView extends AreaView {
     }
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: VAreaData): void {
+  protected _render(ctx: Context2d, _indices: number[], data?: VArea.Data): void {
     const {sx, sy1, sy2} = data ?? this
 
     ctx.beginPath()
@@ -85,6 +83,8 @@ export namespace VArea {
   }
 
   export type Visuals = Area.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface VArea extends VArea.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -1,6 +1,4 @@
 import type {PointGeometry} from "core/geometry"
-import type {FloatArray, ScreenArray} from "core/types"
-import type {AreaData} from "./area"
 import {Area, AreaView} from "./area"
 import type {Context2d} from "core/util/canvas"
 import type {SpatialIndex} from "core/util/spatial"
@@ -8,15 +6,7 @@ import * as hittest from "core/hittest"
 import * as p from "core/properties"
 import {Selection} from "../selections/selection"
 
-export type VAreaData = AreaData & {
-  _x: FloatArray
-  _y1: FloatArray
-  _y2: FloatArray
-
-  sx: ScreenArray
-  sy1: ScreenArray
-  sy2: ScreenArray
-}
+export type VAreaData = p.GlyphDataOf<VArea.Props>
 
 export interface VAreaView extends VAreaData {}
 

--- a/bokehjs/src/lib/models/glyphs/varea.ts
+++ b/bokehjs/src/lib/models/glyphs/varea.ts
@@ -17,9 +17,9 @@ export class VAreaView extends AreaView {
     const {data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const x = this._x[i]
-      const y1 = this._y1[i]
-      const y2 = this._y2[i]
+      const x = this.x[i]
+      const y1 = this.y1[i]
+      const y2 = this.y2[i]
       index.add_rect(x, min(y1, y2), x, max(y1, y2))
     }
   }
@@ -67,9 +67,9 @@ export class VAreaView extends AreaView {
   }
 
   protected override _map_data(): void {
-    this.sx  = this.renderer.xscale.v_compute(this._x)
-    this.sy1 = this.renderer.yscale.v_compute(this._y1)
-    this.sy2 = this.renderer.yscale.v_compute(this._y2)
+    this.sx  = this.renderer.xscale.v_compute(this.x)
+    this.sy1 = this.renderer.yscale.v_compute(this.y1)
+    this.sy2 = this.renderer.yscale.v_compute(this.y2)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/varea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/varea_step.ts
@@ -55,8 +55,8 @@ export class VAreaStepView extends AreaView {
     }
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: VAreaStep.Data): void {
-    const {sx, sy1, sy2} = data ?? this
+  protected _render(ctx: Context2d, _indices: number[], data?: Partial<VAreaStep.Data>): void {
+    const {sx, sy1, sy2} = {...this, ...data}
 
     const forward_mode = this.model.step_mode
     const backward_mode = flip_step_mode(this.model.step_mode)

--- a/bokehjs/src/lib/models/glyphs/varea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/varea_step.ts
@@ -34,16 +34,17 @@ export class VAreaStepView extends AreaView {
     const idx_dir = from_i < to_i ? 1 : -1
     for (let i = from_i + idx_dir; i != to_i; i += idx_dir) {
       switch (mode) {
-        case "before":
+        case "before": {
           ctx.lineTo(prev_x, sy[i])
           ctx.lineTo(sx[i], sy[i])
           break
-        case "after":
+        }
+        case "after": {
           ctx.lineTo(sx[i], prev_y)
           ctx.lineTo(sx[i], sy[i])
           break
-        case "center":
-        {
+        }
+        case "center": {
           const mid_x = (prev_x + sx[i]) / 2
           ctx.lineTo(mid_x, prev_y)
           ctx.lineTo(mid_x, sy[i])
@@ -88,16 +89,17 @@ export class VAreaStepView extends AreaView {
       let py: number[]
 
       switch (this.model.step_mode) {
-        case "before":
+        case "before": {
           px = [sx[i], sx[i+1], sx[i+1], sx[i]]
           py = [sy1[i+1], sy1[i+1], sy2[i+1], sy2[i+1]]
           break
-        case "after":
+        }
+        case "after": {
           px = [sx[i], sx[i+1], sx[i+1], sx[i]]
           py = [sy1[i], sy1[i], sy2[i], sy2[i]]
           break
-        case "center":
-        {
+        }
+        case "center": {
           const mid_x = (sx[i] + sx[i+1]) / 2
           px = [sx[i], mid_x, mid_x, sx[i+1], sx[i+1], mid_x, mid_x, sx[i]]
           py = [sy1[i], sy1[i], sy1[i+1], sy1[i+1], sy2[i+1], sy2[i+1], sy2[i], sy2[i]]

--- a/bokehjs/src/lib/models/glyphs/varea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/varea_step.ts
@@ -1,6 +1,5 @@
 import type {PointGeometry} from "core/geometry"
-import type {FloatArray, ScreenArray} from "core/types"
-import type {AreaData} from "./area"
+import type {Arrayable} from "core/types"
 import {Area, AreaView} from "./area"
 import type {Context2d} from "core/util/canvas"
 import type {SpatialIndex} from "core/util/spatial"
@@ -10,15 +9,7 @@ import {StepMode} from "core/enums"
 import {flip_step_mode} from "core/util/flip_step_mode"
 import {Selection} from "../selections/selection"
 
-export type VAreaStepData = AreaData & {
-  _x: FloatArray
-  _y1: FloatArray
-  _y2: FloatArray
-
-  sx: ScreenArray
-  sy1: ScreenArray
-  sy2: ScreenArray
-}
+export type VAreaStepData = p.GlyphDataOf<VAreaStep.Props>
 
 export interface VAreaStepView extends VAreaStepData {}
 
@@ -37,7 +28,7 @@ export class VAreaStepView extends AreaView {
     }
   }
 
-  protected _step_path(ctx: Context2d, mode: StepMode, sx: ScreenArray, sy: ScreenArray, from_i: number, to_i: number): void {
+  protected _step_path(ctx: Context2d, mode: StepMode, sx: Arrayable<number>, sy: Arrayable<number>, from_i: number, to_i: number): void {
     // Assume the path was already moved to the first point
     let prev_x = sx[from_i]
     let prev_y = sy[from_i]

--- a/bokehjs/src/lib/models/glyphs/varea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/varea_step.ts
@@ -17,12 +17,13 @@ export class VAreaStepView extends AreaView {
 
   protected _index_data(index: SpatialIndex): void {
     const {min, max} = Math
+    const {x, y1, y2} = this
 
     for (let i = 0; i < this.data_size; i++) {
-      const x = this._x[i]
-      const y1 = this._y1[i]
-      const y2 = this._y2[i]
-      index.add_rect(x, min(y1, y2), x, max(y1, y2))
+      const x_i = x[i]
+      const y1_i = y1[i]
+      const y2_i = y2[i]
+      index.add_rect(x_i, min(y1_i, y2_i), x_i, max(y1_i, y2_i))
     }
   }
 
@@ -117,9 +118,9 @@ export class VAreaStepView extends AreaView {
   }
 
   protected override _map_data(): void {
-    this.sx  = this.renderer.xscale.v_compute(this._x)
-    this.sy1 = this.renderer.yscale.v_compute(this._y1)
-    this.sy2 = this.renderer.yscale.v_compute(this._y2)
+    this.sx  = this.renderer.xscale.v_compute(this.x)
+    this.sy1 = this.renderer.yscale.v_compute(this.y1)
+    this.sy2 = this.renderer.yscale.v_compute(this.y2)
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/varea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/varea_step.ts
@@ -116,21 +116,15 @@ export class VAreaStepView extends AreaView {
 
     return new Selection()
   }
-
-  protected override _map_data(): void {
-    this.sx  = this.renderer.xscale.v_compute(this.x)
-    this.sy1 = this.renderer.yscale.v_compute(this.y1)
-    this.sy2 = this.renderer.yscale.v_compute(this.y2)
-  }
 }
 
 export namespace VAreaStep {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Area.Props & {
-    x: p.CoordinateSpec
-    y1: p.CoordinateSpec
-    y2: p.CoordinateSpec
+    x: p.XCoordinateSpec
+    y1: p.YCoordinateSpec
+    y2: p.YCoordinateSpec
     step_mode: p.Property<StepMode>
   }
 

--- a/bokehjs/src/lib/models/glyphs/varea_step.ts
+++ b/bokehjs/src/lib/models/glyphs/varea_step.ts
@@ -9,9 +9,7 @@ import {StepMode} from "core/enums"
 import {flip_step_mode} from "core/util/flip_step_mode"
 import {Selection} from "../selections/selection"
 
-export type VAreaStepData = p.GlyphDataOf<VAreaStep.Props>
-
-export interface VAreaStepView extends VAreaStepData {}
+export interface VAreaStepView extends VAreaStep.Data {}
 
 export class VAreaStepView extends AreaView {
   declare model: VAreaStep
@@ -57,7 +55,7 @@ export class VAreaStepView extends AreaView {
     }
   }
 
-  protected _render(ctx: Context2d, _indices: number[], data?: VAreaStepData): void {
+  protected _render(ctx: Context2d, _indices: number[], data?: VAreaStep.Data): void {
     const {sx, sy1, sy2} = data ?? this
 
     const forward_mode = this.model.step_mode
@@ -136,6 +134,8 @@ export namespace VAreaStep {
   }
 
   export type Visuals = Area.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface VAreaStep extends VAreaStep.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -1,18 +1,9 @@
-import type {LRTBData} from "./lrtb"
 import {LRTB, LRTBView} from "./lrtb"
 import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
-export type VBarData = LRTBData & p.GlyphDataOf<VBar.Props> & {
-  _x: Arrayable<number>
-  width: p.Uniform<number>
-
-  sx: Arrayable<number>
-  swidth: Arrayable<number>
-}
-
-export interface VBarView extends VBarData {}
+export interface VBarView extends VBar.Data {}
 
 export class VBarView extends LRTBView {
   declare model: VBar
@@ -67,6 +58,14 @@ export namespace VBar {
   }
 
   export type Visuals = LRTB.Visuals
+
+  export type Data = LRTB.Data & p.GlyphDataOf<Props> & {
+    _x: Arrayable<number>
+    width: p.Uniform<number>
+
+    sx: Arrayable<number>
+    swidth: Arrayable<number>
+  }
 }
 
 export interface VBar extends VBar.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -29,10 +29,7 @@ export class VBarView extends LRTBView {
   }
 
   protected override _map_data(): void {
-    this.sx = this.renderer.xscale.v_compute(this.x)
     this.swidth = this.sdist(this.renderer.xscale, this.x, this.width, "center")
-    this.stop = this.renderer.yscale.v_compute(this.top)
-    this.sbottom = this.renderer.yscale.v_compute(this.bottom)
 
     const n = this.sx.length
     this.sleft = new ScreenArray(n)
@@ -50,10 +47,10 @@ export namespace VBar {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = LRTB.Props & {
-    x: p.CoordinateSpec
-    bottom: p.CoordinateSpec
+    x: p.XCoordinateSpec
+    bottom: p.YCoordinateSpec
     width: p.DistanceSpec
-    top: p.CoordinateSpec
+    top: p.YCoordinateSpec
   }
 
   export type Visuals = LRTB.Visuals

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -1,21 +1,15 @@
 import type {LRTBData} from "./lrtb"
 import {LRTB, LRTBView} from "./lrtb"
-import type {FloatArray} from "core/types"
+import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
-export type VBarData = LRTBData & {
-  _x: FloatArray
-  _bottom: FloatArray
-  readonly width: p.Uniform<number>
-  _top: FloatArray
+export type VBarData = LRTBData & p.GlyphDataOf<VBar.Props> & {
+  _x: Arrayable<number>
+  width: p.Uniform<number>
 
-  sx: ScreenArray
-  sw: ScreenArray
-  stop: ScreenArray
-  sbottom: ScreenArray
-  sleft: ScreenArray
-  sright: ScreenArray
+  sx: Arrayable<number>
+  swidth: Arrayable<number>
 }
 
 export interface VBarView extends VBarData {}
@@ -46,7 +40,7 @@ export class VBarView extends LRTBView {
 
   protected override _map_data(): void {
     this.sx = this.renderer.xscale.v_compute(this._x)
-    this.sw = this.sdist(this.renderer.xscale, this._x, this.width, "center")
+    this.swidth = this.sdist(this.renderer.xscale, this._x, this.width, "center")
     this.stop = this.renderer.yscale.v_compute(this._top)
     this.sbottom = this.renderer.yscale.v_compute(this._bottom)
 
@@ -54,8 +48,8 @@ export class VBarView extends LRTBView {
     this.sleft = new ScreenArray(n)
     this.sright = new ScreenArray(n)
     for (let i = 0; i < n; i++) {
-      this.sleft[i] = this.sx[i] - this.sw[i]/2
-      this.sright[i] = this.sx[i] + this.sw[i]/2
+      this.sleft[i] = this.sx[i] - this.swidth[i]/2
+      this.sright[i] = this.sx[i] + this.swidth[i]/2
     }
 
     this._clamp_viewport()

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -1,4 +1,5 @@
 import {LRTB, LRTBView} from "./lrtb"
+import type {LRTBRect} from "./lrtb"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
@@ -14,7 +15,7 @@ export class VBarView extends LRTBView {
     return [scx, scy]
   }
 
-  protected _lrtb(i: number): [number, number, number, number] {
+  protected _lrtb(i: number): LRTBRect {
     const half_width_i = this.width.get(i)/2
     const x_i = this.x[i]
     const top_i = this.top[i]
@@ -25,26 +26,35 @@ export class VBarView extends LRTBView {
     const t = Math.max(top_i, bottom_i)
     const b = Math.min(top_i, bottom_i)
 
-    return [l, r, t, b]
+    return {l, r, t, b}
   }
 
   protected override _map_data(): void {
     if (this.inherited_x && this.inherited_width) {
       this._inherit_attr<VBar.Data>("swidth")
+      this._inherit_attr<VBar.Data>("sleft")
+      this._inherit_attr<VBar.Data>("sright")
     } else {
       const swidth = this.sdist(this.renderer.xscale, this.x, this.width, "center")
+
+      const {sx} = this
+      const n = sx.length
+      const sleft = new ScreenArray(n)
+      const sright = new ScreenArray(n)
+
+      for (let i = 0; i < n; i++) {
+        const sx_i = sx[i]
+        const swidth_i = swidth[i]
+        sleft[i] = sx_i - swidth_i/2
+        sright[i] = sx_i + swidth_i/2
+      }
+
       this._define_attr<VBar.Data>("swidth", swidth)
+      this._define_attr<VBar.Data>("sleft", sleft)
+      this._define_attr<VBar.Data>("sright", sright)
     }
 
-    const n = this.sx.length
-    this.sleft = new ScreenArray(n)
-    this.sright = new ScreenArray(n)
-    for (let i = 0; i < n; i++) {
-      this.sleft[i] = this.sx[i] - this.swidth[i]/2
-      this.sright[i] = this.sx[i] + this.swidth[i]/2
-    }
-
-    this._clamp_viewport()
+    this._clamp_to_viewport()
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -29,7 +29,12 @@ export class VBarView extends LRTBView {
   }
 
   protected override _map_data(): void {
-    this.swidth = this.sdist(this.renderer.xscale, this.x, this.width, "center")
+    if (this.inherited_x && this.inherited_width) {
+      this._inherit_attr<VBar.Data>("swidth")
+    } else {
+      const swidth = this.sdist(this.renderer.xscale, this.x, this.width, "center")
+      this._define_attr<VBar.Data>("swidth", swidth)
+    }
 
     const n = this.sx.length
     this.sleft = new ScreenArray(n)

--- a/bokehjs/src/lib/models/glyphs/vbar.ts
+++ b/bokehjs/src/lib/models/glyphs/vbar.ts
@@ -1,5 +1,4 @@
 import {LRTB, LRTBView} from "./lrtb"
-import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
 import * as p from "core/properties"
 
@@ -17,9 +16,9 @@ export class VBarView extends LRTBView {
 
   protected _lrtb(i: number): [number, number, number, number] {
     const half_width_i = this.width.get(i)/2
-    const x_i = this._x[i]
-    const top_i = this._top[i]
-    const bottom_i = this._bottom[i]
+    const x_i = this.x[i]
+    const top_i = this.top[i]
+    const bottom_i = this.bottom[i]
 
     const l = x_i - half_width_i
     const r = x_i + half_width_i
@@ -30,10 +29,10 @@ export class VBarView extends LRTBView {
   }
 
   protected override _map_data(): void {
-    this.sx = this.renderer.xscale.v_compute(this._x)
-    this.swidth = this.sdist(this.renderer.xscale, this._x, this.width, "center")
-    this.stop = this.renderer.yscale.v_compute(this._top)
-    this.sbottom = this.renderer.yscale.v_compute(this._bottom)
+    this.sx = this.renderer.xscale.v_compute(this.x)
+    this.swidth = this.sdist(this.renderer.xscale, this.x, this.width, "center")
+    this.stop = this.renderer.yscale.v_compute(this.top)
+    this.sbottom = this.renderer.yscale.v_compute(this.bottom)
 
     const n = this.sx.length
     this.sleft = new ScreenArray(n)
@@ -53,19 +52,13 @@ export namespace VBar {
   export type Props = LRTB.Props & {
     x: p.CoordinateSpec
     bottom: p.CoordinateSpec
-    width: p.NumberSpec
+    width: p.DistanceSpec
     top: p.CoordinateSpec
   }
 
   export type Visuals = LRTB.Visuals
 
-  export type Data = LRTB.Data & p.GlyphDataOf<Props> & {
-    _x: Arrayable<number>
-    width: p.Uniform<number>
-
-    sx: Arrayable<number>
-    swidth: Arrayable<number>
-  }
+  export type Data = LRTB.Data & p.GlyphDataOf<Props>
 }
 
 export interface VBar extends VBar.Attrs {}
@@ -84,7 +77,7 @@ export class VBar extends LRTB {
     this.define<VBar.Props>(({}) => ({
       x:      [ p.XCoordinateSpec, {field: "x"} ],
       bottom: [ p.YCoordinateSpec, {value: 0} ],
-      width:  [ p.NumberSpec,      {value: 1} ],
+      width:  [ p.DistanceSpec,    {value: 1} ],
       top:    [ p.YCoordinateSpec, {field: "top"} ],
     }))
   }

--- a/bokehjs/src/lib/models/glyphs/vspan.ts
+++ b/bokehjs/src/lib/models/glyphs/vspan.ts
@@ -16,11 +16,7 @@ const {abs, max} = Math
 
 const UNUSED = 0
 
-export type VSpanData = p.GlyphDataOf<VSpan.Props> & {
-  max_line_width: number
-}
-
-export interface VSpanView extends VSpanData {}
+export interface VSpanView extends VSpan.Data {}
 
 export class VSpanView extends GlyphView {
   declare model: VSpan
@@ -53,7 +49,7 @@ export class VSpanView extends GlyphView {
     return [this.sx[i], vcenter]
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: VSpanData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: VSpan.Data): void {
     const {sx} = data ?? this
     const {top, bottom} = this.renderer.plot_view.frame.bbox
 
@@ -142,6 +138,10 @@ export namespace VSpan {
   export type Mixins = LineVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    max_line_width: number
+  }
 }
 
 export interface VSpan extends VSpan.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/vspan.ts
+++ b/bokehjs/src/lib/models/glyphs/vspan.ts
@@ -28,7 +28,7 @@ export class VSpanView extends GlyphView {
   }
 
   protected override _index_data(index: SpatialIndex): void {
-    for (const x_i of this._x) {
+    for (const x_i of this.x) {
       index.add_point(x_i, UNUSED)
     }
   }

--- a/bokehjs/src/lib/models/glyphs/vspan.ts
+++ b/bokehjs/src/lib/models/glyphs/vspan.ts
@@ -41,7 +41,10 @@ export class VSpanView extends GlyphView {
   protected override _map_data(): void {
     super._map_data()
     const {round} = Math
-    this.sx = map(this.sx, (xi) => round(xi))
+    if (!this.inherited_sx) {
+      const sx = map(this.sx, (xi) => round(xi))
+      this._define_attr("sx", sx)
+    }
   }
 
   scenterxy(i: number): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/vspan.ts
+++ b/bokehjs/src/lib/models/glyphs/vspan.ts
@@ -1,10 +1,9 @@
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_line_vector_legend} from "./utils"
 import {Selection} from "../selections/selection"
 import {LineVector} from "core/property_mixins"
 import type {PointGeometry, SpanGeometry, RectGeometry} from "core/geometry"
-import type {FloatArray, ScreenArray, Rect} from "core/types"
+import type {Rect} from "core/types"
 import type * as visuals from "core/visuals"
 import * as uniforms from "core/uniforms"
 import type {Context2d} from "core/util/canvas"
@@ -17,10 +16,7 @@ const {abs, max} = Math
 
 const UNUSED = 0
 
-export type VSpanData = GlyphData & p.UniformsOf<VSpan.Mixins> & {
-  _x: FloatArray
-  sx: ScreenArray
-
+export type VSpanData = p.GlyphDataOf<VSpan.Props> & {
   max_line_width: number
 }
 

--- a/bokehjs/src/lib/models/glyphs/vspan.ts
+++ b/bokehjs/src/lib/models/glyphs/vspan.ts
@@ -49,8 +49,8 @@ export class VSpanView extends GlyphView {
     return [this.sx[i], vcenter]
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: VSpan.Data): void {
-    const {sx} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<VSpan.Data>): void {
+    const {sx} = {...this, ...data}
     const {top, bottom} = this.renderer.plot_view.frame.bbox
 
     for (const i of indices) {

--- a/bokehjs/src/lib/models/glyphs/vstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/vstrip.ts
@@ -66,7 +66,12 @@ export class VStripView extends GlyphView {
     const {max, map, zip} = iter
 
     const {x0, x1} = this
-    this.max_width = max(map(zip(x0, x1), ([x0_i, x1_i]) => abs(x0_i - x1_i)))
+    if (this.inherited_x0 && this.inherited_x1) {
+      this._inherit_attr("max_width")
+    } else {
+      const max_width = max(map(zip(x0, x1), ([x0_i, x1_i]) => abs(x0_i - x1_i)))
+      this._define_attr("max_width", max_width)
+    }
   }
 
   protected override _index_data(index: SpatialIndex): void {
@@ -87,8 +92,14 @@ export class VStripView extends GlyphView {
   protected override _map_data(): void {
     super._map_data()
     const {round} = Math
-    this.sx0 = map(this.sx0, (xi) => round(xi))
-    this.sx1 = map(this.sx1, (xi) => round(xi))
+    if (!this.inherited_sx0) {
+      const sx0 = map(this.sx0, (xi) => round(xi))
+      this._define_attr("sx0", sx0)
+    }
+    if (!this.inherited_sx1) {
+      const sx1 = map(this.sx1, (xi) => round(xi))
+      this._define_attr("sx1", sx1)
+    }
   }
 
   scenterxy(i: number): [number, number] {

--- a/bokehjs/src/lib/models/glyphs/vstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/vstrip.ts
@@ -65,16 +65,16 @@ export class VStripView extends GlyphView {
     const {abs} = Math
     const {max, map, zip} = iter
 
-    const {_x0, _x1} = this
-    this.max_width = max(map(zip(_x0, _x1), ([x0_i, x1_i]) => abs(x0_i - x1_i)))
+    const {x0, x1} = this
+    this.max_width = max(map(zip(x0, x1), ([x0_i, x1_i]) => abs(x0_i - x1_i)))
   }
 
   protected override _index_data(index: SpatialIndex): void {
-    const {_x0, _x1, data_size} = this
+    const {x0, x1, data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const x0_i = _x0[i]
-      const x1_i = _x1[i]
+      const x0_i = x0[i]
+      const x1_i = x1[i]
       index.add_rect(x0_i, UNUSED, x1_i, UNUSED)
     }
   }

--- a/bokehjs/src/lib/models/glyphs/vstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/vstrip.ts
@@ -1,10 +1,9 @@
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import {Selection} from "../selections/selection"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import type {PointGeometry, SpanGeometry, RectGeometry} from "core/geometry"
-import type {FloatArray, Rect} from "core/types"
+import type {Arrayable, Rect} from "core/types"
 import {ScreenArray} from "core/types"
 import type * as visuals from "core/visuals"
 import type {Context2d} from "core/util/canvas"
@@ -17,13 +16,7 @@ import type {LRTBGL} from "./webgl/lrtb"
 
 const UNUSED = 0
 
-export type VStripData = GlyphData & p.UniformsOf<VStrip.Mixins> & {
-  _x0: FloatArray
-  _x1: FloatArray
-
-  sx0: ScreenArray
-  sx1: ScreenArray
-
+export type VStripData = p.GlyphDataOf<VStrip.Props> & {
   max_width: number
 }
 
@@ -46,15 +39,15 @@ export class VStripView extends GlyphView {
     }
   }
 
-  get sleft(): ScreenArray {
+  get sleft(): Arrayable<number> {
     return this.sx0
   }
 
-  get sright(): ScreenArray {
+  get sright(): Arrayable<number> {
     return this.sx1
   }
 
-  get stop(): ScreenArray {
+  get stop(): Arrayable<number> {
     const {top} = this.renderer.plot_view.frame.bbox
     const n = this.data_size
     const stop = new ScreenArray(n)
@@ -62,7 +55,7 @@ export class VStripView extends GlyphView {
     return stop
   }
 
-  get sbottom(): ScreenArray {
+  get sbottom(): Arrayable<number> {
     const {bottom} = this.renderer.plot_view.frame.bbox
     const n = this.data_size
     const sbottom = new ScreenArray(n)

--- a/bokehjs/src/lib/models/glyphs/vstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/vstrip.ts
@@ -96,8 +96,8 @@ export class VStripView extends GlyphView {
     return [(this.sx0[i] + this.sx1[i])/2, vcenter]
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: VStrip.Data): void {
-    const {sx0, sx1} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<VStrip.Data>): void {
+    const {sx0, sx1} = {...this, ...data}
     const {top, bottom, height} = this.renderer.plot_view.frame.bbox
 
     for (const i of indices) {

--- a/bokehjs/src/lib/models/glyphs/vstrip.ts
+++ b/bokehjs/src/lib/models/glyphs/vstrip.ts
@@ -16,11 +16,7 @@ import type {LRTBGL} from "./webgl/lrtb"
 
 const UNUSED = 0
 
-export type VStripData = p.GlyphDataOf<VStrip.Props> & {
-  max_width: number
-}
-
-export interface VStripView extends VStripData {}
+export interface VStripView extends VStrip.Data {}
 
 export class VStripView extends GlyphView {
   declare model: VStrip
@@ -100,7 +96,7 @@ export class VStripView extends GlyphView {
     return [(this.sx0[i] + this.sx1[i])/2, vcenter]
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: VStripData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: VStrip.Data): void {
     const {sx0, sx1} = data ?? this
     const {top, bottom, height} = this.renderer.plot_view.frame.bbox
 
@@ -201,6 +197,10 @@ export namespace VStrip {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = Glyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    max_width: number
+  }
 }
 
 export interface VStrip extends VStrip.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/webgl/base_line.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base_line.ts
@@ -7,6 +7,7 @@ import type {GlyphView} from "../glyph"
 import type * as visuals from "core/visuals"
 import {resolve_line_dash} from "core/visuals/line"
 import type {Framebuffer2D, Texture2D} from "regl"
+import type {Arrayable} from "core/types"
 
 export type BaseLineVisuals = visuals.LineVector | visuals.LineScalar
 
@@ -96,7 +97,7 @@ export abstract class BaseLineGL extends BaseGLGlyph {
     }
   }
 
-  protected _set_points_single(points: Float32Array, sx: Float32Array, sy: Float32Array): void {
+  protected _set_points_single(points: Float32Array, sx: Arrayable<number>, sy: Arrayable<number>): void {
     // Set points array for a single line.
     const npoints = points.length/2 - 2
     const is_closed = (npoints > 2 && sx[0] == sx[npoints-1] && sy[0] == sy[npoints-1] &&

--- a/bokehjs/src/lib/models/glyphs/webgl/buffer.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/buffer.ts
@@ -2,7 +2,7 @@ import type {ReglWrapper} from "./regl_wrap"
 import {cap_lookup, hatch_pattern_to_index, join_lookup} from "./webgl_utils"
 import type {LineCap, LineJoin} from "core/enums"
 import type {HatchPattern} from "core/property_mixins"
-import type {uint32} from "core/types"
+import type {uint32, Arrayable} from "core/types"
 import type {Uniform} from "core/uniforms"
 import {assert} from "core/util/assert"
 import {color2rgba} from "core/util/color"
@@ -55,12 +55,13 @@ abstract class WrappedBuffer<ArrayType extends WrappedArrayType> {
 
   protected abstract new_array(len: number): ArrayType
 
-  set_from_array(numbers: number[] | Float32Array): void {
+  set_from_array(numbers: Arrayable<number>): void {
     const len = numbers.length
     const array = this.get_sized_array(len)
 
-    for (let i = 0; i < len; i++)
+    for (let i = 0; i < len; i++) {
       array[i] = numbers[i]
+    }
 
     this.update()
   }

--- a/bokehjs/src/lib/models/glyphs/webgl/image.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/image.ts
@@ -5,6 +5,7 @@ import type {ReglWrapper} from "./regl_wrap"
 import type {ImageProps} from "./types"
 import type {ImageBaseView} from "../image_base"
 import type {Texture2D, Texture2DOptions} from "regl"
+import {assert} from "core/util/assert"
 
 export class ImageGL extends BaseGLGlyph {
   protected _tex: Array<Texture2D | null> = []
@@ -97,24 +98,27 @@ export class ImageGL extends BaseGLGlyph {
   }
 
   protected _set_image(): void {
-    const {image} = this.glyph
+    const {image, image_data} = this.glyph
     const nimage = image.length
 
-    if (this._tex.length != nimage)
+    assert(image_data != null)
+
+    if (this._tex.length != nimage) {
       this._tex = Array(nimage).fill(null)
+    }
 
     for (let i = 0; i < nimage; i++) {
-      const image_data = this.glyph.image_data[i]
+      const image_data_i = image_data[i]
 
-      if (image_data == null) {
+      if (image_data_i == null) {
         this._tex[i] = null
         continue
       }
 
       const tex_options: Texture2DOptions = {
-        width: image_data.width,
-        height: image_data.height,
-        data: image_data,
+        width: image_data_i.width,
+        height: image_data_i.height,
+        data: image_data_i,
         format: "rgba",
         type: "uint8",
       }

--- a/bokehjs/src/lib/models/glyphs/webgl/image.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/image.ts
@@ -72,7 +72,7 @@ export class ImageGL extends BaseGLGlyph {
       this._bounds = Array(nimage).fill(null)
 
     for (let i = 0; i < nimage; i++) {
-      const {sx, sy, sw, sh, xy_anchor, xy_scale, xy_sign} = this.glyph
+      const {sx, sy, sdw: sw, sdh: sh, xy_anchor, xy_scale, xy_sign} = this.glyph
       const sx_i = sx[i]
       const sy_i = sy[i]
       const sw_i = sw[i]

--- a/bokehjs/src/lib/models/glyphs/webgl/multi_line.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/multi_line.ts
@@ -89,7 +89,7 @@ export class MultiLineGL extends BaseLineGL {
     // Set data properties which are points and show flags for data
     // (taking into account NaNs but not selected indices)
     const line_count = this.glyph.data_size
-    const total_point_count =  this.glyph.sxs.array.length
+    const total_point_count =  this.glyph.sxs.data.length
 
     if (this._points == null)
       this._points = new Float32Buffer(this.regl_wrapper)
@@ -137,7 +137,7 @@ export class MultiLineGL extends BaseLineGL {
 
   protected _set_length(): void {
     const line_count = this.glyph.data_size
-    const total_point_count =  this.glyph.sxs.array.length
+    const total_point_count =  this.glyph.sxs.data.length
 
     const points_array = this._points!.get_array()
     const show_array = this._show!.get_array()

--- a/bokehjs/src/lib/models/glyphs/webgl/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/rect.ts
@@ -15,8 +15,8 @@ export class RectGL extends SXSYGlyphGL {
   protected override _set_data(): void {
     super._set_data()
 
-    this._widths.set_from_array(this.glyph.sw)
-    this._heights.set_from_array(this.glyph.sh)
+    this._widths.set_from_array(this.glyph.swidth)
+    this._heights.set_from_array(this.glyph.sheight)
 
     this._angles.set_from_prop(this.glyph.angle)
 

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -13,11 +13,7 @@ import {Selection} from "../selections/selection"
 import {max} from "../../core/util/arrayable"
 import type {WedgeGL} from "./webgl/wedge"
 
-export type WedgeData = p.GlyphDataOf<Wedge.Props> & {
-  max_sradius: number
-}
-
-export interface WedgeView extends WedgeData {}
+export interface WedgeView extends Wedge.Data {}
 
 export class WedgeView extends XYGlyphView {
   declare model: Wedge
@@ -39,7 +35,7 @@ export class WedgeView extends XYGlyphView {
     this.max_sradius = max(this.sradius)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: WedgeData): void {
+  protected _render(ctx: Context2d, indices: number[], data?: Wedge.Data): void {
     const {sx, sy, sradius, start_angle, end_angle} = data ?? this
     const anticlock = this.model.direction == "anticlock"
 
@@ -131,6 +127,10 @@ export namespace Wedge {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Props> & {
+    max_sradius: number
+  }
 }
 
 export interface Wedge extends Wedge.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -1,4 +1,5 @@
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
+import {inherit} from "./glyph"
 import {generic_area_vector_legend} from "./utils"
 import type {PointGeometry} from "core/geometry"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
@@ -28,11 +29,19 @@ export class WedgeView extends XYGlyphView {
   }
 
   protected override _map_data(): void {
-    if (this.model.properties.radius.units == "data")
-      this.sradius = this.sdist(this.renderer.xscale, this.x, this.radius)
-    else
-      this.sradius = to_screen(this.radius)
-    this.max_sradius = max(this.sradius)
+    this._define_or_inherit_attr<Wedge.Data>("sradius", () => {
+      if (this.model.properties.radius.units == "data") {
+        if (this.inherited_x && this.inherited_radius) {
+          return inherit
+        } else {
+          return this.sdist(this.renderer.xscale, this.x, this.radius)
+        }
+      } else {
+        return this.inherited_radius ? inherit : to_screen(this.radius)
+      }
+    })
+
+    this._define_or_inherit_attr<Wedge.Data>("max_sradius", () => max(this.sradius))
   }
 
   protected _render(ctx: Context2d, indices: number[], data?: Partial<Wedge.Data>): void {
@@ -129,7 +138,7 @@ export namespace Wedge {
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
 
   export type Data = p.GlyphDataOf<Props> & {
-    max_sradius: number
+    readonly max_sradius: number
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -29,7 +29,7 @@ export class WedgeView extends XYGlyphView {
 
   protected override _map_data(): void {
     if (this.model.properties.radius.units == "data")
-      this.sradius = this.sdist(this.renderer.xscale, this._x, this.radius)
+      this.sradius = this.sdist(this.renderer.xscale, this.x, this.radius)
     else
       this.sradius = to_screen(this.radius)
     this.max_sradius = max(this.sradius)
@@ -78,8 +78,8 @@ export class WedgeView extends XYGlyphView {
 
     for (const i of this.index.indices({x0, x1, y0, y1})) {
       const r2 = this.sradius[i]**2
-      ;[sx0, sx1] = this.renderer.xscale.r_compute(x, this._x[i])
-      ;[sy0, sy1] = this.renderer.yscale.r_compute(y, this._y[i])
+      ;[sx0, sx1] = this.renderer.xscale.r_compute(x, this.x[i])
+      ;[sy0, sy1] = this.renderer.yscale.r_compute(y, this.y[i])
       dist = (sx0-sx1)**2 + (sy0-sy1)**2
       if (dist <= r2) {
         candidates.push(i)

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -1,10 +1,9 @@
-import type {XYGlyphData} from "./xy_glyph"
 import {XYGlyph, XYGlyphView} from "./xy_glyph"
 import {generic_area_vector_legend} from "./utils"
 import type {PointGeometry} from "core/geometry"
 import {LineVector, FillVector, HatchVector} from "core/property_mixins"
 import type * as visuals from "core/visuals"
-import type {Rect, ScreenArray} from "core/types"
+import type {Rect} from "core/types"
 import {to_screen} from "core/types"
 import {Direction} from "core/enums"
 import * as p from "core/properties"
@@ -14,14 +13,8 @@ import {Selection} from "../selections/selection"
 import {max} from "../../core/util/arrayable"
 import type {WedgeGL} from "./webgl/wedge"
 
-export type WedgeData = XYGlyphData & p.UniformsOf<Wedge.Mixins> & {
-  readonly radius: p.Uniform<number>
-  sradius: ScreenArray
+export type WedgeData = p.GlyphDataOf<Wedge.Props> & {
   max_sradius: number
-  readonly max_radius: number
-
-  readonly start_angle: p.Uniform<number>
-  readonly end_angle: p.Uniform<number>
 }
 
 export interface WedgeView extends WedgeData {}

--- a/bokehjs/src/lib/models/glyphs/wedge.ts
+++ b/bokehjs/src/lib/models/glyphs/wedge.ts
@@ -35,8 +35,8 @@ export class WedgeView extends XYGlyphView {
     this.max_sradius = max(this.sradius)
   }
 
-  protected _render(ctx: Context2d, indices: number[], data?: Wedge.Data): void {
-    const {sx, sy, sradius, start_angle, end_angle} = data ?? this
+  protected _render(ctx: Context2d, indices: number[], data?: Partial<Wedge.Data>): void {
+    const {sx, sy, sradius, start_angle, end_angle} = {...this, ...data}
     const anticlock = this.model.direction == "anticlock"
 
     for (const i of indices) {

--- a/bokehjs/src/lib/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/xy_glyph.ts
@@ -3,9 +3,7 @@ import {inplace} from "core/util/projections"
 import * as p from "core/properties"
 import {Glyph, GlyphView} from "./glyph"
 
-export type XYGlyphData = p.GlyphDataOf<XYGlyph.Props>
-
-export interface XYGlyphView extends XYGlyphData {}
+export interface XYGlyphView extends XYGlyph.Data {}
 
 export abstract class XYGlyphView extends GlyphView {
   declare model: XYGlyph
@@ -39,6 +37,8 @@ export namespace XYGlyph {
   }
 
   export type Visuals = Glyph.Visuals
+
+  export type Data = p.GlyphDataOf<Props>
 }
 
 export interface XYGlyph extends XYGlyph.Attrs {}

--- a/bokehjs/src/lib/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/xy_glyph.ts
@@ -1,17 +1,9 @@
-import type {FloatArray, ScreenArray} from "core/types"
 import type {SpatialIndex} from "core/util/spatial"
 import {inplace} from "core/util/projections"
 import * as p from "core/properties"
-import type {GlyphData} from "./glyph"
 import {Glyph, GlyphView} from "./glyph"
 
-export type XYGlyphData = GlyphData & {
-  _x: FloatArray
-  _y: FloatArray
-
-  sx: ScreenArray
-  sy: ScreenArray
-}
+export type XYGlyphData = p.GlyphDataOf<XYGlyph.Props>
 
 export interface XYGlyphView extends XYGlyphData {}
 

--- a/bokehjs/src/lib/models/glyphs/xy_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/xy_glyph.ts
@@ -10,16 +10,16 @@ export abstract class XYGlyphView extends GlyphView {
   declare visuals: XYGlyph.Visuals
 
   protected override _project_data(): void {
-    inplace.project_xy(this._x, this._y)
+    inplace.project_xy(this.x, this.y)
   }
 
   protected _index_data(index: SpatialIndex): void {
-    const {_x, _y, data_size} = this
+    const {x, y, data_size} = this
 
     for (let i = 0; i < data_size; i++) {
-      const x = _x[i]
-      const y = _y[i]
-      index.add_point(x, y)
+      const x_i = x[i]
+      const y_i = y[i]
+      index.add_point(x_i, y_i)
     }
   }
 

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -304,6 +304,11 @@ export class GlyphRendererView extends DataRendererView {
     const glsupport = this.has_webgl
 
     this.glyph.map_data()
+    this.decimated_glyph.map_data()
+    this.selection_glyph.map_data()
+    this.nonselection_glyph.map_data()
+    this.hover_glyph?.map_data()
+    this.muted_glyph.map_data()
 
     // all_indices is in full data space, indices is converted to subset space by mask_data (that may use the spatial index)
     const all_indices = [...this.all_indices]

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -253,6 +253,12 @@ export class GlyphRendererView extends DataRendererView {
     const {all_indices} = this
 
     this.glyph.set_data(source, all_indices, indices)
+    this.decimated_glyph.set_data(source, all_indices, indices)
+    this.selection_glyph.set_data(source, all_indices, indices)
+    this.nonselection_glyph.set_data(source, all_indices, indices)
+    this.hover_glyph?.set_data(source, all_indices, indices)
+    this.muted_glyph.set_data(source, all_indices, indices)
+
     this.set_visuals()
 
     this._update_masked_indices()

--- a/bokehjs/test/integration/glyphs/images.ts
+++ b/bokehjs/test/integration/glyphs/images.ts
@@ -81,7 +81,7 @@ describe("ImageRGBA glyph", () => { // TODO: async describe
           dv.setUint32(4*(i*N + j), encode_rgba([r, g, b, a]))
         }
       }
-      return ndarray(d, {shape: [N, N]})
+      return ndarray(d, {dtype: "uint32", shape: [N, N]})
     }
 
     function make_plot(output_backend: OutputBackend) {

--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -85,7 +85,7 @@ function scalar_image(N: number = 100) {
       d[i*N + j] = sin(x[i])*cos(y[j])
     }
   }
-  return ndarray(d, {shape: [N, N]})
+  return ndarray(d, {dtype: "float64", shape: [N, N]})
 }
 
 function rgba_image() {
@@ -103,7 +103,7 @@ function rgba_image() {
       dv.setUint32(4*(i*N + j), encode_rgba([r, g, b, a]))
     }
   }
-  return ndarray(d, {shape: [N, N]})
+  return ndarray(d, {dtype: "uint32", shape: [N, N]})
 }
 
 function svg_image() {

--- a/bokehjs/test/unit/assertions.ts
+++ b/bokehjs/test/unit/assertions.ts
@@ -52,6 +52,7 @@ type Assertions<T> = {
   empty: void
   below(expected: number): void
   above(expected: number): void
+  within(low: number, high: number): void
 }
 
 type ElementAssertions = {
@@ -226,6 +227,14 @@ class Asserts implements Assertions<unknown> {
     if (!(isNumber(value) && value > expected) == !this.negated) {
       const be = this.negated ? "not be" : "be"
       throw new ExpectationError(`expected ${to_string(value)} to ${be} below ${to_string(expected)}`)
+    }
+  }
+
+  within(low: number, high: number): void {
+    const {value} = this
+    if (!(isNumber(value) && low <= value && value <= high) == !this.negated) {
+      const be = this.negated ? "not be" : "be"
+      throw new ExpectationError(`expected ${to_string(value)} to ${be} within ${to_string(low)} .. ${to_string(high)} range`)
     }
   }
 }

--- a/bokehjs/test/unit/models/glyphs/image.ts
+++ b/bokehjs/test/unit/models/glyphs/image.ts
@@ -20,8 +20,8 @@ describe("Image module", () => {
       const image_view = await create_glyph_view(image, data)
       image_view.map_data()
 
-      expect(image_view.sw).to.be.equal(new ScreenArray([34]))
-      expect(image_view.sh).to.be.equal(new ScreenArray([38]))
+      expect(image_view.sdw).to.be.equal(new ScreenArray([34]))
+      expect(image_view.sdh).to.be.equal(new ScreenArray([38]))
     })
 
     it("`_map_data` should correctly map data if w and h units are 'screen'", async () => {
@@ -37,8 +37,8 @@ describe("Image module", () => {
       const image_view = await create_glyph_view(image, data)
       image_view.map_data()
 
-      expect(image_view.sw).to.be.equal(new ScreenArray([1]))
-      expect(image_view.sh).to.be.equal(new ScreenArray([2]))
+      expect(image_view.sdw).to.be.equal(new ScreenArray([1]))
+      expect(image_view.sdh).to.be.equal(new ScreenArray([2]))
     })
   })
 })

--- a/bokehjs/test/unit/models/glyphs/image_rgba.ts
+++ b/bokehjs/test/unit/models/glyphs/image_rgba.ts
@@ -20,8 +20,8 @@ describe("ImageRGBA module", () => {
       const image_rgba_view = await create_glyph_view(image_rgba, data)
       image_rgba_view.map_data()
 
-      expect(image_rgba_view.sw).to.be.equal(new ScreenArray([34]))
-      expect(image_rgba_view.sh).to.be.equal(new ScreenArray([38]))
+      expect(image_rgba_view.sdw).to.be.equal(new ScreenArray([34]))
+      expect(image_rgba_view.sdh).to.be.equal(new ScreenArray([38]))
     })
 
     it("`_map_data` should correctly map data if w and h units are 'screen'", async () => {
@@ -37,8 +37,8 @@ describe("ImageRGBA module", () => {
       const image_rgba_view = await create_glyph_view(image_rgba, data)
       image_rgba_view.map_data()
 
-      expect(image_rgba_view.sw).to.be.equal(new ScreenArray([1]))
-      expect(image_rgba_view.sh).to.be.equal(new ScreenArray([2]))
+      expect(image_rgba_view.sdw).to.be.equal(new ScreenArray([1]))
+      expect(image_rgba_view.sdh).to.be.equal(new ScreenArray([2]))
     })
   })
 })

--- a/bokehjs/test/unit/models/glyphs/rect.ts
+++ b/bokehjs/test/unit/models/glyphs/rect.ts
@@ -113,8 +113,8 @@ describe("Rect", () => {
       const glyph_view = await create_glyph_view(glyph, data, {axis_type: "linear"})
       glyph_view.map_data()
 
-      expect(glyph_view.sw).to.be.equal(ScreenArray.of(20))
-      expect(glyph_view.sh).to.be.equal(ScreenArray.of(40))
+      expect(glyph_view.swidth).to.be.equal(ScreenArray.of(20))
+      expect(glyph_view.sheight).to.be.equal(ScreenArray.of(40))
     })
 
     it("`_map_data` should correctly map data if width and height units are 'screen'", async () => {
@@ -125,8 +125,8 @@ describe("Rect", () => {
       const glyph_view = await create_glyph_view(glyph, data, {axis_type: "linear"})
       glyph_view.map_data()
 
-      expect(glyph_view.sw).to.be.equal(new ScreenArray([10]))
-      expect(glyph_view.sh).to.be.equal(new ScreenArray([20]))
+      expect(glyph_view.swidth).to.be.equal(new ScreenArray([10]))
+      expect(glyph_view.sheight).to.be.equal(new ScreenArray([20]))
     })
 
     // XXX: needs update
@@ -169,7 +169,7 @@ describe("Rect", () => {
     })
     */
 
-    it("`_map_data` should map values for sw and sh when a height is 0", async () => {
+    it("`_map_data` should map values for swidth and sheight when a height is 0", async () => {
       const glyph = new Rect({
         x: {field: "x"},
         y: {field: "y"},
@@ -180,8 +180,8 @@ describe("Rect", () => {
       const glyph_view = await create_glyph_view(glyph, data, {axis_type: "linear"})
       glyph_view.map_data()
 
-      expect(glyph_view.sw).to.be.equal(ScreenArray.of(20))
-      expect(glyph_view.sh).to.be.equal(ScreenArray.of(0))
+      expect(glyph_view.swidth).to.be.equal(ScreenArray.of(20))
+      expect(glyph_view.sheight).to.be.equal(ScreenArray.of(0))
     })
 
     describe("hit-testing", () => {

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -428,40 +428,32 @@ describe("Bug", () => {
       const jpg = "/9j/4AAQSkZJRgABAQEASABIAAD//gATQ3JlYXRlZCB3aXRoIEdJTVD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wgARCAAUABQDAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAWAQEBAQAAAAAAAAAAAAAAAAAABwn/2gAMAwEAAhADEAAAAbIZ30QAAAD/xAAUEAEAAAAAAAAAAAAAAAAAAAAw/9oACAEBAAEFAh//xAAUEQEAAAAAAAAAAAAAAAAAAAAw/9oACAEDAQE/AR//xAAUEQEAAAAAAAAAAAAAAAAAAAAw/9oACAECAQE/AR//xAAUEAEAAAAAAAAAAAAAAAAAAAAw/9oACAEBAAY/Ah//xAAUEAEAAAAAAAAAAAAAAAAAAAAw/9oACAEBAAE/IR//2gAMAwEAAgADAAAAEAAAAB//xAAUEQEAAAAAAAAAAAAAAAAAAAAw/9oACAEDAQE/EB//xAAUEQEAAAAAAAAAAAAAAAAAAAAw/9oACAECAQE/EB//xAAUEAEAAAAAAAAAAAAAAAAAAAAw/9oACAEBAAE/EB//2Q=="
       const png = "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5QwMEBEn745HIwAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAAdElEQVQ4y2NkwA/M/uORZGKgAAycZkbCSnB7m8bO/n+SXGf//w91M6M5Bc7Gaj8jMdaiaDAnQjNWnegGvefnh7AEP34kYCeGTQjNECDw4QMx2rAH2AcBASJ1Yg9tZP2MeEMUe1RB9DMSSgW0SZ6Ynh9M+RkAVKIcx4/3GikAAAAASUVORK5CYII="
 
-      const render = sinon.spy(ImageURLView.prototype, "render")
+      using render = restorable(sinon.spy(ImageURLView.prototype, "render"))
 
-      try {
-        const p0 = fig([200, 200])
-        p0.image_url([data_url(jpg, "image/jpeg")], 0, 0, 10, 10)
-        await display(p0)
-        expect(render.callCount).to.be.equal(1)
+      const p0 = fig([200, 200])
+      p0.image_url([data_url(jpg, "image/jpeg")], 0, 0, 10, 10)
+      await display(p0)
+      expect(render.callCount).to.be.equal(1)
+      render.resetHistory()
 
-        render.resetHistory()
+      const p1 = fig([200, 200])
+      p1.image_url([data_url(png, "image/png")], 0, 0, 10, 10)
+      await display(p1)
+      expect(render.callCount).to.be.equal(1)
+      render.resetHistory()
 
-        const p1 = fig([200, 200])
-        p1.image_url([data_url(png, "image/png")], 0, 0, 10, 10)
-        await display(p1)
-        expect(render.callCount).to.be.equal(1)
+      const url = URL.createObjectURL(new Blob([base64_to_buffer(png)]))
+      const p2 = fig([200, 200])
+      p2.image_url([url], 0, 0, 10, 10)
+      await display(p2)
+      expect(render.callCount).to.be.within(1, 2)
+      render.resetHistory()
 
-        render.resetHistory()
-
-        const url = URL.createObjectURL(new Blob([base64_to_buffer(png)]))
-        const p2 = fig([200, 200])
-        p2.image_url([url], 0, 0, 10, 10)
-        await display(p2)
-        expect(render.callCount).to.be.above(0)
-        expect(render.callCount).to.be.below(3)
-
-        render.resetHistory()
-
-        const p3 = fig([200, 200])
-        p3.image_url(["/assets/images/pattern.png"], 0, 0, 10, 10)
-        await display(p3)
-        expect(render.callCount).to.be.above(0)
-        expect(render.callCount).to.be.below(3)
-      } finally {
-        render.restore()
-      }
+      const p3 = fig([200, 200])
+      p3.image_url(["/assets/images/pattern.png"], 0, 0, 10, 10)
+      await display(p3)
+      expect(render.callCount).to.be.within(1, 2)
+      render.resetHistory()
     })
   })
 

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -124,7 +124,7 @@ function scalar_image(N: number = 100) {
       d[i*N + j] = sin(x[i])*cos(y[j])
     }
   }
-  return ndarray(d, {shape: [N, N]})
+  return ndarray(d, {dtype: "float64", shape: [N, N]})
 }
 
 describe("Bug", () => {

--- a/docs/bokeh/source/docs/releases/3.4.0.rst
+++ b/docs/bokeh/source/docs/releases/3.4.0.rst
@@ -13,3 +13,4 @@ Bokeh version ``3.4.0`` (December 2023) is a minor milestone of Bokeh project.
 * Added support for xor selection mode and selection inversion (only for point selections) to select tools (:bokeh-pull:`13545`)
 * Changed the default selection mode of ``TapTool`` to ``"xor"`` to allow deselect with tap gesture (:bokeh-pull:`13545`)
 * Migrated bokehjs' bundles from ES2017 JavaScript standard to ES2020 (:bokeh-pull:`13565`)
+* Added support for non-visual glyph data property overrides (:bokeh-pull:`13554`)

--- a/docs/bokeh/source/docs/user_guide/styling/plots.rst
+++ b/docs/bokeh/source/docs/user_guide/styling/plots.rst
@@ -228,11 +228,6 @@ If you use the |bokeh.models| interface, use the
                 selection_glyph=selected_circle,
                 nonselection_glyph=nonselected_circle)
 
-.. warning::
-    When rendering, Bokeh considers only the *visual* properties of
-    ``selection_glyph`` and ``nonselection_glyph``. Changing
-    positions, sizes, etc., will have no effect.
-
 .. _ug_styling_plots_hover_inspections:
 
 Hover inspections
@@ -250,10 +245,6 @@ This example uses the first method of passing a color parameter with the
 
 .. bokeh-plot:: __REPO__/examples/styling/plots/glyph_hover.py
     :source-position: above
-
-.. warning::
-    When rendering, Bokeh considers only the *visual* properties of
-    ``hover_glyph``. Changing positions, sizes, etc. will have no effect.
 
 .. _ug_styling_plots_axes:
 

--- a/examples/advanced/extensions/gears/gear.ts
+++ b/examples/advanced/extensions/gears/gear.ts
@@ -17,7 +17,7 @@ export class GearView extends XYGlyphView {
   declare visuals: Gear.Visuals
 
   override _map_data(): void {
-    this.smodule = this.sdist(this.renderer.xscale, this._x, this.module, 'edge')
+    this.smodule = this.sdist(this.renderer.xscale, this.x, this.module, "edge")
   }
 
   _render(ctx: Context2d, indices: number[], data?: Partial<Gear.Data>): void {

--- a/examples/advanced/extensions/gears/gear.ts
+++ b/examples/advanced/extensions/gears/gear.ts
@@ -1,8 +1,8 @@
-import {XYGlyph, XYGlyphView, XYGlyphData} from "@bokehjs/models/glyphs/xy_glyph"
+import {XYGlyph, XYGlyphView} from "@bokehjs/models/glyphs/xy_glyph"
 import {generic_area_vector_legend} from "@bokehjs/models/glyphs/utils"
 import {isString} from "@bokehjs/core/util/types"
 import {Context2d} from "@bokehjs/core/util/canvas"
-import {ScreenArray, Rect} from "@bokehjs/core/types"
+import type {Arrayable, Rect} from "@bokehjs/core/types"
 import {LineVector, FillVector, HatchVector} from "@bokehjs/core/property_mixins"
 import * as visuals from "@bokehjs/core/visuals"
 import * as p from "@bokehjs/core/properties"
@@ -10,18 +10,7 @@ import * as p from "@bokehjs/core/properties"
 import {Draw, gear_tooth, internal_gear_tooth}  from "./gear_utils"
 import {arc_to_bezier} from "./bezier"
 
-export interface GearData extends XYGlyphData {
-  angle: p.Uniform<number>
-  module: p.Uniform<number>
-  pressure_angle: p.Uniform<number>
-  shaft_size: p.Uniform<number>
-  teeth: p.Uniform<number>
-  internal: p.Uniform<boolean>
-
-  smodule: ScreenArray
-}
-
-export interface GearView extends GearData {}
+export interface GearView extends Gear.Data {}
 
 export class GearView extends XYGlyphView {
   declare model: Gear
@@ -31,8 +20,8 @@ export class GearView extends XYGlyphView {
     this.smodule = this.sdist(this.renderer.xscale, this._x, this.module, 'edge')
   }
 
-  _render(ctx: Context2d, indices: number[], data?: GearData): void {
-    const {sx, sy, smodule, angle, teeth, pressure_angle, shaft_size, internal} = data ?? this
+  _render(ctx: Context2d, indices: number[], data?: Partial<Gear.Data>): void {
+    const {sx, sy, smodule, angle, teeth, pressure_angle, shaft_size, internal} = {...this, ...data}
 
     for (const i of indices) {
       const sx_i = sx[i]
@@ -165,6 +154,10 @@ export namespace Gear {
   export type Mixins = LineVector & FillVector & HatchVector
 
   export type Visuals = XYGlyph.Visuals & {line: visuals.LineVector, fill: visuals.FillVector, hatch: visuals.HatchVector}
+
+  export type Data = p.GlyphDataOf<Gear.Props> & {
+    smodule: Arrayable<number>
+  }
 }
 
 export interface Gear extends Gear.Attrs {}

--- a/examples/basic/annotations/scale_bar_image.py
+++ b/examples/basic/annotations/scale_bar_image.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from bokeh.core.properties import value
 from bokeh.io import show
 from bokeh.models import MetricLength, ScaleBar
 from bokeh.plotting import figure
@@ -22,7 +21,7 @@ p.y_range.bounds = (0, 1)
 pollen_png = Path(__file__).parent / "assets" / "pollen.png"
 img = pollen_png.read_bytes()
 
-p.image_url(x=0, y=0, w=1, h=1, url=value(img), anchor="bottom_left")
+p.image_url(x=0, y=0, w=1, h=1, url=[img], anchor="bottom_left")
 
 scale_bar = ScaleBar(
     range=p.x_range,

--- a/src/bokeh/models/glyphs.py
+++ b/src/bokeh/models/glyphs.py
@@ -424,11 +424,11 @@ class Block(LRTBGlyph):
     The y-coordinates of the centers of the blocks.
     """)
 
-    width = NumberSpec(default=1, help="""
+    width = DistanceSpec(default=1, help="""
     The widths of the blocks.
     """)
 
-    height = NumberSpec(default=1, help="""
+    height = DistanceSpec(default=1, help="""
     The heights of the blocks.
     """)
 
@@ -646,7 +646,7 @@ class HBar(LRTBGlyph):
     The y-coordinates of the centers of the horizontal bars.
     """)
 
-    height = NumberSpec(default=1, help="""
+    height = DistanceSpec(default=1, help="""
     The heights of the vertical bars.
     """)
 
@@ -1670,7 +1670,7 @@ class VBar(LRTBGlyph):
     The x-coordinates of the centers of the vertical bars.
     """)
 
-    width = NumberSpec(default=1, help="""
+    width = DistanceSpec(default=1, help="""
     The widths of the vertical bars.
     """)
 

--- a/tests/unit/bokeh/models/test_glyphs.py
+++ b/tests/unit/bokeh/models/test_glyphs.py
@@ -196,7 +196,9 @@ def test_Block() -> None:
         "x",
         "y",
         "width",
+        "width_units",
         "height",
+        "height_units",
         "border_radius",
     ], FILL, HATCH, LINE, GLYPH)
 
@@ -244,6 +246,7 @@ def test_HBar() -> None:
     check_properties_existence(glyph, [
         "y",
         "height",
+        "height_units",
         "left",
         "right",
         "border_radius",
@@ -609,6 +612,7 @@ def test_VBar() -> None:
     check_properties_existence(glyph, [
         "x",
         "width",
+        "width_units",
         "top",
         "bottom",
         "border_radius",


### PR DESCRIPTION
This PR has the following goals:

1. Clean up definitions of data, visual and mapped properties of glyph views (set by `set_data()`, `set_visuals()` and `map_data()`), by removing all definitions that can auto-generated, fixing any issues and bugs along the way.
2. Allow derived glyphs to override non-visual data properties from the base glyph and/or allow derived glyphs to be unrelated to the base glyph, under the assumption that any hit testing, indexing, etc. will still be done only on the base glyph.

Example of a derived hover glyph with 2x the radius:

[Screencast from 28.11.2023 21:38:10.webm](https://github.com/bokeh/bokeh/assets/27475/f3fdb036-0b81-493f-acec-380819b1d234)

and with selection glyph unrelated to the base glyph:

![image](https://github.com/bokeh/bokeh/assets/27475/bfc850a0-b6cb-4291-914c-44262ad3fef8)

Example usage:
```python
import numpy as np

from bokeh.core.properties import field
from bokeh.models import Rect
from bokeh.plotting import figure, show

N = 1000
x = np.random.random(size=N) * 100
y = np.random.random(size=N) * 100
radii = np.random.random(size=N) * 1.5
radii_big = radii * 2
colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")

p = figure()
p.add_tools("hover", "box_select")

gr = p.circle(x, y, radius=radii,
    fill_color=colors, fill_alpha=0.8, line_color=None, hover_fill_alpha=0.5)

gr.hover_glyph.radius = field("radii_big")
gr.data_source.data["radii_big"] = radii_big

gr.selection_glyph = Rect(
    line_color=None,
    fill_color=field("fill_color"),
    width=field("radii_big"),
    height=field("radius"),
)

show(p)
```

fixes #2367