### PR TITLE
Avoid spurious warning about Py/Js version mismatch

### DIFF
--- a/bokehjs/src/lib/core/util/version.ts
+++ b/bokehjs/src/lib/core/util/version.ts
@@ -1,3 +1,73 @@
-export function pyify_version(version: string): string {
-  return version.replace(/-(dev|rc)\./, ".$1")
+import type {Equatable} from "./eq"
+import {equals} from "./eq"
+
+const version_re = /^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:(?<type>-dev\.|-rc\.|.dev|rc)(?<revision>\d+))?(?:\+(?<build>\d+)\..+)?$/
+
+export enum ReleaseType {
+  Dev = 0,
+  Candidate = 1,
+  Release = 2,
+}
+
+export class Version implements Equatable {
+  constructor(
+    readonly major: number,
+    readonly minor: number,
+    readonly patch: number,
+    readonly type: ReleaseType = ReleaseType.Release,
+    readonly revision: number = 0,
+    readonly build: number = 0,
+  ) {}
+
+  static from(version: string): Version | null {
+    return parse_version(version)
+  }
+
+  toString(): string {
+    const {major, minor, patch, type, revision, build} = this
+    let version = `${major}.${minor}.${patch}`
+    switch (type) {
+      case ReleaseType.Dev:       version += `-dev.${revision}`
+      case ReleaseType.Candidate: version += `-rc.${revision}`
+      case ReleaseType.Release:
+    }
+    if (build != 0) {
+      version += `+${build}`
+    }
+    return version
+  }
+
+  [equals](that: this): boolean {
+    // ignore build field, because bokehjs doesn't provide it
+    const {major, minor, patch, type, revision} = this
+    return major == that.major &&
+           minor == that.minor &&
+           patch == that.patch &&
+           type == that.type &&
+           revision == that.revision
+  }
+}
+
+function parse_version(version: string): Version | null {
+  const result = version_re.exec(version)
+  if (result == null || result.groups == null) {
+    return null
+  }
+  const {groups} = result
+  const major = Number(groups.major)
+  const minor = Number(groups.minor)
+  const patch = Number(groups.patch)
+  const type = (() => {
+    switch (groups.type) {
+      case "-dev.":
+      case ".dev": return ReleaseType.Dev
+      case "-rc.":
+      case "rc":   return ReleaseType.Candidate
+      default:     return ReleaseType.Release
+    }
+  })()
+  // typeof due to bad stdlib typings or enable exactOptionalPropertyTypes
+  const revision = typeof groups.revision == "undefined" ? 0 : Number(groups.revision)
+  const build = typeof groups.build == "undefined" ? 0 : Number(groups.build)
+  return new Version(major, minor, patch, type, revision, build)
 }

--- a/bokehjs/test/unit/core/logging.ts
+++ b/bokehjs/test/unit/core/logging.ts
@@ -2,6 +2,7 @@ import {expect} from "assertions"
 
 import type {LogLevel} from "@bokehjs/core/logging"
 import {Logger, logger, set_log_level} from "@bokehjs/core/logging"
+import {version} from "@bokehjs/version"
 
 import {trap} from "../../util"
 
