### PR TITLE
Let client ping failure clean up session

### DIFF
--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -36,6 +36,7 @@ from urllib.parse import urljoin
 # External imports
 from tornado.ioloop import PeriodicCallback
 from tornado.web import Application as TornadoApplication, StaticFileHandler
+from tornado.websocket import WebSocketClosedError
 
 if TYPE_CHECKING:
     from tornado.ioloop import IOLoop
@@ -783,8 +784,11 @@ class BokehTornado(TornadoApplication):
 
     def _keep_alive(self) -> None:
         log.trace("Running keep alive job") # type: ignore[attr-defined]
-        for c in self._clients:
-            c.send_ping()
+        for c in list(self._clients):
+            try:
+                c.send_ping()
+            except WebsocketClosedError:
+                self.client_lost(c)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -787,7 +787,7 @@ class BokehTornado(TornadoApplication):
         for c in list(self._clients):
             try:
                 c.send_ping()
-            except WebsocketClosedError:
+            except WebSocketClosedError:
                 self.client_lost(c)
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -17,10 +17,9 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import asyncio
 import json
 import logging
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 # External imports
 from _util_server import http_get, url
@@ -264,7 +263,7 @@ def test_keep_alive_websocket_error(ManagedServerLoop: MSL) -> None:
             server._tornado._clients = {mock_client}
             server._tornado._keep_alive()
             assert client_lost.called
-        
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -17,12 +17,15 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
 import json
 import logging
+from unittest.mock import MagicMock, Mock, patch
 
 # External imports
 from _util_server import http_get, url
 from tornado.web import StaticFileHandler
+from tornado.websocket import WebSocketClosedError
 
 # Bokeh imports
 from bokeh.application import Application
@@ -252,6 +255,16 @@ async def test_metadata(ManagedServerLoop: MSL) -> None:
         meta_json = json.loads(meta_resp.buffer.read().decode())
         assert meta_json == {'data': {'name': 'myname', 'value': 'no value'}, 'url': '/'}
 
+def test_keep_alive_websocket_error(ManagedServerLoop: MSL) -> None:
+    application = Application()
+    mock_client = Mock()
+    mock_client.send_ping.side_effect = WebSocketClosedError()
+    with ManagedServerLoop(application, keep_alive_milliseconds=100) as server:
+        with patch('bokeh.server.tornado.BokehTornado.client_lost') as client_lost:
+            server._tornado._clients = {mock_client}
+            server._tornado._keep_alive()
+            assert client_lost.called
+        
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Ideally we would figure out why server clients are sometimes not cleaned up correctly, however as a safeguard I think it is still a good idea to add error handling around the keep alive pings so that if a single client isn't cleaned up correctly we don't end up breaking pings for all other clients.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/13654
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
