### PR TITLE
Ignore `pytest.PytestUnraisableExceptionWarning`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ filterwarnings = [
     '''ignore:Could not infer format, so each element will be parsed individually, falling back to `dateutil`\. To ensure parsing is consistent and as-expected, please specify a format\.:UserWarning''',
     '''ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version:DeprecationWarning:dateutil''',
     '''ignore:\s*Pyarrow will become a required dependency of pandas:DeprecationWarning''',
+    '''ignore:Exception ignored in. <.*>:pytest.PytestUnraisableExceptionWarning''',
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
This is an attempt to work around failing async tests on Windows (and potentially on other platforms in the near future). It would be preferable to actually fix our async test suite, but my earlier attempts failed thus far.
