### PR TITLE
Rename `Figure` -> `figure` in `examples/`

### DIFF
--- a/examples/interaction/linking/linked_panning.py
+++ b/examples/interaction/linking/linked_panning.py
@@ -1,7 +1,7 @@
 '''An example of linked panning with three scatter plots.
 
 .. bokeh-example-metadata::
-    :apis: bokeh.plotting.Figure.scatter
+    :apis: bokeh.plotting.figure.scatter
     :refs: :ref:`ug_basic_scatters_markers`
     :keywords: scatter, linked panning
 

--- a/examples/plotting/trefoil.py
+++ b/examples/plotting/trefoil.py
@@ -3,7 +3,7 @@ rendering annular wegdes, different arrow heads and adding arc and segment
 glyphs.
 
 .. bokeh-example-metadata::
-    :apis: bokeh.plotting.Figure.annular_wedge, bokeh.plotting.Figure.arc, bokeh.plotting.Figure.segment, bokeh.models.TeeHead, bokeh.models.VeeHead
+    :apis: bokeh.plotting.figure.annular_wedge, bokeh.plotting.figure.arc, bokeh.plotting.figure.segment, bokeh.models.TeeHead, bokeh.models.VeeHead
     :refs: :ref:`ug_basic_annotations_arrows`, :ref:`ug_styling_mathtext`
     :keywords: trefoil, teehead, veehead, arrow, arrow head, segment, arc, circle, annular wedge
 

--- a/examples/server/api/notebook_embed.ipynb
+++ b/examples/server/api/notebook_embed.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "    doc.theme = Theme(json=yaml.load(\"\"\"\n",
     "        attrs:\n",
-    "            Figure:\n",
+    "            figure:\n",
     "                background_fill_color: \"#DDDDDD\"\n",
     "                outline_line_color: white\n",
     "                toolbar_location: above\n",


### PR DESCRIPTION
This PR renames a few left-over cases.

fixes #13679