### PR TITLE
Update examples for legends

### DIFF
--- a/examples/models/legends.py
+++ b/examples/models/legends.py
@@ -24,12 +24,14 @@ xdr = DataRange1d()
 ydr = DataRange1d()
 
 plot = Plot(
-    x_range=xdr, y_range=ydr,
-    width=1000, height=600,
+    x_range=xdr,
+    y_range=ydr,
+    width=1000,
+    height=1000,
     min_border=0,
     toolbar_location=None,
-    background_fill_color='#F0F0F0',
-    border_fill_color='lightgray',
+    background_fill_color="#F0F0F0",
+    border_fill_color="lightgray",
 )
 
 line_glyph = Line(x="x", y="y", line_color="navy", line_width=2, line_dash="dashed")
@@ -43,24 +45,32 @@ preview_save = SaveTool()
 
 plot.add_tools(pan, wheel_zoom, preview_save)
 
-# Add axes (Note it's important to add these before adding legends in side panels)
-plot.add_layout(LinearAxis(), 'below')
-plot.add_layout(LinearAxis(), 'left')
-plot.add_layout(LinearAxis(), 'right')
+# Add axes (Note it"s important to add these before adding legends in side panels)
+plot.add_layout(LinearAxis(), "below")
+plot.add_layout(LinearAxis(), "left")
+plot.add_layout(LinearAxis(), "right")
 
-def add_legend(location, orientation, side):
+def add_legend(location, orientation, side, background_fill_color="#FFFFFF"):
     legend = Legend(
-        # TODO: title
         items=[("line", [line]), ("circle", [circle])],
-        location=location, orientation=orientation,
+        location=location,
+        orientation=orientation,
         border_line_color="black",
-        title='Example Title',
+        background_fill_color=background_fill_color,
+        title=f"Legend at\n{location!r}\n{orientation!r}\n{side!r}",
     )
     plot.add_layout(legend, side)
 
-# Add legends in names positions e.g. 'top_right', 'top_left' (see plot for all)
+# Add legends in names positions e.g. "top_right", "top_left" (see plot for all)
 for location in LegendLocation:
-    add_legend(location, "vertical", "center")
+    # redundant positions get a different background color and a vertical orientation to show ambiguity
+    if "_" not in location:
+        background_fill_color = "#999999"
+        orientation = "vertical"
+    else:
+        background_fill_color ="#CCCCCC"
+        orientation = "horizontal"
+    add_legend(location, orientation, "center", background_fill_color=background_fill_color)
 
 # Add legend at fixed positions
 add_legend((150, 50), "horizontal", "center")

--- a/examples/models/legends.py
+++ b/examples/models/legends.py
@@ -45,7 +45,7 @@ preview_save = SaveTool()
 
 plot.add_tools(pan, wheel_zoom, preview_save)
 
-# Add axes (Note it"s important to add these before adding legends in side panels)
+# Add axes (Note it's important to add these before adding legends in side panels)
 plot.add_layout(LinearAxis(), "below")
 plot.add_layout(LinearAxis(), "left")
 plot.add_layout(LinearAxis(), "right")


### PR DESCRIPTION
This is a pull request without an issue. I want to update the example for legends. I added a multi line title to each legend and because some legends were not visible in the latest version I added a `background_fill_color` to some legends, too.

The example with my changes looks like this:
![grafik](https://github.com/mosc9575/bokeh/assets/68053396/74801537-ecc5-4c28-be8b-87cbb24f76ff)
