### PR TITLE
Added metadata to position_toolbar.py, position_toolbar_clash.py, and toolbar_autohide.py

### DIFF
--- a/examples/interaction/tools/position_toolbar.py
+++ b/examples/interaction/tools/position_toolbar.py
@@ -1,7 +1,5 @@
-''' A basic scatter plot with the toolbar positioned below the plot,
-outside of the axes, titles, etc.
-This example shows a way to set the toolbar's location relative to the plot,
-outside of the axes, titles, etc.
+''' This example demonstrates a basic scatter plot with the toolbar
+positioned below the plot, outside of the axes, titles, etc.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.toolbar_location, bokeh.plotting.figure.toolbar_sticky, bokeh.plotting.figure.scatter, bokeh.plotting.show

--- a/examples/interaction/tools/position_toolbar.py
+++ b/examples/interaction/tools/position_toolbar.py
@@ -1,4 +1,4 @@
-''' A basic scatter plot with the toolbar positioned above the plot,
+''' A basic scatter plot with the toolbar positioned below the plot,
 outside of the axes, titles, etc.
 This example shows a way to set the toolbar's location relative to the plot,
 outside of the axes, titles, etc.
@@ -12,7 +12,7 @@ outside of the axes, titles, etc.
 from bokeh.plotting import figure, show
 
 p = figure(width=400, height=400,
-           title='Toolbar Location & Sticky Off', toolbar_location="above",
+           title=None, toolbar_location="below",
            toolbar_sticky=False)
 
 p.scatter([1, 2, 3, 4, 5], [2, 5, 8, 2, 7], size=10)

