### PR TITLE
Robustify and simplify `View.has_finished()` logic

### DIFF
--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -141,8 +141,28 @@ export abstract class View implements ISignalable, Equatable {
 
   protected _has_finished: boolean = false
 
-  mark_finished(): void {
+  has_finished(): boolean {
+    if (!this._has_finished) {
+      return false
+    }
+
+    for (const child of this.children_views()) {
+      if (!child.has_finished()) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  mark_finished(recursive: boolean = false): void {
     this._has_finished = true
+
+    if (recursive) {
+      for (const child of this.children_views()) {
+        child.mark_finished(recursive)
+      }
+    }
   }
 
   /**
@@ -150,6 +170,10 @@ export abstract class View implements ISignalable, Equatable {
    */
   force_finished(): void {
     this.mark_finished()
+
+    for (const child of this.children()) {
+      child.force_finished()
+    }
   }
 
   finish(): void {
@@ -189,10 +213,6 @@ export abstract class View implements ISignalable, Equatable {
 
   get is_root(): boolean {
     return this.parent == null
-  }
-
-  has_finished(): boolean {
-    return this._has_finished
   }
 
   get is_idle(): boolean {

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -190,6 +190,9 @@ export class ArrowView extends DataAnnotationView {
 
       ctx.restore()
     }
+
+    this.start?.mark_finished()
+    this.end?.mark_finished()
   }
 }
 

--- a/bokehjs/src/lib/models/annotations/contour_color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/contour_color_bar.ts
@@ -74,6 +74,7 @@ export class ContourColorBarView extends BaseColorBarView {
       }
       ctx.restore()
     }
+    this._fill_view.force_finished() // MultiPolygonsView.paint() wasn't called
 
     const multi_line = this._line_view.glyph as MultiLineView
     const nline = multi_line.data_size
@@ -94,6 +95,7 @@ export class ContourColorBarView extends BaseColorBarView {
       }
       ctx.restore()
     }
+    this._line_view.force_finished() // MultiLineView.paint() wasn't called
   }
 }
 

--- a/bokehjs/src/lib/models/annotations/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/text_annotation.ts
@@ -65,18 +65,6 @@ export abstract class TextAnnotationView extends AnnotationView {
     super.remove()
   }
 
-  override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-
-    if (!this._text_view.has_finished()) {
-      return false
-    }
-
-    return true
-  }
-
   override get displayed(): boolean {
     return super.displayed && this._text_view.model.text != "" && this.visuals.text.doit
   }

--- a/bokehjs/src/lib/models/annotations/toolbar_panel.ts
+++ b/bokehjs/src/lib/models/annotations/toolbar_panel.ts
@@ -20,10 +20,6 @@ export class ToolbarPanelView extends AnnotationView {
     this.toolbar_view.after_render()
   }
 
-  override has_finished(): boolean {
-    return super.has_finished() && this.toolbar_view.has_finished()
-  }
-
   override children_views(): View[] {
     return [...super.children_views(), this.toolbar_view]
   }

--- a/bokehjs/src/lib/models/annotations/whisker.ts
+++ b/bokehjs/src/lib/models/annotations/whisker.ts
@@ -63,6 +63,8 @@ export class WhiskerView extends UpperLowerView {
         this.lower_head.paint(ctx, i)
         ctx.restore()
       }
+
+      this.lower_head.mark_finished()
     }
 
     if (this.upper_head != null) {
@@ -73,6 +75,8 @@ export class WhiskerView extends UpperLowerView {
         this.upper_head.paint(ctx, i)
         ctx.restore()
       }
+
+      this.upper_head.mark_finished()
     }
   }
 }

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -737,26 +737,6 @@ export abstract class AxisView extends GuideRendererView {
 
     super.remove()
   }
