### PR TITLE
Robustify `node make pack` and display versions

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -106,6 +106,8 @@ jobs:
         run: |
           conda info
           conda list
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
 
       - name: Run codebase checks
         run: pytest --color=yes tests/codebase
@@ -150,6 +152,8 @@ jobs:
         run: |
           conda info
           conda list
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
           chromium --version
 
       - name: Start chrome headless
@@ -196,6 +200,8 @@ jobs:
         run: |
           conda info
           conda list
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
 
       - name: Run tests
         run: pytest -v --cov=bokeh --cov-report=xml --tb=short --driver chrome --color=yes tests/integration
@@ -237,6 +243,8 @@ jobs:
         run: |
           conda info
           conda list
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
 
       - name: Test defaults
         run: pytest tests/test_defaults.py
@@ -281,6 +289,8 @@ jobs:
         run: |
           conda info
           conda list
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
 
       - name: Run tests
         run: pytest -m "not sampledata" --cov=bokeh --cov-report=xml --color=yes tests/unit
@@ -310,6 +320,8 @@ jobs:
         run: |
           conda info
           conda list
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
 
       - name: Build docs
         run: bash scripts/ci/build_docs.sh
@@ -341,6 +353,8 @@ jobs:
         run: |
           conda info
           conda list
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
 
       - name: Run tests
         run: bash scripts/ci/run_downstream_tests.sh

--- a/.github/workflows/composite/test-setup/action.yml
+++ b/.github/workflows/composite/test-setup/action.yml
@@ -59,6 +59,11 @@ runs:
       working-directory: ./bokehjs/build/dist/
       run: ln -s $(ls -t bokeh-bokehjs-*.tgz | head -n 1) bokeh-bokehjs.tgz
 
+    - name: Upgrade npm
+      shell: bash -l {0}
+      run: |
+        npm install --location=global npm
+
     - name: Cache node modules
       if: ${{ inputs.source-tree == 'keep' }}
       uses: actions/cache@v4

