### PR TITLE
Normalize enum definitions in bokehjs; remove redundancy

### DIFF
--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -1,127 +1,117 @@
 import {Enum} from "./kinds"
 
-export type Align = "start" | "center" | "end"
 export const Align = Enum("start", "center", "end")
+export type Align = typeof Align["__type__"]
 
-export type HAlign = "left" | "center" | "right"
 export const HAlign = Enum("left", "center", "right")
+export type HAlign = typeof HAlign["__type__"]
 
-export type VAlign = "top" | "center" | "bottom"
 export const VAlign = Enum("top", "center", "bottom")
+export type VAlign = typeof VAlign["__type__"]
 
-export type Anchor = `${VAlign}_${HAlign}` | HAlign | VAlign
 export const Anchor = Enum(
   "top_left",    "top_center",    "top_right",
   "center_left", "center_center", "center_right",
   "bottom_left", "bottom_center", "bottom_right",
   "top", "left", "center", "right", "bottom",
 )
+export type Anchor = typeof Anchor["__type__"]
 
-export type AngleUnits = "deg" | "rad" | "grad" | "turn"
 export const AngleUnits = Enum("deg", "rad", "grad", "turn")
+export type AngleUnits = typeof AngleUnits["__type__"]
 
-export type AlternationPolicy = typeof AlternationPolicy["__type__"]
 export const AlternationPolicy = Enum("none", "even", "odd", "every")
+export type AlternationPolicy = typeof AlternationPolicy["__type__"]
 
-export type BoxOrigin = "corner" | "center"
 export const BoxOrigin = Enum("corner", "center")
+export type BoxOrigin = typeof BoxOrigin["__type__"]
 
-export type ButtonType = "default" | "primary" | "success" | "warning" | "danger" | "light"
 export const ButtonType = Enum("default", "primary", "success", "warning", "danger", "light")
+export type ButtonType = typeof ButtonType["__type__"]
 
-export type CalendarPosition = "auto" | "above" | "below"
 export const CalendarPosition = Enum("auto", "above", "below")
+export type CalendarPosition = typeof CalendarPosition["__type__"]
 
-export type Clock = typeof Clock["__type__"]
 export const Clock = Enum("12h", "24h")
+export type Clock = typeof Clock["__type__"]
 
-export type CoordinateUnits = "canvas" | "screen" | "data"
 export const CoordinateUnits = Enum("canvas", "screen", "data")
+export type CoordinateUnits = typeof CoordinateUnits["__type__"]
 
-export type ContextWhich = "start" | "center" | "end" | "all"
 export const ContextWhich = Enum("start", "center", "end", "all")
+export type ContextWhich = typeof ContextWhich["__type__"]
 
-export type Dimension = "width" | "height"
 export const Dimension = Enum("width", "height")
+export type Dimension = typeof Dimension["__type__"]
 
-export type Dimensions = "width" | "height" | "both"
 export const Dimensions = Enum("width", "height", "both")
+export type Dimensions = typeof Dimensions["__type__"]
 
-export type Direction = "clock" | "anticlock"
 export const Direction = Enum("clock", "anticlock")
+export type Direction = typeof Direction["__type__"]
 
-export type Distribution = "uniform" | "normal"
 export const Distribution = Enum("uniform", "normal")
+export type Distribution = typeof Distribution["__type__"]
 
-export type Face = typeof Face["__type__"]
 export const Face = Enum("front", "back")
+export type Face = typeof Face["__type__"]
 
-export type FlowMode = typeof FlowMode["__type__"]
 export const FlowMode = Enum("block", "inline")
+export type FlowMode = typeof FlowMode["__type__"]
 
-export type FontStyle = "normal" | "italic" | "bold" | "bold italic"
 export const FontStyle = Enum("normal", "italic", "bold", "bold italic")
+export type FontStyle = typeof FontStyle["__type__"]
 
