### PR TITLE
Don't use implicit command-line arguments in bokehjs

### DIFF
--- a/bokehjs/make/main.ts
+++ b/bokehjs/make/main.ts
@@ -1,13 +1,39 @@
 import yargs from "yargs"
 
-const {argv} = yargs.help(false)
+export const argv = yargs.help(false).options({
+  // paths
+  "build-dir": {type: "string"},
+  // lint
+  fix: {type: "boolean", default: false},
+  // scripts, compiler
+  cache: {type: "boolean", default: true},
+  // scripts, compiler, test
+  rebuild: {type: "boolean", default: false},
+  // scripts
+  detectCycles: {type: "boolean", default: true},
+  // server, test
+  host: {type: "string", default: "127.0.0.1"},
+  // server
+  port: {type: "number", default: 5877},
+  inspect: {type: "boolean", default: false},
+  // test
+  executable: {type: "string", alias: "e"},
+  debug: {type: "boolean", default: false},
+  keyword: {type: "string", array: true, alias: "k"},
+  grep: {type: "string", array: true},
+  ref: {type: "string"},
+  "baselines-root": {type: "string"},
+  randomize: {type: "boolean"},
+  seed: {type: "number"},
+  pedantic: {type: "boolean"},
+  screenshot: {type: "string", choices: ["test", "save", "skip"] as const, default: "test"},
+}).parseSync()
 
 import {task, run, log, task_names, show_error, show_failure} from "./task"
 import "./tasks"
 
