### PR TITLE
allow embedded server document to forward credentials

### DIFF
--- a/src/bokeh/core/_templates/autoload_request_tag.html
+++ b/src/bokeh/core/_templates/autoload_request_tag.html
@@ -32,6 +32,7 @@ ID is not specified, the entire document will be rendered.
     {% for header, value in headers.items() %}
     xhr.setRequestHeader("{{ header }}", "{{ value }}")
     {% endfor %}
+    xhr.withCredentials = {{ with_credentials | lower }};
     xhr.onload = function (event) {
       const script = document.createElement('script');
       const src = URL.createObjectURL(event.target.response);

--- a/src/bokeh/core/_templates/autoload_request_tag.html
+++ b/src/bokeh/core/_templates/autoload_request_tag.html
@@ -32,7 +32,7 @@ ID is not specified, the entire document will be rendered.
     {% for header, value in headers.items() %}
     xhr.setRequestHeader("{{ header }}", "{{ value }}")
     {% endfor %}
-    xhr.withCredentials = {{ with_credentials | to_json }};
+    xhr.withCredentials = {{ with_credentials | tojson }};
     xhr.onload = function (event) {
       const script = document.createElement('script');
       const src = URL.createObjectURL(event.target.response);

--- a/src/bokeh/core/_templates/autoload_request_tag.html
+++ b/src/bokeh/core/_templates/autoload_request_tag.html
@@ -32,7 +32,7 @@ ID is not specified, the entire document will be rendered.
     {% for header, value in headers.items() %}
     xhr.setRequestHeader("{{ header }}", "{{ value }}")
     {% endfor %}
-    xhr.withCredentials = {{ with_credentials | lower }};
+    xhr.withCredentials = {{ with_credentials | to_json }};
     xhr.onload = function (event) {
       const script = document.createElement('script');
       const src = URL.createObjectURL(event.target.response);

--- a/src/bokeh/embed/server.py
+++ b/src/bokeh/embed/server.py
@@ -124,11 +124,11 @@ def server_document(url: str = "default", relative_urls: bool = False, resources
         warnings.warn()
 
     tag = AUTOLOAD_REQUEST_TAG.render(
-        src_path=src_path,
-        app_path=app_path,
-        elementid=elementid,
-        headers=headers,
-        with_credentials=with_credentials,
+        src_path         = src_path,
+        app_path         = app_path,
+        elementid        = elementid,
+        headers          = headers,
+        with_credentials = with_credentials,
     )
 
     return tag

--- a/src/bokeh/embed/server.py
+++ b/src/bokeh/embed/server.py
@@ -138,7 +138,8 @@ def server_document(url: str = "default", relative_urls: bool = False, resources
     return tag
 
 def server_session(model: Model | None = None, session_id: ID | None = None, url: str = "default",
-        relative_urls: bool = False, resources: Literal["default"] | None = "default", headers: dict[str, str] = {}) -> str:
+        relative_urls: bool = False, resources: Literal["default"] | None = "default", headers: dict[str, str] = {},
+        with_credentials: bool = False) -> str:
     ''' Return a script tag that embeds content from a specific existing session on
     a Bokeh server.
 
@@ -191,6 +192,13 @@ def server_session(model: Model | None = None, session_id: ID | None = None, url
             A dictionary of key/values to be passed as HTTP Headers
             to Bokeh application code (default: None)
 
+            Mutually exclusive with ``with_credentials``
+
+       with_credentials (bool, optional):
+            Whether cookies should be passed to Bokeh application code (default: False)
+
+            Mutually exclusive with ``headers``
+
     Returns:
         A ``<script>`` tag that will embed content from a Bokeh Server.
 
@@ -216,15 +224,21 @@ def server_session(model: Model | None = None, session_id: ID | None = None, url
     src_path += _process_relative_urls(relative_urls, url)
     src_path += _process_resources(resources)
 
-    headers = dict(headers) if headers else {}
+    if headers and with_credentials:
+        raise ValueError("'headers' and 'with_credentials' are mutually exclusive")
+    elif not headers:
+        headers = {}
+    else:
+        headers = dict(headers)
     headers['Bokeh-Session-Id'] = session_id
 
     tag = AUTOLOAD_REQUEST_TAG.render(
-        src_path  = src_path,
-        app_path  = app_path,
-        elementid = elementid,
-        modelid   = modelid,
-        headers   = headers,
+        src_path         = src_path,
+        app_path         = app_path,
+        elementid        = elementid,
+        modelid          = modelid,
+        headers          = headers,
+        with_credentials = with_credentials,
     )
 
     return tag

--- a/src/bokeh/embed/server.py
+++ b/src/bokeh/embed/server.py
@@ -58,7 +58,7 @@ __all__ = (
 #-----------------------------------------------------------------------------
 
 def server_document(url: str = "default", relative_urls: bool = False, resources: Literal["default"] | None = "default",
-        arguments: dict[str, str] | None = None, headers: dict[str, str] | None = None) -> str:
+        arguments: dict[str, str] | None = None, headers: dict[str, str] | None = None, with_credentials: bool = False) -> str:
     ''' Return a script tag that embeds content from a Bokeh server.
 
     Bokeh apps embedded using these methods will NOT set the browser window title.
@@ -99,6 +99,9 @@ def server_document(url: str = "default", relative_urls: bool = False, resources
             A dictionary of key/values to be passed as HTTP Headers
             to Bokeh application code (default: None)
 
+       with_credentials (bool, optional):
+            Whether cookies should be passed to Bokeh application code (default: False)
+
     Returns:
         A ``<script>`` tag that will embed content from a Bokeh Server.
 
@@ -117,11 +120,15 @@ def server_document(url: str = "default", relative_urls: bool = False, resources
 
     headers = headers or {}
 
+    if headers and with_credentials:
+        warnings.warn()
+
     tag = AUTOLOAD_REQUEST_TAG.render(
-        src_path  = src_path,
-        app_path  = app_path,
-        elementid = elementid,
-        headers   = headers,
+        src_path=src_path,
+        app_path=app_path,
+        elementid=elementid,
+        headers=headers,
+        with_credentials=with_credentials,
     )
 
     return tag

--- a/src/bokeh/embed/server.py
+++ b/src/bokeh/embed/server.py
@@ -99,8 +99,12 @@ def server_document(url: str = "default", relative_urls: bool = False, resources
             A dictionary of key/values to be passed as HTTP Headers
             to Bokeh application code (default: None)
 
+            Mutually exclusive with ``with_credentials``
+
        with_credentials (bool, optional):
             Whether cookies should be passed to Bokeh application code (default: False)
+
+            Mutually exclusive with ``headers``
 
     Returns:
         A ``<script>`` tag that will embed content from a Bokeh Server.
@@ -118,10 +122,10 @@ def server_document(url: str = "default", relative_urls: bool = False, resources
     src_path += _process_resources(resources)
     src_path += _process_arguments(arguments)
 
-    headers = headers or {}
-
     if headers and with_credentials:
-        warnings.warn()
+        raise ValueError("'headers' and 'with_credentials' are mutually exclusive")
+    elif not headers:
+        headers = {}
 
     tag = AUTOLOAD_REQUEST_TAG.render(
         src_path         = src_path,

--- a/src/bokeh/server/views/autoload_js_handler.py
+++ b/src/bokeh/server/views/autoload_js_handler.py
@@ -54,11 +54,14 @@ class AutoloadJsHandler(SessionHandler):
     '''
 
     def set_default_headers(self):
-        self.set_header("Access-Control-Allow-Headers", "*")
-        self.set_header('Access-Control-Allow-Methods', 'PUT, GET, OPTIONS')
         self.set_header("Access-Control-Allow-Origin", "*")
+        self.set_header("Access-Control-Allow-Headers", "*")
+        self.set_header("Access-Control-Allow-Credentials", "true")
 
     async def get(self, *args, **kwargs):
+        if self.request.cookies:
+            self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
+
         session = await self.get_session()
 
         element_id = self.get_argument("bokeh-autoload-element", default=None)
@@ -89,6 +92,8 @@ class AutoloadJsHandler(SessionHandler):
 
     async def options(self, *args, **kwargs):
         '''Browsers make OPTIONS requests under the hood before a GET request'''
+        self.set_header('Access-Control-Allow-Methods', 'PUT, GET, OPTIONS')
+        self.set_header("Access-Control-Allow-Origin", self.request.headers["Origin"])
 
 #-----------------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
- [x] issues: closes #13792
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

This PR does two things:

1. It adds a `with_credentials: bool = False` parameter to `bokeh.embed.server.server_document`. When set, the request in the generated script also forwards credentials.
2. If a browser forwards credentials, it expects specific CORS headers being set in the response. If they are not present or have invalid values, the response is rejected by the browser. Thus, this PR also adjusts `bokeh.server.views.autoload_js_handler.AutoloadJsHandler`, i.e. the handler that is called by the `server_document`, to account for the CORS headers.

cc @bryevdv I need advice on how you want me to add tests for this.