### PR TITLE
Don't configure `font-weight` in tooltips

### DIFF
--- a/bokehjs/src/less/tooltips.less
+++ b/bokehjs/src/less/tooltips.less
@@ -15,7 +15,6 @@
 :host {
   // TODO: contain: layout style paint;
   width: max-content;
-  font-weight: 300;
   font-size: var(--font-size);
   position: fixed;
   padding: 5px;


### PR DESCRIPTION
This was only causing issues due to different user agent stylesheets in different browsers.

fixes #13852
