### PR TITLE
Relativize imports paths also in type declaration files (`*.d.ts`)

### DIFF
--- a/bokehjs/src/compiler/transforms.ts
+++ b/bokehjs/src/compiler/transforms.ts
@@ -59,6 +59,12 @@ export function relativize_modules(relativize: (file: string, module_path: strin
               const {expression, typeArguments} = node
               return factory.updateCallExpression(node, expression, typeArguments, [moduleSpecifier])
             }
+          } else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
+            const literal = relativize_specifier(context, root, node.argument.literal)
+            if (literal != null) {
+              const argument = factory.updateLiteralTypeNode(node.argument, literal)
+              return factory.updateImportTypeNode(node, argument, node.attributes, node.qualifier, node.typeArguments, node.isTypeOf)
+            }
           }
 
           return ts.visitEachChild(node, visit, context)

--- a/bokehjs/src/lib/document/defs.ts
+++ b/bokehjs/src/lib/document/defs.ts
@@ -1,5 +1,5 @@
 import {Model} from "../model"
-import * as kinds from "../core/kinds"
+import * as kinds from "core/kinds"
 import type {HasProps} from "core/has_props"
 import type {AnyVal} from "core/serialization"
 import type {Deserializer} from "core/serialization/deserializer"

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -14,7 +14,7 @@ import type {PanEvent, PinchEvent, Pannable, Pinchable, MoveEvent, Moveable, Key
 import {Signal} from "core/signaling"
 import type {Rect} from "core/types"
 import {assert} from "core/util/assert"
-import {Enum, Number, Nullable, Ref, Or} from "../../core/kinds"
+import {Enum, Number, Nullable, Ref, Or} from "core/kinds"
 import {BorderRadius} from "../common/kinds"
 import {round_rect} from "../common/painting"
 import * as resolve from "../common/resolve"

--- a/bokehjs/src/lib/models/annotations/scale_bar.ts
+++ b/bokehjs/src/lib/models/annotations/scale_bar.ts
@@ -26,7 +26,7 @@ import {clamp} from "core/util/math"
 import {assert} from "core/util/assert"
 import {enumerate} from "core/util/iterator"
 import {process_placeholders, sprintf} from "core/util/templating"
-import {Enum} from "../../core/kinds"
+import {Enum} from "core/kinds"
 
 const {round} = Math
 

--- a/bokehjs/src/lib/models/common/kinds.ts
+++ b/bokehjs/src/lib/models/common/kinds.ts
@@ -1,4 +1,4 @@
-import type {Kind, Constructor} from "../../core/kinds"
+import type {Kind, Constructor} from "core/kinds"
 import {
   Array,
   Auto,
@@ -13,7 +13,7 @@ import {
   Ref,
   String,
   Tuple,
-} from "../../core/kinds"
+} from "core/kinds"
 import type {HasProps} from "core/has_props"
 import * as enums from "core/enums"
 

--- a/bokehjs/src/lib/models/coordinates/node.ts
+++ b/bokehjs/src/lib/models/coordinates/node.ts
@@ -1,7 +1,7 @@
 import {Coordinate} from "./coordinate"
 import {Model} from "../../model"
 import type * as p from "core/properties"
-import {Enum, Or, Ref} from "../../core/kinds"
+import {Enum, Or, Ref} from "core/kinds"
 
 export const ImplicitTarget = Enum("canvas", "plot", "frame", "parent")
 export type ImplicitTarget = typeof ImplicitTarget["__type__"]

--- a/bokehjs/src/lib/models/dom/html.ts
+++ b/bokehjs/src/lib/models/dom/html.ts
@@ -6,7 +6,7 @@ import {empty, span} from "core/dom"
 import {assert} from "core/util/assert"
 import {isString, isArray} from "core/util/types"
 import type * as p from "core/properties"
-import {String, Ref, Or} from "../../core/kinds"
+import {String, Ref, Or} from "core/kinds"
 
 const HTMLRef = Or(Ref(DOMNode), Ref(UIElement))
 type HTMLRef = typeof HTMLRef["__type__"]

--- a/bokehjs/src/lib/models/layouts/hbox.ts
+++ b/bokehjs/src/lib/models/layouts/hbox.ts
@@ -1,7 +1,7 @@
 import {CSSGridBox, CSSGridBoxView} from "./css_grid_box"
 import {TracksSizing, Index, Span} from "../common/kinds"
 import {UIElement} from "../ui/ui_element"
-import {Struct, Ref, Opt} from "../../core/kinds"
+import {Struct, Ref, Opt} from "core/kinds"
 import type * as p from "core/properties"
 
 type HBoxChild = {child: UIElement, col?: number, span?: number} // XXX: can't infere ?

--- a/bokehjs/src/lib/models/layouts/vbox.ts
+++ b/bokehjs/src/lib/models/layouts/vbox.ts
@@ -1,7 +1,7 @@
 import {CSSGridBox, CSSGridBoxView} from "./css_grid_box"
 import {TracksSizing, Index, Span} from "../common/kinds"
 import {UIElement} from "../ui/ui_element"
-import {Struct, Ref, Opt} from "../../core/kinds"
+import {Struct, Ref, Opt} from "core/kinds"
 import type * as p from "core/properties"
 
 type VBoxChild = {child: UIElement, row?: number, span?: number} // XXX: can't infere ?

--- a/bokehjs/src/lib/models/ranges/factor_range.ts
+++ b/bokehjs/src/lib/models/ranges/factor_range.ts
@@ -1,7 +1,7 @@
 import {Range} from "./range"
 import {PaddingUnits} from "core/enums"
 import * as p from "core/properties"
-import {Or, String as Str, Array as Arr, Tuple} from "../../core/kinds"
+import {Or, String as Str, Array as Arr, Tuple} from "core/kinds"
 import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
 import {Signal0} from "core/signaling"

--- a/bokehjs/src/lib/models/ranges/range.ts
+++ b/bokehjs/src/lib/models/ranges/range.ts
@@ -1,7 +1,7 @@
 import {Model} from "../../model"
 import type {PlotView} from "../plots/plot"
 import type * as p from "core/properties"
-import {Nullable, Or, Tuple, Number, Auto} from "../../core/kinds"
+import {Nullable, Or, Tuple, Number, Auto} from "core/kinds"
 
 const Bounds = Nullable(Or(Tuple(Nullable(Number), Nullable(Number)), Auto))
 type Bounds = typeof Bounds["__type__"]

--- a/bokehjs/src/lib/models/selections/selection.ts
+++ b/bokehjs/src/lib/models/selections/selection.ts
@@ -4,7 +4,7 @@ import type {SelectionMode} from "core/enums"
 import {union, intersection, difference, symmetric_difference} from "core/util/array"
 import {merge, entries, to_object} from "core/util/object"
 import type {Glyph, GlyphView} from "../glyphs/glyph"
-import {Arrayable, Int} from "../../core/kinds"
+import {Arrayable, Int} from "core/kinds"
 import {map} from "core/util/arrayable"
 
 export type OpaqueIndices = typeof OpaqueIndices["__type__"]

--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -9,7 +9,7 @@ import {Dimensions} from "core/enums"
 import {logger} from "core/logging"
 import {assert} from "core/util/assert"
 import {tool_icon_wheel_zoom} from "styles/icons.css"
-import {Enum, Array, Ref, Or, Auto} from "../../../core/kinds"
+import {Enum, Array, Ref, Or, Auto} from "core/kinds"
 
 const ZoomTogether = Enum("none", "cross", "all")
 type ZoomTogether = typeof ZoomTogether["__type__"]

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -239,7 +239,7 @@ export class ToolbarView extends UIElementView {
   }
 }
 