@@ -26,48 +27,51 @@ describe("logging module", () => {
 
       it("trace", () => {
         const out = trap(() => original = set_log_level("trace"))
-        expect(out.log).to.be.equal("[bokeh] setting log level to: 'trace'\n")
+        expect(out.log).to.be.equal(`[bokeh ${version}] setting log level to: 'trace'\n`)
         expect(logger.level).to.be.equal(Logger.TRACE)
       })
 
       it("debug", () => {
         const out = trap(() => original = set_log_level("debug"))
-        expect(out.log).to.be.equal("[bokeh] setting log level to: 'debug'\n")
+        expect(out.log).to.be.equal(`[bokeh ${version}] setting log level to: 'debug'\n`)
         expect(logger.level).to.be.equal(Logger.DEBUG)
       })
 
       it("info", () => {
         const out = trap(() => original = set_log_level("info"))
-        expect(out.log).to.be.equal("[bokeh] setting log level to: 'info'\n")
+        expect(out.log).to.be.equal(`[bokeh ${version}] setting log level to: 'info'\n`)
         expect(logger.level).to.be.equal(Logger.INFO)
       })
       it("warn", () => {
         const out = trap(() => original = set_log_level("warn"))
-        expect(out.log).to.be.equal("[bokeh] setting log level to: 'warn'\n")
+        expect(out.log).to.be.equal(`[bokeh ${version}] setting log level to: 'warn'\n`)
         expect(logger.level).to.be.equal(Logger.WARN)
       })
       it("error", () => {
         const out = trap(() => original = set_log_level("error"))
-        expect(out.log).to.be.equal("[bokeh] setting log level to: 'error'\n")
+        expect(out.log).to.be.equal(`[bokeh ${version}] setting log level to: 'error'\n`)
         expect(logger.level).to.be.equal(Logger.ERROR)
       })
 
       it("fatal", () => {
         const out = trap(() => original = set_log_level("fatal"))
-        expect(out.log).to.be.equal("[bokeh] setting log level to: 'fatal'\n")
+        expect(out.log).to.be.equal(`[bokeh ${version}] setting log level to: 'fatal'\n`)
         expect(logger.level).to.be.equal(Logger.FATAL)
       })
 
       it("off", () => {
         const out = trap(() => original = set_log_level("off"))
-        expect(out.log).to.be.equal("[bokeh] setting log level to: 'off'\n")
+        expect(out.log).to.be.equal(`[bokeh ${version}] setting log level to: 'off'\n`)
         expect(logger.level).to.be.equal(Logger.OFF)
       })
     })
 
     it("ignores unknown levels", () => {
       const out = trap(() => set_log_level("bad"))
-      expect(out.log).to.be.equal("[bokeh] unrecognized logging level 'bad' passed to Bokeh.set_log_level(), ignoring\n[bokeh] valid log levels are: trace, debug, info, warn, error, fatal, off\n")
+      expect(out.log).to.be.equal(`\
+[bokeh ${version}] unrecognized logging level 'bad' passed to Bokeh.set_log_level(), ignoring
+[bokeh ${version}] valid log levels are: trace, debug, info, warn, error, fatal, off
+`)
     })
   })
 })

--- a/bokehjs/test/unit/core/util/version.ts
+++ b/bokehjs/test/unit/core/util/version.ts
@@ -1,19 +1,25 @@
 import {expect} from "assertions"