--- a/examples/interaction/tools/position_toolbar.py
+++ b/examples/interaction/tools/position_toolbar.py
@@ -1,3 +1,12 @@
+''' A basic scatter plot with the toolbar positioned below the plot outside of the axes, titles, etc.
+This example demonstrates a way to set the toolbar's location relative to the plot outside of the axes, titles, etc.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.toolbar_location, bokeh.plotting.figure.toolbar_sticky, bokeh.plotting.figure.scatter, bokeh.plotting.show
+    :refs: :ref:`_ug_interaction_tools_toolbar`
+    :keywords: position, location, sticky, toolbar
+'''
+
 from bokeh.plotting import figure, show
 
 p = figure(width=400, height=400,

--- a/examples/interaction/tools/position_toolbar.py
+++ b/examples/interaction/tools/position_toolbar.py
@@ -1,5 +1,7 @@
-''' A basic scatter plot with the toolbar positioned above the plot outside of the axes, titles, etc.
-This example demonstrates a way to set the toolbar's location relative to the plot outside of the axes, titles, etc.
+''' A basic scatter plot with the toolbar positioned above the plot, 
+outside of the axes, titles, etc.
+This example shows a way to set the toolbar's location relative to the plot, 
+outside of the axes, titles, etc.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.toolbar_location, bokeh.plotting.figure.toolbar_sticky, bokeh.plotting.figure.scatter, bokeh.plotting.show

--- a/examples/interaction/tools/position_toolbar.py
+++ b/examples/interaction/tools/position_toolbar.py
@@ -5,7 +5,7 @@ outside of the axes, titles, etc.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.toolbar_location, bokeh.plotting.figure.toolbar_sticky, bokeh.plotting.figure.scatter, bokeh.plotting.show
-    :refs: :ref:`_ug_interaction_tools_toolbar`
+    :refs: :ref:`ug_interaction_tools_toolbar`
     :keywords: position, location, sticky, toolbar
 '''
 

--- a/examples/interaction/tools/position_toolbar.py
+++ b/examples/interaction/tools/position_toolbar.py
@@ -1,4 +1,4 @@
-''' A basic scatter plot with the toolbar positioned below the plot outside of the axes, titles, etc.
+''' A basic scatter plot with the toolbar positioned above the plot outside of the axes, titles, etc.
 This example demonstrates a way to set the toolbar's location relative to the plot outside of the axes, titles, etc.
 
 .. bokeh-example-metadata::
@@ -10,7 +10,7 @@ This example demonstrates a way to set the toolbar's location relative to the pl
 from bokeh.plotting import figure, show
 
 p = figure(width=400, height=400,
-           title=None, toolbar_location="below",
+           title='Toolbar Location & Sticky Off', toolbar_location="above",
            toolbar_sticky=False)
 
 p.scatter([1, 2, 3, 4, 5], [2, 5, 8, 2, 7], size=10)

--- a/examples/interaction/tools/position_toolbar.py
+++ b/examples/interaction/tools/position_toolbar.py
@@ -1,6 +1,6 @@
-''' A basic scatter plot with the toolbar positioned above the plot, 
+''' A basic scatter plot with the toolbar positioned above the plot,
 outside of the axes, titles, etc.
-This example shows a way to set the toolbar's location relative to the plot, 
+This example shows a way to set the toolbar's location relative to the plot,
 outside of the axes, titles, etc.
 
 .. bokeh-example-metadata::

--- a/examples/interaction/tools/position_toolbar_clash.py
+++ b/examples/interaction/tools/position_toolbar_clash.py
@@ -1,4 +1,4 @@
-''' A basic scatter plot with the toolbar positioned above the plot.
+''' A basic scatter plot with the toolbar positioned below the plot.
 This example demonstrates a way to set the toolbar's location relative
 to the edge of the plot.
 
@@ -11,7 +11,7 @@ to the edge of the plot.
 from bokeh.plotting import figure, show
 
 p = figure(width=400, height=400,
-           title='Toolbar Location', toolbar_location="above")
+           title=None, toolbar_location="below")
 
 p.scatter([1, 2, 3, 4, 5], [2, 5, 8, 2, 7], size=10)
 

--- a/examples/interaction/tools/position_toolbar_clash.py
+++ b/examples/interaction/tools/position_toolbar_clash.py
@@ -1,5 +1,6 @@
 ''' A basic scatter plot with the toolbar positioned above the plot.
-This example demonstrates a way to set the toolbar's location relative to the edge of the plot.
+This example demonstrates a way to set the toolbar's location relative 
+to the edge of the plot.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.toolbar_location, bokeh.plotting.figure.scatter, bokeh.plotting.show

--- a/examples/interaction/tools/position_toolbar_clash.py
+++ b/examples/interaction/tools/position_toolbar_clash.py
@@ -1,4 +1,4 @@
-''' A basic scatter plot with the toolbar positioned below the plot.
+''' A basic scatter plot with the toolbar positioned above the plot.
 This example demonstrates a way to set the toolbar's location relative to the edge of the plot.
 
 .. bokeh-example-metadata::
@@ -10,7 +10,7 @@ This example demonstrates a way to set the toolbar's location relative to the ed
 from bokeh.plotting import figure, show
 
 p = figure(width=400, height=400,
-           title=None, toolbar_location="below")
+           title='Toolbar Location', toolbar_location="above")
 
 p.scatter([1, 2, 3, 4, 5], [2, 5, 8, 2, 7], size=10)
 

--- a/examples/interaction/tools/position_toolbar_clash.py
+++ b/examples/interaction/tools/position_toolbar_clash.py
@@ -1,5 +1,5 @@
 ''' A basic scatter plot with the toolbar positioned above the plot.
-This example demonstrates a way to set the toolbar's location relative 
+This example demonstrates a way to set the toolbar's location relative
 to the edge of the plot.
 
 .. bokeh-example-metadata::

--- a/examples/interaction/tools/position_toolbar_clash.py
+++ b/examples/interaction/tools/position_toolbar_clash.py
@@ -4,7 +4,7 @@ to the edge of the plot.
 
 .. bokeh-example-metadata::
     :apis: bokeh.plotting.figure.toolbar_location, bokeh.plotting.figure.scatter, bokeh.plotting.show
-    :refs: :ref:`_ug_interaction_tools_toolbar`
+    :refs: :ref:`ug_interaction_tools_toolbar`
     :keywords: position, location, toolbar
 '''
 