-export type HatchPatternType =
-  "blank" | "dot" | "ring" | "horizontal_line" | "vertical_line" | "cross" | "horizontal_dash" |
-  "vertical_dash" | "spiral" | "right_diagonal_line" | "left_diagonal_line" | "diagonal_cross" |
-  "right_diagonal_dash" | "left_diagonal_dash" | "horizontal_wave" | "vertical_wave" | "criss_cross" |
-  " " | "." | "o" | "-" | "|" | "+" | '"' | ":" | "@" | "/" | "\\" | "x" | "," | "`" | "v" | ">" | "*"
 export const HatchPatternType = Enum(
   "blank", "dot", "ring", "horizontal_line", "vertical_line", "cross", "horizontal_dash",
   "vertical_dash", "spiral", "right_diagonal_line", "left_diagonal_line", "diagonal_cross",
   "right_diagonal_dash", "left_diagonal_dash", "horizontal_wave", "vertical_wave", "criss_cross",
-  " ", ".", "o", "-", "|", "+", '"', ":", "@",  "/", "\\", "x", ",", "`", "v", ">", "*",
+  " ", ".", "o", "-", "|", "+", '"', ":", "@", "/", "\\", "x", ",", "`", "v", ">", "*",
 )
+export type HatchPatternType = typeof HatchPatternType["__type__"]
 
-export type HTTPMethod = "POST" | "GET"
 export const HTTPMethod = Enum("POST", "GET")
+export type HTTPMethod = typeof HTTPMethod["__type__"]
 
-export type HexTileOrientation = "pointytop" | "flattop"
 export const HexTileOrientation = Enum("pointytop", "flattop")
+export type HexTileOrientation = typeof HexTileOrientation["__type__"]
 
-export type HoverMode = "mouse" | "hline" | "vline"
 export const HoverMode = Enum("mouse", "hline", "vline")
+export type HoverMode = typeof HoverMode["__type__"]
 
-export type ImageOrigin = "bottom_left" | "top_left" | "bottom_right" | "top_right"
 export const ImageOrigin = Enum("bottom_left", "top_left", "bottom_right", "top_right")
+export type ImageOrigin = typeof ImageOrigin["__type__"]
 
-export type LatLon = "lat" | "lon"
 export const LatLon = Enum("lat", "lon")
+export type LatLon = typeof LatLon["__type__"]
 
-export type LegendClickPolicy = "none" | "hide" | "mute"
 export const LegendClickPolicy = Enum("none", "hide", "mute")
+export type LegendClickPolicy = typeof LegendClickPolicy["__type__"]
 
-export type LegendLocation = Anchor
 export const LegendLocation = Anchor
+export type LegendLocation = Anchor
 
-export type LineCap = "butt" | "round" | "square"
 export const LineCap = Enum("butt", "round", "square")
+export type LineCap = typeof LineCap["__type__"]
 
-export type LineDash = "solid" | "dashed" | "dotted" | "dotdash" | "dashdot"
 export const LineDash = Enum("solid", "dashed", "dotted", "dotdash", "dashdot")
+export type LineDash = typeof LineDash["__type__"]
 
-export type LineJoin = "miter" | "round" | "bevel"
 export const LineJoin = Enum("miter", "round", "bevel")
+export type LineJoin = typeof LineJoin["__type__"]
 
-export type LinePolicy = "prev" | "next" | "nearest" | "interp" | "none"
 export const LinePolicy = Enum("prev", "next", "nearest", "interp", "none")
+export type LinePolicy = typeof LinePolicy["__type__"]
 
-export type Location = "above" | "below" | "left" | "right"
 export const Location = Enum("above", "below", "left", "right")
+export type Location = typeof Location["__type__"]
 
-export type Logo = "normal" | "grey"
 export const Logo = Enum("normal", "grey")
+export type Logo = typeof Logo["__type__"]
 
-export type MapType = typeof MapType["__type__"]
 export const MapType = Enum("satellite", "roadmap", "terrain", "hybrid")
+export type MapType = typeof MapType["__type__"]
 
