### PR TITLE
Include generated TS modules in extensions' build

### DIFF
--- a/bokehjs/make/tasks/styles.ts
+++ b/bokehjs/make/tasks/styles.ts
@@ -1,11 +1,12 @@
-import {compile_styles} from "@compiler/styles"
+import {collect_styles, compile_styles} from "@compiler/styles"
 import {task, BuildError} from "../task"
 import * as paths from "../paths"
 
 task("styles:compile", async () => {
   const less_dir = paths.src_dir.less
   const css_dir = paths.build_dir.css
-  if (!await compile_styles(less_dir, css_dir)) {
+  const styles = collect_styles(less_dir)
+  if (!await compile_styles(styles, less_dir, css_dir)) {
     throw new BuildError("styles:compile", "failed to compile *.less and *.css source files")
   }
 })

--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -200,6 +200,7 @@ export async function init(base_dir: Path, _bokehjs_dir: Path, base_setup: InitO
 }
 
 export type BuildOptions = {
+  verbose?: boolean
   rebuild?: boolean
   bokeh_version: string
 }
@@ -208,6 +209,7 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
   print(`Working directory: ${cyan(base_dir)}`)
 
   const setup: Required<BuildOptions> = {
+    verbose: base_setup.verbose ?? false,
     rebuild: base_setup.rebuild ?? false,
     bokeh_version: base_setup.bokeh_version,
   }
@@ -323,6 +325,11 @@ export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: Build
   const host = compiler_host(new Map(), options, tslib_dir)
 
   print(`Compiling TypeScript (${magenta(`${files.length} files`)})`)
+  if (setup.verbose) {
+    for (const file of files) {
+      print(`  ${file}`)
+    }
+  }
   const tsoutput = compile_files(files, options, transformers, host)
 
   if (is_failed(tsoutput)) {

--- a/bokehjs/src/compiler/main.ts
+++ b/bokehjs/src/compiler/main.ts
@@ -13,6 +13,7 @@ const argv = yargs(process.argv.slice(2)).options({
   "bokehjs-dir": {type: "string", default: "./build"}, // this is what bokeh.settings defaults to
   "bokeh-version": {type: "string"},
   "bokehjs-version": {type: "string"},
+  verbose: {type: "boolean", default: false},
   rebuild: {type: "boolean", default: false},
   interactive: {type: "boolean", default: false},
 }).parseSync()
@@ -58,9 +59,10 @@ async function main() {
     try {
       const base_dir = resolve(argv.baseDir!)
       const bokehjs_dir = resolve(argv.bokehjsDir)
+      const verbose = argv.verbose
       const rebuild = argv.rebuild
       const bokeh_version = argv.bokehVersion!
-      const result = await build(base_dir, bokehjs_dir, {rebuild, bokeh_version})
+      const result = await build(base_dir, bokehjs_dir, {verbose, rebuild, bokeh_version})
       process.exit(result ? 0 : 1)
     } catch (error) {
       const msg = error instanceof Error && error.stack != null ? error.stack : `${error}`

--- a/bokehjs/src/compiler/styles.ts
+++ b/bokehjs/src/compiler/styles.ts
@@ -5,22 +5,29 @@ import CSS from "css"
 
 import {scan, read, write, rename} from "./sys"
 
-export async function compile_styles(styles_dir: string, css_dir: string): Promise<boolean> {
-  let success = true
-
-  for (const src of scan(styles_dir, [".less", ".css"])) {
-    if (basename(src).startsWith("_")) {
+export function collect_styles(styles_dir: string): string[] {
+  const paths = []
+  for (const path of scan(styles_dir, [".less", ".css"])) {
+    if (basename(path).startsWith("_")) {
       continue
     }
+    paths.push(path)
+  }
+  return paths
+}
 
+export async function compile_styles(paths: string[], styles_dir: string, css_dir: string): Promise<boolean> {
+  let success = true
+
+  for (const path of paths) {
     try {
-      const style = read(src)!
-      const {css} = await lesscss.render(style, {filename: src})
-      const dst = rename(src, {base: styles_dir, dir: css_dir, ext: ".css"})
+      const style = read(path)!
+      const {css} = await lesscss.render(style, {filename: path})
+      const dst = rename(path, {base: styles_dir, dir: css_dir, ext: ".css"})
       write(dst, css)
     } catch (error) {
       success = false
-      console.log(`${chalk.red("\u2717")} failed to compile ${chalk.magenta(src)}:`)
+      console.log(`${chalk.red("\u2717")} failed to compile ${chalk.magenta(path)}:`)
       console.log(`${error}`)
     }
   }

--- a/src/bokeh/command/subcommands/build.py
+++ b/src/bokeh/command/subcommands/build.py
@@ -63,6 +63,10 @@ class Build(Subcommand):
             action="store_true",
             help="Ignore all caches and perform a full rebuild",
         )),
+        ("--verbose", Argument(
+            action="store_true",
+            help="Display detailed build information",
+        )),
         ("--debug", Argument(
             action="store_true",
             help="Run nodejs in debug mode (use --inspect-brk)",
@@ -70,7 +74,7 @@ class Build(Subcommand):
     )
 
     def invoke(self, args: Namespace) -> bool:
-        return build(args.base_dir, rebuild=args.rebuild, debug=args.debug)
+        return build(args.base_dir, rebuild=args.rebuild, verbose=args.verbose, debug=args.debug)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/ext.py
+++ b/src/bokeh/ext.py
@@ -37,14 +37,22 @@ __all__ = ("init", "build")
 # General API
 #-----------------------------------------------------------------------------
 
-def init(base_dir: PathLike, *, interactive: bool = False,
-         bokehjs_version: str | None = None, debug: bool = False) -> bool:
+def init(
+    base_dir: PathLike,
+    *,
+    interactive: bool = False,
+    verbose: bool = False,
+    bokehjs_version: str | None = None,
+    debug: bool = False,
+) -> bool:
     """ Initialize a directory as a new bokeh extension.
 
     Arguments:
         base_dir (str) : The location of the extension.
 
         interactive (bool) : Guide the user step-by-step.
+
+        verbose (bool) : Display detailed build information.
 
         bokehjs_version (str) : Use a specific version of bokehjs.
 
@@ -57,19 +65,23 @@ def init(base_dir: PathLike, *, interactive: bool = False,
     args: list[str] = []
     if interactive:
         args.append("--interactive")
+    if verbose:
+        args.append("--verbose")
     if bokehjs_version:
         args.extend(["--bokehjs-version", bokehjs_version])
     proc = _run_command("init", base_dir, args, debug)
     return proc.returncode == 0
 
 
-def build(base_dir: PathLike, *, rebuild: bool = False, debug: bool = False) -> bool:
+def build(base_dir: PathLike, *, rebuild: bool = False, verbose: bool = False, debug: bool = False) -> bool:
     """ Build a bokeh extension in the given directory.
 
     Arguments:
         base_dir (str) : The location of the extension.
 
         rebuild (bool) : Ignore caches and rebuild from scratch.
+
+        verbose (bool) : Display detailed build information.
 
         debug (bool) : Allow for remote debugging.
 
@@ -80,6 +92,8 @@ def build(base_dir: PathLike, *, rebuild: bool = False, debug: bool = False) -> 
     args: list[str] = []
     if rebuild:
         args.append("--rebuild")
+    if verbose:
+        args.append("--verbose")
     proc = _run_command("build", base_dir, args, debug)
     return proc.returncode == 0
 


### PR DESCRIPTION
Previously they wouldn't be included in the first pass, causing build failure. They would be picked up on the second pass. This affects e.g. `*.less` to CSS module compilation. I also added `--verbose` flag to `bokeh build`, to allow tracking files included in the build, etc.

Previously:
```
$ cd panel/panel/
$ git clean -dfx dist/
$ bokeh build .
Working directory: /home/anaconda/repo/panel/panel
TypeScript lib: /home/anaconda/repo/bokeh/src/bokeh/server/static/lib
Using /home/anaconda/repo/panel/panel/tsconfig.json
Compiling styles
Compiling TypeScript (64 files)
models/video.ts:6:23 - error TS2307: Cannot find module 'styles/models/video.css' or its corresponding type declarations.

6 import video_css from "styles/models/video.css"
                        ~~~~~~~~~~~~~~~~~~~~~~~~~

Linking modules
Output written to /home/anaconda/repo/panel/panel/dist
All done.
```
Now:
```
$ cd panel/panel/
$ git clean -dfx dist/
$ bokeh build .
Working directory: /home/anaconda/repo/panel/panel
TypeScript lib: /home/anaconda/repo/bokeh/src/bokeh/server/static/lib
Using /home/anaconda/repo/panel/panel/tsconfig.json
Compiling styles (1 file)
Compiling TypeScript (65 files)
Linking modules
Output written to /home/anaconda/repo/panel/panel/dist
All done.
```

Adding this to 3.4 milestone, because this blocks my work on panel. Otherwise we would have to release 3.4.1 in short succession.