### PR TITLE
remove consecutive "the" and fix typos in touched files

### DIFF
--- a/docs/bokeh/source/docs/user_guide/basic/bars.rst
+++ b/docs/bokeh/source/docs/user_guide/basic/bars.rst
@@ -235,7 +235,7 @@ To apply different colors to the bars, use |factor_cmap| for
 
     p.vbar(x='x', top='counts', width=0.9, source=source, line_color="white",
 
-           # use the palette to colormap based on the the x[1:2] values
+           # use the palette to colormap based on the x[1:2] values
            fill_color=factor_cmap('x', palette=palette, factors=years, start=1, end=2))
 
 

--- a/release/checks.py
+++ b/release/checks.py
@@ -67,7 +67,7 @@ def check_repo_is_bokeh(config: Config, system: System) -> ActionReturn:
     try:
         remote = system.run("git config --get remote.origin.url")
         if remote.strip() in ("git@github.com:bokeh/bokeh.git", "https://github.com/bokeh/bokeh"):
-            return PASSED("Executing inside the the bokeh/bokeh repository")
+            return PASSED("Executing inside the bokeh/bokeh repository")
         else:
             return FAILED(f"Executing OUTSIDE the bokeh/bokeh repository (bad remote: {remote})")
     except RuntimeError as e:

--- a/src/bokeh/events.py
+++ b/src/bokeh/events.py
@@ -30,8 +30,8 @@ event object that triggered the callback.
 
 Alternatively it is possible to trigger Python code to run when events
 happen, in the context of a Bokeh application running on a Bokeh server.
-This can accomplished by passing an event class, and a callback function
-to the the :func:`~bokeh.model.Model.on_event` method. The callback should
+This can be accomplished by passing an event class, and a callback function
+to the :func:`~bokeh.model.Model.on_event` method. The callback should
 accept a single argument ``event``, which will be passed the concrete
 event object that triggered the callback.
 
@@ -399,7 +399,7 @@ class PointEvent(PlotEvent):
         y (float) : y-coordinate of the event in *data* space
 
     Note that data space coordinates are relative to the default range, not
-    any extra ranges, and the the screen space origin is at the top left of
+    any extra ranges, and the screen space origin is at the top left of
     the HTML canvas.
 
     '''

--- a/src/bokeh/io/notebook.py
+++ b/src/bokeh/io/notebook.py
@@ -121,7 +121,7 @@ class CommsHandle:
         self._doc = cell_doc
 
         # Our internal copy of the doc is in perpetual "hold". Events from the
-        # originating doc will be triggered and collected it it. Events are
+        # originating doc will be triggered and collected. Events are
         # processed/cleared when push_notebook is called for this comms handle
         self._doc.hold()
 
@@ -143,7 +143,7 @@ class CommsHandle:
     # and Document model changed events. If we find that the event is
     # for a model in our internal copy of the docs, then trigger the
     # internal doc with the event so that it is collected (until a
-    # call to push_notebook processes and clear colleted events)
+    # call to push_notebook processes and clear collected events)
     def _document_model_changed(self, event: ModelChangedEvent) -> None:
         if event.model.id in self.doc.models:
             self.doc.callbacks.trigger_on_change(event)
@@ -221,7 +221,7 @@ def install_notebook_hook(notebook_type: NotebookType, load: Load, show_doc: Sho
 
             If the notebook platform is capable of supporting in-place updates
             to plots then this function may return an opaque notebook handle
-            that can  be used for that purpose. The handle will be returned by
+            that can be used for that purpose. The handle will be returned by
             ``show()``, and can be used by as appropriate to update plots, etc.
             by additional functions in the library that installed the hooks.
 
@@ -259,7 +259,7 @@ def push_notebook(*, document: Document | None = None, state: State | None = Non
     ''' Update Bokeh plots in a Jupyter notebook output cells with new data
     or property values.
 
