### PR TITLE
add forensic glass and emissions to sampledata.rst

### DIFF
--- a/docs/bokeh/source/docs/reference/sampledata.rst
+++ b/docs/bokeh/source/docs/reference/sampledata.rst
@@ -85,6 +85,21 @@ degrees
 
 .. automodule:: bokeh.sampledata.degrees
 
+.. _sampledata_emissions:
+
+emissions
+---------
+
+.. automodule:: bokeh.sampledata.emissions
+
+
+.. _sampledata_forensic_glass:
+
+forensic_glass
+--------------
+
+.. automodule:: bokeh.sampledata.forensic_glass
+
 .. _sampledata_gapminder:
 
 gapminder

--- a/docs/bokeh/source/docs/user_guide/topics/categorical.rst
+++ b/docs/bokeh/source/docs/user_guide/topics/categorical.rst
@@ -97,6 +97,8 @@ category:
 .. bokeh-plot:: __REPO__/examples/topics/categorical/ridgeplot.py
     :source-position: below
 
+.. _ug_topics_categorical_slope_graph:
+
 Slopegraphs
 ~~~~~~~~~~~
 
@@ -144,6 +146,8 @@ The following periodic table uses several of the techniques in this chapter:
 
 .. bokeh-plot:: __REPO__/examples/topics/categorical/periodic.py
     :source-position: below
+
+.. _ug_topics_categorical_correlograms:
 
 Correlograms
 ~~~~~~~~~~~~

--- a/examples/topics/categorical/correlogram.py
+++ b/examples/topics/categorical/correlogram.py
@@ -9,7 +9,7 @@ The magnitude of each correlation is encoded in the size of the circles.
 .. bokeh-example-metadata::
     :sampledata: forensic_glass
     :apis: bokeh.plotting.figure.scatter
-    :refs: :ref:`ug_topics_categorical_scatters`
+    :refs: :ref:`ug_topics_categorical_correlograms`
     :keywords: scatter, correlogram
 
 '''

--- a/examples/topics/categorical/slope_graph.py
+++ b/examples/topics/categorical/slope_graph.py
@@ -4,7 +4,7 @@ demonstrates using the `segment` glyph.
 .. bokeh-example-metadata::
     :sampledata: emissions
     :apis: bokeh.plotting.figure.scatter
-    :refs: :ref:`ug_topics_categorical_scatters_segment`
+    :refs: :ref:`ug_topics_categorical_slope_graph`
     :keywords: segment, scatter
 
 '''

--- a/src/bokeh/sampledata/emissions.py
+++ b/src/bokeh/sampledata/emissions.py
@@ -4,7 +4,8 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-''' CO2 emmisions of selected countries in the years 2000 and 2010.
+''' CO2 emmisions of selected countries in the years from 1950 to 2012.
+Note that not all countries have values for the whole time range.
 
 License: `Public Domain`_
 


### PR DESCRIPTION
This is an issue without a ticket. I was trying to add `-W` to the build process for the docs and on the way I found more warnings.

```
/home/jovyan/private/bokeh/docs/bokeh/source/docs/examples/topics/categorical/correlogram.rst:3: WARNING: undefined label: 'sampledata_forensic_glass'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/examples/topics/categorical/correlogram.rst:5: WARNING: undefined label: 'ug_topics_categorical_scatters'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/examples/topics/categorical/slope_graph.rst:3: WARNING: undefined label: 'sampledata_emissions'
/home/jovyan/private/bokeh/docs/bokeh/source/docs/examples/topics/categorical/slope_graph.rst:5: WARNING: undefined label: 'ug_topics_categorical_scatters_segment'
```

The reasons and solution are similar to the PR earlier today.