-
-  override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-
-    if (this._axis_label_view != null) {
-      if (!this._axis_label_view.has_finished()) {
-        return false
-      }
-    }
-
-    for (const label_view of this._major_label_views.values()) {
-      if (!label_view.has_finished()) {
-        return false
-      }
-    }
-
-    return true
-  }
 }
 
 export namespace Axis {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -113,6 +113,8 @@ export abstract class GlyphView extends DOMComponentView {
       const cls = await this.load_glglyph() as BaseGLGlyphConstructor
       this.glglyph = new cls(webgl.regl_wrapper, this)
     }
+
+    this.mark_finished()
   }
 
   request_paint(): void {
@@ -134,14 +136,6 @@ export abstract class GlyphView extends DOMComponentView {
   }
 
   protected abstract _paint(ctx: Context2d, indices: number[], data?: Glyph.Data): void
-
-  override has_finished(): boolean {
-    return true
-  }
-
-  override notify_finished(): void {
-    this.renderer.notify_finished()
-  }
 
   protected _bounds(bounds: Rect): Rect {
     return bounds

--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -47,6 +47,7 @@ export class ImageURLView extends XYGlyphView {
 
   protected override _set_data(): void {
     if (this.inherited_url) {
+      this._images_rendered = true
       return
     }
 

--- a/bokehjs/src/lib/models/glyphs/math_text_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/math_text_glyph.ts
@@ -24,20 +24,6 @@ export abstract class MathTextGlyphView extends TextView {
     return [...super.children_views(), ...this._label_views.values()]
   }
 
-  override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-
-    for (const view of this._label_views.values()) {
-      if (!view.has_finished()) {
-        return false
-      }
-    }
-
-    return true
-  }
-
   protected abstract _build_label(text: string): BaseText
 
   protected override async _build_labels(text: p.Uniform<string | null>): Promise<(GraphicsBox | null)[]> {

--- a/bokehjs/src/lib/models/graphics/decoration.ts
+++ b/bokehjs/src/lib/models/graphics/decoration.ts
@@ -21,6 +21,7 @@ export class DecorationView extends View {
   override async lazy_initialize(): Promise<void> {
     await super.lazy_initialize()
     this.marking = await build_view(this.model.marking, {parent: this.parent})
+    this.mark_finished()
   }
 }
 

--- a/bokehjs/src/lib/models/graphics/marking.ts
+++ b/bokehjs/src/lib/models/graphics/marking.ts
@@ -36,6 +36,7 @@ export abstract class MarkingView extends DOMComponentView implements visuals.Pa
       const uniform = prop.uniform(source).select(indices)
       self[`${prop.attr}`] = uniform
     }
+    this.mark_finished()
   }
 
   abstract paint(ctx: Context2d, i: number): void

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -493,21 +493,7 @@ export abstract class LayoutDOMView extends PaneView {
   }
 
   override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-
-    if (this.is_layout_root && !this._layout_computed) {
-      return false
-    }
-
-    for (const child_view of this.child_views) {
-      if (!child_view.has_finished()) {
-        return false
-      }
-    }
-
-    return true
+    return super.has_finished() && (!this.is_layout_root || this._layout_computed)
   }
 
   override box_sizing(): DOMBoxSizing {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -1098,22 +1098,6 @@ export class PlotView extends LayoutDOMView implements Paintable {
     `)
   }
 
-  override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-
-    if (this.model.visible) {
-      for (const [, renderer_view] of this.renderer_views) {
-        if (!renderer_view.has_finished()) {
-          return false
-        }
-      }
-    }
-
-    return true
-  }
-
   override _after_layout(): void {
     super._after_layout()
     this.unpause(true)

--- a/bokehjs/src/lib/models/renderers/composite_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/composite_renderer.ts
@@ -123,26 +123,6 @@ export abstract class CompositeRendererView extends RendererView {
       element_view.reposition(displayed)
     }
   }
-
-  override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-
-    for (const renderer_view of this.renderer_views) {
-      if (!renderer_view.has_finished()) {
-        return false
-      }
-    }
-
-    for (const element_view of this.element_views) {
-      if (!element_view.has_finished()) {
-        return false
-      }
-    }
-
-    return true
-  }
 }
 
 export namespace CompositeRenderer {

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -322,6 +322,16 @@ export class GlyphRendererView extends DataRendererView {
     return this.glyph.has_webgl()
   }
 
+  override paint(ctx: Context2d): void {
+    super.paint(ctx)
+
+    this.decimated_glyph.force_finished()
+    this.selection_glyph.force_finished()
+    this.nonselection_glyph.force_finished()
+    this.hover_glyph?.force_finished()
+    this.muted_glyph.force_finished()
+  }
+
   protected _paint(ctx: Context2d): void {
     const {has_webgl} = this
 

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -142,10 +142,6 @@ export abstract class RendererView extends StyledElementView implements visuals.
     this.plot_view.request_layout()
   }
 
-  override notify_finished(): void {
-    this.plot_view.notify_finished()
-  }
-
   notify_finished_after_paint(): void {
     this.plot_view.notify_finished_after_paint()
   }

--- a/bokehjs/src/lib/models/sources/cds_view.ts
+++ b/bokehjs/src/lib/models/sources/cds_view.ts
@@ -18,6 +18,7 @@ export class CDSViewView extends View {
   override initialize(): void {
     super.initialize()
     this.compute_indices()
+    this.mark_finished()
   }
 
   override connect_signals(): void {

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -79,6 +79,11 @@ export type EventRole = EventType | "multi"
 export abstract class ToolView extends View {
   declare model: Tool
 
+  override initialize(): void {
+    super.initialize()
+    this._has_finished = true
+  }
+
   override connect_signals(): void {
     super.connect_signals()
     this.connect(this.model.properties.active.change, () => {

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -60,20 +60,6 @@ export class ToolbarView extends UIElementView {
     return [...super.children_views(), ...this._tool_button_views.values()]
   }
 
-  override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-
-    for (const child_view of this._tool_button_views.values()) {
-      if (!child_view.has_finished()) {
-        return false
-      }
-    }
-
-    return true
-  }
-
   override initialize(): void {
     super.initialize()
 

--- a/bokehjs/src/lib/models/ui/dialog.ts
+++ b/bokehjs/src/lib/models/ui/dialog.ts
@@ -92,6 +92,10 @@ export class DialogView extends UIElementView {
 
     this._title = await build_view(title, {parent: this})
     this._content = await build_view(content, {parent: this})
+
+    if (!this.model.visible) {
+      this.force_finished()
+    }
   }
 
   override connect_signals(): void {

--- a/bokehjs/src/lib/models/ui/pane.ts
+++ b/bokehjs/src/lib/models/ui/pane.ts
@@ -75,20 +75,6 @@ export class PaneView extends UIElementView {
       element_view.render_to(target)
     }
   }
-
-  override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-
-    for (const element_view of this.element_views) {
-      if (!element_view.has_finished()) {
-        return false
-      }
-    }
-
-    return true
-  }
 }
 
 export namespace Pane {

--- a/bokehjs/test/integration/contour.ts
+++ b/bokehjs/test/integration/contour.ts
@@ -31,7 +31,7 @@ describe("ContourRenderer", () => {
       lower_levels: [-0.5,  1.5],
       upper_levels: [1.5, 3.5],
       fill_color: ["red", "yellow"],
-      hatch_pattern: ["", "/"],
+      hatch_pattern: [" ", "/"],
     }})
     const fill_renderer = new GlyphRenderer({
       glyph: new MultiPolygons({


### PR DESCRIPTION
The goals of this PR are:

- [x] use `View.children()` in `View.has_finished()` instead of overriding `has_finished()` in subclasses
- [ ] make sure that all views participate in `has_finished()` and are marked as `finished` at some point in their life-cycle
- [ ] reduce the number of exceptions to ground rules of `View.has_finished()`