-import {Struct, Ref, Nullable, Array, Or} from "../../core/kinds"
+import {Struct, Ref, Nullable, Array, Or} from "core/kinds"
 
 const GestureToolLike = Or(Ref(GestureTool), Ref(ToolProxy<GestureTool>))
 const GestureEntry = Struct({

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -5,7 +5,7 @@ import {empty, display, undisplay, div} from "core/dom"
 import type * as p from "core/properties"
 import {take} from "core/util/iterator"
 import {clamp} from "core/util/math"
-import {Enum} from "../../core/kinds"
+import {Enum} from "core/kinds"
 
 import dropdown_css, * as dropdown from "styles/dropdown.css"
 

--- a/bokehjs/src/lib/models/widgets/base_date_picker.ts
+++ b/bokehjs/src/lib/models/widgets/base_date_picker.ts
@@ -3,7 +3,7 @@ import type flatpickr from "flatpickr"
 import {PickerBase, PickerBaseView} from "./picker_base"
 import type * as p from "core/properties"
 import {isArray} from "core/util/types"
-import {Or, Tuple, String, Number, Array, Ref, Struct} from "../../core/kinds"
+import {Or, Tuple, String, Number, Array, Ref, Struct} from "core/kinds"
 
 export type DateLike = typeof DateLike["__type__"]
 export const DateLike = Or(Ref(Date), String, Number)

--- a/bokehjs/src/lib/models/widgets/palette_select.ts
+++ b/bokehjs/src/lib/models/widgets/palette_select.ts
@@ -15,7 +15,7 @@ import * as item_css from "styles/widgets/palette_select_item.css"
 import * as pane_css from "styles/widgets/palette_select_pane.css"
 import * as icons_css from "styles/icons.css"
 
-import {Tuple, String, Arrayable, Color} from "../../core/kinds"
+import {Tuple, String, Arrayable, Color} from "core/kinds"
 
 const Item = Tuple(String, Arrayable(Color))
 type Item = typeof Item["__type__"]

--- a/bokehjs/src/lib/models/widgets/select.ts
+++ b/bokehjs/src/lib/models/widgets/select.ts
@@ -6,7 +6,7 @@ import type * as p from "core/properties"
 import {InputWidget, InputWidgetView} from "./input_widget"
 import * as inputs from "styles/widgets/inputs.css"
 
-import {Unknown, String, Array, Tuple, Or, Dict} from "../../core/kinds"
+import {Unknown, String, Array, Tuple, Or, Dict} from "core/kinds"
 
 const Value = Unknown
 type Value = typeof Value["__type__"]

--- a/bokehjs/src/lib/models/widgets/time_picker.ts
+++ b/bokehjs/src/lib/models/widgets/time_picker.ts
@@ -1,7 +1,7 @@
 import type flatpickr from "flatpickr"
 
 import {PickerBase, PickerBaseView} from "./picker_base"
-import {String, Number, Or} from "../../core/kinds"
+import {String, Number, Or} from "core/kinds"
 import {Clock} from "core/enums"
 import type * as p from "core/properties"
 import {assert} from "core/util/assert"


### PR DESCRIPTION
This is a follow-up to PR #13254, where I manually relativized offending imports. Here I added automated transform and revert previous changes. One can verify correctness of this PR with:

```
$ grep --only-matching -R '".*core/kinds"' bokehjs/build/js/lib/ | uniq
bokehjs/build/js/lib/document/defs.js:"../core/kinds"
bokehjs/build/js/lib/models/coordinates/node.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/coordinates/node.js:"../../core/kinds"
bokehjs/build/js/lib/models/selections/selection.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/selections/selection.js:"../../core/kinds"
bokehjs/build/js/lib/models/annotations/scale_bar.js:"../../core/kinds"
bokehjs/build/js/lib/models/annotations/box_annotation.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/annotations/box_annotation.js:"../../core/kinds"
bokehjs/build/js/lib/models/annotations/scale_bar.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/layouts/vbox.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/layouts/vbox.js:"../../core/kinds"
bokehjs/build/js/lib/models/layouts/hbox.js:"../../core/kinds"
bokehjs/build/js/lib/models/layouts/hbox.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/ranges/factor_range.js:"../../core/kinds"
bokehjs/build/js/lib/models/ranges/factor_range.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/ranges/range.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/ranges/range.js:"../../core/kinds"
bokehjs/build/js/lib/models/dom/html.js:"../../core/kinds"
bokehjs/build/js/lib/models/dom/html.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/tools/toolbar.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/tools/gestures/wheel_zoom_tool.js:"../../../core/kinds"
bokehjs/build/js/lib/models/tools/gestures/wheel_zoom_tool.d.ts:"../../../core/kinds"
bokehjs/build/js/lib/models/tools/toolbar.js:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/select.js:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/time_picker.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/select.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/palette_select.js:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/autocomplete_input.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/base_date_picker.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/time_picker.js:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/autocomplete_input.js:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/palette_select.d.ts:"../../core/kinds"
bokehjs/build/js/lib/models/widgets/base_date_picker.js:"../../core/kinds"
bokehjs/build/js/lib/models/common/kinds.js:"../../core/kinds"
bokehjs/build/js/lib/models/common/kinds.d.ts:"../../core/kinds"
```
i.e. there should be no absolute imports to bokehjs' modules (specifically `core/kinds`) in `*.d.ts` files.