--- a/examples/interaction/tools/position_toolbar_clash.py
+++ b/examples/interaction/tools/position_toolbar_clash.py
@@ -1,3 +1,12 @@
+''' A basic scatter plot with the toolbar positioned below the plot.
+This example demonstrates a way to set the toolbar's location relative to the edge of the plot.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.plotting.figure.toolbar_location, bokeh.plotting.figure.scatter, bokeh.plotting.show
+    :refs: :ref:`_ug_interaction_tools_toolbar`
+    :keywords: position, location, toolbar
+'''
+
 from bokeh.plotting import figure, show
 
 p = figure(width=400, height=400,

--- a/examples/interaction/tools/toolbar_autohide.py
+++ b/examples/interaction/tools/toolbar_autohide.py
@@ -1,5 +1,5 @@
 ''' A basic line plot with the toolbar set to autohide.
-This example demonstrates a way to hide the toolbar when 
+This example demonstrates a way to hide the toolbar when
 the cursor is outside the plot.
 
 .. bokeh-example-metadata::

--- a/examples/interaction/tools/toolbar_autohide.py
+++ b/examples/interaction/tools/toolbar_autohide.py
@@ -4,7 +4,7 @@ the cursor is outside the plot.
 
 .. bokeh-example-metadata::
     :apis: bokeh.models.Toolbar.autohide, bokeh.plotting.figure.line, bokeh.plotting.show
-    :refs: :ref:`_ug_interaction_tools_autohide`
+    :refs: :ref:`ug_interaction_tools_autohide`
     :keywords: autohide, toolbar
 '''
 

--- a/examples/interaction/tools/toolbar_autohide.py
+++ b/examples/interaction/tools/toolbar_autohide.py
@@ -1,3 +1,12 @@
+''' A basic line plot with the toolbar set to autohide.
+This example demonstrates a way to hide the toolbar when the cursor is outside the plot.
+
+.. bokeh-example-metadata::
+    :apis: bokeh.models.Toolbar.autohide, bokeh.plotting.figure.line, bokeh.plotting.show
+    :refs: :ref:`_ug_interaction_tools_autohide`
+    :keywords: autohide, toolbar
+'''
+
 from bokeh.plotting import figure, show
 
 # Basic plot setup

--- a/examples/interaction/tools/toolbar_autohide.py
+++ b/examples/interaction/tools/toolbar_autohide.py
@@ -1,5 +1,6 @@
 ''' A basic line plot with the toolbar set to autohide.
-This example demonstrates a way to hide the toolbar when the cursor is outside the plot.
+This example demonstrates a way to hide the toolbar when 
+the cursor is outside the plot.
 
 .. bokeh-example-metadata::
     :apis: bokeh.models.Toolbar.autohide, bokeh.plotting.figure.line, bokeh.plotting.show


### PR DESCRIPTION
I added metadata to the following examples:
- `examples/interaction/tools/toolbar_autohide.py`
- `examples/interaction/tools/position_toolbar_clash.py`
- `examples/interaction/tools/position_toolbar.py`

- [x] issues: fixes #11765 

I also made minor edits to `position_toolbar_clash.py` and `position_toolbar.py` to clearly show difference when `toolbar_sticky` is set to False. However, this does not fix any issues. Please let me know if you want me to revert the changes.

**Before the change:**
position_toolbar.html:
![image](https://github.com/bokeh/bokeh/assets/64668622/3edbef2b-2442-4026-878a-fe4191710b50)
position_toolbar_clash.html:
![image](https://github.com/bokeh/bokeh/assets/64668622/db0ffa7c-f469-462c-af66-1ee42ff10025)

**After the change:**
position_toolbar.html
![image](https://github.com/bokeh/bokeh/assets/64668622/dfa40ea7-cd10-452d-b6ea-af983c47a603)
position_toolbar_clash.html:
![image](https://github.com/bokeh/bokeh/assets/64668622/f8b0b4ee-c924-42b9-af1b-dedb1b91f006)
