### PR TITLE
Link sub-coordinate and context dependent ranges in `RangesUpdate`

### DIFF
--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -4,6 +4,7 @@ import {Canvas} from "../canvas/canvas"
 import type {Renderer} from "../renderers/renderer"
 import {RendererView} from "../renderers/renderer"
 import type {DataRenderer} from "../renderers/data_renderer"
+import type {Range} from "../ranges/range"
 import type {Tool} from "../tools/tool"
 import {ToolProxy} from "../tools/tool_proxy"
 import type {Selection} from "../selections/selection"
@@ -599,13 +600,21 @@ export class PlotView extends LayoutDOMView implements Renderable {
     this.trigger_ranges_update_event()
   }
 
-  trigger_ranges_update_event(): void {
-    const {x_range, y_range} = this.model
-    const linked_plots = new Set([...x_range.plots, ...y_range.plots])
+  trigger_ranges_update_event(extra_ranges: Range[] = []): void {
+    /**
+     * Emits `RangesUpdate` event on all plots linked by all
+     * ranges managed by this plot's range manager and linked
+     * by additional context dependent ranges (`extra_ranges`).
+     */
+    const {x_ranges, y_ranges} = this._range_manager.ranges()
+    const ranges = [...x_ranges, ...y_ranges, ...extra_ranges]
+
+    const linked_plots = new Set(ranges.flatMap((r) => [...r.plots]))
 
     for (const plot_view of linked_plots) {
       const {x_range, y_range} = plot_view.model
-      plot_view.model.trigger_event(new RangesUpdate(x_range.start, x_range.end, y_range.start, y_range.end))
+      const event = new RangesUpdate(x_range.start, x_range.end, y_range.start, y_range.end)
+      plot_view.model.trigger_event(event)
     }
   }
 

--- a/bokehjs/src/lib/models/plots/range_manager.ts
+++ b/bokehjs/src/lib/models/plots/range_manager.ts
@@ -43,20 +43,37 @@ export class RangeManager {
     this._update_ranges_individually(range_state, options)
   }
 
-  reset(): void {
-    const {x_ranges, y_ranges} = this.frame
-    for (const range of x_ranges.values()) {
-      range.reset()
+  ranges(): {x_ranges: Range[], y_ranges: Range[]} {
+    const x_ranges = new Set<Range>()
+    const y_ranges = new Set<Range>()
+
+    for (const range of this.frame.x_ranges.values()) {
+      x_ranges.add(range)
     }
-    for (const range of y_ranges.values()) {
-      range.reset()
+    for (const range of this.frame.y_ranges.values()) {
+      y_ranges.add(range)
     }
     for (const renderer of this.parent.model.data_renderers) {
       const {coordinates} = renderer
       if (coordinates != null) {
-        coordinates.x_source.reset()
-        coordinates.y_source.reset()
+        x_ranges.add(coordinates.x_source)
+        y_ranges.add(coordinates.y_source)
       }
+    }
+
+    return {
+      x_ranges: [...x_ranges],
+      y_ranges: [...y_ranges],
+    }
+  }
+
+  reset(): void {
+    const {x_ranges, y_ranges} = this.ranges()
+    for (const range of x_ranges) {
+      range.reset()
+    }
+    for (const range of y_ranges) {
+      range.reset()
     }
     this.update_dataranges()
   }

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -2,9 +2,10 @@ import {Tool, ToolView} from "../tool"
 import {OnOffButton} from "../on_off_button"
 import type {PlotView} from "../../plots/plot"
 import {BoxAnnotation} from "../../annotations/box_annotation"
-import {Range1d} from "../../ranges/range1d"
+import {Range} from "../../ranges/range"
 import {logger} from "core/logging"
 import type * as p from "core/properties"
+import {non_null} from "core/util/types"
 import {tool_icon_range} from "styles/icons.css"
 import {Node} from "../../coordinates/node"
 
@@ -24,16 +25,19 @@ export class RangeToolView extends ToolView {
   override connect_signals(): void {
     super.connect_signals()
 
-    if (this.model.x_range != null)
+    if (this.model.x_range != null) {
       this.connect(this.model.x_range.change, () => this.model.update_overlay_from_ranges())
-    if (this.model.y_range != null)
+    }
+    if (this.model.y_range != null) {
       this.connect(this.model.y_range.change, () => this.model.update_overlay_from_ranges())
+    }
 
     this.model.overlay.pan.connect(([state, _]) => {
       if (state == "pan") {
         this.model.update_ranges_from_overlay()
       } else if (state == "pan:end") {
-        this.parent.trigger_ranges_update_event()
+        const ranges = [this.model.x_range, this.model.y_range].filter(non_null)
+        this.parent.trigger_ranges_update_event(ranges)
       }
     })
 
@@ -72,8 +76,8 @@ export namespace RangeTool {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Tool.Props & {
-    x_range: p.Property<Range1d | null>
-    y_range: p.Property<Range1d | null>
+    x_range: p.Property<Range | null>
+    y_range: p.Property<Range | null>
     x_interaction: p.Property<boolean>
     y_interaction: p.Property<boolean>
     overlay: p.Property<BoxAnnotation>
@@ -94,8 +98,8 @@ export class RangeTool extends Tool {
     this.prototype.default_view = RangeToolView
 
     this.define<RangeTool.Props>(({Boolean, Ref, Nullable}) => ({
-      x_range:       [ Nullable(Ref(Range1d)), null ],
-      y_range:       [ Nullable(Ref(Range1d)), null ],
+      x_range:       [ Nullable(Ref(Range)), null ],
+      y_range:       [ Nullable(Ref(Range)), null ],
       x_interaction: [ Boolean, true ],
       y_interaction: [ Boolean, true ],
       overlay:       [ Ref(BoxAnnotation), DEFAULT_RANGE_OVERLAY ],

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -113,7 +113,7 @@ from .glyphs import (
     VStrip,
     XYGlyph,
 )
-from .ranges import Range1d
+from .ranges import Range
 from .renderers import DataRenderer, GlyphRenderer
 from .ui import UIElement
 
@@ -476,12 +476,12 @@ class RangeTool(Tool):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    x_range = Nullable(Instance(Range1d), help="""
+    x_range = Nullable(Instance(Range), help="""
     A range synchronized to the x-dimension of the overlay. If None, the overlay
     will span the entire x-dimension.
     """)
 
-    y_range = Nullable(Instance(Range1d), help="""
+    y_range = Nullable(Instance(Range), help="""
     A range synchronized to the y-dimension of the overlay. If None, the overlay
     will span the entire y-dimension.
     """)


### PR DESCRIPTION
This PR allows `PlotView.trigger_ranges_update_event()` to also consider sub-coordinate and other context dependent ranges. For example, when two plots are indirectly linked by a `RangeTool`, then previously `RangesUpdate` would only trigger on the plot  that owns the `RangeTool`, but not on the plot manipulated by the tool. Indirect linking means that plots don't share any ranges.

fixes #13507