### PR TITLE
remove refs to twitter

### DIFF
--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -144,8 +144,6 @@ napoleon_include_init_with_doc = True
 ogp_site_url = "https://docs.bokeh.org/en/latest/"
 ogp_image = "http://static.bokeh.org/og/logotype-on-hex.png"
 ogp_custom_meta_tags = [
-    '<meta name="twitter:card" content="summary_large_image" />',
-    '<meta property="twitter:site" content="@bokeh" />',
     '<meta name="image" property="og:image" content="http://static.bokeh.org/og/logotype-on-hex.png">',
 ]
 
@@ -195,7 +193,6 @@ html_theme_options = {
         "json_url": "https://docs.bokeh.org/switcher.json",
         "version_match": version,
     },
-    "twitter_url": "https://twitter.com/bokeh",
     "use_edit_page_button": False,
     "header_links_before_dropdown": 8,
 }

--- a/docs/bokeh/source/docs/dev_guide.rst
+++ b/docs/bokeh/source/docs/dev_guide.rst
@@ -187,15 +187,16 @@ plots for display in a browser.
 There are currently three known bindings that expose Bokeh to languages other
 than Python:
 
-* `rbokeh <bokeh_r_>`_ adds support for Bokeh to the R language. It
-  was started by `@hafen <hafen_>`_.
-* `bokeh-scala <bokeh_scala_>`_ exposes Bokeh in the Scala language. The
-  project was created by the Bokeh core dev team member `@mattpap <mattpap_>`_.
 * `Bokeh.jl <Bokeh_jl_>`_ brings Bokeh to Julia users. It was created by community
   member `@cjdoris <cjdoris_>`_.
 * `BokehServer.jl <BokehServer_jl_>`_ also implements Julia bindings to BokehJS,
   including a server for synchronizing plots from Julia. It was authored by community
   member `@poldavezac <poldavezac_>`_.
+* `rbokeh <bokeh_r_>`_ adds support for Bokeh to the R language. It
+  was started by `@hafen <hafen_>`_. (This project is currently archived.)
+* `bokeh-scala <bokeh_scala_>`_ exposes Bokeh in the Scala language. The
+  project was created by the Bokeh core dev team member `@mattpap <mattpap_>`_.
+  (This project is currently archived.)
 
 The low-level object interface in Python mirrors the JSON schema exactly.
 Therefore, the best, most authoritative source of information for anyone
@@ -220,19 +221,6 @@ Report a vulnerability
 
 To report a security vulnerability, please use the `Tidelift security contact`_.
 Tidelift will coordinate the fix and disclosure.
-
-.. _contributor_guide_spread_the_word:
-
-Spread the word
-^^^^^^^^^^^^^^^
-
-Finally, as an open source project, Bokeh relies on word-of-mouth to reach new
-users. If you enjoy using Bokeh or are already contributing to Bokeh, please
-tell your friends and the people you work with about Bokeh.
-
-Bokeh is also on `Twitter`_ and `LinkedIn`_. Please follow those accounts for
-updates and news about Bokeh. And we always appreciate it if you tag Bokeh's
-accounts when you talk about anything that you made with Bokeh!
 
 
 .. _Code of Conduct: https://github.com/bokeh/bokeh/blob/main/docs/CODE_OF_CONDUCT.md
@@ -263,5 +251,4 @@ accounts when you talk about anything that you made with Bokeh!
 .. _bokeh_scala: https://github.com/bokeh/bokeh-scala
 .. _mattpap: https://github.com/mattpap
 .. _Tidelift security contact: https://tidelift.com/security
-.. _Twitter: https://twitter.com/bokeh
 .. _LinkedIn: https://www.linkedin.com/company/project-bokeh/

--- a/docs/bokeh/source/index.rst
+++ b/docs/bokeh/source/index.rst
@@ -70,8 +70,7 @@ There are various ways to get in touch with the `Bokeh community`_:
 * If you think you've found a bug, or would like to request a feature, please
   report an issue at `Bokeh's GitHub repository`_.
 
-You can also find more information about Bokeh on `Twitter`_, `Medium`_, and
-`LinkedIn`_.
+You can also find more information about Bokeh on `Medium`_, and `LinkedIn`_.
 
 
 .. toctree::
@@ -97,7 +96,6 @@ You can also find more information about Bokeh on `Twitter`_, `Medium`_, and
 .. _Bokeh Discourse: https://discourse.bokeh.org
 .. _`"bokeh" tag on Stack Overflow`: https://stackoverflow.com/questions/tagged/bokeh
 .. _`Bokeh's GitHub repository`: https://github.com/bokeh/bokeh
-.. _Twitter: https://twitter.com/bokeh
 .. _Medium: https://medium.com/bokeh
 .. _LinkedIn: https://www.linkedin.com/company/project-bokeh/
 .. _gallery: docs/gallery.html


### PR DESCRIPTION
This PR removes references to Twitter in the docs, and also makes a few other small updates e.g. to note that some of the bindings projects are currently archived. It also simplifies the devguide to remove the LinkedIn reference as well, which we use even far less than twitter. 

- [x] issues: fixes #13772
- [x] release document entry (if new feature or API change)
