### PR TITLE
make links relative

### DIFF
--- a/docs/bokeh/source/docs/dev_guide/documentation.rst
+++ b/docs/bokeh/source/docs/dev_guide/documentation.rst
@@ -92,7 +92,7 @@ throughout the narrative documentation:
    "Python", "Always capitalize Python (the language)"
 
 For definitions and concepts used throughout Bokeh's documentation, see the
-:ref:`ug_glossary` in :ref:`ug_intro`.
+:ref:`ug_glossary`.
 
 In general, see the `word list of the Google developer documentation style
 guide`_ for reference.
@@ -103,7 +103,7 @@ Setting up and building Bokeh's documentation
 ---------------------------------------------
 
 Bokeh uses :doc:`Sphinx <sphinx:index>` to generate the HTML files displayed
-at docs.bokeh.org_. The documentation is written in
+at :ref:`docs.bokeh.org <about>`. The documentation is written in
 :doc:`reStructuredText (ReST) <sphinx:usage/restructuredtext/index>`.
 
 HTML is the only output format supported by Bokeh's documentation. Many pages
@@ -311,7 +311,7 @@ To learn more about options for the Sphinx build process, see
 
 Writing Bokeh's documentation
 -----------------------------
-The documentation available at docs.bokeh.org_ mainly consists of those two
+The documentation available at :ref:`docs.bokeh.org <about>` mainly consists of those two
 elements:
 
 :ref:`Narrative documentation <contributor_guide_documentation_edit_narrative>`
