### PR TITLE
Swap out Stadia tiles

### DIFF
--- a/docs/bokeh/source/docs/user_guide/topics/geo.rst
+++ b/docs/bokeh/source/docs/user_guide/topics/geo.rst
@@ -65,42 +65,6 @@ Tile Source for Open Street Map Mapnik.
 
     <img src="https://c.tile.openstreetmap.org/14/2627/6331.png" />
 
-Stadia/Stamen Terrain
-~~~~~~~~~~~~~~~~~~~~~
-
-Tile Source for Stadia/Stamen Terrain Service
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_terrain/14/2627/6331.png" />
-
-Stadia/Stamen Toner
-~~~~~~~~~~~~~~~~~~~
-
-Tile Source for Stadia/Stamen Toner Service
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_toner/14/2627/6331.png" />
-
-Stadia/Stamen Toner Background
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Tile Source for Stadia/Stamen Toner Background Service which does not include labels
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_toner_background/14/2627/6331.png" />
-
-Stadia/Stamen Toner Labels
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Tile Source for Stadia/Stamen Toner Service which includes only labels
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_toner_labels/14/2627/6331.png" />
-
 .. _ug_topics_geo_google_maps:
 
 Google Maps

--- a/examples/topics/geo/tile_demo.py
+++ b/examples/topics/geo/tile_demo.py
@@ -32,12 +32,9 @@ y_range = (EN[1]-dN, EN[1]+dN) # (m) Northing y_lo, y_hi
 providers = [
     "CartoDB Positron",
     "CartoDB Positron retina",
-    "Stamen Terrain",
-    "Stamen Terrain retina",
-    "Stamen Toner",
-    "Stamen Toner Background",
-    "Stamen Toner Labels",
     "OpenStreetMap Mapnik",
+    "OpenTopoMap",
+    "USGS.USTopo",
     "Esri World Imagery",
 ]
 
@@ -57,7 +54,6 @@ layout = layout([
     [description],
     plots[0:3],
     plots[3:6],
-    plots[6:9],
 ])
 
 show(layout)

--- a/src/bokeh/tile_providers.py
+++ b/src/bokeh/tile_providers.py
@@ -58,51 +58,6 @@ Tile Source for Open Street Maps.
 
     <img src="https://c.tile.openstreetmap.org/14/2627/6331.png" />
 
-STAMEN_TERRAIN
---------------
-
-Tile Source for Stadia/Stamen Terrain Service
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_terrain/14/2627/6331.png" />
-
-STAMEN_TERRAIN_RETINA
----------------------
-
-Tile Source for Stadia/Stamen Terrain Service (tiles at 2x or 'retina' resolution)
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_terrain/14/2627/6331@2x.png" />
-
-STAMEN_TONER
-------------
-
-Tile Source for Stadia/Stamen Toner Service
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_toner/14/2627/6331.png" />
-
-STAMEN_TONER_BACKGROUND
------------------------
-
-Tile Source for Stadia/Stamen Toner Background Service which does not include labels
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_toner_background/14/2627/6331.png" />
-
-STAMEN_TONER_LABELS
--------------------
-
-Tile Source for Stadia/Stamen Toner Service which includes only labels
-
-.. raw:: html
-
-    <img src="https://tiles.stadiamaps.com/tiles/stamen_toner_labels/14/2627/6331.png" />
-
 '''
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
fixes #13669

Removes Stadia from examples and docs (see issue for discussion)

Uses OpenTopoMap and USGS.USTopo instead:
![image](https://github.com/bokeh/bokeh/assets/39711796/432bf9e2-4a2c-4014-b93d-728ed8feeffa)
