### PR TITLE
Enable RUF001 to lint confusable characters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
+allowed-confusables = ["σ"]
 exclude = [
     ".git",
     'node_modules',
@@ -166,7 +167,6 @@ ignore = [
     'E731', # Do not assign a lambda expression, use a def
     'E741', # Ambiguous variable name: I
     'UP035',  # Import from `collections.abc` instead: `Iterator`
-    'RUF001', # String contains ambiguous unicode character `σ` (did you mean `o`?)
     'RUF012', # Mutable class attributes should be annotated with `typing.ClassVar`
     'TID252', # Prefer absolute imports over relative imports from parent modules
 ]


### PR DESCRIPTION
Characters which look the same but have different underlying codes (homographs) are problematic. Enable Ruff's "confusable" character linter to prevent new code from accidentally including them.

Allow small sigma because of its use in statistics, using the approach suggested by @mattpap https://github.com/bokeh/bokeh/pull/13668#issuecomment-1910601841.

- [x] issues: follow-up to #13667
- [x] tests: `ruff .` passes
- [ ] release document entry: none