-const {_} = argv
-
 async function main(): Promise<void> {
+  const {_} = argv
   if (_.length != 0 && _[0] == "help") {
     log(`tasks: ${task_names().filter((name) => !name.includes(":")).join(", ")}`)
   } else {

--- a/bokehjs/make/package.json
+++ b/bokehjs/make/package.json
@@ -15,7 +15,7 @@
     "@types/eslint": "^8.44.9",
     "@types/node": "^20.5.6",
     "@types/which": "^3.0.3",
-    "@types/yargs": "^16.0.4",
+    "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "acorn": "^8.11.2",

--- a/bokehjs/make/paths.ts
+++ b/bokehjs/make/paths.ts
@@ -1,11 +1,11 @@
 import {resolve, join} from "path"
-import {argv} from "yargs"
+
+import {argv} from "./main"
 
 export const base_dir = resolve("./")
-
 export const make_dir = join(base_dir, "make")
 
-const BUILD_DIR = argv.buildDir ? resolve(argv.buildDir as string) : join(base_dir, "build")
+const BUILD_DIR = argv.buildDir != null ? resolve(argv.buildDir) : join(base_dir, "build")
 const JS_BUILD_DIR = join(BUILD_DIR, "js")
 const CSS_BUILD_DIR = join(BUILD_DIR, "css")
 

--- a/bokehjs/make/tasks/compiler.ts
+++ b/bokehjs/make/tasks/compiler.ts
@@ -1,10 +1,11 @@
 import {join} from "path"
-import {argv} from "yargs"
 
 import {task, BuildError} from "../task"
 import {compile_typescript} from "@compiler/compiler"
 import {Linker} from "@compiler/linker"
 import * as preludes from "@compiler/prelude"
+
+import {argv} from "../main"
 import {src_dir, build_dir} from "../paths"
 
 task("compiler:ts", async () => {
@@ -19,7 +20,7 @@ task("compiler:build", ["compiler:ts"], async () => {
   const minify = false
   const es_modules = false
   const apply_transforms = false
-  const cache = argv.cache !== false ? join(build_dir.js, "compiler.json") : undefined
+  const cache = argv.cache ? join(build_dir.js, "compiler.json") : undefined
 
   const linker = new Linker({entries, bases, externals, builtins, minify, es_modules, apply_transforms, cache})
 

--- a/bokehjs/make/tasks/lint.ts
+++ b/bokehjs/make/tasks/lint.ts
@@ -1,16 +1,16 @@
-import {argv} from "yargs"
 import {join, normalize} from "path"
 
 import {ESLint} from "eslint"
 import chalk from "chalk"
 
+import {argv} from "../main"
 import {task, log, BuildError} from "../task"
 import * as paths from "../paths"
 
 import {glob} from "@compiler/sys"
 
 async function eslint(dir: string): Promise<void> {
-  const fix = argv.fix === true
+  const {fix} = argv
   const eslint = new ESLint({
     cache: true,
     extensions: [".ts"],

--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -1,5 +1,4 @@
 import {join, relative} from "path"
-import {argv} from "yargs"
 import fs from "fs"
 
 import {task, passthrough, BuildError} from "../task"
@@ -9,6 +8,8 @@ import {compile_typescript} from "@compiler/compiler"
 import type {AssemblyOptions} from "@compiler/linker"
 import {Linker} from "@compiler/linker"
 import * as preludes from "@compiler/prelude"
+
+import {argv} from "../main"
 import * as paths from "../paths"
 
 import pkg from "../../package.json"
@@ -68,10 +69,10 @@ task("scripts:bundle", [passthrough("scripts:compile")], async () => {
   const linker = new Linker({
     entries: packages.map((pkg) => pkg.main),
     bases: [paths.build_dir.lib, "./node_modules"],
-    cache: argv.cache !== false ? join(paths.build_dir.js, "bokeh.json") : undefined,
+    cache: argv.cache ? join(paths.build_dir.js, "bokeh.json") : undefined,
     target: "ES2020",
     exports: ["tslib"],
-    detect_cycles: argv.detectCycles as boolean | undefined,
+    detect_cycles: argv.detectCycles,
     overrides: {
       // https://github.com/bokeh/bokeh/issues/12142
       "mathjax-full/js/components/version.js": `\

--- a/bokehjs/make/tasks/server.ts
+++ b/bokehjs/make/tasks/server.ts
@@ -1,7 +1,7 @@
 import type {ChildProcess} from "child_process"
 import {spawn} from "child_process"
-import {argv} from "yargs"
 
+import {argv} from "../main"
 import {task, task2, success, BuildError} from "../task"
 import {find_port, retry, terminate, keep_alive} from "./_util"
 
@@ -38,9 +38,7 @@ async function server(host?: string, port?: number, inspect?: boolean): Promise<
   })
 }
 
-const host = argv.host as string | undefined
-const port = parseInt(argv.port as string | undefined ?? "5877")
-const inspect = argv.inspect as boolean | undefined
+const {host, port, inspect} = argv
 
 task("run:server", async () => {
   await server(host, port, inspect)

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -31,7 +31,7 @@
         "@types/eslint": "^8.44.9",
         "@types/node": "^20.5.6",
         "@types/which": "^3.0.3",
-        "@types/yargs": "^16.0.4",
+        "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "acorn": "^8.11.2",
@@ -693,9 +693,10 @@
       }
     },
     "node_modules/@types/yargs": {
-      "version": "16.0.5",
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -3679,7 +3680,7 @@
         "@types/css": "^0.0.37",
         "@types/less": "^3.0.6",
         "@types/node": "^20.10.4",
-        "@types/yargs": "^16.0.4",
+        "@types/yargs": "^17.0.32",
         "chalk": "^4.1.2",
         "combine-source-map": "^0.8.0",
         "convert-source-map": "^2.0.0",
@@ -3721,7 +3722,7 @@
       "devDependencies": {
         "@types/node": "^20.10.4",
         "@types/ws": "^8.5.10",
-        "@types/yargs": "^16.0.4",
+        "@types/yargs": "^17.0.32",
         "chalk": "^4.1.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
@@ -3745,7 +3746,7 @@
         "@types/pngjs": "^6.0.4",
         "@types/sinon": "^17.0.2",
         "@types/source-map-support": "^0.5.10",
-        "@types/yargs": "^16.0.4",
+        "@types/yargs": "^17.0.32",
         "chalk": "^4.1.2",
         "chrome-remote-interface": "^0.33.0",
         "cli-progress": "^3.11.2",

--- a/bokehjs/src/compiler/package.json
+++ b/bokehjs/src/compiler/package.json
@@ -14,7 +14,7 @@
     "@types/css": "^0.0.37",
     "@types/less": "^3.0.6",
     "@types/node": "^20.10.4",
-    "@types/yargs": "^16.0.4",
+    "@types/yargs": "^17.0.32",
     "chalk": "^4.1.2",
     "combine-source-map": "^0.8.0",
     "convert-source-map": "^2.0.0",

--- a/bokehjs/src/server/package.json
+++ b/bokehjs/src/server/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/node": "^20.10.4",
     "@types/ws": "^8.5.10",
-    "@types/yargs": "^16.0.4",
+    "@types/yargs": "^17.0.32",
     "chalk": "^4.1.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/bokehjs/src/server/server.ts
+++ b/bokehjs/src/server/server.ts
@@ -11,7 +11,7 @@ declare global {
 
 import type {IncomingMessage} from "http"
 import WebSocket from "ws"
-import {argv} from "yargs"
+import yargs from "yargs"
 
 import {version} from "./package.json"
 import {Receiver} from "./receiver"
@@ -69,8 +69,12 @@ type PullDoc = {
 const TOKEN = Symbol("TOKEN")
 type Request = IncomingMessage & {[TOKEN]?: string}
 
-const host = argv.host as string | undefined ?? "127.0.0.1"
-const port = parseInt(argv.port as string | undefined ?? "5877")
+const argv = yargs(process.argv.slice(2)).options({
+  host: {type: "string", default: "127.0.0.1"},
+  port: {type: "number", default: 5877},
+}).parseSync()
+
+const {host, port} = argv
 
 function log(_message: string): void {
   //console.log(message)

--- a/bokehjs/test/devtools/server.ts
+++ b/bokehjs/test/devtools/server.ts
@@ -2,7 +2,7 @@ import fs from "fs"
 import {spawn} from "child_process"
 import {join, resolve, dirname} from "path"
 
-import {argv} from "yargs"
+import yargs from "yargs"
 import express from "express"
 import cors from "cors"
 import nunjucks from "nunjucks"
@@ -239,9 +239,12 @@ process.once("SIGTERM", () => {
   process.exit(0)
 })
 
-const host = argv.host as string | undefined ?? "127.0.0.1"
-const port = parseInt(argv.port as string | undefined ?? "5777")
+const argv = yargs(process.argv.slice(2)).options({
+  host: {type: "string", default: "127.0.0.1"},
+  port: {type: "number", default: 5777},
+}).parseSync()
 
+const {host, port} = argv
 const server = app.listen(port, host)
 
 server.on("listening", () => {

--- a/bokehjs/test/package.json
+++ b/bokehjs/test/package.json
@@ -20,7 +20,7 @@
     "@types/pngjs": "^6.0.4",
     "@types/sinon": "^17.0.2",
     "@types/source-map-support": "^0.5.10",
-    "@types/yargs": "^16.0.4",
+    "@types/yargs": "^17.0.32",
     "chalk": "^4.1.2",
     "chrome-remote-interface": "^0.33.0",
     "cli-progress": "^3.11.2",


### PR DESCRIPTION
Migrates to non-implicit command-line arguments in bokehjs' tooling and thus allows to finally upgrade `@types/yargs`.