### PR TITLE
fix code-block

### DIFF
--- a/src/bokeh/models/filters.py
+++ b/src/bokeh/models/filters.py
@@ -220,17 +220,17 @@ class CustomJSFilter(Filter):
 
     Example:
 
-        .. code-block
+    .. code-block::
 
-            code = '''
-            const indices = []
-            for (let i = 0; i <= source.data['some_column'].length; i++) {
-                if (source.data['some_column'][i] == 'some_value') {
-                    indices.push(i)
-                }
+        code = '''
+        const indices = []
+        for (let i = 0; i <= source.data['some_column'].length; i++) {
+            if (source.data['some_column'][i] == 'some_value') {
+                indices.push(i)
             }
-            return indices
-            '''
+        }
+        return indices
+        '''
 
     """)
 


### PR DESCRIPTION
This change enables a code block in `filters.py` and changes the indentation. The section has the issue with the not working `Example:` again. We could make it bold or leave it as it is.

The docs with this changes would look like below:

----

![code_block](https://github.com/bokeh/bokeh/assets/68053396/4a79851d-ce37-48c6-974d-a0b6ad65b5df)

----

- [ ] issues: fixes #13795

