### PR TITLE
avoid duplicated pages

### DIFF
--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -30,7 +30,7 @@ version = settings.docs_version() or __version__
 
 add_module_names = False
 
-exclude_patterns = ["docs/releases/*"]
+exclude_patterns = ["docs/includes/*", "docs/releases/*"]
 
 extensions = [
     "sphinxext.opengraph",


### PR DESCRIPTION
I added `"docs/includes/*"` to the `exclude_patterns` in the `conf.py` because all rst-files in this folder are used in the `/bokeh/docs/bokeh/source/docs/user_guide/styling/visuals.rst`. This change will avoid duplicated pages. No information will be lost.

- [ ] issues: fixes #13717
