### PR TITLE
fix broken link in first_steps_9.rst

### DIFF
--- a/docs/bokeh/source/docs/first_steps/first_steps_9.rst
+++ b/docs/bokeh/source/docs/first_steps/first_steps_9.rst
@@ -192,7 +192,7 @@ widgets on the left to change the sine wave on the right:
     </div>
 
 Find the source code for this Bokeh server app at
-:bokeh-tree:`examples/server/app/slider.py`.
+:bokeh-tree:`examples/server/app/sliders.py`.
 For more examples of Bokeh server applications, see the
 :ref:`gallery`.
 


### PR DESCRIPTION
This PR corrects a typo in a link. At the moment a 404 error page appears. This PR is not related to an issue.