### PR TITLE
fix some sphinx warnings

### DIFF
--- a/examples/topics/stats/density.py
+++ b/examples/topics/stats/density.py
@@ -7,7 +7,7 @@ the `sklearn.neighbors.KernelDensity`_ function and `Bokeh` varea glyph
     :refs: :ref:`ug_topics_stats_density`
     :keywords: density, varea
 
-.. _kernel density estimation: https://en.wikipedia.org/wiki/Kernel_density_estimation
+.. _multiple kernel density estimation: https://en.wikipedia.org/wiki/Kernel_density_estimation
 .. _sklearn.neighbors.KernelDensity: https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KernelDensity.html
 
 '''

--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -550,10 +550,12 @@ class ScaleBar(Annotation):
     Defines how the length of the bar is interpreted.
 
     This can either be:
+
     * ``"adaptive"`` - the computed length is fit into a set of ticks provided
         be the dimensional model. If no ticks are provided, then the behavior
         is the same as if ``"exact"`` sizing was used
     * ``"exact"`` - the computed length is used as-is
+
     """)
 
     bar_length = NonNegative(Either(Float, Int))(default=0.2, help="""
@@ -577,11 +579,13 @@ class ScaleBar(Annotation):
     The label template.
 
     This can use special variables:
+
     * ``@{value}`` The current value. Optionally can provide a number
         formatter with e.g. ``@{value}{%.2f}``.
     * ``@{unit}`` The unit of measure, by default in the short form.
         Optionally can provide a format ``@{unit}{short}`` or
         ``@{unit}{long}``.
+
     """)
 
     label_text = Include(ScalarTextProps, prefix="label", help="""

--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -552,8 +552,8 @@ class ScaleBar(Annotation):
     This can either be:
 
     * ``"adaptive"`` - the computed length is fit into a set of ticks provided
-        be the dimensional model. If no ticks are provided, then the behavior
-        is the same as if ``"exact"`` sizing was used
+      be the dimensional model. If no ticks are provided, then the behavior
+      is the same as if ``"exact"`` sizing was used
     * ``"exact"`` - the computed length is used as-is
 
     """)
@@ -581,10 +581,9 @@ class ScaleBar(Annotation):
     This can use special variables:
 
     * ``@{value}`` The current value. Optionally can provide a number
-        formatter with e.g. ``@{value}{%.2f}``.
+      formatter with e.g. ``@{value}{%.2f}``.
     * ``@{unit}`` The unit of measure, by default in the short form.
-        Optionally can provide a format ``@{unit}{short}`` or
-        ``@{unit}{long}``.
+      Optionally can provide a format ``@{unit}{short}`` or ``@{unit}{long}``.
 
     """)
 


### PR DESCRIPTION
This is a pull request without an issue.

On the last build of the docs I found some warnings:

```
<bokeh-content>:1: ERROR: Unknown target name: "multiple kernel density estimation".
<bokeh-prop>:1: ERROR: Unexpected indentation.
<bokeh-model>:1: WARNING: Block quote ends without a blank line; unexpected unindent.
<bokeh-prop>:1: ERROR: Unexpected indentation.
<bokeh-model>:1: WARNING: Block quote ends without a blank line; unexpected unindent.
```

In this PR I silence all of them.

|**old**|**new**|
|--|--|
|![Legend](https://github.com/bokeh/bokeh/assets/68053396/a08681bf-eae1-4e24-affd-4945e0b7e860)|![Legend_new](https://github.com/bokeh/bokeh/assets/68053396/07ffda9c-0fb8-4d57-b1ba-b3c79167357e)|

Edit:

This warnings are cause by #13527 and #13319.