### PR TITLE
fix warnings caused by sampledata

### DIFF
--- a/docs/bokeh/source/docs/reference/sampledata.rst
+++ b/docs/bokeh/source/docs/reference/sampledata.rst
@@ -64,6 +64,13 @@ commits
 
 .. automodule:: bokeh.sampledata.commits
 
+.. _sampledata_cows:
+
+cows
+----
+
+.. automodule:: bokeh.sampledata.cows
+
 .. _sampledata_daylight:
 
 daylight
@@ -105,6 +112,13 @@ iris
 ----
 
 .. automodule:: bokeh.sampledata.iris
+
+.. _sampledata_lincoln:
+
+lincoln
+-------
+
+.. automodule:: bokeh.sampledata.lincoln
 
 .. _sampledata_les_mis:
 
@@ -189,6 +203,13 @@ sprint
 ------
 
 .. automodule:: bokeh.sampledata.sprint
+
+.. _sampledata_titanic:
+
+titanic
+-------
+
+.. automodule:: bokeh.sampledata.titanic
 
 .. _sampledata_stocks:
 

--- a/docs/bokeh/source/docs/user_guide/interaction/tools.rst
+++ b/docs/bokeh/source/docs/user_guide/interaction/tools.rst
@@ -816,6 +816,9 @@ renderer.
 
 .. _ug_interaction_tools_default_values:
 
+Interaction tools default values
+''''''''''''''''''''''''''''''''
+
 Columns' default values are computed based on (in order):
 
 1. Tool's ``default_overrides``, which are user provided.

--- a/docs/bokeh/source/docs/user_guide/topics/stats.rst
+++ b/docs/bokeh/source/docs/user_guide/topics/stats.rst
@@ -13,8 +13,6 @@ Use |quad| glyphs to create a histogram plotted from ``np.histogram`` output
 .. bokeh-plot:: __REPO__/examples/topics/stats/histogram.py
     :source-position: above
 
-.. _ug_topics_stats_pyramid:
-
 A population pyramid plot is a divergent horizontal bar plot that can be used to compare distributions between two groups.
 In Bokeh they can be created using |hbar| glyphs.
 
@@ -40,14 +38,12 @@ Kernel density estimation
 .. bokeh-plot:: __REPO__/examples/topics/stats/kde2d.py
     :source-position: above
 
-.. _ug_topics_stats_sinaplot:
-
 Kernel density estimates can also be plotted using |varea| glyphs:
 
 .. bokeh-plot:: __REPO__/examples/topics/stats/density.py
     :source-position: above
 
-.. _ug_topics_stats_density:
+.. _ug_topics_stats_sinaplot:
 
 SinaPlot
 --------
@@ -60,7 +56,7 @@ SinaPlots can be assembled using the |harea| and |scatter| glyphs:
 .. _ug_topics_stats_splom:
 
 SPLOM
--------
+-----
 
 A SPLOM is "scatter plot matrix" that arranges multiple scatter plots in a
 grid fashion in order to highlight correlations between dimensions. Key

--- a/examples/topics/stats/density.py
+++ b/examples/topics/stats/density.py
@@ -4,7 +4,7 @@ the `sklearn.neighbors.KernelDensity`_ function and `Bokeh` varea glyph
 .. bokeh-example-metadata::
     :sampledata: cows
     :apis: bokeh.plotting.figure.varea
-    :refs: :ref:`ug_topics_stats_density`
+    :refs: :ref:`ug_topics_stats_sinaplot`
     :keywords: density, varea
 
 .. _multiple kernel density estimation: https://en.wikipedia.org/wiki/Kernel_density_estimation

--- a/examples/topics/stats/pyramid.py
+++ b/examples/topics/stats/pyramid.py
@@ -3,7 +3,7 @@
 .. bokeh-example-metadata::
     :sampledata: titanic
     :apis: bokeh.plotting.figure.hbar
-    :refs: :ref:`ug_topics_stats_pyramid`
+    :refs: :ref:`ug_topics_stats_histogram`
     :keywords: pyramid, hbar
 '''
 import numpy as np

--- a/src/bokeh/models/ranges.py
+++ b/src/bokeh/models/ranges.py
@@ -384,7 +384,7 @@ class FactorRange(Range):
 
         FactorRange(factors=[["foo", "1"], ["foo", "2"], ["bar", "1"]])
 
-    The top level groups correspond to ``"foo"` and ``"bar"``, and the
+    The top level groups correspond to ``"foo"`` and ``"bar"``, and the
     group padding will be applied between the factors ``["foo", "2"]`` and
     ``["bar", "1"]``
     """)

--- a/src/bokeh/sampledata/titanic.py
+++ b/src/bokeh/sampledata/titanic.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-''' Demographic details of the passengers in the Titanic
+''' Demographic details of the passengers on board of the Titanic.
 
 License: `Public Domain`_
 


### PR DESCRIPTION
This is an issue without a ticket. I found some warnings while building the docs caused by new examples. The reasons are

* we forgot to add the references for the new sampledate in the `sampledata.rst`
* a reference link always needs a headline

```
/home/jovyan/private/bokeh/docs/bokeh/source/docs/examples/topics/stats/pyramid.rst:3: WARNING: undefined label: 'sampledata_titanic'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/examples/topics/stats/pyramid.rst:5: WARNING: Failed to create a cross reference. A title or caption not found: 'ug_topics_stats_pyramid'
WARNING: page docs/examples/topics/stats/pyramid matches two patterns in html_sidebars: 'docs/examples/**' and '**'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/examples/topics/stats/sinaplot.rst:3: WARNING: undefined label: 'sampledata_lincoln'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/examples/topics/stats/sinaplot.rst:5: WARNING: Failed to create a cross reference. A title or caption not found: 'ug_topics_stats_sinaplot'
WARNING: page docs/examples/topics/stats/sinaplot matches two patterns in html_sidebars: 'docs/examples/**' and '**'
WARNING: page docs/examples/topics/stats/splom matches two patterns in html_sidebars: 'docs/examples/**' and '**'
WARNING: page docs/examples/topics/timeseries/candlestick matches two patterns in html_sidebars: 'docs/examples/**' and '**'
WARNING: page docs/examples/topics/timeseries/missing_dates matches two patterns in html_sidebars: 'docs/examples/**' and '**'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/user_guide/interaction/tools.rst:889: WARNING: Failed to create a cross reference. A title or caption not found: 'ug_interaction_tools_default_values'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/user_guide/interaction/tools.rst:943: WARNING: Failed to create a cross reference. A title or caption not found: 'ug_interaction_tools_default_values'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/user_guide/interaction/tools.rst:1002: WARNING: Failed to create a cross reference. A title or caption not found: 'ug_interaction_tools_default_values'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/user_guide/interaction/tools.rst:1059: WARNING: Failed to create a cross reference. A title or caption not found: 'ug_interaction_tools_default_values'
```

All the warnings are solved and a typo is corrected as well.