### PR TITLE
Remove unnecessary arcTo calls in round_rect

### DIFF
--- a/bokehjs/src/lib/models/common/painting.ts
+++ b/bokehjs/src/lib/models/common/painting.ts
@@ -28,13 +28,21 @@ export function round_rect(ctx: Context2d, bbox: BBox, border_radius: Corners<nu
 
     ctx.moveTo(left + top_left, top)
     ctx.lineTo(right - top_right, top)
-    ctx.arcTo(right, top, right, top + top_right, top_right)
+    if (top_right != 0) {
+      ctx.arcTo(right, top, right, top + top_right, top_right)
+    }
     ctx.lineTo(right, bottom - bottom_right)
-    ctx.arcTo(right, bottom, right - bottom_right, bottom, bottom_right)
+    if (bottom_right != 0) {
+      ctx.arcTo(right, bottom, right - bottom_right, bottom, bottom_right)
+    }
     ctx.lineTo(left + bottom_left, bottom)
-    ctx.arcTo(left, bottom, left, bottom - bottom_left, bottom_left)
+    if (bottom_left != 0) {
+      ctx.arcTo(left, bottom, left, bottom - bottom_left, bottom_left)
+    }
     ctx.lineTo(left, top + top_left)
-    ctx.arcTo(left, top, left + top_left, top, top_left)
+    if (top_left != 0) {
+      ctx.arcTo(left, top, left + top_left, top, top_left)
+    }
     ctx.closePath()
   } else {
     const {left, top, width, height} = bbox


### PR DESCRIPTION
Whilst investigating #12699 I noticed that the current BokehJS implementation of `round_rect` uses `arcTo` for all four corners even if only one of them should be rounded. This isn't wrong, it produces the correct visual results, but it is unnecessary. This PR only uses `arcTo` for those corners that are rounded.

There are no new tests for this as there are already some (e.g. BoxAnnotation "should support rounded corners (border_radius property)") and the fact that the visual tests pass after this change shows that the extra `arcTo`s are not necessary.