### PR TITLE
Fix slowness for on_change corner case

### DIFF
--- a/src/bokeh/util/callback_manager.py
+++ b/src/bokeh/util/callback_manager.py
@@ -205,13 +205,12 @@ def _nargs(fn: Callable[..., Any]) -> int:
 def _check_callback(callback: Callable[..., Any], fargs: Sequence[str], what: str ="Callback functions") -> None:
     '''Bokeh-internal function to check callback signature'''
     sig = signature(callback)
-    formatted_args = str(sig)
-    error_msg = what + " must have signature func(%s), got func%s"
-
     all_names, default_values = get_param_info(sig)
 
     nargs = len(all_names) - len(default_values)
     if nargs != len(fargs):
+        formatted_args = str(sig)
+        error_msg = what + " must have signature func(%s), got func%s"
         raise ValueError(error_msg % (", ".join(fargs), formatted_args))
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/util/callback_manager.py
+++ b/src/bokeh/util/callback_manager.py
@@ -209,9 +209,9 @@ def _check_callback(callback: Callable[..., Any], fargs: Sequence[str], what: st
 
     nargs = len(all_names) - len(default_values)
     if nargs != len(fargs):
-        formatted_args = str(sig)
-        error_msg = what + " must have signature func(%s), got func%s"
-        raise ValueError(error_msg % (", ".join(fargs), formatted_args))
+        expected = ", ".join(fargs)
+        received = str(sig)
+        raise ValueError(f"{what} must have signature func({expected}), got func{received}")
 
 #-----------------------------------------------------------------------------
 # Code


### PR DESCRIPTION
This small patch just displace an error message construction for the on_call method. It used to be done even when the error in itself was not triggered. As described in #13688 , in the event where you have optional argument in the callback with a big data structure, the message was calling str on the default argument which could prove long.

The patch is just moving the error message construction within the error trigger block, which anyway is better and is fixing the potential slowness.

- [x] issues: fixes #13688 