-import {pyify_version} from "@bokehjs/core/util/version"
+import {Version, ReleaseType} from "@bokehjs/core/util/version"
 
 describe("core/util/version module", () => {
-  it("should implement pyify_version() function for full versions", () => {
-    const out = pyify_version("1.2.3")
-    expect(out).to.be.equal("1.2.3")
+  it("should implement Version.from() function for full versions", () => {
+    const out = Version.from("1.2.3")
+    expect(out).to.be.equal(new Version(1, 2, 3))
   })
 
-  it("should implement pyify_version() function for dev versions", () => {
-    const out = pyify_version("1.2.3-dev.18")
-    expect(out).to.be.equal("1.2.3.dev18")
+  it("should implement Version.from() function for dev versions", () => {
+    const ver0 = Version.from("1.2.3-dev.18")
+    expect(ver0).to.be.equal(new Version(1, 2, 3, ReleaseType.Dev, 18))
+
+    const ver1 = Version.from("1.2.3.dev18")
+    expect(ver1).to.be.equal(new Version(1, 2, 3, ReleaseType.Dev, 18))
   })
 
-  it("should implement pyify_version() function for rc versions", () => {
-    const out = pyify_version("1.2.3-rc.18")
-    expect(out).to.be.equal("1.2.3.rc18")
+  it("should implement Version.from() function for rc versions", () => {
+    const ver0 = Version.from("1.2.3-rc.18")
+    expect(ver0).to.be.equal(new Version(1, 2, 3, ReleaseType.Candidate, 18))
+
+    const ver1 = Version.from("1.2.3rc18")
+    expect(ver1).to.be.equal(new Version(1, 2, 3, ReleaseType.Candidate, 18))
   })
 })

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -635,34 +635,30 @@ describe("Document", () => {
     try {
       const json = d.to_json_string()
       const parsed = JSON.parse(json)
-      const py_version = js_version.replace(/-(dev|rc)\./, ".$1")
-      parsed.version = `${py_version}`
+      parsed.version = js_version.replace(/-dev\./, ".dev").replace(/-rc\./, "rc")
       const out0 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
       expect(out0.warn).to.be.equal("")
 
       parsed.version = "0.0.1"
       const out1 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
-      expect(out1.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
+      expect(out1.warn).to.be.equal(`[bokeh ${js_version}] Bokeh/BokehJS version mismatch: new document using Bokeh ${parsed.version} and BokehJS ${js_version}\n`)
 
+      const py_version = js_version.replace(/-.*/, "")
       parsed.version = `${py_version}rc123`
       const out2 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
-      expect(out2.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
+      expect(out2.warn).to.be.equal(`[bokeh ${js_version}] Bokeh/BokehJS version mismatch: new document using Bokeh ${parsed.version} and BokehJS ${js_version}\n`)
 
-      parsed.version = `${py_version}dev123`
+      parsed.version = `${py_version}.dev123`
       const out3 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
-      expect(out3.warn).to.be.equal(`[bokeh] JS/Python version mismatch\n[bokeh] Library versions: JS (${js_version}) / Python (${parsed.version})\n`)
+      expect(out3.warn).to.be.equal(`[bokeh ${js_version}] Bokeh/BokehJS version mismatch: new document using Bokeh ${parsed.version} and BokehJS ${js_version}\n`)
 
-      parsed.version = `${py_version}-foo`
+      parsed.version = `${py_version}rc123+4.ffaa11dd`
       const out4 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
-      expect(out4.warn).to.be.equal("")
+      expect(out4.warn).to.be.equal(`[bokeh ${js_version}] Bokeh/BokehJS version mismatch: new document using Bokeh ${parsed.version} and BokehJS ${js_version}\n`)
 
-      parsed.version = `${py_version}rc123-foo`
+      parsed.version = `${py_version}.dev123+4.ffaa11dd`
       const out5 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
-      expect(out5.warn).to.be.equal("")
-
-      parsed.version = `${py_version}dev123-bar`
-      const out6 = trap(() => Document.from_json_string(JSON.stringify(parsed)))
-      expect(out6.warn).to.be.equal("")
+      expect(out5.warn).to.be.equal(`[bokeh ${js_version}] Bokeh/BokehJS version mismatch: new document using Bokeh ${parsed.version} and BokehJS ${js_version}\n`)
     } finally {
       logging.set_log_level(original)
     }

--- a/bokehjs/test/unit/models/glyphs/glyph.ts
+++ b/bokehjs/test/unit/models/glyphs/glyph.ts
@@ -6,6 +6,7 @@ import type {PointGeometry, SpanGeometry, RectGeometry, PolyGeometry} from "@bok
 import type {SpatialIndex} from "@bokehjs/core/util/spatial"
 import type {Context2d} from "@bokehjs/core/util/canvas"
 import {with_log_level} from "@bokehjs/core/logging"
+import {version} from "@bokehjs/version"
 
 import {create_glyph_view} from "./_util"
 import {trap} from "../../../util"
@@ -64,7 +65,7 @@ describe("glyph module", () => {
         const out_rect0 = trap(() => {
           expect(glyph_view.hit_test(rect)).to.be.null
         })
-        expect(out_rect0.debug).to.be.equal("[bokeh] 'rect' selection not available for SomeGlyph\n")
+        expect(out_rect0.debug).to.be.equal(`[bokeh ${version}] 'rect' selection not available for SomeGlyph\n`)
         const out_rect1 = trap(() => {
           expect(glyph_view.hit_test(rect)).to.be.null
         })
@@ -74,7 +75,7 @@ describe("glyph module", () => {
         const out_poly0 = trap(() => {
           expect(glyph_view.hit_test(poly)).to.be.null
         })
-        expect(out_poly0.debug).to.be.equal("[bokeh] 'poly' selection not available for SomeGlyph\n")
+        expect(out_poly0.debug).to.be.equal(`[bokeh ${version}] 'poly' selection not available for SomeGlyph\n`)
         const out_poly1 = trap(() => {
           expect(glyph_view.hit_test(poly)).to.be.null
         })

--- a/bokehjs/test/unit/models/sources/column_data_source.ts
+++ b/bokehjs/test/unit/models/sources/column_data_source.ts
@@ -1,6 +1,7 @@
 import {expect} from "assertions"
 
 import {with_log_level} from "@bokehjs/core/logging"
+import {version} from "@bokehjs/version"
 
 import {keys} from "@bokehjs/core/util/object"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
@@ -99,11 +100,11 @@ describe("column_data_source module", () => {
       with_log_level("info", () => {
         const r0 = new ColumnDataSource({data: {foo: [1], bar: [1, 2]}})
         const out0 = trap(() => r0.get_length())
-        expect(out0.warn).to.be.equal("[bokeh] data source has columns of inconsistent lengths\n")
+        expect(out0.warn).to.be.equal(`[bokeh ${version}] data source has columns of inconsistent lengths\n`)
 
         const r1 = new ColumnDataSource({data: {foo: [1], bar: [1, 2], baz: [1]}})
         const out1 = trap(() => r1.get_length())
-        expect(out1.warn).to.be.equal("[bokeh] data source has columns of inconsistent lengths\n")
+        expect(out1.warn).to.be.equal(`[bokeh ${version}] data source has columns of inconsistent lengths\n`)
       })
     })
   })

--- a/bokehjs/test/util.ts
+++ b/bokehjs/test/util.ts
@@ -1,5 +1,6 @@
 import {stub} from "sinon"
 import {logger} from "@bokehjs/core/logging"
+import {version} from "@bokehjs/version"
 
 export type TrapOutput = {
   log: string
@@ -19,27 +20,29 @@ export function trap(fn: () => void): TrapOutput {
     warn: "",
     error: "",
   }
-  function join(args: unknown[]): string {
+  function join(...args: unknown[]): string {
     return args.map((arg) => `${arg}`).join(" ") + "\n"
   }
-  // XXX: stubing both console and logger, and including logger's name manually is a hack,
+  // XXX: stubbing both console and logger, and including logger's name manually is a hack,
   // but that's be best we can do (at least for now) while preserving logger's ability to
   // to reference the original location from where a logging method was called.
-  const log = stub(console, "log").callsFake((...args) => {result.log += join(args)})
-  const ctrace = stub(console, "trace").callsFake((...args) => {result.trace += join(args)})
-  const ltrace = stub(logger, "trace").callsFake((...args) => {result.trace += join(["[bokeh]", ...args])})
-  const cdebug = stub(console, "debug").callsFake((...args) => {result.debug += join(args)})
-  const ldebug = stub(logger, "debug").callsFake((...args) => {result.debug += join(["[bokeh]", ...args])})
-  const cinfo = stub(console, "info").callsFake((...args) => {result.info += join(args)})
-  const linfo = stub(logger, "info").callsFake((...args) => {result.info += join(["[bokeh]", ...args])})
-  const cwarn = stub(console, "warn").callsFake((...args) => {result.warn += join(args)})
-  const lwarn = stub(logger, "warn").callsFake((...args) => {result.warn += join(["[bokeh]", ...args])})
-  const cerror = stub(console, "error").callsFake((...args) => {result.error += join(args)})
-  const lerror = stub(logger, "error").callsFake((...args) => {result.error += join(["[bokeh]", ...args])})
+  const log    = stub(console, "log").callsFake((...args)   => result.log   += join(...args))
+  const clog   = stub(logger, "log").callsFake((...args)    => result.log   += join(`[bokeh ${version}]`, ...args))
+  const ctrace = stub(console, "trace").callsFake((...args) => result.trace += join(...args))
+  const ltrace = stub(logger, "trace").callsFake((...args)  => result.trace += join(`[bokeh ${version}]`, ...args))
+  const cdebug = stub(console, "debug").callsFake((...args) => result.debug += join(...args))
+  const ldebug = stub(logger, "debug").callsFake((...args)  => result.debug += join(`[bokeh ${version}]`, ...args))
+  const cinfo  = stub(console, "info").callsFake((...args)  => result.info  += join(...args))
+  const linfo  = stub(logger, "info").callsFake((...args)   => result.info  += join(`[bokeh ${version}]`, ...args))
+  const cwarn  = stub(console, "warn").callsFake((...args)  => result.warn  += join(...args))
+  const lwarn  = stub(logger, "warn").callsFake((...args)   => result.warn  += join(`[bokeh ${version}]`, ...args))
+  const cerror = stub(console, "error").callsFake((...args) => result.error += join(...args))
+  const lerror = stub(logger, "error").callsFake((...args)  => result.error += join(`[bokeh ${version}]`, ...args))
   try {
     fn()
   } finally {
     log.restore()
+    clog.restore()
     ctrace.restore()
     ltrace.restore()
     cdebug.restore()


### PR DESCRIPTION
Fixes handling of pre-releases in `Document._handle_version()` and simplifies/robustifies its logic.

This PR also includes version number in bokehjs' log entries:
```
[bokeh 3.4.0-rc.1] setting log level to: 'debug'              logging.js:103
[bokeh 3.4.0-rc.1] document idle at 303 ms                    document.js:91
```