-export type MarkerType =
-  "asterisk" | "circle" | "circle_cross" | "circle_dot" | "circle_x" |
-  "circle_y" | "cross" | "dash" | "diamond" | "diamond_cross" | "diamond_dot" |
-  "dot" | "hex" | "hex_dot" | "inverted_triangle" | "plus" | "square" |
-  "square_cross" | "square_dot" | "square_pin" | "square_x" | "star" | "star_dot" |
-  "triangle" | "triangle_dot" | "triangle_pin" | "x" | "y"
 export const MarkerType = Enum(
   "asterisk", "circle", "circle_cross", "circle_dot", "circle_x",
   "circle_y", "cross", "dash", "diamond", "diamond_cross", "diamond_dot",
@@ -129,90 +119,91 @@ export const MarkerType = Enum(
   "square_cross", "square_dot", "square_pin", "square_x", "star", "star_dot",
   "triangle", "triangle_dot", "triangle_pin", "x", "y",
 )
+export type MarkerType = typeof MarkerType["__type__"]
 
-export type MutedPolicy = "show" | "ignore"
 export const MutedPolicy = Enum("show", "ignore")
+export type MutedPolicy = typeof MutedPolicy["__type__"]
 
-export type Orientation = "vertical" | "horizontal"
 export const Orientation = Enum("vertical", "horizontal")
+export type Orientation = typeof Orientation["__type__"]
 
-export type OutputBackend = "canvas" | "svg" | "webgl"
 export const OutputBackend = Enum("canvas", "svg", "webgl")
+export type OutputBackend = typeof OutputBackend["__type__"]
 
-export type PaddingUnits = "percent" | "absolute"
 export const PaddingUnits = Enum("percent", "absolute")
+export type PaddingUnits = typeof PaddingUnits["__type__"]
 
-export type Place = Side | "center"
 export const Place = Enum("above", "below", "left", "right", "center")
+export type Place = typeof Place["__type__"]
 
-export type PointPolicy = "snap_to_data" | "follow_mouse" | "none"
 export const PointPolicy = Enum("snap_to_data", "follow_mouse", "none")
+export type PointPolicy = typeof PointPolicy["__type__"]
 
-export type RadiusDimension = "x" | "y" | "max" | "min"
 export const RadiusDimension = Enum("x", "y", "max", "min")
+export type RadiusDimension = typeof RadiusDimension["__type__"]
 
-export type RenderLevel = "image" | "underlay" | "glyph" | "guide" | "annotation" | "overlay"
 export const RenderLevel = Enum("image", "underlay", "glyph", "guide", "annotation", "overlay")
+export type RenderLevel = typeof RenderLevel["__type__"]
 
-export type ResetPolicy = "standard" | "event_only"
 export const ResetPolicy = Enum("standard", "event_only")
+export type ResetPolicy = typeof ResetPolicy["__type__"]
 
-export type ResolutionType = "microseconds" | "milliseconds" | "seconds" | "minsec" | "minutes" | "hourmin" | "hours" | "days" | "months" | "years"
 export const ResolutionType = Enum("microseconds", "milliseconds", "seconds", "minsec", "minutes", "hourmin", "hours", "days", "months", "years")
+export type ResolutionType = typeof ResolutionType["__type__"]
 
-export type RoundingFunction = "round" | "nearest" | "floor" | "rounddown" | "ceil" | "roundup"
 export const RoundingFunction = Enum("round", "nearest", "floor", "rounddown", "ceil", "roundup")
+export type RoundingFunction = typeof RoundingFunction["__type__"]
 
-export type ScrollbarPolicy = typeof ScrollbarPolicy["__type__"]
 export const ScrollbarPolicy = Enum("auto", "visible", "hidden")
+export type ScrollbarPolicy = typeof ScrollbarPolicy["__type__"]
 
-export type SelectionMode = typeof SelectionMode["__type__"]
 export const SelectionMode = Enum("replace", "append", "intersect", "subtract", "xor")
+export type SelectionMode = typeof SelectionMode["__type__"]
 
-export type Side = "above" | "below" | "left" | "right"
 export const Side = Enum("above", "below", "left", "right")
+export type Side = typeof Side["__type__"]
 
-export type SizingMode = "stretch_width" | "stretch_height" | "stretch_both" | "scale_width" | "scale_height" | "scale_both" | "fixed" | "inherit"
 export const SizingMode = Enum("stretch_width", "stretch_height", "stretch_both", "scale_width", "scale_height", "scale_both", "fixed", "inherit")
+export type SizingMode = typeof SizingMode["__type__"]
 
-export type Sort = "ascending" | "descending"
 export const Sort = Enum("ascending", "descending")
+export type Sort = typeof Sort["__type__"]
 
-export type SpatialUnits = "screen" | "data"
 export const SpatialUnits = Enum("screen", "data")
+export type SpatialUnits = typeof SpatialUnits["__type__"]
 
-export type StartEnd = "start" | "end"
 export const StartEnd = Enum("start", "end")
+export type StartEnd = typeof StartEnd["__type__"]
 
-export type StepMode = "after" | "before" | "center"
 export const StepMode = Enum("after", "before", "center")
+export type StepMode = typeof StepMode["__type__"]
 
-export type TapBehavior = "select" | "inspect"
 export const TapBehavior = Enum("select", "inspect")
+export type TapBehavior = typeof TapBehavior["__type__"]
 
-export type TapGesture = typeof TapGesture["__type__"]
 export const TapGesture = Enum("tap", "doubletap")
+export type TapGesture = typeof TapGesture["__type__"]
 
-export type TextAlign = "left" | "right" | "center"
 export const TextAlign = Enum("left", "right", "center")
+export type TextAlign = typeof TextAlign["__type__"]
 
-export type TextBaseline = "top" | "middle" | "bottom" | "alphabetic" | "hanging" | "ideographic"
 export const TextBaseline = Enum("top", "middle", "bottom", "alphabetic", "hanging", "ideographic")
+export type TextBaseline = typeof TextBaseline["__type__"]
 
-export type TextureRepetition = "repeat" | "repeat_x" | "repeat_y" | "no_repeat"
 export const TextureRepetition = Enum("repeat", "repeat_x", "repeat_y", "no_repeat")
+export type TextureRepetition = typeof TextureRepetition["__type__"]
 
-export type LabelOrientation = "vertical" | "horizontal" | "parallel" | "normal"
 export const LabelOrientation = Enum("vertical", "horizontal", "parallel", "normal")
+export type LabelOrientation = typeof LabelOrientation["__type__"]
 
-export type TooltipAttachment = "horizontal" | "vertical" | "left" | "right" | "above" | "below"
 export const TooltipAttachment = Enum("horizontal", "vertical", "left", "right", "above", "below")
+export type TooltipAttachment = typeof TooltipAttachment["__type__"]
 
-export type UpdateMode = "replace" | "append"
 export const UpdateMode = Enum("replace", "append")
+export type UpdateMode = typeof UpdateMode["__type__"]
 
-export type VerticalAlign = "top" | "middle" | "bottom"
 export const VerticalAlign = Enum("top", "middle", "bottom")
+export type VerticalAlign = typeof VerticalAlign["__type__"]
 
 // Keep this in sync with bokehjs/src/less/icons.less
 export const ToolIcon = Enum(

--- a/bokehjs/src/lib/core/layout/types.ts
+++ b/bokehjs/src/lib/core/layout/types.ts
@@ -75,8 +75,8 @@ export type SizeHint = Size & {
   align?: LRTB<boolean> & {fixed_width?: boolean, fixed_height?: boolean}
 }
 
-export type SizingPolicy = "fixed" | "fit" | "min" | "max"
 export const SizingPolicy = Enum("fixed", "fit", "min", "max")
+export type SizingPolicy = typeof SizingPolicy["__type__"]
 
 export type Sizing = number | "fit" | "min" | "max"
 

--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -12,7 +12,7 @@ import {is_NDArray} from "./ndarray"
 import {isArray, isNumber, isString, isTypedArray} from "./types"
 
 export const FormatterType = Enum("numeral", "printf", "datetime")
-export type FormatterType = "numeral" | "printf" | "datetime"
+export type FormatterType = typeof FormatterType["__type__"]
 
 export type FormatterSpec = CustomJSHover | FormatterType
 export type Formatters = Dict<FormatterSpec>

--- a/bokehjs/src/lib/models/common/kinds.ts
+++ b/bokehjs/src/lib/models/common/kinds.ts
@@ -17,14 +17,13 @@ import {
 import type {HasProps} from "core/has_props"
 import * as enums from "core/enums"
 
-export type Length = typeof Length["__type__"]
 export const Length = NonNegative(Int)
+export type Length = typeof Length["__type__"]
 
 const XY = <T>(type: Kind<T>) => PartialStruct({x: type, y: type})
 
 const LRTB = <T>(type: Kind<T>) => PartialStruct({left: type, right: type, top: type, bottom: type})
 
-export type Anchor = typeof Anchor["__type__"]
 export const Anchor = (
   Or(
     enums.Anchor,
@@ -34,11 +33,11 @@ export const Anchor = (
     ),
   )
 )
+export type Anchor = typeof Anchor["__type__"]
 
-export type TextAnchor = typeof TextAnchor["__type__"]
 export const TextAnchor = Or(Anchor, Auto)
+export type TextAnchor = typeof TextAnchor["__type__"]
 
-export type Padding = typeof Padding["__type__"]
 export const Padding = (
   Or(
     Length,
@@ -48,8 +47,8 @@ export const Padding = (
     LRTB(Length),
   )
 )
+export type Padding = typeof Padding["__type__"]
 
-export type BorderRadius = typeof BorderRadius["__type__"]
 export const BorderRadius = (
   Or(
     Length,
@@ -62,29 +61,30 @@ export const BorderRadius = (
     }),
   )
 )
+export type BorderRadius = typeof BorderRadius["__type__"]
 
-export type Index = typeof Index["__type__"]
 export const Index = NonNegative(Int)
+export type Index = typeof Index["__type__"]
 
-export type Span = typeof Span["__type__"]
 export const Span = NonNegative(Int)
+export type Span = typeof Span["__type__"]
 
 export const GridChild = <T extends HasProps>(child: Constructor<T>) => Tuple(Ref(child), Index, Index, Opt(Span), Opt(Span))
 
-export type GridSpacing = typeof GridSpacing["__type__"]
 export const GridSpacing = Or(Length, Tuple(Length, Length))
+export type GridSpacing = typeof GridSpacing["__type__"]
 
-export type TrackAlign = typeof TrackAlign["__type__"]
 export const TrackAlign = Enum("start", "center", "end", "auto")
+export type TrackAlign = typeof TrackAlign["__type__"]
 
-export type TrackSize = typeof TrackSize["__type__"]
 export const TrackSize = String
+export type TrackSize = typeof TrackSize["__type__"]
 
-export type TrackSizing = typeof TrackSizing["__type__"]
 export const TrackSizing = PartialStruct({size: TrackSize, align: TrackAlign})
+export type TrackSizing = typeof TrackSizing["__type__"]
 
-export type TrackSizingLike = typeof TrackSizingLike["__type__"]
 export const TrackSizingLike = Or(TrackSize, TrackSizing)
+export type TrackSizingLike = typeof TrackSizingLike["__type__"]
 
-export type TracksSizing = typeof TracksSizing["__type__"]
 export const TracksSizing = Or(TrackSizingLike, Array(TrackSizingLike), Mapping(Int, TrackSizingLike))
+export type TracksSizing = typeof TracksSizing["__type__"]

--- a/bokehjs/src/lib/models/glyphs/tex_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/tex_glyph.ts
@@ -3,7 +3,11 @@ import type {BaseText} from "../text/base_text"
 import {TeX} from "../text/math_text"
 import type * as p from "core/properties"
 import type {Dict} from "core/types"
+import {Enum, Or, Auto} from "core/kinds"
 import {parse_delimited_string} from "../text/utils"
+
+const DisplayMode = Or(Enum("inline", "block"), Auto)
+type DisplayMode = typeof DisplayMode["__type__"]
 
 export interface TeXGlyphView extends TeXGlyph.Data {}
 
@@ -30,7 +34,7 @@ export namespace TeXGlyph {
 
   export type Props = MathTextGlyph.Props & {
     macros: p.Property<Dict<string | [string, number]>>
-    display: p.Property<"inline" | "block" | "auto">
+    display: p.Property<DisplayMode>
   }
 
   export type Visuals = MathTextGlyph.Visuals
@@ -51,9 +55,9 @@ export class TeXGlyph extends MathTextGlyph {
   static {
     this.prototype.default_view = TeXGlyphView
 
-    this.define<TeXGlyph.Props>(({Enum, Number, String, Dict, Tuple, Or, Auto}) => ({
+    this.define<TeXGlyph.Props>(({Number, String, Dict, Tuple, Or}) => ({
       macros: [ Dict(Or(String, Tuple(String, Number))), {} ],
-      display: [ Or(Enum("inline", "block"), Auto), "auto" ],
+      display: [ DisplayMode, "auto" ],
     }))
   }
 }

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -9,8 +9,8 @@ import {Enum} from "core/kinds"
 
 import dropdown_css, * as dropdown from "styles/dropdown.css"
 
-type SearchStrategy = typeof SearchStrategy["__type__"]
 const SearchStrategy = Enum("starts_with", "includes")
+type SearchStrategy = typeof SearchStrategy["__type__"]
 
 export class AutocompleteInputView extends TextInputView {
   declare model: AutocompleteInput


### PR DESCRIPTION
Replaces e.g.:
```ts
export type Align = "start" | "center" | "end"
export const Align = Enum("start", "center", "end")
```
with
```ts
export const Align = Enum("start", "center", "end")
export type Align = typeof Align["__type__"]
```