### PR TITLE
fix path and typos related to jupyter.rst

### DIFF
--- a/docs/bokeh/source/docs/user_guide/output/jupyter.rst
+++ b/docs/bokeh/source/docs/user_guide/output/jupyter.rst
@@ -147,7 +147,7 @@ either from the GUI or with the following command:
 JupyterHub for Administrators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are a JupyterHub admin you can make Bokeh work autotomatically with
+If you are a JupyterHub admin you can make Bokeh work automatically with
 unchanged notebooks by setting an environment variable in the notebook
 environment:
 
@@ -410,7 +410,7 @@ is the name of the application (see :ref:`ug_server` for details).
 This application is available at http://localhost:5006/ipy_slider.
 
 You can build on the above to create more complex layouts and include advanced widgets,
-such as `ipyleaflet`_ and `ipyvolume`_. For more examples, see ``examples/howto/ipywidgets``
+such as `ipyleaflet`_ and `ipyvolume`_. For more examples, see :bokeh-tree:`examples/output/jupyter/ipywidgets`
 in the Bokeh repository.
 
 .. _IPyWidgets: https://ipywidgets.readthedocs.io

--- a/examples/output/jupyter/ipywidgets/README.md
+++ b/examples/output/jupyter/ipywidgets/README.md
@@ -1,4 +1,4 @@
-Examples in this directory show off bokeh's capability to integrate with Jupyer widgets
+Examples in this directory show off bokeh's capability to integrate with Jupyter widgets
 outside of JupyterLab or classical Notebook environments. All examples are bokeh server
 examples, so you run them with `bokeh server app_name`, and then you have to navigate
 to `http://localhost:5006/app_name`:


### PR DESCRIPTION
This PR updates an old path in https://docs.bokeh.org/en/latest/docs/user_guide/output/jupyter.html and will link in future to the folder in the github repo [ipywidgets](https://github.com/bokeh/bokeh/tree/3.4.0/examples/output/jupyter/ipywidgets).

![grafik](https://github.com/bokeh/bokeh/assets/68053396/ec072fc1-4885-4727-ad17-b738f0fd5c9f)

If it is not to much work this could be added to #13816.