### PR TITLE
remove unnecessary code from ProtocolHandler.handle

### DIFF
--- a/src/bokeh/server/protocol_handler.py
+++ b/src/bokeh/server/protocol_handler.py
@@ -88,9 +88,6 @@ class ProtocolHandler:
         handler = self._handlers.get(message.msgtype)
 
         if handler is None:
-            handler = self._handlers.get(message.msgtype)
-
-        if handler is None:
             raise ProtocolError(f"{message} not expected on server")
 
         try:


### PR DESCRIPTION
Removes an unnecessary dict lookup that is likely just the remnant of a previous implementation. We are currently doing

```python
value = dct.get(key)

if value is None:
    value = dct.get(key)

if value is None:
    raise Exception
```

Meaning, if we don't find a value the first time, we try again with the same key. Unless `dct.get` has any side-effects, this makes no sense. This is equivalent to 

```python
value = dct.get(key)

if value is None:
    raise Exception
```

as implemented in this PR.
