### PR TITLE
Improve `PlainObjectProxy` and remove unnecessary `hasOwnProperty()`

### DIFF
--- a/bokehjs/src/lib/api/expr.ts
+++ b/bokehjs/src/lib/api/expr.ts
@@ -1,5 +1,6 @@
 import type {Arrayable} from "core/types"
 import {isFunction} from "core/util/types"
+import {dict} from "core/util/object"
 import type {NDArrayType} from "core/util/ndarray"
 import type {Expression} from "./parser"
 import {
@@ -10,6 +11,7 @@ import type {Numerical} from "./linalg"
 import {np, is_Numerical} from "./linalg"
 
 function evaluate(ast: Expression, refs: unknown[]): unknown {
+  const np_proxy = dict(np)
 
   function resolve(ast: Expression): unknown {
     switch (ast.type) {
@@ -35,13 +37,14 @@ function evaluate(ast: Expression, refs: unknown[]): unknown {
         const obj = resolve(ast.object)
         if (obj === np) {
           const {name} = ast.member
-          if (Object.prototype.hasOwnProperty.call(np, name)) {
-            return (np as any)[name]
+          const member = np_proxy.get(name)
+          if (member !== undefined) {
+            return member
           } else {
             throw new Error(`'np.${name}' doesn't exist`)
           }
         } else {
-          throw new Error("not an accessable expression")
+          throw new Error("not an accessible expression")
         }
       case INDEX:
         throw new Error("not an indexable expression")

--- a/bokehjs/src/lib/api/figure.ts
+++ b/bokehjs/src/lib/api/figure.ts
@@ -46,8 +46,6 @@ import {GestureTool} from "../models/tools/gestures/gesture_tool"
 import type {TypedGlyphRenderer, NamesOf, AuxGlyph} from "./glyph_api"
 import {GlyphAPI} from "./glyph_api"
 
-const {hasOwnProperty} = Object.prototype
-
 export type ToolName = keyof ToolAliases
 
 const _default_tools: ToolName[] = ["pan", "wheel_zoom", "box_zoom", "save", "reset", "help"]
@@ -370,17 +368,25 @@ export class Figure extends BaseFigure {
     }
 
     defaults = {...defaults}
-    if (!hasOwnProperty.call(defaults, "text_color")) {
+    const trait_defaults: Attrs = {}
+
+    const props_proxy = dict(props)
+    const prototype_props_proxy = dict(cls.prototype._props)
+    const defaults_proxy = dict(defaults)
+    const trait_defaults_proxy = dict(trait_defaults)
+    const override_defaults_proxy = dict(override_defaults)
+
+    if (!defaults_proxy.has("text_color")) {
       defaults.text_color = "black"
     }
-    if (!hasOwnProperty.call(defaults, "hatch_color")) {
+    if (!defaults_proxy.has("hatch_color")) {
       defaults.hatch_color = "black"
     }
-    const trait_defaults: Attrs = {}
-    if (!hasOwnProperty.call(trait_defaults, "color")) {
+
+    if (!trait_defaults_proxy.has("color")) {
       trait_defaults.color = _default_color
     }
-    if (!hasOwnProperty.call(trait_defaults, "alpha")) {
+    if (!trait_defaults_proxy.has("alpha")) {
       trait_defaults.alpha = _default_alpha
     }
 
@@ -389,19 +395,19 @@ export class Figure extends BaseFigure {
     for (const pname of keys(cls.prototype._props)) {
       if (_is_visual(pname)) {
         const trait = _split_feature_trait(pname)[1]
-        if (hasOwnProperty.call(props, prefix + pname)) {
+        if (props_proxy.has(prefix + pname)) {
           result[pname] = props[prefix + pname]
           delete props[prefix + pname]
-        } else if (!hasOwnProperty.call(cls.prototype._props, trait) && hasOwnProperty.call(props, prefix + trait)) {
+        } else if (!prototype_props_proxy.has(trait) && props_proxy.has(prefix + trait)) {
           result[pname] = props[prefix + trait]
-        } else if (hasOwnProperty.call(override_defaults, trait)) {
+        } else if (override_defaults_proxy.has(trait)) {
           result[pname] = override_defaults[trait]
-        } else if (hasOwnProperty.call(defaults, pname)) {
+        } else if (defaults_proxy.has(pname)) {
           result[pname] = defaults[pname]
-        } else if (hasOwnProperty.call(trait_defaults, trait)) {
+        } else if (trait_defaults_proxy.has(trait)) {
           result[pname] = trait_defaults[trait]
         }
-        if (!hasOwnProperty.call(cls.prototype._props, trait)) {
+        if (!prototype_props_proxy.has(trait)) {
           traits.add(trait)
         }
       }

--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -1,7 +1,7 @@
 import type * as types from "./types"
 import * as tp from "./util/types"
 import {is_Color} from "./util/color"
-import {keys, values, typed_values, typed_entries} from "./util/object"
+import {keys, values, typed_values, typed_entries, PlainObjectProxy} from "./util/object"
 import {has_refs} from "./util/refs"
 
 type ESMap<K, V> = globalThis.Map<K, V>
@@ -11,8 +11,6 @@ type ESSet<V> = globalThis.Set<V>
 const ESSet = globalThis.Set
 
 type ESIterable<V> = globalThis.Iterable<V>
-
-const {hasOwnProperty} = Object.prototype
 
 export abstract class Kind<T> {
   __type__: T
@@ -194,23 +192,23 @@ export namespace Kinds {
     }
 
     valid(value: unknown): value is this["__type__"] {
-      if (!tp.isPlainObject(value))
+      if (!tp.isPlainObject(value)) {
         return false
-
-      const {struct_type} = this
-
-      for (const key of keys(value)) {
-        if (!hasOwnProperty.call(struct_type, key))
-          return false
       }
 
-      for (const key in struct_type) {
-        if (hasOwnProperty.call(struct_type, key)) {
-          const item_type = struct_type[key]
-          const item = value[key]
+      const struct_type_proxy = new PlainObjectProxy(this.struct_type as types.PlainObject<Kind<unknown>>)
 
-          if (!item_type.valid(item))
-            return false
+      for (const key of keys(value)) {
+        if (!struct_type_proxy.has(key)) {
+          return false
+        }
+      }
+
+      for (const [key, item_type] of struct_type_proxy) {
+        const item = value[key]
+
+        if (!item_type.valid(item)) {
+          return false
         }
       }
 
@@ -234,26 +232,26 @@ export namespace Kinds {
     }
 
     valid(value: unknown): value is this["__type__"] {
-      if (!tp.isPlainObject(value))
+      if (!tp.isPlainObject(value)) {
         return false
-
-      const {struct_type} = this
-
-      for (const key of keys(value)) {
-        if (!hasOwnProperty.call(struct_type, key))
-          return false
       }
 
-      for (const key in struct_type) {
-        if (!hasOwnProperty.call(value, key))
+      const value_proxy = new PlainObjectProxy(value)
+      const struct_type_proxy = new PlainObjectProxy(this.struct_type as types.PlainObject<Kind<unknown>>)
+
+      for (const key of value_proxy.keys()) {
+        if (!struct_type_proxy.has(key)) {
+          return false
+        }
+      }
+
+      for (const [key, item_type] of struct_type_proxy) {
+        const item = value_proxy.get(key)
+        if (item === undefined) {
           continue
-
-        if (hasOwnProperty.call(struct_type, key)) {
-          const item_type = struct_type[key]
-          const item = value[key]
-
-          if (!item_type.valid(item))
-            return false
+        }
+        if (!item_type.valid(item)) {
+          return false
         }
       }
 

--- a/bokehjs/src/lib/core/kinds.ts
+++ b/bokehjs/src/lib/core/kinds.ts
@@ -427,7 +427,7 @@ export namespace Kinds {
     }
   }
 
-  export class Dict<ItemType> extends Kind<types.DictLike<ItemType>> {
+  export class Dict<ItemType> extends Kind<types.Dict<ItemType>> {
 
     constructor(readonly item_type: Kind<ItemType>) {
       super()

--- a/bokehjs/src/lib/core/patching.ts
+++ b/bokehjs/src/lib/core/patching.ts
@@ -1,4 +1,4 @@
-import type {Arrayable, Data, DictLike} from "core/types"
+import type {Arrayable, Data, Dict} from "core/types"
 import {isTypedArray, isArray, isNumber} from "core/util/types"
 import type {NDArray} from "core/util/ndarray"
 import {dict} from "core/util/object"
@@ -86,7 +86,7 @@ export function slice(ind: number | Slice, length: number): [number, number, num
 
 export type Patch<T> = [number, T] | [[number, number | Slice] | [number, number | Slice, number | Slice], T[]] | [Slice, T[]]
 
-export type PatchSet<T> = DictLike<Patch<T>[]>
+export type PatchSet<T> = Dict<Patch<T>[]>
 
 // exported for testing
 export function patch_to_column<T>(col: NDArray | NDArray[], patch: Patch<T>[]): Set<number> {

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -2,7 +2,7 @@ import {Signal0} from "./signaling"
 import {logger} from "./logging"
 import type {HasProps} from "./has_props"
 import * as enums from "./enums"
-import type {Arrayable, IntArray, FloatArray, TypedArray, uint32, DictLike} from "./types"
+import type {Arrayable, IntArray, FloatArray, TypedArray, uint32, Dict} from "./types"
 import {RGBAArray, ColorArray} from "./types"
 import type * as types from "./types"
 import {includes, repeat} from "./util/array"
@@ -363,7 +363,7 @@ export abstract class ScalarSpec<T, S extends Scalar<T> = Scalar<T>> extends Pro
 
 /** @deprecated */
 export class AnyScalar extends ScalarSpec<any> {}
-export class DictScalar<T> extends ScalarSpec<DictLike<T>> {}
+export class DictScalar<T> extends ScalarSpec<Dict<T>> {}
 export class ColorScalar extends ScalarSpec<types.Color | null> {}
 export class NumberScalar extends ScalarSpec<number> {}
 export class StringScalar extends ScalarSpec<string> {}

--- a/bokehjs/src/lib/core/property_mixins.ts
+++ b/bokehjs/src/lib/core/property_mixins.ts
@@ -1,5 +1,5 @@
 import * as p from "./properties"
-import type {Color, DictLike} from "./types"
+import type {Color, Dict} from "./types"
 import {LineJoin, LineCap, LineDash, FontStyle, HatchPatternType, TextAlign, TextBaseline} from "./enums"
 import * as k from "./kinds"
 import type {Texture} from "models/textures/texture"
@@ -8,7 +8,7 @@ import {isString} from "./util/types"
 import type {HasProps} from "./has_props"
 
 export type HatchPattern = HatchPatternType | string
-export type HatchExtra = DictLike<Texture>
+export type HatchExtra = Dict<Texture>
 
 // Primitive
 

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -71,9 +71,9 @@ export type ArrayableOf<T> = T extends unknown ? Arrayable<T> : never
 
 export type PlainObject<T = unknown> = {[key: string]: T}
 
-export type DictLike<T> = PlainObject<T> | Map<string, T>
+export type Dict<T> = PlainObject<T> | Map<string, T>
 
-export type Data<T = unknown> = DictLike<Arrayable<T>>
+export type Data<T = unknown> = Dict<Arrayable<T>>
 
 export type Attrs = PlainObject<unknown>
 

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -66,29 +66,33 @@ export function is_empty(obj: DictLike<unknown>): boolean {
   return size(obj) == 0
 }
 
-export class MapProxy<V> implements Map<string, V> {
+const {hasOwnProperty} = Object.prototype
+
+export class PlainObjectProxy<V> implements Map<string, V> {
   constructor(readonly obj: {[key: string]: V}) {}
 
   readonly [Symbol.toStringTag] = "Dict"
 
   clear(): void {
-    for (const key of keys(this.obj)) {
+    for (const key of this.keys()) {
       delete this.obj[key]
     }
   }
 
   delete(key: string): boolean {
-    const had = key in this
-    delete this.obj[key]
-    return had
-  }
-
-  get(key: string): V | undefined {
-    return key in this.obj ? this.obj[key] : undefined
+    const exists = this.has(key)
+    if (exists) {
+      delete this.obj[key]
+    }
+    return exists
   }
 
   has(key: string): boolean {
-    return key in this.obj
+    return hasOwnProperty.call(this.obj, key)
+  }
+
+  get(key: string): V | undefined {
+    return this.has(key) ? this.obj[key] : undefined
   }
 
   set(key: string, value: V): this {
@@ -124,5 +128,5 @@ export class MapProxy<V> implements Map<string, V> {
 }
 
 export function dict<V>(obj: DictLike<V>): Map<string, V> {
-  return isPlainObject(obj) ? new MapProxy(obj) : obj
+  return isPlainObject(obj) ? new PlainObjectProxy(obj) : obj
 }

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -71,7 +71,7 @@ const {hasOwnProperty} = Object.prototype
 export class PlainObjectProxy<V> implements Map<string, V> {
   constructor(readonly obj: {[key: string]: V}) {}
 
-  readonly [Symbol.toStringTag] = "Dict"
+  readonly [Symbol.toStringTag] = "PlainObjectProxy"
 
   clear(): void {
     for (const key of this.keys()) {

--- a/bokehjs/src/lib/core/util/object.ts
+++ b/bokehjs/src/lib/core/util/object.ts
@@ -1,4 +1,4 @@
-import type {Arrayable, DictLike, PlainObject} from "../types"
+import type {Arrayable, Dict, PlainObject} from "../types"
 import {isPlainObject} from "./types"
 import {union} from "./array"
 
@@ -36,7 +36,7 @@ export const typed_values: <T extends object>(obj: T) => T[keyof T][] = Object.v
 
 export const typed_entries: <T extends object>(obj: T) => [keyof T, T[keyof T]][] = Object.entries
 
-export function clone<T>(obj: DictLike<T>): DictLike<T> {
+export function clone<T>(obj: Dict<T>): Dict<T> {
   return obj instanceof Map ? new Map(obj) : {...obj}
 }
 
@@ -58,11 +58,11 @@ export function merge<K, V>(obj0: Map<K, Arrayable<V>>, obj1: Map<K, Arrayable<V
   return result
 }
 
-export function size(obj: DictLike<unknown>): number {
+export function size(obj: Dict<unknown>): number {
   return obj instanceof Map ? obj.size : Object.keys(obj).length
 }
 
-export function is_empty(obj: DictLike<unknown>): boolean {
+export function is_empty(obj: Dict<unknown>): boolean {
   return size(obj) == 0
 }
 
@@ -127,6 +127,6 @@ export class PlainObjectProxy<V> implements Map<string, V> {
   }
 }
 
-export function dict<V>(obj: DictLike<V>): Map<string, V> {
+export function dict<V>(obj: Dict<V>): Map<string, V> {
   return isPlainObject(obj) ? new PlainObjectProxy(obj) : obj
 }

--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -4,7 +4,7 @@ import type {ColumnarDataSource} from "models/sources/columnar_data_source"
 import type {CustomJSHover} from "models/tools/inspectors/customjs_hover"
 import {sprintf as sprintf_js} from "sprintf-js"
 import tz from "timezone"
-import type {DictLike} from "../types"
+import type {Dict} from "../types"
 import {Enum} from "../kinds"
 import {logger} from "../logging"
 import {dict} from "./object"
@@ -15,7 +15,7 @@ export const FormatterType = Enum("numeral", "printf", "datetime")
 export type FormatterType = "numeral" | "printf" | "datetime"
 
 export type FormatterSpec = CustomJSHover | FormatterType
-export type Formatters = DictLike<FormatterSpec>
+export type Formatters = Dict<FormatterSpec>
 export type FormatterFunc = (value: unknown, format: string, special_vars: Vars) => string
 export type Index = number | ImageIndex
 export type Vars = {[key: string]: unknown}

--- a/bokehjs/src/lib/core/util/types.ts
+++ b/bokehjs/src/lib/core/util/types.ts
@@ -3,9 +3,9 @@
 //     (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 
-import type {Arrayable, TypedArray} from "../types"
+import type {Arrayable, TypedArray, Dict} from "../types"
 
-const toString = Object.prototype.toString
+const {toString} = Object.prototype
 
 export function is_undefined(obj: unknown): obj is undefined {
   return typeof obj === "undefined"
@@ -104,6 +104,10 @@ export function isBasicObject<T>(obj: unknown): obj is {[key: string]: T} {
 
 export function isPlainObject<T>(obj: unknown): obj is {[key: string]: T} {
   return isObject(obj) && (is_nullish(obj.constructor) || obj.constructor === Object)
+}
+
+export function isDict<T>(obj: unknown): obj is Dict<T> {
+  return obj instanceof Map || isPlainObject(obj)
 }
 
 export function isIterable(obj: unknown): obj is Iterable<unknown> {

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -1,6 +1,6 @@
 import {HasProps} from "./core/has_props"
 import type {Class} from "./core/class"
-import type {DictLike} from "./core/types"
+import type {Dict} from "./core/types"
 import type {ModelEvent, ModelEventType, BokehEventMap} from "./core/bokeh_events"
 import type * as p from "./core/properties"
 import {isString, isPlainObject} from "./core/util/types"
@@ -23,8 +23,8 @@ export namespace Model {
   export type Props = HasProps.Props & {
     tags: p.Property<unknown[]>
     name: p.Property<string | null>
-    js_property_callbacks: p.Property<DictLike<ChangeCallback[]>>
-    js_event_callbacks: p.Property<DictLike<EventCallback[]>>
+    js_property_callbacks: p.Property<Dict<ChangeCallback[]>>
+    js_event_callbacks: p.Property<Dict<EventCallback[]>>
     subscribed_events: p.Property<Set<string>>
     syncable: p.Property<boolean>
   }

--- a/bokehjs/src/lib/models/annotations/dimensional.ts
+++ b/bokehjs/src/lib/models/annotations/dimensional.ts
@@ -1,5 +1,5 @@
 import {Model} from "../../model"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import type * as p from "core/properties"
 import {assert} from "core/util/assert"
 import {entries} from "core/util/object"
@@ -40,7 +40,7 @@ export abstract class Dimensional extends Model {
     super(attrs)
   }
 
-  abstract get_basis(): DictLike<[number, string, string?]>
+  abstract get_basis(): Dict<[number, string, string?]>
 
   static {
     this.define<Dimensional.Props>(({Nullable, Array, String, Number}) => ({
@@ -103,7 +103,7 @@ export abstract class Dimensional extends Model {
 export namespace CustomDimensional {
   export type Attrs = p.AttrsOf<Props>
   export type Props = Dimensional.Props & {
-    basis: p.Property<DictLike<[number, string, string?]>>
+    basis: p.Property<Dict<[number, string, string?]>>
   }
 }
 
@@ -122,7 +122,7 @@ export abstract class CustomDimensional extends Dimensional {
     }))
   }
 
-  get_basis(): DictLike<[number, string, string?]> {
+  get_basis(): Dict<[number, string, string?]> {
     return this.basis
   }
 }
@@ -182,7 +182,7 @@ export class Metric extends Dimensional {
     ["q", 1e-30, "q",    "quecto"],
   ] as const
 
-  get_basis(): DictLike<[number, string, string?]> {
+  get_basis(): Dict<[number, string, string?]> {
     const {base_unit, full_unit} = this
     const basis: {[key: string]: [number, string, string?]} = {}
 
@@ -211,7 +211,7 @@ export class ReciprocalMetric extends Metric {
     super(attrs)
   }
 
-  override get_basis(): DictLike<[number, string, string?]> {
+  override get_basis(): Dict<[number, string, string?]> {
     const basis = super.get_basis()
     const reciprocal_basis: {[key: string]: [number, string]} = {}
 

--- a/bokehjs/src/lib/models/callbacks/customjs.ts
+++ b/bokehjs/src/lib/models/callbacks/customjs.ts
@@ -6,7 +6,7 @@ import {use_strict} from "core/util/string"
 
 import type {Model} from "../../model"
 import {logger} from "core/logging"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {isFunction} from "core/util/types"
 import type {ViewManager} from "core/view"
 import {index} from "embed/standalone"
@@ -26,7 +26,7 @@ export namespace CustomJS {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Callback.Props & {
-    args: p.Property<DictLike<unknown>>
+    args: p.Property<Dict<unknown>>
     code: p.Property<string>
     module: p.Property<"auto" | boolean>
   }

--- a/bokehjs/src/lib/models/canvas/cartesian_frame.ts
+++ b/bokehjs/src/lib/models/canvas/cartesian_frame.ts
@@ -10,10 +10,10 @@ import {BBox} from "core/util/bbox"
 import {entries} from "core/util/object"
 import {assert} from "core/util/assert"
 import {Signal0} from "core/signaling"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 
-type Ranges = DictLike<Range>
-type Scales = DictLike<Scale>
+type Ranges = Dict<Range>
+type Scales = Dict<Scale>
 
 export class CartesianFrame {
 

--- a/bokehjs/src/lib/models/dom/dom_element.ts
+++ b/bokehjs/src/lib/models/dom/dom_element.ts
@@ -3,7 +3,7 @@ import {Styles} from "./styles"
 import {UIElement} from "../ui/ui_element"
 import type {ViewStorage, IterViews} from "core/build_views"
 import {build_views, remove_views} from "core/build_views"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {entries} from "core/util/object"
 import {isString} from "core/util/types"
 import type * as p from "core/properties"
@@ -77,7 +77,7 @@ export abstract class DOMElementView extends DOMNodeView {
 export namespace DOMElement {
   export type Attrs = p.AttrsOf<Props>
   export type Props = DOMNode.Props & {
-    style: p.Property<Styles | DictLike<string> | null>
+    style: p.Property<Styles | Dict<string> | null>
     children: p.Property<(string | DOMNode | UIElement)[]>
   }
 }

--- a/bokehjs/src/lib/models/expressions/customjs_expr.ts
+++ b/bokehjs/src/lib/models/expressions/customjs_expr.ts
@@ -2,7 +2,7 @@ import {HasProps} from "core/has_props"
 import {Expression} from "./expression"
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import type * as p from "core/properties"
-import type {Arrayable, DictLike} from "core/types"
+import type {Arrayable, Dict} from "core/types"
 import {GeneratorFunction} from "core/types"
 import {repeat} from "core/util/array"
 import {keys, values} from "core/util/object"
@@ -13,7 +13,7 @@ export namespace CustomJSExpr {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Expression.Props & {
-    args: p.Property<DictLike<unknown>>
+    args: p.Property<Dict<unknown>>
     code: p.Property<string>
   }
 }

--- a/bokehjs/src/lib/models/filters/customjs_filter.ts
+++ b/bokehjs/src/lib/models/filters/customjs_filter.ts
@@ -1,6 +1,6 @@
 import {Filter} from "./filter"
 import type * as p from "core/properties"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {Indices} from "core/types"
 import {keys, values} from "core/util/object"
 import {isArrayOf, isBoolean, isInteger} from "core/util/types"
@@ -11,7 +11,7 @@ export namespace CustomJSFilter {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Filter.Props & {
-    args: p.Property<DictLike<unknown>>
+    args: p.Property<Dict<unknown>>
     code: p.Property<string>
   }
 }

--- a/bokehjs/src/lib/models/formatters/customjs_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/customjs_tick_formatter.ts
@@ -1,6 +1,6 @@
 import {TickFormatter} from "./tick_formatter"
 import type * as p from "core/properties"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
 
@@ -8,7 +8,7 @@ export namespace CustomJSTickFormatter {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = TickFormatter.Props & {
-    args: p.Property<DictLike<unknown>>
+    args: p.Property<Dict<unknown>>
     code: p.Property<string>
   }
 }

--- a/bokehjs/src/lib/models/glyphs/tex_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/tex_glyph.ts
@@ -2,7 +2,7 @@ import {MathTextGlyph, MathTextGlyphView} from "./math_text_glyph"
 import type {BaseText} from "../text/base_text"
 import {TeX} from "../text/math_text"
 import type * as p from "core/properties"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {parse_delimited_string} from "../text/utils"
 
 export interface TeXGlyphView extends TeXGlyph.Data {}
@@ -29,7 +29,7 @@ export namespace TeXGlyph {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = MathTextGlyph.Props & {
-    macros: p.Property<DictLike<string | [string, number]>>
+    macros: p.Property<Dict<string | [string, number]>>
     display: p.Property<"inline" | "block" | "auto">
   }
 

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -8,7 +8,7 @@ import {concat, remove_by} from "core/util/array"
 import {difference} from "core/util/set"
 import {isString} from "core/util/types"
 import type {LRTB} from "core/util/bbox"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 
 import {LayoutDOM} from "../layouts/layout_dom"
 import {Axis} from "../axes/axis"
@@ -64,11 +64,11 @@ export namespace Plot {
     x_scale: p.Property<Scale>
     y_scale: p.Property<Scale>
 
-    extra_x_ranges: p.Property<DictLike<Range>>
-    extra_y_ranges: p.Property<DictLike<Range>>
+    extra_x_ranges: p.Property<Dict<Range>>
+    extra_y_ranges: p.Property<Dict<Range>>
 
-    extra_x_scales: p.Property<DictLike<Scale>>
-    extra_y_scales: p.Property<DictLike<Scale>>
+    extra_x_scales: p.Property<Dict<Scale>>
+    extra_y_scales: p.Property<Dict<Scale>>
 
     lod_factor: p.Property<number>
     lod_interval: p.Property<number>

--- a/bokehjs/src/lib/models/policies/labeling.ts
+++ b/bokehjs/src/lib/models/policies/labeling.ts
@@ -4,7 +4,7 @@ import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
 import type {BBox} from "core/util/bbox"
 import {isIterable} from "core/util/types"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {Indices, GeneratorFunction} from "core/types"
 
 export type DistanceMeasure = (i: number, j: number) => number
@@ -85,7 +85,7 @@ export namespace CustomLabelingPolicy {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = LabelingPolicy.Props & {
-    args: p.Property<DictLike<unknown>>
+    args: p.Property<Dict<unknown>>
     code: p.Property<string>
   }
 }

--- a/bokehjs/src/lib/models/sources/ajax_data_source.ts
+++ b/bokehjs/src/lib/models/sources/ajax_data_source.ts
@@ -1,5 +1,5 @@
 import {WebDataSource} from "./web_data_source"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import type {UpdateMode} from "core/enums"
 import {HTTPMethod} from "core/enums"
 import {logger} from "core/logging"
@@ -12,7 +12,7 @@ export namespace AjaxDataSource {
   export type Props = WebDataSource.Props & {
     polling_interval: p.Property<number | null>
     content_type: p.Property<string>
-    http_headers: p.Property<DictLike<string>>
+    http_headers: p.Property<Dict<string>>
     method: p.Property<HTTPMethod>
     if_modified: p.Property<boolean>
   }

--- a/bokehjs/src/lib/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/lib/models/sources/columnar_data_source.ts
@@ -3,7 +3,7 @@ import {logger} from "core/logging"
 import type * as p from "core/properties"
 import {SelectionManager} from "core/selection_manager"
 import {Signal, Signal0} from "core/signaling"
-import type {Arrayable, ArrayableNew, Data, DictLike} from "core/types"
+import type {Arrayable, ArrayableNew, Data, Dict} from "core/types"
 import type {PatchSet} from "core/patching"
 import {assert} from "core/util/assert"
 import {uniq} from "core/util/array"
@@ -23,7 +23,7 @@ export namespace ColumnarDataSource {
 
   export type Props = DataSource.Props & {
     data: p.Property<Data> // XXX: this is hack!!!
-    default_values: p.Property<DictLike<unknown>>
+    default_values: p.Property<Dict<unknown>>
     selection_policy: p.Property<SelectionPolicy>
     inspected: p.Property<Selection>
   }

--- a/bokehjs/src/lib/models/sources/geojson_data_source.ts
+++ b/bokehjs/src/lib/models/sources/geojson_data_source.ts
@@ -9,7 +9,7 @@ import type * as p from "core/properties"
 import type {Arrayable} from "core/types"
 import {is_undefined} from "core/util/types"
 import {range} from "core/util/array"
-import {entries} from "core/util/object"
+import {dict} from "core/util/object"
 
 type GeoItem = Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon | GeometryCollection
 
@@ -36,8 +36,6 @@ export interface GeoJSONDataSource extends GeoJSONDataSource.Attrs {}
 function orNaN(v: number | undefined): number {
   return v != null ? v : NaN
 }
-
-const {hasOwnProperty} = Object.prototype
 
 export class GeoJSONDataSource extends ColumnarDataSource {
   declare properties: GeoJSONDataSource.Props
@@ -80,9 +78,11 @@ export class GeoJSONDataSource extends ColumnarDataSource {
 
   private _add_properties(item: Feature<GeoItem>, data: GeoData, i: number, item_count: number): void {
     const properties = item.properties ?? {}
-    for (const [property, value] of entries(properties)) {
-      if (!hasOwnProperty.call(data, property))
+    const data_proxy = dict(data)
+    for (const [property, value] of dict(properties)) {
+      if (!data_proxy.has(property)) {
         data[property] = this._get_new_nan_array(item_count)
+      }
       // orNaN necessary here to prevent null values from ending up in the column
       data[property][i] = orNaN(value)
     }

--- a/bokehjs/src/lib/models/text/math_text.ts
+++ b/bokehjs/src/lib/models/text/math_text.ts
@@ -6,7 +6,7 @@ import type {Context2d} from "core/util/canvas"
 import {load_image} from "core/util/image"
 import type {CanvasImage} from "models/glyphs/image_url"
 import {color2css, color2hexrgb, color2rgba} from "core/util/color"
-import type {Size, DictLike} from "core/types"
+import type {Size, Dict} from "core/types"
 import type {GraphicsBox, TextHeightMetric, Position} from "core/graphics"
 import {text_width} from "core/graphics"
 import {font_metrics, parse_css_font_size, parse_css_length} from "core/util/text"
@@ -574,7 +574,7 @@ export namespace TeX {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = MathText.Props & {
-    macros: p.Property<DictLike<string | [string, number]>>
+    macros: p.Property<Dict<string | [string, number]>>
     inline: p.Property<boolean>
   }
 }

--- a/bokehjs/src/lib/models/tiles/tile_source.ts
+++ b/bokehjs/src/lib/models/tiles/tile_source.ts
@@ -1,7 +1,7 @@
 import {Model} from "../../model"
 //import {DOMElement} from "../dom"
 import type {Extent, Bounds} from "./tile_utils"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {entries} from "core/util/object"
 import type * as p from "core/properties"
 
@@ -17,7 +17,7 @@ export namespace TileSource {
     tile_size: p.Property<number>
     max_zoom: p.Property<number>
     min_zoom: p.Property<number>
-    extra_url_vars: p.Property<DictLike<string>>
+    extra_url_vars: p.Property<Dict<string>>
     attribution: p.Property<string/* | DOMElement | (string | DOMElement)[] | null*/>
     x_origin_offset: p.Property<number>
     y_origin_offset: p.Property<number>
@@ -61,7 +61,7 @@ export abstract class TileSource extends Model {
     this.connect(this.change, () => this._clear_cache())
   }
 
-  string_lookup_replace(str: string, lookup: DictLike<string>): string {
+  string_lookup_replace(str: string, lookup: Dict<string>): string {
     let result_str = str
     for (const [key, value] of entries(lookup)) {
       result_str = result_str.replace(`{${key}}`, value)

--- a/bokehjs/src/lib/models/tools/edit/edit_tool.ts
+++ b/bokehjs/src/lib/models/tools/edit/edit_tool.ts
@@ -2,7 +2,7 @@ import type * as p from "core/properties"
 import type {PointGeometry} from "core/geometry"
 import type {UIEvent, MoveEvent} from "core/ui_events"
 import type {Dimensions, SelectionMode} from "core/enums"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {includes} from "core/util/array"
 import {dict} from "core/util/object"
 import {isArray} from "core/util/types"
@@ -191,7 +191,7 @@ export namespace EditTool {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = GestureTool.Props & {
-    default_overrides: p.Property<DictLike<unknown>>
+    default_overrides: p.Property<Dict<unknown>>
     empty_value: p.Property<unknown>
   }
 }

--- a/bokehjs/src/lib/models/tools/inspectors/customjs_hover.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/customjs_hover.ts
@@ -1,6 +1,6 @@
 import {Model} from "../../../model"
 import type * as p from "core/properties"
-import type {DictLike} from "core/types"
+import type {Dict} from "core/types"
 import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
 
@@ -8,7 +8,7 @@ export namespace CustomJSHover {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Model.Props & {
-    args: p.Property<DictLike<unknown>>
+    args: p.Property<Dict<unknown>>
     code: p.Property<string>
   }
 }

--- a/bokehjs/src/lib/models/transforms/customjs_transform.ts
+++ b/bokehjs/src/lib/models/transforms/customjs_transform.ts
@@ -1,6 +1,6 @@
 import {Transform} from "./transform"
 import type * as p from "core/properties"
-import type {Arrayable, DictLike} from "core/types"
+import type {Arrayable, Dict} from "core/types"
 import {keys, values} from "core/util/object"
 import {use_strict} from "core/util/string"
 
@@ -8,7 +8,7 @@ export namespace CustomJSTransform {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Transform.Props & {
-    args: p.Property<DictLike<unknown>>
+    args: p.Property<Dict<unknown>>
     func: p.Property<string>
     v_func: p.Property<string>
   }

--- a/bokehjs/test/unit/core/serialization.ts
+++ b/bokehjs/test/unit/core/serialization.ts
@@ -7,7 +7,7 @@ import type {MapRep, NDArrayRep} from "@bokehjs/core/serialization/reps"
 import {default_resolver} from "@bokehjs/base"
 import {ModelResolver} from "@bokehjs/core/resolvers"
 import {HasProps} from "@bokehjs/core/has_props"
-import type {DictLike} from "@bokehjs/core/types"
+import type {Dict} from "@bokehjs/core/types"
 import type * as p from "@bokehjs/core/properties"
 import {Slice} from "@bokehjs/core/util/slice"
 import {ndarray} from "@bokehjs/core/util/ndarray"
@@ -25,7 +25,7 @@ namespace SomeModel {
   export type Props = HasProps.Props & {
     value: p.Property<number>
     array: p.Property<number[]>
-    dict: p.Property<DictLike<number>>
+    dict: p.Property<Dict<number>>
     map: p.Property<Map<number[], number>>
     set: p.Property<Set<number[]>>
     obj: p.Property<SomeModel | null>

--- a/bokehjs/test/unit/core/util/object.ts
+++ b/bokehjs/test/unit/core/util/object.ts
@@ -1,6 +1,7 @@
 import {expect} from "assertions"
 
 import * as object from "@bokehjs/core/util/object"
+import type {PlainObject} from "@bokehjs/core/types"
 
 describe("object module", () => {
 
@@ -34,5 +35,105 @@ describe("object module", () => {
       const obj2 = {key3: 5}
       expect(object.extend(obj1, obj2)).to.be.equal({key1: [], key2: [0], key3: 5})
     })
+  })
+})
+
+describe("PlainObjectProxy", () => {
+  it("supports clear() method", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    dict.clear()
+    expect(obj).to.be.equal({})
+  })
+
+  it("supports delete() method", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    expect(dict.delete("y")).to.be.true
+    expect(obj).to.be.equal({x: 1, z: 3})
+    expect(dict.delete("x")).to.be.true
+    expect(obj).to.be.equal({z: 3})
+    expect(dict.delete("z")).to.be.true
+    expect(obj).to.be.equal({})
+    expect(dict.delete("x")).to.be.false
+    expect(dict.delete("t")).to.be.false
+  })
+
+  it("supports has() method", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    expect(dict.has("x")).to.be.true
+    expect(dict.has("y")).to.be.true
+    expect(dict.has("z")).to.be.true
+    expect(dict.has("t")).to.be.false
+    expect(dict.has("toString")).to.be.false
+    expect(obj).to.be.equal({x: 1, y: 2, z: 3})
+  })
+
+  it("supports get() method", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    expect(dict.get("x")).to.be.equal(1)
+    expect(dict.get("y")).to.be.equal(2)
+    expect(dict.get("z")).to.be.equal(3)
+    expect(dict.get("t")).to.be.undefined
+    expect(dict.get("toString")).to.be.undefined
+    expect(obj).to.be.equal({x: 1, y: 2, z: 3})
+  })
+
+  it("supports set() method", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    dict.set("x", 10)
+    dict.set("y", 20)
+    dict.set("z", 30)
+    dict.set("t", 40)
+    expect(obj).to.be.equal({x: 10, y: 20, z: 30, t: 40})
+  })
+
+  it("supports size getter", () => {
+    expect(new object.PlainObjectProxy({}).size).to.be.equal(0)
+    expect(new object.PlainObjectProxy({x: 1, y: 2, z: 3}).size).to.be.equal(3)
+  })
+
+  it("supports default iterator", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    const iter = dict[Symbol.iterator]()
+    expect([...iter]).to.be.equal([["x", 1], ["y", 2], ["z", 3]])
+    expect(obj).to.be.equal({x: 1, y: 2, z: 3})
+  })
+
+  it("supports keys() iterator", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    const iter = dict.keys()
+    expect([...iter]).to.be.equal(["x", "y", "z"])
+    expect(obj).to.be.equal({x: 1, y: 2, z: 3})
+  })
+
+  it("supports values() iterator", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    const iter = dict.values()
+    expect([...iter]).to.be.equal([1, 2, 3])
+    expect(obj).to.be.equal({x: 1, y: 2, z: 3})
+  })
+
+  it("supports entries() iterator", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    const iter = dict.entries()
+    expect([...iter]).to.be.equal([["x", 1], ["y", 2], ["z", 3]])
+    expect(obj).to.be.equal({x: 1, y: 2, z: 3})
+  })
+
+  it("supports forEach() method", () => {
+    const obj: PlainObject = {x: 1, y: 2, z: 3}
+    const dict = new object.PlainObjectProxy(obj)
+    const collected: [unknown, string][] = []
+    dict.forEach((value, key) => collected.push([value, key]))
+    expect(collected).to.be.equal([[1, "x"], [2, "y"], [3, "z"]])
+    expect(obj).to.be.equal({x: 1, y: 2, z: 3})
   })
 })

--- a/bokehjs/test/unit/core/util/object.ts
+++ b/bokehjs/test/unit/core/util/object.ts
@@ -85,8 +85,11 @@ describe("PlainObjectProxy", () => {
     const obj: PlainObject = {x: 1, y: 2, z: 3}
     const dict = new object.PlainObjectProxy(obj)
     dict.set("x", 10)
+    expect(obj).to.be.equal({x: 10, y: 2, z: 3})
     dict.set("y", 20)
+    expect(obj).to.be.equal({x: 10, y: 20, z: 3})
     dict.set("z", 30)
+    expect(obj).to.be.equal({x: 10, y: 20, z: 30})
     dict.set("t", 40)
     expect(obj).to.be.equal({x: 10, y: 20, z: 30, t: 40})
   })

--- a/bokehjs/test/unit/core/util/types.ts
+++ b/bokehjs/test/unit/core/util/types.ts
@@ -2,6 +2,7 @@ import {expect} from "assertions"
 
 import {
   isBoolean,
+  isDict,
   isNumber,
   isInteger,
   isString,
@@ -149,6 +150,20 @@ describe("core/util/types module", () => {
     expect(isPlainObject({})).to.be.true
     expect(isPlainObject(Object.create(null))).to.be.true
     expect(isPlainObject(new X())).to.be.false
+    expect(isPlainObject(new Map())).to.be.false
+    expect(isPlainObject(new Map([[new X(), 1]]))).to.be.false
+    expect(isPlainObject(new Set())).to.be.false
+    expect(isPlainObject(new Set([new X()]))).to.be.false
+  })
+
+  it("should support isDict() function", () => {
+    expect(isDict(0)).to.be.false
+    expect(isDict({})).to.be.true
+    expect(isDict(Object.create(null))).to.be.true
+    expect(isDict(new Map())).to.be.true
+    expect(isDict(new Map([[new X(), 1]]))).to.be.true
+    expect(isDict(new Set())).to.be.false
+    expect(isDict(new Set([new X()]))).to.be.false
   })
 
   it("should support isBasicObject() function", () => {


### PR DESCRIPTION
This PR makes `Object.hasOwnProperty()` mostly unnecessary, except for code actually managing low-level objects. This way plain objects are manipulated using more familiar `Map` interface like API. Also renamed `DictLike` type to `Dict` (this was added in this release cycle), and added `isDict()` type query.