### PR TITLE
Update util.py

### DIFF
--- a/src/bokeh/server/util.py
+++ b/src/bokeh/server/util.py
@@ -45,7 +45,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def bind_sockets(address: str | None, port: int) -> tuple[list[socket], int]:
+def bind_sockets(address: str | None, port: int, reuse_port: bool = False) -> tuple[list[socket], int]:
     ''' Bind a socket to a port on an address.
 
     Args:
@@ -65,7 +65,7 @@ def bind_sockets(address: str | None, port: int) -> tuple[list[socket], int]:
         (socket, port)
 
     '''
-    ss = netutil.bind_sockets(port=port or 0, address=address)
+    ss = netutil.bind_sockets(port=port or 0, address=address, reuse_port = reuse_port)
     assert len(ss)
     ports = {s.getsockname()[1] for s in ss}
     assert len(ports) == 1, "Multiple ports assigned??"


### PR DESCRIPTION
Added reuse_port option to bokeh.server.util  bind_sockets, to allow for this behavior in a bokeh emded context.  Otherwise, when requesting a specific port from within a Flask app, we get an error "OSError: [Errno 98] Address already in use".   The specific port is required to most efficiently manage open ports in a container environment.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #13812
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
