### PR TITLE
Fix selections being out of sync after filtering a data table

### DIFF
--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -12,6 +12,7 @@ import {dict} from "core/util/object"
 import {unique_id} from "core/util/string"
 import {isString, isNumber, is_defined} from "core/util/types"
 import {some, range, sort_by, map} from "core/util/array"
+import {filter} from "core/util/arrayable"
 import {is_NDArray} from "core/util/ndarray"
 import {logger} from "core/logging"
 import type {DOMBoxSizing} from "../../layouts/layout_dom"
@@ -463,24 +464,22 @@ export class DataTableView extends WidgetView {
     return this.grid.getSelectedRows()
   }
 
-  _sync_selected_with_view(): void {
-    const notFiltered = [...this.data.source.selected.indices].filter((element) =>
-      this.data.index.includes(element))
+  protected _sync_selected_with_view(): void {
+    const {index, source} = this.data
 
-    const wasFiltered = this._filtered_selection.filter((element) =>
-      this.data.index.includes(element))
+    const not_filtered = filter(source.selected.indices, (item) => index.includes(item))
+    const was_filtered = filter(this._filtered_selection, (item) => index.includes(item))
 
-    this._filtered_selection=this._filtered_selection.filter((element)=>
-      !wasFiltered.includes(element))
+    this._filtered_selection = [
+      ...filter(this._filtered_selection, (item) => !was_filtered.includes(item)),
+      ...filter(source.selected.indices, (item) => !index.includes(item)),
+    ]
 
-    this._filtered_selection.push(
-      ...[...this.data.source.selected.indices].filter(
-        (element) => !this.data.index.includes(element),
-      ))
-
-    this.data.source.selected.indices = [...wasFiltered, ...notFiltered]
+    source.selected.indices = [
+      ...was_filtered,
+      ...not_filtered,
+    ]
   }
-
 }
 
 export namespace DataTable {

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -153,6 +153,8 @@ export class DataTableView extends WidgetView {
   protected _in_selection_update = false
   protected _width: number | null = null
 
+  private _filtered_selection: number[] = []
+
   get data_source(): p.Property<ColumnarDataSource> {
     return this.model.properties.source
   }
@@ -252,6 +254,8 @@ export class DataTableView extends WidgetView {
 
       this.data.sort(sorters)
     }
+    this._sync_selected_with_view()
+    this.updateSelection()
     this.grid.invalidate()
     this.updateLayout(true, true)
   }
@@ -458,6 +462,22 @@ export class DataTableView extends WidgetView {
   get_selected_rows(): number[] {
     return this.grid.getSelectedRows()
   }
+
+  _sync_selected_with_view(): void {
+    const notFiltered = [...this.data.source.selected.indices].filter((element) =>
+      this.data.index.includes(element),
+    )
+    const wasFiltered = this._filtered_selection.filter((element) =>
+      this.data.index.includes(element),
+    )
+    this._filtered_selection.push(
+      ...[...this.data.source.selected.indices].filter(
+        (element) => !this.data.index.includes(element),
+      ),
+    )
+    this.data.source.selected.indices = [...wasFiltered, ...notFiltered]
+  }
+
 }
 
 export namespace DataTable {

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -465,14 +465,15 @@ export class DataTableView extends WidgetView {
   }
 
   protected _sync_selected_with_view(): void {
-    const {index, source} = this.data
+    const index = this.data.view.indices
+    const {source} = this.data
 
-    const not_filtered = filter(source.selected.indices, (item) => index.includes(item))
-    const was_filtered = filter(this._filtered_selection, (item) => index.includes(item))
+    const not_filtered = filter(source.selected.indices, (i) => index.get(i))
+    const was_filtered = new Set(filter(this._filtered_selection, (i) => index.get(i)))
 
     this._filtered_selection = [
-      ...filter(this._filtered_selection, (item) => !was_filtered.includes(item)),
-      ...filter(source.selected.indices, (item) => !index.includes(item)),
+      ...filter(this._filtered_selection, (i) => !was_filtered.has(i)),
+      ...filter(source.selected.indices, (i) => !index.get(i)),
     ]
 
     source.selected.indices = [

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -465,16 +465,19 @@ export class DataTableView extends WidgetView {
 
   _sync_selected_with_view(): void {
     const notFiltered = [...this.data.source.selected.indices].filter((element) =>
-      this.data.index.includes(element),
-    )
+      this.data.index.includes(element))
+
     const wasFiltered = this._filtered_selection.filter((element) =>
-      this.data.index.includes(element),
-    )
+      this.data.index.includes(element))
+
+    this._filtered_selection=this._filtered_selection.filter((element)=>
+      !wasFiltered.includes(element))
+
     this._filtered_selection.push(
       ...[...this.data.source.selected.indices].filter(
         (element) => !this.data.index.includes(element),
-      ),
-    )
+      ))
+
     this.data.source.selected.indices = [...wasFiltered, ...notFiltered]
   }
 

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -1516,29 +1516,33 @@ describe("Bug", () => {
         new TableColumn({field: "y", title: "y", width: 50}),
       ]
       const filter = new AllIndices()
-      const CDSview = new CDSView({filter})
+      const cds_view = new CDSView({filter})
 
-      const table = new DataTable({source, columns, selectable: "checkbox", view: CDSview, width: 300, height: 400})
+      const table = new DataTable({source, columns, selectable: "checkbox", view: cds_view, width: 300, height: 400})
       const {view} = await display(table, [350, 450])
 
       await view.ready
 
       const checkbox1 = view.shadow_el.querySelectorAll(".slick-cell.l1.r1.bk-cell-select")[2]
-      await mouse_click(checkbox1.querySelector('input[type="checkbox"]')!)
+      const checkbox1_el = checkbox1.querySelector('input[type="checkbox"]')
+      expect_not_null(checkbox1_el)
+      await mouse_click(checkbox1_el)
       expect(view.get_selected_rows()).to.be.equal([2])
       expect(table.source.selected.indices).to.be.equal([2])
 
-      table.view.filter=new IndexFilter({indices: [0, 1]})
+      table.view.filter = new IndexFilter({indices: [0, 1]})
 
       expect(view.get_selected_rows()).to.be.equal([])
       expect(table.source.selected.indices).to.be.equal([])
 
       const checkbox2 = view.shadow_el.querySelectorAll(".slick-cell.l1.r1.bk-cell-select")[0]
-      await mouse_click(checkbox2.querySelector('input[type="checkbox"]')!)
+      const checkbox2_el = checkbox2.querySelector('input[type="checkbox"]')
+      expect_not_null(checkbox2_el)
+      await mouse_click(checkbox2_el)
       expect(view.get_selected_rows()).to.be.equal([0])
       expect(table.source.selected.indices).to.be.equal([0])
 
-      table.view.filter=new IndexFilter({indices: [0, 1, 2]})
+      table.view.filter = new IndexFilter({indices: [0, 1, 2]})
 
       expect(view.get_selected_rows().slice().sort()).to.be.equal([0, 2].sort())
       expect(table.source.selected.indices.slice().sort()).to.be.equal([0, 2].sort())

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -2,9 +2,10 @@ import sinon from "sinon"
 
 import {expect, expect_instanceof, expect_not_null} from "assertions"
 import {display, fig, restorable} from "./_util"
-import {PlotActions, actions, xy, line, tap} from "../interactive"
+import {PlotActions, actions, xy, line, tap, mouse_click} from "../interactive"
 
 import {
+  AllIndices,
   BooleanFilter,
   BoxAnnotation,
   BoxEditTool,
@@ -19,6 +20,7 @@ import {
   DataRange1d,
   GlyphRenderer,
   HoverTool,
+  IndexFilter,
   Legend,
   LegendItem,
   Line,
@@ -74,7 +76,7 @@ import {UIElement, UIElementView} from "@bokehjs/models/ui/ui_element"
 import type {GlyphRendererView} from "@bokehjs/models/renderers/glyph_renderer"
 import {ImageURLView} from "@bokehjs/models/glyphs/image_url"
 import {CopyToolView} from "@bokehjs/models/tools/actions/copy_tool"
-import {TableDataProvider} from "@bokehjs/models/widgets/tables/data_table"
+import {TableDataProvider, DataTable} from "@bokehjs/models/widgets/tables/data_table"
 import {TableColumn} from "@bokehjs/models/widgets/tables/table_column"
 import {DTINDEX_NAME} from "@bokehjs/models/widgets/tables/definitions"
 import {Spinner} from "@bokehjs/models/widgets"
@@ -1495,6 +1497,51 @@ describe("Bug", () => {
       await view.ready
 
       expect(updates.target && updates.range).to.be.true
+    })
+  })
+
+  describe("in issue #13536", () => {
+    it("doesn't allow selected rows to sync correctly when rows are filtered", async () => {
+      const source = new ColumnDataSource({
+        data: {
+          index: [0, 1, 2],
+          x: [1, 2, 3],
+          y: ["a", "b", "c"],
+        },
+      })
+
+      const columns = [
+        new TableColumn({field: "index", title: "#", width: 50}),
+        new TableColumn({field: "x", title: "x", width: 50}),
+        new TableColumn({field: "y", title: "y", width: 50}),
+      ]
+      const filter = new AllIndices()
+      const CDSview = new CDSView({filter})
+
+      const table = new DataTable({source, columns, selectable: "checkbox", view: CDSview, width: 300, height: 400})
+      const {view} = await display(table, [350, 450])
+
+      await view.ready
+
+      const checkbox1 = view.shadow_el.querySelectorAll(".slick-cell.l1.r1.bk-cell-select")[2]
+      await mouse_click(checkbox1.querySelector('input[type="checkbox"]')!)
+      expect(view.get_selected_rows()).to.be.equal([2])
+      expect(table.source.selected.indices).to.be.equal([2])
+
+      table.view.filter=new IndexFilter({indices: [0, 1]})
+
+      expect(view.get_selected_rows()).to.be.equal([])
+      expect(table.source.selected.indices).to.be.equal([])
+
+      const checkbox2 = view.shadow_el.querySelectorAll(".slick-cell.l1.r1.bk-cell-select")[0]
+      await mouse_click(checkbox2.querySelector('input[type="checkbox"]')!)
+      expect(view.get_selected_rows()).to.be.equal([0])
+      expect(table.source.selected.indices).to.be.equal([0])
+
+      table.view.filter=new IndexFilter({indices: [0, 1, 2]})
+
+      expect(view.get_selected_rows().slice().sort()).to.be.equal([0, 2].sort())
+      expect(table.source.selected.indices.slice().sort()).to.be.equal([0, 2].sort())
     })
   })
 })


### PR DESCRIPTION
Added a member that remembers the selected rows that were filtered so the selection state is preserved if they are unfiltered back
Added a function that syncs the selected indices with the view in-case updategrid is called (in-case of filtering) to avoid out of bounds access
Added a regression test for the bug

- [x] issues: fixes #13536 


