### PR TITLE
Minify GLSL shaders

### DIFF
--- a/bokehjs/test/codebase/size.ts
+++ b/bokehjs/test/codebase/size.ts
@@ -10,7 +10,7 @@ const LIMITS = new Map([
   ["js/bokeh-widgets.min.js",         350],
   ["js/bokeh-tables.min.js",          350],
   ["js/bokeh-api.min.js",             150],
-  ["js/bokeh-gl.min.js",              250],
+  ["js/bokeh-gl.min.js",              200],
   ["js/bokeh-mathjax.min.js",        1800],
 ])
 


### PR DESCRIPTION
Fixes #13335.

This minifies the WebGL shaders, mostly by removing comments and unnecessary whitespace. Example of shader before minifying:
```glsl
precision mediump float;

attribute vec2 a_position;
attribute vec4 a_bounds;

uniform float u_pixel_ratio;
uniform vec2 u_canvas_size;

varying vec2 v_tex_coords;

void main()
{
  v_tex_coords = vec2(a_position.x < 0.0 ? 0.0 : 1.0, a_position.y < 0.0 ? 0.0 : 1.0);

  float x = a_position.x < 0.0 ? a_bounds[0] : a_bounds[2];
  float y = a_position.y < 0.0 ? a_bounds[1] : a_bounds[3];
  vec2 xy = vec2(x, y);

  vec2 pos = xy + 0.5;  // Bokeh's offset.
  pos /= u_canvas_size / u_pixel_ratio;  // in 0..1
  gl_Position = vec4(2.0*pos.x - 1.0, 1.0 - 2.0*pos.y, 0.0, 1.0);
}
```
and after:
```glsl
precision mediump float;attribute vec2 a_position;attribute vec4 a_bounds;uniform float u_pixel_ratio;uniform vec2 u_canvas_size;varying vec2 v_tex_coords;void main(){v_tex_coords=vec2(a_position.x<0.?0.:1.,a_position.y<0.?0.:1.);float x=a_position.x<0.?a_bounds[0]:a_bounds[2];float y=a_position.y<0.?a_bounds[1]:a_bounds[3];vec2 xy=vec2(x,y);vec2 pos=xy+.5;pos/=u_canvas_size/u_pixel_ratio;gl_Position=vec4(2.*pos.x-1.,1.-2.*pos.y,0.,1.);}
```
Bundle sizes on `branch-3.4`:
```
    - bokeh-gl.js          :  551.5 KB
    - bokeh-gl.min.js      :  204.7 KB
```
and after this PR:
```
    - bokeh-gl.js          :  551.5 KB
    - bokeh-gl.min.js      :  186.9 KB
```
so it saves 17.8 KB of the `gl-min` bundles, about 8.7%.

I looked at existing NPM packages for this and didn't find any I liked. Mostly they are unmaintained and tightly coupled to webpack. So I wrote my own as a sequence of regex replacements. These should by understandable by anyone (including my future self) with some regex knowledge. The multiple passes of each shader, one per regex, are probably not very quick but GLSL is such a small fraction of the BokehJS codebase that there isn't any measurable increase in build time on my dev machine.

In future we could extend the minifying to replace local function and variable names with smaller strings, but that would require storing state so would need a different implementation.

Testing is a problem. I think that the visual baseline tests use the unminified bundles so this will not be tested by CI. Could you confirm this @mattpap?