### PR TITLE
add sd-gutter to custom css

### DIFF
--- a/docs/bokeh/source/_static/custom.css
+++ b/docs/bokeh/source/_static/custom.css
@@ -39,6 +39,9 @@ img.image-border {
   font-weight: 700;
   font-size: 110%;
 }
+.sd-row{
+    --sd-gutter-y: 1.5em;
+}
 
 /* Tweak sphinx-design cards */
 .bokeh-examples div {


### PR DESCRIPTION
This change adds a nice gap between the grit card items in the first start section.

The result will look like this:

![grafik](https://github.com/bokeh/bokeh/assets/68053396/1ec1f9e0-0a30-4842-acff-96c943ae1a00)


- [ ] issues: fixes #13631

