### PR TITLE
fix indentation of layout_function param

### DIFF
--- a/src/bokeh/plotting/graph.py
+++ b/src/bokeh/plotting/graph.py
@@ -46,12 +46,12 @@ def from_networkx(graph: nx.Graph, layout_function: dict[int | str, Sequence[flo
         layout function. Any keyword arguments will be passed to the
         layout function.
 
-        Only two dimensional layouts are supported.
+        Only two-dimensional layouts are supported.
 
         Args:
             graph (networkx.Graph) : a networkx graph to render
             layout_function (function or dict) : a networkx layout function or mapping of node keys to positions.
-            The position is a two element sequence containing the x and y coordinate.
+                The position is a two element sequence containing the x and y coordinate.
 
         Returns:
             instance (GraphRenderer)


### PR DESCRIPTION
This PR fixes the docstring of the function `from_networkx`.

|[current](https://docs.bokeh.org/en/latest/docs/reference/plotting/helpers.html#from-networkx)|suggested|
|--|--|
|![grafik](https://github.com/bokeh/bokeh/assets/68053396/8edf683c-7bbf-4d38-8bb8-55a5903e9d75)|![grafik](https://github.com/bokeh/bokeh/assets/68053396/41de5e5e-83bd-4aca-af45-cdeeec35ff98)|


If it is not to much work this could be added to #13816.

