### PR TITLE
Display Greek small letter mu

### DIFF
--- a/examples/interaction/tools/subcoordinates_zoom.py
+++ b/examples/interaction/tools/subcoordinates_zoom.py
@@ -19,7 +19,7 @@ channels = [f"EEG {i}" for i in range(n_channels)]
 hover = HoverTool(tooltips=[
     ("Channel", "$name"),
     ("Time", "$x s"),
-    ("Amplitude", "$y µV"),
+    ("Amplitude", "$y μV"),
 ])
 
 x_range = Range1d(start=time.min(), end=time.max())


### PR DESCRIPTION
Characters which look the same but have different underlying codes (homographs) are problematic. The abbreviation for microvolts is best represented as μV, using the 0x03bc Greek small letter mu instead of the 0x00b5 Latin Extended micro sign. This aligns with:
- [The International System of Units (SI) brochure](https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf)
- NFKC normalized [Python code](https://peps.python.org/pep-3131/) and [domain names](https://unicode.org/reports/tr36/)
- Section 2.5 Duplicated Characters of [Unicode Technical Report 25](https://www.unicode.org/reports/tr25/)
- Bokeh's [histogram example](/bokeh/bokeh/tree/branch-3.4/examples/plotting/histogram.py#L44-L57)
- Ruff confusable mapping [updates](https://github.com/astral-sh/ruff/pull/4430/files) (currently in the "preview" stage)

Tested on:
- Chrome, Firefox, Safari on Darwin 23.1.0 arm64
- Chrome, Edge on Windows 10 x86_64

- [x] issues: fixes #13667
- [ ] no tests added: enabling RUF001 is probably best considered separately
- [ ] release document entry: none