-    When working the the notebook, the ``show`` function can be passed the
+    When working inside the notebook, the ``show`` function can be passed the
     argument ``notebook_handle=True``, which will cause it to return a
     handle object that can be used to update the Bokeh output later. When
     ``push_notebook`` is called, any property updates (e.g. plot titles or
@@ -347,10 +347,10 @@ def run_notebook_hook(notebook_type: NotebookType, action: Literal["load", "doc"
     ''' Run an installed notebook hook with supplied arguments.
 
     Args:
-        noteboook_type (str) :
+        notebook_type (str) :
             Name of an existing installed notebook hook
 
-        actions (str) :
+        action (str) :
             Name of the hook action to execute, ``'doc'`` or ``'app'``
 
     All other arguments and keyword arguments are passed to the hook action
@@ -700,7 +700,7 @@ def _remote_jupyter_proxy_url(port: int | None) -> str:
 
 def _update_notebook_url_from_env(notebook_url: str | ProxyUrlFunc) -> str | ProxyUrlFunc:
     """If the environment variable ``JUPYTER_BOKEH_EXTERNAL_URL`` is defined, returns a function which
-    generates URLs which can traverse the JupyterHub proxy.  Otherwise returns ``notebook_url`` unmodified.
+    generates URLs which can traverse the JupyterHub proxy. Otherwise returns ``notebook_url`` unmodified.
 
     A warning is issued if ``notebook_url`` is not the default and
     ``JUPYTER_BOKEH_EXTERNAL_URL`` is also defined since setting the
@@ -713,9 +713,9 @@ def _update_notebook_url_from_env(notebook_url: str | ProxyUrlFunc) -> str | Pro
 
     Returns:
        str | ProxyUrlFunc
-          Either a URL string or a function that generates a URL string given a port number.  The
+          Either a URL string or a function that generates a URL string given a port number. The
           latter function may be user supplied as the input parameter or defined internally by Bokeh
-          when ``JUPYER_BOKEH_EXTERNAL_URL`` is set.
+          when ``JUPYTER_BOKEH_EXTERNAL_URL`` is set.
 
     """
     if os.environ.get("JUPYTER_BOKEH_EXTERNAL_URL"):

--- a/src/bokeh/models/css.py
+++ b/src/bokeh/models/css.py
@@ -54,7 +54,7 @@ class InlineStyleSheet(StyleSheet):
 
     .. note::
         Depending on the context, this stylesheet will be appended either to
-        the the parent shadow root, if used in a component, or otherwise to
+        the parent shadow root, if used in a component, or otherwise to
         the ``<head>`` element. If you want to append globally regardless of
         the context, use ``GlobalInlineStyleSheet`` instead.
     """
@@ -72,7 +72,7 @@ class ImportedStyleSheet(StyleSheet):
 
     .. note::
         Depending on the context, this stylesheet will be appended either to
-        the the parent shadow root, if used in a component, or otherwise to
+        the parent shadow root, if used in a component, or otherwise to
         the ``<head>`` element. If you want to append globally regardless of
         the context, use ``GlobalImportedStyleSheet`` instead.
     """

--- a/src/bokeh/models/ranges.py
+++ b/src/bokeh/models/ranges.py
@@ -304,7 +304,7 @@ class FactorRange(Range):
     coordinate system called *synthetic coordinates*. In the simplest cases,
     factors are separated by a distance of 1.0 in synthetic coordinates,
     however the exact mapping from factors to synthetic coordinates is
-    affected by he padding properties as well as whether the number of levels
+    affected by the padding properties as well as whether the number of levels
     the factors have.
 
     Users typically do not need to worry about the details of this mapping,
@@ -371,7 +371,7 @@ class FactorRange(Range):
         ])
 
     This property dictates how much padding to add between the three factors
-    in the `['foo', 'A']` group, and between the two factors in the the
+    in the `['foo', 'A']` group, and between the two factors in the
     [`bar`]
     """)
 

--- a/src/bokeh/sphinxext/bokeh_palette.py
+++ b/src/bokeh/sphinxext/bokeh_palette.py
@@ -15,7 +15,7 @@ following:
 
 * An explicit list of colors: ``['#000000', '#333333', '#666666', '#999999', '#cccccc', '#ffffff']``
 
-The following usage of the the directive is valid:
+The following usage of the directive is valid:
 
 -----
 
@@ -49,7 +49,7 @@ The following usage of the the directive is valid:
 
 -----
 
-Palette swatches are 20 pixels in height. For palettes short than 20 colors,
+Palette swatches are 20 pixels in height. For palettes shorter than 20 colors,
 the default width for the swatches is 20 pixels. If larger palettes are given,
 the width of the HTML spans is progressively reduced, down to a minimum of one
 pixel. For instance displaying the full Viridis palette with the expression

--- a/src/bokeh/sphinxext/bokeh_palette_group.py
+++ b/src/bokeh/sphinxext/bokeh_palette_group.py
@@ -11,7 +11,7 @@ and ``d3`` that provide groups of palettes. The ``bokeh-palette-group``
 directive accepts the name of one of these groups, and generates a visual
 matrix of colors for every palette in the group.
 
-As an example, the following usage of the the directive:
+As an example, the following usage of the directive:
 
 .. code-block:: rest
 
@@ -91,7 +91,7 @@ class bokeh_palette_group(nodes.General, nodes.Element):
         names = sorted(group)
         for name in names:
             palettes = group[name]
-            # arbitrary cutoff here, idea is to not show large (e.g 256 length) palettes
+            # arbitrary cutoff here, idea is to not show large (e.g. 256 length) palettes
             numbers = [x for x in sorted(palettes) if x < 30]
             html = PALETTE_GROUP_DETAIL.render(name=name, numbers=numbers, palettes=palettes)
             visitor.body.append(html)


### PR DESCRIPTION
This PR corrects the common typo `the the`, which was present all over the repo, and some other typos in the already touched files, too.