@@ -435,7 +435,7 @@ For example:
         """)
 
 .. note::
-  `Release Notes`_ are generally handled by the Bokeh core team as part of
+  :ref:`Release Notes <releases>` are generally handled by the Bokeh core team as part of
   Bokeh's `release management`_. Each release should add a new file under
   ``docs/bokeh/source/docs/releases`` that briefly describes the changes in the
   release, including any migration notes. The filename should be
@@ -450,12 +450,10 @@ For example:
 .. _inclusive: https://developers.google.com/style/inclusive-documentation
 .. _accessible: https://developers.google.com/style/accessibility
 .. _word list of the Google developer documentation style guide: https://developers.google.com/style/word-list
-.. _docs.bokeh.org: https://docs.bokeh.org/en/latest/
 .. _Google developers website: https://developers.google.com/maps/documentation/javascript/get-api-key
 .. _Napoleon: http://sphinxcontrib-napoleon.readthedocs.org/en/latest/index.html
 .. _Napoleon's Google style: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google
 .. _Google Python Style Guide: https://google.github.io/styleguide/pyguide.html#383-functions-and-methods
 .. _official reStructuredText website: https://docutils.sourceforge.io/rst.html
 .. _experimental Sphinx feature: https://github.com/sphinx-doc/sphinx/issues/6881
-.. _Release Notes: https://docs.bokeh.org/en/latest/docs/releases.html
 .. _release management: https://github.com/bokeh/bokeh/wiki/BEP-2:-Release-Management

--- a/docs/bokeh/source/docs/user_guide/advanced/compat.rst
+++ b/docs/bokeh/source/docs/user_guide/advanced/compat.rst
@@ -15,7 +15,7 @@ BokehJS. You can also use BokehJS as a standalone library or in
 combination with JavaScript frameworks, such as React_, Vue_, Angular_,
 and others.
 
-See `Developing with JavaScript`_ for more information about BokehJS.
+See :ref:`Developing with JavaScript <ug_advanced_bokehjs>` for more information about BokehJS.
 
 hvPlot
 ------
@@ -30,8 +30,8 @@ Panel
 
 The `Panel`_ library provides a high-level reactive interface that makes
 it easy to build data-intensive dashboards and web applications on top of
-Bokeh. Panel enables full interoperability between `Jupyter notebooks`_
-and `Bokeh server`_. This lets you develop or prototype applications in
+Bokeh. Panel enables full interoperability between :ref:`Jupyter notebooks <ug_output_jupyter>`
+and :ref:`Bokeh server <ug_server>`. This lets you develop or prototype applications in
 a notebook and deploy them on a server. Panel also interfaces with other
 plotting libraries and lets you incorporate multiple data-science
 artifacts into a single Bokeh application. Furthermore, the library
@@ -96,11 +96,8 @@ is an `example`_ of interaction HoloViews.
 .. _React: https://reactjs.org
 .. _Angular: https://angular.io
 .. _Vue: https://vuejs.org/
-.. _Developing with JavaScript: https://docs.bokeh.org/en/dev/docs/user_guide/bokehjs.html
 .. _hvPlot: https://hvplot.holoviz.org/
 .. _Panel: https://panel.holoviz.org/
-.. _Jupyter notebooks: https://docs.bokeh.org/en/latest/docs/user_guide/jupyter.html
-.. _Bokeh server: https://docs.bokeh.org/en/latest/docs/user_guide/server.html
 .. _Datashader: https://github.com/bokeh/datashader
 .. _overplotting: https://anaconda.org/jbednar/plotting_pitfalls
 .. _HoloViews: http://holoviews.org

--- a/docs/bokeh/source/docs/user_guide/output/export.rst
+++ b/docs/bokeh/source/docs/user_guide/output/export.rst
@@ -217,7 +217,6 @@ You can export an SVG plot in several ways:
 
 .. _Selenium: https://www.selenium.dev/documentation/en/
 .. _web drivers: https://www.selenium.dev/documentation/en/webdriver/
-.. _Conda: https://docs.bokeh.org/en/latest/docs/dev_guide/setup.html?highlight=conda#id4
 .. _ChromeDriver documentation: https://chromedriver.chromium.org/
 .. _geckodriver repository on GitHub: https://github.com/mozilla/geckodriver/releases
 .. _geckodriver documentation: https://firefox-source-docs.mozilla.org/testing/geckodriver/Usage.html

--- a/examples/plotting/filtering.py
+++ b/examples/plotting/filtering.py
@@ -1,4 +1,4 @@
-''' A map representation of unemployment rate in US using the `US_States Dataset <sampledata_us_states>`.
+''' A map representation of unemployment rate in US using the :ref:`US_States Dataset <sampledata_us_states>`.
 This example demonstrates using IndexFilter, ColorMapper and HoverTool with
 basic plot elements such as patches. When hovering over the points,
 the state and its umemployment rate is shown.

--- a/examples/plotting/filtering.py
+++ b/examples/plotting/filtering.py
@@ -1,4 +1,4 @@
-''' A map representation of unemployment rate in US using the `US_States Dataset`_.
+''' A map representation of unemployment rate in US using the `US_States Dataset <sampledata_us_states>`.
 This example demonstrates using IndexFilter, ColorMapper and HoverTool with
 basic plot elements such as patches. When hovering over the points,
 the state and its umemployment rate is shown.
@@ -8,8 +8,6 @@ the state and its umemployment rate is shown.
     :apis: bokeh.models.IndexFilter, bokeh.models.HoverTool, bokeh.models.LinearColorMapper
     :refs: :ref:`ug_basic_areas_patches`, :ref:`ug_basic_data_filtering_index`
     :keywords: hover tool, indexfilter, filtering, US
-
-.. _US_States Dataset: https://docs.bokeh.org/en/latest/docs/reference/sampledata.html#module-bokeh.sampledata.us_states
 '''
 from bokeh.core.properties import field
 from bokeh.models import ColorBar, HoverTool, IndexFilter, LinearColorMapper

--- a/tests/codebase/test_code_quality.py
+++ b/tests/codebase/test_code_quality.py
@@ -63,6 +63,7 @@ message_carriage  = "File contains carriage returns at end of line: {path}, line
 message_eof       = "File does not end with a newline: {path}, line {line_no}"
 message_multi_bof = "File starts with more than 1 empty line: {path}, line {line_no}"
 message_multi_eof = "File ends with more than 1 empty line: {path}, line {line_no}"
+message_bokeh_ref = "File contains static reference to bokeh.org: {path}, line {line_no}"
 message_too_long  = f"File contains a line with over {MAX_LINE_LENGTH} characters: {{path}}, line {{line_no}}"
 
 def tab_in_leading(s: str) -> bool:
@@ -107,6 +108,8 @@ def collect_errors() -> list[str]:
                 errors.append((message_carriage, fname, line_no))
             if use_tab_rule(fname) and tab_in_leading(line):
                 errors.append((message_tabs, fname, line_no))
+            if line.strip().startswith('..') and 'https://docs.bokeh.org' in line:
+                errors.append((message_bokeh_ref, fname, line_no))
             #if len(line) > MAX_LINE_LENGTH:
             #    errors.append((message_too_long, fname, line_no))
 


### PR DESCRIPTION
The goal of this PR is to make all static links relative using `:ref:`. If fixed the two examples in the linked issue and found three more static links. I also removed one line to the `Introduction` (`:ref:'ug_intro'`) because this page was linked twice in one sentence.

- [ ] issues: fixes #13698
