### PR TITLE
Use simpler shader for rect-like glyphs without rounded corners

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/base_marker.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/base_marker.ts
@@ -30,6 +30,7 @@ export abstract class BaseMarkerGL extends BaseGLGlyph {
 
   // used by RectGL
   protected _border_radius: Vec4 = [0.0, 0.0, 0.0, 0.0]
+  protected _border_radius_nonzero: boolean = false
 
   // indices properties
   protected readonly _show = new Uint8Buffer(this.regl_wrapper)

--- a/bokehjs/src/lib/models/glyphs/webgl/lrtb.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/lrtb.ts
@@ -21,7 +21,7 @@ export class LRTBGL extends SingleMarkerGL {
   }
 
   get marker_type(): GLMarkerType {
-    return "rect"
+    return this._border_radius_nonzero ? "round_rect" : "rect"
   }
 
   protected override _set_data(): void {
@@ -62,8 +62,10 @@ export class LRTBGL extends SingleMarkerGL {
     if (this.glyph.border_radius != null) {
       const {top_left, top_right, bottom_right, bottom_left} = this.glyph.border_radius
       this._border_radius = [top_left, top_right, bottom_right, bottom_left]
+      this._border_radius_nonzero = Math.max(...this._border_radius) > 0.0
     } else {
       this._border_radius = [0, 0, 0, 0]
+      this._border_radius_nonzero = false
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/webgl/marker.frag
+++ b/bokehjs/src/lib/models/glyphs/webgl/marker.frag
@@ -58,7 +58,7 @@ varying float v_end_angle;
 varying float v_radius;
 #endif
 
-#ifdef USE_RECT
+#ifdef USE_ROUND_RECT
 varying vec4 v_border_radius;
 #endif
 
@@ -446,7 +446,7 @@ float marker_distance(in vec2 p, in int line_cap, in int line_join)
 }
 #endif
 
-#if defined(USE_RECT)
+#if defined(USE_ROUND_RECT)
 float marker_distance(in vec2 p, in int line_cap, in int line_join)
 {
   vec2 halfsize = v_size/2.0;
@@ -480,7 +480,7 @@ float marker_distance(in vec2 p, in int line_cap, in int line_join)
 }
 #endif
 
-#if defined(USE_SQUARE) || defined(USE_SQUARE_CROSS) || defined(USE_SQUARE_DOT) || defined(USE_SQUARE_X)
+#if defined(USE_RECT) || defined(USE_SQUARE) || defined(USE_SQUARE_CROSS) || defined(USE_SQUARE_DOT) || defined(USE_SQUARE_X)
 float marker_distance(in vec2 p, in int line_cap, in int line_join)
 {
   vec2 p2 = abs(p) - v_size/2.0;  // Offset from corner

--- a/bokehjs/src/lib/models/glyphs/webgl/marker.vert
+++ b/bokehjs/src/lib/models/glyphs/webgl/marker.vert
@@ -28,7 +28,7 @@ uniform float u_antialias;
 uniform float u_size_hint;
 #endif
 
-#ifdef USE_RECT
+#ifdef USE_ROUND_RECT
 uniform vec4 u_border_radius;
 varying vec4 v_border_radius;
 #endif
@@ -118,7 +118,7 @@ vec2 enclosing_size() {
 
 void main()
 {
-#if defined(USE_RECT) || defined(USE_HEX_TILE)
+#if defined(USE_RECT) || defined(USE_ROUND_RECT) || defined(USE_HEX_TILE)
   v_size = vec2(a_width, a_height);
 #elif defined(USE_ANNULUS) || defined(USE_ANNULAR_WEDGE) || defined(USE_WEDGE)
   v_size = vec2(2.0*a_width, 2.0*a_width);
@@ -154,7 +154,7 @@ void main()
   v_radius = 0.5*a_width;
 #endif
 
-#ifdef USE_RECT
+#ifdef USE_ROUND_RECT
   // Scale corner radii if they are too large, the same as canvas
   // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect
   // Order of border_radius is top_left, top_right, bottom_right, bottom_left

--- a/bokehjs/src/lib/models/glyphs/webgl/rect.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/rect.ts
@@ -9,7 +9,7 @@ export class RectGL extends SXSYGlyphGL {
   }
 
   get marker_type(): GLMarkerType {
-    return "rect"
+    return this._border_radius_nonzero ? "round_rect" : "rect"
   }
 
   protected override _set_data(): void {
@@ -22,6 +22,7 @@ export class RectGL extends SXSYGlyphGL {
 
     const {top_left, top_right, bottom_right, bottom_left} = this.glyph.border_radius
     this._border_radius = [top_left, top_right, bottom_right, bottom_left]
+    this._border_radius_nonzero = Math.max(...this._border_radius) > 0.0
   }
 
   protected override _set_once(): void {

--- a/bokehjs/src/lib/models/glyphs/webgl/single_marker.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/single_marker.ts
@@ -23,10 +23,10 @@ export abstract class SingleMarkerGL extends BaseMarkerGL {
   }
 
   draw(indices: number[], main_glyph: SingleMarkerGlyphView, transform: Transform): void {
-    this._draw_impl(indices, transform, main_glyph.glglyph!, this.marker_type)
+    this._draw_impl(indices, transform, main_glyph.glglyph!)
   }
 
-  protected _draw_impl(indices: number[], transform: Transform, main_gl_glyph: SingleMarkerGL, marker_type: GLMarkerType): void {
+  protected _draw_impl(indices: number[], transform: Transform, main_gl_glyph: SingleMarkerGL): void {
     if (main_gl_glyph.data_changed || main_gl_glyph.data_mapped) {
       main_gl_glyph.set_data()
       main_gl_glyph.data_changed = false
@@ -58,6 +58,6 @@ export abstract class SingleMarkerGL extends BaseMarkerGL {
     }
     this._show.update()
 
-    this._draw_one_marker_type(marker_type, transform, main_gl_glyph)
+    this._draw_one_marker_type(main_gl_glyph.marker_type, transform, main_gl_glyph)
   }
 }

--- a/bokehjs/src/lib/models/glyphs/webgl/types.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/types.ts
@@ -2,7 +2,7 @@ import type {Float32Buffer, NormalizedUint8Buffer, Uint8Buffer} from "./buffer"
 import type {AttributeConfig, BoundingBox, Framebuffer2D, Texture2D, Vec2, Vec4} from "regl"
 
 import type {MarkerType} from "core/enums"
-export type GLMarkerType = MarkerType | "hex_tile" | "rect" | "ellipse" | "annulus" | "wedge" | "annular_wedge"
+export type GLMarkerType = MarkerType | "hex_tile" | "rect" | "round_rect" | "ellipse" | "annulus" | "wedge" | "annular_wedge"
 
 // Props are used to pass properties from GL glyph classes to ReGL functions.
 export type AccumulateProps = {


### PR DESCRIPTION
`Rect` glyphs and their relatives (`Block`, `Quad`, etc) support rounded corners via the `border_radius` property. The WebGL backend now has full support for these rounded corners (#13649). Because of the way GLSL shaders work (massively in parallel) the rounded corner rendering code is executed even if rounded corners are not required. This is unnecessary processing for those `Rect`-like glyphs that don't have rounded corners.

This PR introduces a new `GLMarkerType` of `"round_rect"` for rects with rounded corners, and keeps the use of `"rect"` for non-rounded corners. Actually the `"rect"` marker type reuses the `"square"` shader code, so it is not even new shader code. There is a new boolean flag on `BaseMarkerGL` to indicate if round corners are set and this is used to determine which `GLMarkerType` is used for rendering.

There are no changes at all in baseline test images.