### PR TITLE
Fix indentation issue

### DIFF
--- a/docs/bokeh/source/docs/user_guide/styling/plots.rst
+++ b/docs/bokeh/source/docs/user_guide/styling/plots.rst
@@ -488,7 +488,7 @@ options:
 .. bokeh-plot:: __REPO__/examples/styling/plots/datetime_tick_context.py
     :source-position: above
 
-It is possible to "chain" multiple ``DatetimeTickFomatter`` instances together,
+It is possible to "chain" multiple ``DatetimeTickFormatter`` instances together,
 for as many levels of context as desired. For example:
 
 .. code-block:: python

--- a/src/bokeh/models/axes.py
+++ b/src/bokeh/models/axes.py
@@ -156,7 +156,7 @@ class Axis(GuideRenderer):
     """)
 
     axis_label_orientation = Either(Enum(LabelOrientation), Float)(default="parallel", help="""
-    What direction the asix label text should be oriented. If a number
+    What direction the axis label text should be oriented. If a number
     is supplied, the angle of the text is measured from horizontal.
     """)
 

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -642,7 +642,7 @@ class DatetimeTickFormatter(TickFormatter):
     Whether to strip any leading zeros in the formatted ticks.
 
     Valid values are:
-    
+
     * ``True`` or ``False`` (default) to set stripping across all resolutions.
     * A sequence of resolution types, e.g. ``["microseconds", "milliseconds"]``, to enable
       scale-dependent stripping of leading zeros.

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -642,9 +642,10 @@ class DatetimeTickFormatter(TickFormatter):
     Whether to strip any leading zeros in the formatted ticks.
 
     Valid values are:
+    
     * ``True`` or ``False`` (default) to set stripping across all resolutions.
     * A sequence of resolution types, e.g. ``["microseconds", "milliseconds"]``, to enable
-    scale-dependent stripping of leading zeros.
+      scale-dependent stripping of leading zeros.
     """)
 
     context = Nullable(Either(String, Instance("bokeh.models.formatters.DatetimeTickFormatter")), default=None, help="""

--- a/src/bokeh/models/plots.py
+++ b/src/bokeh/models/plots.py
@@ -649,7 +649,7 @@ class Plot(LayoutDOM):
     Allows to specify which frame edges to align in multiple-plot layouts.
 
     The default is to align all edges, but users can opt-out from alignment
-    of each individual edge or all edges. Note also that other proproperties
+    of each individual edge or all edges. Note also that other properties
     may disable alignment of certain edges, especially when using fixed frame
     size (``frame_width`` and ``frame_height`` properties).
     """)
@@ -823,7 +823,7 @@ class Plot(LayoutDOM):
     """)
 
     reset_policy = Enum(ResetPolicy, default="standard", help="""
-    How a plot should respond to being reset. By deafult, the standard actions
+    How a plot should respond to being reset. By default, the standard actions
     are to clear any tool state history, return plot ranges to their original
     values, undo all selections, and emit a ``Reset`` event. If customization
     is desired, this property may be set to ``"event_only"``, which will
@@ -891,7 +891,7 @@ class GridPlot(LayoutDOM, GridCommon):
         Tuple(Instance(LayoutDOM), Int, Int),
         Tuple(Instance(LayoutDOM), Int, Int, Int, Int)), default=[], help="""
     A list of subplots with their associated position in the grid, row and column
-    index and optional row and column spans (the defaul span is 1).
+    index and optional row and column spans (the default span is 1).
     """)
 
     @error(REPEATED_LAYOUT_CHILD)


### PR DESCRIPTION
This pull request has no issue and solves an older indentation warning in the sphinx build and a few typos.

|**old**|**new**|
|--|--|
|![old](https://github.com/bokeh/bokeh/assets/68053396/68cf1476-52e9-4f9a-aad3-e8f3109067af)|![new](https://github.com/bokeh/bokeh/assets/68053396/72826541-01dd-48c3-af2b-296c82f5ee3c)|
