### PR TITLE
Remove legacy font measurement logic

### DIFF
--- a/bokehjs/src/lib/core/util/text.ts
+++ b/bokehjs/src/lib/core/util/text.ts
@@ -1,5 +1,4 @@
-import {assert, unreachable} from "./assert"
-import {is_defined} from "./types"
+import {assert} from "./assert"
 
 export type BoxMetrics = {
   width: number
@@ -16,165 +15,32 @@ export type FontMetrics = {
   x_height: number
 }
 
-const has_OffscreenCanvas = (() => {
-  try {
-    return typeof OffscreenCanvas !== "undefined" && new OffscreenCanvas(0, 0).getContext("2d") != null
-  } catch {
-    return false
-  }
-})()
-
-const _offscreen_canvas = (() => {
-  if (has_OffscreenCanvas) {
-    return (w: number, h: number) => new OffscreenCanvas(w, h)
-  } else {
-    return (w: number, h: number) => {
-      const canvas = document.createElement("canvas")
-      canvas.width = w
-      canvas.height = h
-      return canvas
-    }
-  }
-})()
-
-const _native_font_metrics = (() => {
-  const canvas = _offscreen_canvas(0, 0)
-
-  // XXX: explicit type required due to insuffient quality of stdlib's type declarations
+const _offscreen_context = (() => {
+  const canvas = new OffscreenCanvas(0, 0)
   const ctx = canvas.getContext("2d")
   assert(ctx != null, "can't obtain 2d context")
-
-  return (font: string): FontMetrics => {
-    ctx.font = font
-
-    const cap_metrics = ctx.measureText("M")
-    const x_metrics = ctx.measureText("x")
-    const metrics = ctx.measureText("ÅŚg|")
-
-    const font_ascent = metrics.fontBoundingBoxAscent
-    const font_descent = metrics.fontBoundingBoxDescent
-
-    if (is_defined(font_ascent) && is_defined(font_descent)) {
-      return {
-        height: font_ascent + font_descent,
-        ascent: font_ascent,
-        descent: font_descent,
-        cap_height: cap_metrics.actualBoundingBoxAscent,
-        x_height: x_metrics.actualBoundingBoxAscent,
-      }
-    }
-
-    const text_ascent = metrics.actualBoundingBoxAscent
-    const text_descent = metrics.actualBoundingBoxDescent
-
-    if (is_defined(text_ascent) && is_defined(text_descent)) {
-      return {
-        height: text_ascent + text_descent,
-        ascent: text_ascent,
-        descent: text_descent,
-        cap_height: cap_metrics.actualBoundingBoxAscent,
-        x_height: x_metrics.actualBoundingBoxAscent,
-      }
-    }
-
-    unreachable()
-  }
+  return ctx
 })()
 
-const _internal_font_metrics = (() => {
-  const canvas = document.createElement("canvas")
-  const ctx = canvas.getContext("2d")!
+function _font_metrics(font: string): FontMetrics {
+  const ctx = _offscreen_context
+  ctx.font = font
 
-  let cwidth = -1
-  let cheight = -1
+  const cap_metrics = ctx.measureText("M")
+  const x_metrics = ctx.measureText("x")
+  const metrics = ctx.measureText("ÅŚg|")
 
-  return (font: string, scale: number = 1): FontMetrics => {
-    ctx.font = font
-    const {width: _em} = ctx.measureText("M")
-    const em = _em*scale
+  const ascent = metrics.fontBoundingBoxAscent
+  const descent = metrics.fontBoundingBoxDescent
 
-    const width = Math.ceil(em)
-    const height = Math.ceil(2.0*em)
-    const baseline = Math.ceil(1.5*em)
-
-    if (cwidth < width) {
-      cwidth = width
-      canvas.width = width
-    }
-    if (cheight < height) {
-      cheight = height
-      canvas.height = height
-    }
-
-    ctx.save()
-    ctx.scale(scale, scale)
-
-    ctx.fillStyle = "#f00"
-    ctx.fillRect(0, 0, width, height)
-
-    const measure_ascent = (data: Uint8ClampedArray) => {
-      let k = 0
-      for (let i = 0; i <= baseline; i++) {
-        for (let j = 0; j < width; j++, k += 4) {
-          if (data[k] != 255) {
-            return baseline - i
-          }
-        }
-      }
-      return 0
-    }
-
-    const measure_descent = (data: Uint8ClampedArray) => {
-      let k = data.length - 4
-      for (let i = height; i >= baseline; i--) {
-        for (let j = 0; j < width; j++, k -= 4) {
-          if (data[k] != 255) {
-            return i - baseline
-          }
-        }
-      }
-      return 0
-    }
-
-    ctx.font = font
-    ctx.fillStyle = "#000"
-
-    for (const c of "xa") {
-      ctx.fillText(c, 0, baseline/scale)
-    }
-
-    const {data: data0} = ctx.getImageData(0, 0, width, height)
-    const x_height = measure_ascent(data0)/scale
-
-    for (const c of "ASQ") {
-      ctx.fillText(c, 0, baseline/scale)
-    }
-
-    const {data: data1} = ctx.getImageData(0, 0, width, height)
-    const cap_height = measure_ascent(data1)/scale
-
-    for (const c of "ÅŚgy") {
-      ctx.fillText(c, 0, baseline/scale)
-    }
-
-    const {data: data2} = ctx.getImageData(0, 0, width, height)
-    const ascent = measure_ascent(data2)/scale
-    const descent = measure_descent(data2)/scale
-
-    ctx.restore()
-
-    return {height: ascent + descent, ascent, cap_height, x_height, descent}
+  return {
+    height: ascent + descent,
+    ascent,
+    descent,
+    cap_height: cap_metrics.actualBoundingBoxAscent,
+    x_height: x_metrics.actualBoundingBoxAscent,
   }
-})()
-
-const _font_metrics = (() => {
-  try {
-    _native_font_metrics("normal 10px sans-serif")
-    return _native_font_metrics
-  } catch {
-    return _internal_font_metrics
-  }
-})()
+}
 
 const _metrics_cache: Map<string, {font: FontMetrics}> = new Map()
 


### PR DESCRIPTION
All of this custom logic isn't needed anymore, because web browsers that need this aren't supported by bokehjs anyway.