--- a/bokehjs/make/index.js
+++ b/bokehjs/make/index.js
@@ -6,8 +6,9 @@ const {join, dirname, basename} = require("path")
 function npm_install() {
   const npm = process.platform != "win32" ? "npm" : "npm.cmd"
   const {status} = cp.spawnSync(npm, ["install"], {stdio: "inherit"})
-  if (status !== 0)
+  if (status !== 0) {
     process.exit(status)
+  }
 }
 
 if (!fs.existsSync("node_modules/")) {
@@ -35,14 +36,16 @@ if (!semver.satisfies(npm_version, engines.npm)) {
 function is_up_to_date(file) {
   const hash_file = join(dirname(file), `.${basename(file)}`)
 
-  if (!fs.existsSync(hash_file))
+  if (!fs.existsSync(hash_file)) {
     return false
+  }
 
   const old_hash = fs.readFileSync(hash_file)
 
-  const new_hash = crypto.createHash("sha256")
-                         .update(fs.readFileSync(file))
-                         .digest("hex")
+  const new_hash = crypto
+    .createHash("sha256")
+    .update(fs.readFileSync(file))
+    .digest("hex")
 
   return old_hash == new_hash
 }
@@ -58,7 +61,7 @@ for (const workspace of ["", ...workspaces]) {
 
 const {register} = require("ts-node")
 
-process.on('uncaughtException', function(err) {
+process.on("uncaughtException", function(err) {
   console.error(err)
   process.exit(1)
 })
@@ -74,5 +77,6 @@ tsconfig_paths.register({
   },
 })
 
-if (require.main != null)
+if (require.main != null) {
   require("./main")
+}

--- a/bokehjs/make/index.js
+++ b/bokehjs/make/index.js
@@ -4,8 +4,9 @@ const fs = require("fs")
 const {join, dirname, basename} = require("path")
 
 function npm_install() {
-  const npm = process.platform != "win32" ? "npm" : "npm.cmd"
-  const {status} = cp.spawnSync(npm, ["install"], {stdio: "inherit"})
+  const is_windows = process.platform == "win32"
+  const npm = is_windows ? "npm.cmd" : "npm"
+  const {status} = cp.spawnSync(npm, ["install"], {stdio: "inherit", shell: is_windows})
   if (status !== 0) {
     process.exit(status)
   }

--- a/bokehjs/make/main.ts
+++ b/bokehjs/make/main.ts
@@ -1,4 +1,8 @@
 import yargs from "yargs"
+import cp from "child_process"
+
+import chalk from "chalk"
+const {magenta} = chalk
 
 export const argv = yargs.help(false).options({
   // paths
@@ -32,7 +36,14 @@ export const argv = yargs.help(false).options({
 import {task, run, log, task_names, show_error, show_failure} from "./task"
 import "./tasks"
 
+const node_version = process.version
+
+function npm_version(): string {
+  return cp.execSync("npm --version").toString().trim()
+}
+
 async function main(): Promise<void> {
+  log(`Using nodejs ${magenta(node_version)} and npm ${magenta(npm_version())}`)
   const {_} = argv
   if (_.length != 0 && _[0] == "help") {
     log(`tasks: ${task_names().filter((name) => !name.includes(":")).join(", ")}`)

--- a/bokehjs/make/tasks/pack.ts
+++ b/bokehjs/make/tasks/pack.ts
@@ -10,8 +10,9 @@ function npm_pack() {
     fs.mkdirSync(dist, {recursive: true})
   }
 
-  const npm = process.platform != "win32" ? "npm" : "npm.cmd"
-  const {status, stdout, stderr} = cp.spawnSync(npm, ["pack", `--pack-destination=${dist}`], {stdio: "pipe", encoding: "utf-8"})
+  const is_windows = process.platform == "win32"
+  const npm = is_windows ? "npm.cmd" : "npm"
+  const {status, stdout, stderr} = cp.spawnSync(npm, ["pack", `--pack-destination=${dist}`], {stdio: "pipe", encoding: "utf-8", shell: is_windows})
   if (status !== 0) {
     console.error(stdout)
     console.error(stderr)

--- a/bokehjs/make/tasks/pack.ts
+++ b/bokehjs/make/tasks/pack.ts
@@ -18,8 +18,8 @@ function npm_pack() {
     throw new BuildError("pack", `failed to run '${npm} pack'`)
   }
 
-  const tgz = stdout.trim()
-  if (!tgz.endsWith(".tgz")) {
+  const tgz = stdout.trim().split("\n").at(-1)?.trim()
+  if (tgz == null || !tgz.endsWith(".tgz")) {
     throw new BuildError("pack", "can't find tgz archive name in the output")
   }
 

--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -61,6 +61,12 @@ function count_files(files: string[]): string {
   return n == 1 ? str : `${str}s`
 }
 
+const node_version = process.version
+
+function npm_version(base_dir: Path): string {
+  return cp.execSync("npm --version", {cwd: base_dir}).toString().trim()
+}
+
 function npm_install(base_dir: Path): void {
   const npm = process.platform != "win32" ? "npm" : "npm.cmd"
   const {status} = cp.spawnSync(npm, ["install"], {stdio: "inherit", cwd: base_dir})
@@ -68,6 +74,11 @@ function npm_install(base_dir: Path): void {
     print(`${cyan("npm install")} failed with exit code ${red(`${status}`)}.`)
     process.exit(status)
   }
+}
+
+function preamble(base_dir: Path): void {
+  print(`Using nodejs ${magenta(node_version)} and npm ${magenta(npm_version(base_dir))}`)
+  print(`Working directory: ${cyan(base_dir)}`)
 }
 
 type Metadata = {
@@ -109,7 +120,7 @@ export type InitOptions = {
 }
 
 export async function init(base_dir: Path, _bokehjs_dir: Path, base_setup: InitOptions): Promise<boolean> {
-  print(`Working directory: ${cyan(base_dir)}`)
+  preamble(base_dir)
 
   const setup: Required<InitOptions> = {
     interactive: base_setup.interactive ?? false,
@@ -218,7 +229,7 @@ export type BuildOptions = {
 }
 
 export async function build(base_dir: Path, bokehjs_dir: Path, base_setup: BuildOptions): Promise<boolean> {
-  print(`Working directory: ${cyan(base_dir)}`)
+  preamble(base_dir)
 
   const setup: Required<BuildOptions> = {
     verbose: base_setup.verbose ?? false,

--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -68,8 +68,9 @@ function npm_version(base_dir: Path): string {
 }
 
 function npm_install(base_dir: Path): void {
-  const npm = process.platform != "win32" ? "npm" : "npm.cmd"
-  const {status} = cp.spawnSync(npm, ["install"], {stdio: "inherit", cwd: base_dir})
+  const is_windows = process.platform == "win32"
+  const npm = is_windows ? "npm.cmd" : "npm"
+  const {status} = cp.spawnSync(npm, ["install"], {stdio: "inherit", cwd: base_dir, shell: is_windows})
   if (status != null && status != 0) {
     print(`${cyan("npm install")} failed with exit code ${red(`${status}`)}.`)
     process.exit(status)

--- a/conda/environment-test-downstream.yml
+++ b/conda/environment-test-downstream.yml
@@ -19,3 +19,4 @@ dependencies:
   - pytest >=7.0
   - pytest-timeout
   - scipy
+  - nodejs 20.*


### PR DESCRIPTION
I was able to reproduce this on Linux as well, so it was much easier to fix. I also displayed nodejs and npm versions in various relevant outputs (bokehjs' build, extensions compiler, bokeh-ci (previously it was only bokehjs-ci)).

fixes #13848
fixes #13834