### PR TITLE
avoid Sphinx ThemeError and set Sphinx to a minimum of 7.1.0

### DIFF
--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -38,7 +38,7 @@ dependencies:
   - pip:
     # docs
     - pydata_sphinx_theme
-    - sphinx < 7
+    - sphinx >= 7.1.0
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -68,7 +68,7 @@ dependencies:
     # docs
     - pydata_sphinx_theme
     - requests-unixsocket >= 0.3.0
-    - sphinx
+    - sphinx >= 7.1.0
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -68,7 +68,7 @@ dependencies:
     # docs
     - pydata_sphinx_theme
     - requests-unixsocket >= 0.3.0
-    - sphinx
+    - sphinx >= 7.1.0
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -68,7 +68,7 @@ dependencies:
     # docs
     - pydata_sphinx_theme
     - requests-unixsocket >= 0.3.0
-    - sphinx
+    - sphinx >= 7.1.0
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -68,7 +68,7 @@ dependencies:
     # docs
     - pydata_sphinx_theme
     - requests-unixsocket >= 0.3.0
-    - sphinx
+    - sphinx >= 7.1.0
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -57,7 +57,7 @@ dependencies:
     # docs
     - pydata_sphinx_theme
     - requests-unixsocket >= 0.3.0
-    - sphinx
+    - sphinx >= 7.1.0
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon

--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -164,7 +164,7 @@ html_context = {
     "VERSION": version,
 }
 
-html_css_files = [f"custom.css?v={version}"]
+html_css_files = ["custom.css"]
 
 html_static_path = ["_static"]
 


### PR DESCRIPTION
This change solves a problem in the build of the docs if Sphinx 7.2.0 or newer is used. This also changes the minimum version of SPhinx to 7.1.0

- [x] issues: fixes #13548

@bryevdv I am not sure about the check you were asking for. I created the docs on my local machine and the pages are looking good to me. But I think this is not enough.
