### PR TITLE
Bump `tornado` minimum dependency to version 6.2

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -13,7 +13,7 @@ dependencies:
   - pillow >=4.0
   - python-dateutil >=2.1
   - pyyaml >=3.10
-  - tornado >=5
+  - tornado >=6.2
   - xyzservices>=2021.09.1
 
   # tests

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -13,7 +13,7 @@ dependencies:
   - pillow >=4.0
   - python-dateutil >=2.1
   - pyyaml >=3.10
-  - tornado >=5
+  - tornado >=6.2
   - xyzservices>=2021.09.1
 
   # tests

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -13,7 +13,7 @@ dependencies:
   - pillow >=4.0
   - python-dateutil >=2.1
   - pyyaml >=3.10
-  - tornado >=5
+  - tornado >=6.2
   - xyzservices>=2021.09.1
 
   # tests

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -13,7 +13,7 @@ dependencies:
   - pillow >=4.0
   - python-dateutil >=2.1
   - pyyaml >=3.10
-  - tornado >=5
+  - tornado >=6.2
   - xyzservices>=2021.09.1
 
   # tests

--- a/conda/environment-test-downstream.yml
+++ b/conda/environment-test-downstream.yml
@@ -12,7 +12,7 @@ dependencies:
   - pillow >=4.0
   - python-dateutil >=2.1
   - pyyaml >=3.10
-  - tornado >=5
+  - tornado >=6.2
   - xyzservices>=2021.09.1
 
   # tests

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -13,7 +13,7 @@ dependencies:
   - pillow >=4.0
   - python-dateutil >=2.1
   - pyyaml >=3.10
-  - tornado 5.1.*
+  - tornado 6.2.*
   - xyzservices>=2021.09.1
 
   # tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas >=1.2",
     "pillow >=7.1.0",
     "PyYAML >=3.10",
-    "tornado >=5.1",
+    "tornado >=6.2",
     "xyzservices >=2021.09.1",
 ]
 authors = [


### PR DESCRIPTION
Seeing that minimal-deps tests pass in PR #13634, maybe allowing newer Tornado will help with the issue, especially given that tests pass in other jobs and setups.

fixes #13583