### PR TITLE
Added push_session to serve.py

### DIFF
--- a/examples/output/apis/server_session/serve.py
+++ b/examples/output/apis/server_session/serve.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template
 
-from bokeh.client import pull_session
+from bokeh.client import pull_session, push_session
 from bokeh.embed import server_session
 
 app_url = "http://localhost:5100/bokeh_app"
@@ -16,9 +16,12 @@ def bkapp_page():
         # update or customize that session
         session.document.roots[0].title.text = "Special Plot Title For A Specific User!"
 
+        # overwrite the document in current session
+        push_session(session_id=session.id, document=session.document, url=app_url)
+
         # generate a script to load the customized session
         script = server_session(session_id=session.id, url=app_url)
-
+        
         # use the script in the rendered page
         return render_template("embed.html", script=script, template="Flask")
 

--- a/examples/output/apis/server_session/serve.py
+++ b/examples/output/apis/server_session/serve.py
@@ -21,7 +21,7 @@ def bkapp_page():
 
         # generate a script to load the customized session
         script = server_session(session_id=session.id, url=app_url)
-        
+
         # use the script in the rendered page
         return render_template("embed.html", script=script, template="Flask")
 

--- a/examples/output/apis/server_session/serve.py
+++ b/examples/output/apis/server_session/serve.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template
 
-from bokeh.client import pull_session, push_session
+from bokeh.client import pull_session
 from bokeh.embed import server_session
 
 app_url = "http://localhost:5100/bokeh_app"

--- a/examples/output/apis/server_session/serve.py
+++ b/examples/output/apis/server_session/serve.py
@@ -16,8 +16,8 @@ def bkapp_page():
         # update or customize that session
         session.document.roots[0].title.text = "Special Plot Title For A Specific User!"
 
-        # overwrite the document in current session
-        push_session(session_id=session.id, document=session.document, url=app_url)
+        # push the changes in document to the current session
+        session.push()
 
         # generate a script to load the customized session
         script = server_session(session_id=session.id, url=app_url)


### PR DESCRIPTION
I added `push_session` function in `bokeh/examples/output/apis/server_session/serve.py` to update the plot title in `server_session` example.

This function has to be called to update the document in Bokeh session and retrieve the correct script in the following line:
https://github.com/bokeh/bokeh/blob/cb2de9ea4b92e54f2fe4b3b4a460c6d49c762f53/examples/output/apis/server_session/serve.py#L20

With the change, I get the expected result with the updated title:
![image](https://github.com/bokeh/bokeh/assets/64668622/cc9e04e7-e4c8-4c6e-ae40-f4e8c5ac7bb0)

- [ ] issues: fixes #13172 
