### PR TITLE
Upgrade CI actions to most recent versions

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history to get proper build version
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: 'latest'
           activate-environment: bk-test
@@ -68,13 +68,13 @@ jobs:
         run: bash scripts/ci/verify_conda_install.sh
 
       - name: Upload wheel package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheel-package
           path: dist/bokeh-*-py3-none-any.whl
 
       - name: Upload bokehjs package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bokehjs-package
           path: bokehjs/build/dist/bokeh-bokehjs-*.tgz
@@ -93,7 +93,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: examples-report
           path: examples-report
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -201,7 +201,7 @@ jobs:
         run: pytest -v --cov=bokeh --cov-report=xml --tb=short --driver chrome --color=yes tests/integration
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           flags: integration
           verbose: true
@@ -221,7 +221,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -249,7 +249,7 @@ jobs:
         run: pytest --cov=bokeh --cov-report=xml --color=yes tests/unit
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: success() || failure()
         with:
           env_vars: OS,PYTHON
@@ -268,7 +268,7 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -286,7 +286,7 @@ jobs:
         run: pytest -m "not sampledata" --cov=bokeh --cov-report=xml --color=yes tests/unit
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           env_vars: OS
           flags: unit,minimal
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -315,7 +315,7 @@ jobs:
         run: bash scripts/ci/build_docs.sh
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-html
           path: docs/bokeh/docs-html.tgz
@@ -325,7 +325,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Environment
         uses: ./.github/workflows/composite/test-setup
@@ -353,11 +353,11 @@ jobs:
       IMAGE_TAG: bokeh/bokeh-dev:branch-3.1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download wheel package
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheel-package
           path: dist/

--- a/.github/workflows/bokeh-docker-build.yml
+++ b/.github/workflows/bokeh-docker-build.yml
@@ -22,7 +22,7 @@ jobs:
           echo "branch_name=$(echo ${{ github.ref_name }} | tr / -)" >> $GITHUB_ENV
 
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: scripts/docker
           load: true
@@ -50,7 +50,7 @@ jobs:
 
       - name: Push image to Docker Hub
         if: ${{ inputs.push_or_save_image }} == "Push to Docker Hub"
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: scripts/docker
           push: true
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload artifact
         if: ${{ inputs.push_to_docker_hub }} == "Save as artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifact
           path: bokeh-dev.tar

--- a/.github/workflows/bokeh-docker-test.yml
+++ b/.github/workflows/bokeh-docker-test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history to get proper build version
 
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bokeh-report-docker
           path: bokeh-report-docker

--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -44,9 +44,9 @@ jobs:
           echo "Please contact @bokeh/core about conducting releases."
           exit 1
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: 'latest'
           activate-environment: bk-release-build

--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -42,9 +42,9 @@ jobs:
           echo "Please contact @bokeh/core about conducting releases."
           exit 1
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: 'latest'
           activate-environment: bk-release-deploy

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -121,14 +121,14 @@ jobs:
 
       - name: Upload package
         if: runner.os == 'Linux' && (success() || failure())
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bokehjs-package
           path: bokehjs/build/dist/bokeh-bokehjs-*.tgz
 
       - name: Upload report
         if: runner.os == 'Linux' && (success() || failure())
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bokehjs-report
           path: bokehjs-report

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/composite/test-setup/action.yml
+++ b/.github/workflows/composite/test-setup/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         miniconda-version: 'latest'
         activate-environment: bk-test
@@ -39,7 +39,7 @@ runs:
 
     - name: Download wheel package
       id: download
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: wheel-package
         path: dist/
@@ -49,7 +49,7 @@ runs:
       run: pip install dist/bokeh-*-py3-none-any.whl
 
     - name: Download bokehjs package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: bokehjs-package
         path: bokehjs/build/dist/
@@ -61,7 +61,7 @@ runs:
 
     - name: Cache node modules
       if: ${{ inputs.source-tree == 'keep' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
         key: ${{ runner.os }}-node-${{ hashFiles('bokehjs/package-lock.json') }}
@@ -73,7 +73,7 @@ runs:
 
     - name: Cache sampledata
       if: ${{ inputs.sampledata == 'cache' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.bokeh/data
         key: ${{ runner.os }}-sampledata-${{ hashFiles('bokeh/util/sampledata.json') }}


### PR DESCRIPTION
This should clear warnings like this in CI:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: `actions/checkout@v3`, `conda-incubator/setup-miniconda@v2`, `actions/upload-artifact@v3`. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.