### PR TITLE
fix broken search on the start page

### DIFF
--- a/docs/bokeh/source/_static/custom.css
+++ b/docs/bokeh/source/_static/custom.css
@@ -10,6 +10,11 @@ html[data-theme=light] {
   --pst-color-inline-code: var(--pst-color-text-base);
 }
 
+/* disable the border line for the sidebar search form */
+.bd-search {
+  border: none;
+}
+
 /* make sure the article container uses all available space */
 .bd-article-container {
   max-width: 100% !important;

--- a/docs/bokeh/source/index.rst
+++ b/docs/bokeh/source/index.rst
@@ -12,10 +12,11 @@ to complex dashboards with streaming datasets. With Bokeh, you can create
 JavaScript-powered visualizations without writing any JavaScript yourself.
 
 .. raw:: html
-
-    <form class="bd-search align-items-center" action="search.html" method="get">
-      <input type="search" class="form-control search-front-page" name="q" id="search-input" placeholder="&#128269; Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
-    </form>
+    <div>
+        <form class="bd-search align-items-center" action="search.html" method="get">
+          <input type="search" class="form-control search-front-page" name="q" id="search-input" placeholder="&#128269; Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
+        </form>
+    </div>
 
 Finding the right documentation resources
 -----------------------------------------


### PR DESCRIPTION
This PR will fix the broken search on the start page of the documentation. The search was broken, because the `search-button` is searching for a valid `from` inside a `<div></div>`. This was missing and because of this, the button raised an error.

See the gif below to see how this works on the latest published page.

---

![broken-search](https://github.com/bokeh/bokeh/assets/68053396/c9ccf070-4e7e-415f-9159-9b95732f7eb2)

----

I also want to quote from https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/search.html:

> If a page includes both the search button and an always-visible search field, the keyboard shortcuts will focus on the always-visible field and the hidden search field overlay will not display. This may not be what you want: on small screens (i.e. mobile devices) the sidebars may be hidden in a drawer, and if the persistent search field is there, it may receive focus without actually being made visible. It is strongly recommended that you use either the search button and the hidden/overlaid field that comes with it, or use a persistent search field in a place that makes sense for your layout.

This is the case on the docs of bokeh. For smaller screens the search button will go to the side bar without any visiable change for the user.

- [ ] adresses: fixes #13789

This PR does not solve the JS error with the version banner. The banner is broken for

* https://docs.bokeh.org/en/3.2.2/docs/first_steps.html
* https://docs.bokeh.org/en/3.3.0/docs/first_steps.html
* https://docs.bokeh.org/en/3.4.0/docs/first_steps.html

