### PR TITLE
replacing iris data from examples

### DIFF
--- a/examples/basic/layouts/words_and_plots.py
+++ b/examples/basic/layouts/words_and_plots.py
@@ -2,7 +2,7 @@ from bokeh.layouts import layout
 from bokeh.models import ColumnDataSource, Div, HoverTool, Paragraph
 from bokeh.plotting import figure, show
 from bokeh.sampledata.glucose import data
-from bokeh.sampledata.iris import flowers
+from bokeh.sampledata.penguins import data as penguins
 
 
 def text():
@@ -25,13 +25,13 @@ def text():
 
 
 def scatter():
-    colormap = {'setosa': 'red', 'versicolor': 'green', 'virginica': 'blue'}
-    source = ColumnDataSource(flowers)
-    source.data['colors'] = [colormap[x] for x in flowers['species']]
-    s = figure(title = "Iris Morphology")
-    s.xaxis.axis_label = 'Petal Length'
-    s.yaxis.axis_label = 'Petal Width'
-    s.scatter("petal_length", "petal_width", color="colors", source=source,
+    colormap = {'Adelie': 'red', 'Chinstrap': 'green', 'Gentoo': 'Blue'}
+    penguins["colors"] = penguins["species"].map(colormap)
+    source = ColumnDataSource(penguins)
+    s = figure(title = "Penguin size")
+    s.xaxis.axis_label = "Flipper Length (mm)"
+    s.yaxis.axis_label = "Body Mass (g)"
+    s.scatter("flipper_length_mm", "body_mass_g", color="colors", source=source,
               fill_alpha=0.2, size=10, legend_group="species")
     # Lets move the legend off-canvas!
     legend = s.legend[0]

--- a/examples/basic/layouts/words_and_plots.py
+++ b/examples/basic/layouts/words_and_plots.py
@@ -25,7 +25,7 @@ def text():
 
 
 def scatter():
-    colormap = {'Adelie': 'red', 'Chinstrap': 'green', 'Gentoo': 'Blue'}
+    colormap = {'Adelie': 'red', 'Chinstrap': 'green', 'Gentoo': 'blue'}
     penguins["colors"] = penguins["species"].map(colormap)
     source = ColumnDataSource(penguins)
     s = figure(title = "Penguin size")

--- a/examples/models/widgets.py
+++ b/examples/models/widgets.py
@@ -20,7 +20,7 @@ from bokeh.models import (BuiltinIcon, ByCSS, Column, ColumnDataSource, Dialog,
 from bokeh.models.dom import HTML, ValueOf
 from bokeh.plotting import figure
 from bokeh.sampledata.autompg2 import autompg2 as mpg
-from bokeh.sampledata.iris import flowers
+from bokeh.sampledata.penguins import data
 from bokeh.util.browser import view
 
 palette_items = [
@@ -231,7 +231,7 @@ pre_text = w.PreText(text="some text")
 
 def mk_tab(color: str):
     plot = figure(width=300, height=300)
-    plot.scatter(flowers["petal_length"], flowers["petal_width"], color=color, fill_alpha=0.2, size=12)
+    plot.scatter(data["flipper_length_mm"], data["body_mass_g"], color=color, fill_alpha=0.2, size=12)
     return TabPanel(title=f"Tab 1: {color.capitalize()}", child=plot, closable=True)
 
 tabs = Tabs(tabs=[mk_tab("red"), mk_tab("green"), mk_tab("blue")])

--- a/examples/output/apis/autoload_static.py
+++ b/examples/output/apis/autoload_static.py
@@ -5,7 +5,7 @@ from tornado.web import Application, RequestHandler
 from bokeh.embed import autoload_static
 from bokeh.plotting import figure
 from bokeh.resources import CDN
-from bokeh.sampledata.iris import flowers
+from bokeh.sampledata.penguins import data
 from bokeh.util.browser import view
 
 template = Template("""
@@ -43,14 +43,14 @@ class JSHandler(RequestHandler):
     def get(self): self.write(self.js)
 
 def make_plot():
-    colormap = {'setosa': 'red', 'versicolor': 'green', 'virginica': 'blue'}
-    colors = [colormap[x] for x in flowers['species']]
+    colormap = {'Adelie': 'red', 'Chinstrap': 'green', 'Gentoo': 'blue'}
+    colors = [colormap[x] for x in data['species']]
 
-    p = figure(title = "Iris Morphology")
-    p.xaxis.axis_label = 'Petal Length'
-    p.yaxis.axis_label = 'Petal Width'
+    p = figure(title = "Penguin size")
+    p.xaxis.axis_label = "Bill Length (mm)"
+    p.yaxis.axis_label = "Body Mass (g)"
 
-    p.circle(flowers["petal_length"], flowers["petal_width"],
+    p.scatter(data["bill_length_mm"], data["body_mass_g"],
              color=colors, fill_alpha=0.2, size=10)
 
     return p

--- a/examples/output/apis/components_themed.py
+++ b/examples/output/apis/components_themed.py
@@ -3,19 +3,19 @@ from jinja2 import Template
 from bokeh.embed import components
 from bokeh.plotting import figure
 from bokeh.resources import INLINE
-from bokeh.sampledata.iris import flowers
+from bokeh.sampledata.penguins import data
 from bokeh.themes import Theme
 from bokeh.transform import factor_cmap, factor_mark
 from bokeh.util.browser import view
 
-SPECIES = ['setosa', 'versicolor', 'virginica']
+SPECIES = ['Adelie', 'Chinstrap', 'Gentoo']
 MARKERS = ['hex', 'circle_x', 'triangle']
 
-p = figure(title = "Iris Morphology")
-p.xaxis.axis_label = 'Petal Length'
-p.yaxis.axis_label = 'Sepal Width'
+p = figure(title = "Penguin size")
+p.xaxis.axis_label = "Flipper Length (mm)"
+p.yaxis.axis_label = "Body Mass (g)"
 
-p.scatter("petal_length", "sepal_width", source=flowers, legend_group="species", fill_alpha=0.4, size=12,
+p.scatter("flipper_length_mm", "body_mass_g", source=data, legend_group="species", fill_alpha=0.4, size=12,
           marker=factor_mark('species', MARKERS, SPECIES),
           color=factor_cmap('species', 'Category10_3', SPECIES))
 

--- a/examples/output/apis/json_item.py
+++ b/examples/output/apis/json_item.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 from bokeh.embed import json_item
 from bokeh.plotting import figure
 from bokeh.resources import CDN
-from bokeh.sampledata.iris import flowers
+from bokeh.sampledata.penguins import data
 
 app = Flask(__name__)
 
@@ -33,14 +33,14 @@ page = Template("""
 </body>
 """)
 
-colormap = {'setosa': 'red', 'versicolor': 'green', 'virginica': 'blue'}
-colors = [colormap[x] for x in flowers['species']]
+colormap = {'Adelie': 'red', 'Chinstrap': 'green', 'Gentoo': 'blue'}
+colors = [colormap[x] for x in data['species']]
 
 def make_plot(x, y):
-    p = figure(title = "Iris Morphology", sizing_mode="fixed", width=400, height=400)
+    p = figure(title = "Penguin size", sizing_mode="fixed", width=400, height=400)
     p.xaxis.axis_label = x
     p.yaxis.axis_label = y
-    p.scatter(flowers[x], flowers[y], color=colors, fill_alpha=0.2, size=10)
+    p.scatter(data[x], data[y], color=colors, fill_alpha=0.2, size=10)
     return p
 
 @app.route('/')
@@ -49,12 +49,12 @@ def root():
 
 @app.route('/plot')
 def plot():
-    p = make_plot('petal_width', 'petal_length')
+    p = make_plot('flipper_length_mm', 'body_mass_g')
     return json.dumps(json_item(p, "myplot"))
 
 @app.route('/plot2')
 def plot2():
-    p = make_plot('sepal_width', 'sepal_length')
+    p = make_plot('bill_length_mm', 'body_mass_g')
     return json.dumps(json_item(p))
 
 if __name__ == '__main__':

--- a/examples/output/apis/json_item_themed.py
+++ b/examples/output/apis/json_item_themed.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 from bokeh.embed import json_item
 from bokeh.plotting import figure
 from bokeh.resources import CDN
-from bokeh.sampledata.iris import flowers
+from bokeh.sampledata.penguins import data
 from bokeh.themes import Theme
 
 app = Flask(__name__)
@@ -34,16 +34,16 @@ page = Template("""
 </body>
 """)
 
-colormap = {'setosa': 'red', 'versicolor': 'green', 'virginica': 'blue'}
-colors = [colormap[x] for x in flowers['species']]
+colormap = {'Adelie': 'red', 'Chinstrap': 'green', 'Gentoo': 'blue'}
+colors = [colormap[x] for x in data['species']]
 
 gray_theme = Theme(json={'attrs':{'Plot':{'background_fill_color':'#eeeeee'}}})
 
 def make_plot(x, y):
-    p = figure(title = "Iris Morphology", sizing_mode="fixed", width=400, height=400)
+    p = figure(title = "Penguin size", sizing_mode="fixed", width=400, height=400)
     p.xaxis.axis_label = x
     p.yaxis.axis_label = y
-    p.scatter(flowers[x], flowers[y], color=colors, fill_alpha=0.2, size=10)
+    p.scatter(data[x], data[y], color=colors, fill_alpha=0.2, size=10)
     return p
 
 @app.route('/')
@@ -52,12 +52,12 @@ def root():
 
 @app.route('/plot')
 def plot():
-    p = make_plot('petal_width', 'petal_length')
+    p = make_plot('flipper_length_mm', 'body_mass_g')
     return json.dumps(json_item(p, "myplot")) # default theme applied
 
 @app.route('/plot2')
 def plot2():
-    p = make_plot('sepal_width', 'sepal_length')
+    p = make_plot('bill_length_mm', 'body_mass_g')
     return json.dumps(json_item(p, theme=gray_theme)) # specific theme (gray) applied
 
 if __name__ == '__main__':


### PR DESCRIPTION
I removed the iris data from all examples except https://docs.bokeh.org/en/latest/docs/examples/plotting/iris.html, because is has already a comment on it.

- [ ] issues: fixes #10157 
