### PR TITLE
enable docs on windows

### DIFF
--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -124,8 +124,7 @@ bokeh_sampledata_xref_skiplist = [
     "examples/basic/data/ajax_source.py",
     "examples/basic/data/server_sent_events_source.py",
     "examples/basic/layouts/custom_layout.py",
-    "examples/plotting/css_classes.py",
-    "examples/models/donut.py",
+    "examples/styling/dom/css_classes.py",
     "examples/models/widgets.py",
 ]
 

--- a/src/bokeh/sphinxext/bokeh_gallery.py
+++ b/src/bokeh/sphinxext/bokeh_gallery.py
@@ -161,10 +161,8 @@ def get_details(app):
         subdir_path = _REPO_TOP / "examples" / subdir
         for name in os.listdir(subdir_path):
             path = (subdir_path / name).as_posix()
-            if "bokeh/" in path:
-                path = path.split("bokeh/")[1]
-
-            if not name.startswith('_') and name.endswith('.py') and path not in app.config.bokeh_sampledata_xref_skiplist:
+            forbidden = any(skip in path for skip in app.config.bokeh_sampledata_xref_skiplist)
+            if not forbidden and not name.startswith('_') and name.endswith('.py'):
                 name = name.replace('.py', '')
                 rst_file_path = join(subdir, f'{name}.rst')
                 ref = f'.. _example_{name}_{subdir}:'

--- a/src/bokeh/sphinxext/bokeh_gallery.py
+++ b/src/bokeh/sphinxext/bokeh_gallery.py
@@ -158,11 +158,9 @@ def config_inited_handler(app, config):
 def get_details(app):
     details = []
     for subdir in app.config.bokeh_example_subdirs:
-        subdir_path = _REPO_TOP / "examples" / subdir
-        for name in os.listdir(subdir_path):
-            path = (subdir_path / name).as_posix()
-            forbidden = any(skip in path for skip in app.config.bokeh_sampledata_xref_skiplist)
-            if not forbidden and not name.startswith('_') and name.endswith('.py'):
+        for name in os.listdir(_REPO_TOP / "examples" / subdir):
+            path = PurePath("examples", subdir, name).as_posix()
+            if not name.startswith('_') and name.endswith('.py') and path not in app.config.bokeh_sampledata_xref_skiplist:
                 name = name.replace('.py', '')
                 rst_file_path = join(subdir, f'{name}.rst')
                 ref = f'.. _example_{name}_{subdir}:'

--- a/src/bokeh/sphinxext/bokeh_gallery.py
+++ b/src/bokeh/sphinxext/bokeh_gallery.py
@@ -158,8 +158,12 @@ def config_inited_handler(app, config):
 def get_details(app):
     details = []
     for subdir in app.config.bokeh_example_subdirs:
-        for name in os.listdir(join(_REPO_TOP, "examples", subdir)):
-            path = join("examples", subdir, name)
+        subdir_path = _REPO_TOP / "examples" / subdir
+        for name in os.listdir(subdir_path):
+            path = (subdir_path / name).as_posix()
+            if "bokeh/" in path:
+                path = path.split("bokeh/")[1]
+
             if not name.startswith('_') and name.endswith('.py') and path not in app.config.bokeh_sampledata_xref_skiplist:
                 name = name.replace('.py', '')
                 rst_file_path = join(subdir, f'{name}.rst')


### PR DESCRIPTION
- [ ] issues: fixes #13544

The initial issues are solved on my windows machine but I am getting now an error running the `jitter` example.

```
WARNING: Failed to import bokeh.sampledata.commits.
Possible hints:
* AttributeError: module 'bokeh.sampledata' has no attribute 'commits'
* ValueError: time data " 25 Mar 2017 11:32:41 -0500" doesn't match format " %d %b %Y %H:%M:%S %z", at position 19. You might want to try:
    - passing `format` if your strings have a consistent format;
    - passing `format='ISO8601'` if your strings are all ISO8601 but not necessarily in exactly the same format;
    - passing `format='mixed'`, and the format will be inferred for each element individually. You might want to use `dayfirst` alongside this.
```