### PR TITLE
Migrate bokehjs' bundles from ES2017 to ES2020

### DIFF
--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -69,7 +69,7 @@ task("scripts:bundle", [passthrough("scripts:compile")], async () => {
     entries: packages.map((pkg) => pkg.main),
     bases: [paths.build_dir.lib, "./node_modules"],
     cache: argv.cache !== false ? join(paths.build_dir.js, "bokeh.json") : undefined,
-    target: "ES2017",
+    target: "ES2020",
     exports: ["tslib"],
     detect_cycles: argv.detectCycles as boolean | undefined,
     overrides: {

--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -346,7 +346,7 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
     cache: join(dist_dir, `${artifact}.json`),
     excluded: (dep) => dep == "tslib" || dep.startsWith("@bokehjs/"),
     plugin: true,
-    target: "ES2017",
+    target: "ES2020",
   })
 
   print("Linking modules")

--- a/bokehjs/src/compiler/compile.ts
+++ b/bokehjs/src/compiler/compile.ts
@@ -21,7 +21,7 @@ export function compile_typescript(base_dir: string, inputs: Inputs, bokehjs_dir
 
   const preconfigure: ts.CompilerOptions = {
     module: ts.ModuleKind.CommonJS,
-    target: ts.ScriptTarget.ES2017,
+    target: ts.ScriptTarget.ES2020,
     paths: {
       "*": [
         join(bokehjs_dir, "js/lib/*"),

--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -436,8 +436,8 @@ export class Linker {
           const ecma = (() => {
             switch (this.target) {
               case "ES2022": return 2020 // TODO: 2022
-              case "ES2020": return 2020
               case null:
+              case "ES2020": return 2020
               case "ES2017": return 2017
               case "ES2015": return 5
             }
@@ -841,8 +841,8 @@ export ${export_type} yaml;
         const target = (() => {
           switch (this.target) {
             case "ES2022": return ES2022
-            case "ES2020": return ES2020
             case null:
+            case "ES2020": return ES2020
             case "ES2017": return ES2017
             case "ES2015": return ES2015
           }

--- a/bokehjs/src/compiler/transforms.ts
+++ b/bokehjs/src/compiler/transforms.ts
@@ -428,7 +428,7 @@ export function wrap_in_function(module_name: string) {
   }
 }
 
-export function parse_es(file: string, code?: string, target: ts.ScriptTarget = ts.ScriptTarget.ES2017): ts.SourceFile {
+export function parse_es(file: string, code?: string, target: ts.ScriptTarget = ts.ScriptTarget.ES2020): ts.SourceFile {
   return ts.createSourceFile(file, code != null ? code : ts.sys.readFile(file)!, target, true, ts.ScriptKind.JS)
 }
 

--- a/bokehjs/test/codebase/size.ts
+++ b/bokehjs/test/codebase/size.ts
@@ -5,7 +5,7 @@ import chalk from "chalk"
 const build_dir = normalize(`${__dirname}/../..`) // build/test/codebase -> build
 
 const LIMITS = new Map([
-  // es2017
+  // es2020
   ["js/bokeh.min.js",                1000],
   ["js/bokeh-widgets.min.js",         350],
   ["js/bokeh-tables.min.js",          350],

--- a/docs/bokeh/source/docs/releases/3.4.0.rst
+++ b/docs/bokeh/source/docs/releases/3.4.0.rst
@@ -12,3 +12,4 @@ Bokeh version ``3.4.0`` (December 2023) is a minor milestone of Bokeh project.
 * Enabled JavaScript's strict mode (``"use strict";``) in bokehjs' bundles (:bokeh-pull:`13523`)
 * Added support for xor selection mode and selection inversion (only for point selections) to select tools (:bokeh-pull:`13545`)
 * Changed the default selection mode of ``TapTool`` to ``"xor"`` to allow deselect with tap gesture (:bokeh-pull:`13545`)
+* Migrated bokehjs' bundles from ES2017 JavaScript standard to ES2020 (:bokeh-pull:`13565`)


### PR DESCRIPTION
This allows to use more modern and compact syntax in the bundles, which results in smaller binaries and faster load times. I verified that any browsers that don't support ES2020 wouldn't work with bokehjs anyway, so this should be a non-breaking change.