### PR TITLE
Redesign `CartesianFrame` as an internal model/view

### DIFF
--- a/bokehjs/src/lib/models/annotations/color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/color_bar.ts
@@ -186,11 +186,11 @@ export class ColorBarView extends BaseColorBarView {
       // Update the frame's LinearInterpolationScale and Range1d as they are
       // different objects to this._major_scale and this._major_range.
       const vertical = this.orientation == "vertical"
-      const frame_scale = vertical ? this._frame.y_scale : this._frame.x_scale
+      const frame_scale = vertical ? this._frame_view.y_scale : this._frame_view.x_scale
       if (frame_scale instanceof LinearInterpolationScale) {
         frame_scale.binning = binning
 
-        const frame_range = vertical ? this._frame.y_range : this._frame.x_range
+        const frame_range = vertical ? this._frame_view.y_range : this._frame_view.x_range
         if (frame_range instanceof Range1d) {
           frame_range.start = binning[0]
           frame_range.end = binning[binning.length-1]

--- a/bokehjs/src/lib/models/canvas/cartesian_frame.ts
+++ b/bokehjs/src/lib/models/canvas/cartesian_frame.ts
@@ -1,59 +1,69 @@
+import {StyledElement, StyledElementView} from "../ui/styled_element"
+import type {PlotView} from "../plots/plot"
 import {CategoricalScale} from "../scales/categorical_scale"
 import {LogScale} from "../scales/log_scale"
-import type {Scale} from "../scales/scale"
-import type {Range} from "../ranges/range"
+import {Scale} from "../scales/scale"
+import {LinearScale} from "../scales/linear_scale"
+import {Range} from "../ranges/range"
 import {Range1d} from "../ranges/range1d"
 import {DataRange1d} from "../ranges/data_range1d"
 import {FactorRange} from "../ranges/factor_range"
 import type {Node} from "../coordinates/node"
-
 import type {XY} from "core/util/bbox"
 import {BBox} from "core/util/bbox"
 import {entries} from "core/util/object"
 import {assert} from "core/util/assert"
-import {Signal0} from "core/signaling"
-import type {Dict} from "core/types"
 import {isNumber} from "core/util/types"
+import type {Dict} from "core/types"
+import type * as p from "core/properties"
 
 type Ranges = Dict<Range>
 type Scales = Dict<Scale>
 
-export class CartesianFrame {
+export class CartesianFrameView extends StyledElementView {
+  declare model: CartesianFrame
+  declare parent: PlotView
 
   private _bbox: BBox = new BBox()
   get bbox(): BBox {
     return this._bbox
   }
 
-  readonly change = new Signal0<this>(this, "change")
-
-  constructor(public in_x_scale: Scale,
-              public in_y_scale: Scale,
-              public x_range: Range,
-              public y_range: Range,
-              public extra_x_ranges: Ranges = {},
-              public extra_y_ranges: Ranges = {},
-              public extra_x_scales: Scales = {},
-              public extra_y_scales: Scales = {}) {
-    assert(in_x_scale.properties.source_range.is_unset && in_x_scale.properties.target_range.is_unset)
-    assert(in_y_scale.properties.source_range.is_unset && in_y_scale.properties.target_range.is_unset)
+  override initialize(): void {
+    super.initialize()
     this._configure_scales()
+  }
+
+  override remove(): void {
+    this._unregister_frame()
+    super.remove()
+  }
+
+  override connect_signals(): void {
+    super.connect_signals()
+    const {x_range, y_range, x_scale, y_scale, extra_x_ranges, extra_y_ranges, extra_x_scales, extra_y_scales} = this.model.properties
+    this.on_change([x_range, y_range, x_scale, y_scale, extra_x_ranges, extra_y_ranges, extra_x_scales, extra_y_scales], () => {
+      this._configure_scales()
+    })
   }
 
   protected _x_target: Range1d
   protected _y_target: Range1d
 
-  protected _x_ranges: Map<string, Range>
-  protected _y_ranges: Map<string, Range>
+  protected _x_ranges: Map<string, Range> = new Map()
+  protected _y_ranges: Map<string, Range> = new Map()
 
-  protected _x_scales: Map<string, Scale>
-  protected _y_scales: Map<string, Scale>
+  protected _x_scales: Map<string, Scale> = new Map()
+  protected _y_scales: Map<string, Scale> = new Map()
+
+  protected _x_scale: Scale
+  protected _y_scale: Scale
 
   protected _get_ranges(range: Range, extra_ranges: Ranges): Map<string, Range> {
     return new Map([...entries(extra_ranges), ["default", range]])
   }
 
-  /*protected*/ _get_scales(scale: Scale, extra_scales: Scales, ranges: Map<string, Range>, frame_range: Range): Map<string, Scale> {
+  protected _get_scales(scale: Scale, extra_scales: Scales, ranges: Map<string, Range>, frame_range: Range): Map<string, Scale> {
     const in_scales = new Map([...entries(extra_scales), ["default", scale]])
     const scales: Map<string, Scale> = new Map()
 
@@ -62,7 +72,7 @@ export class CartesianFrame {
       const categorical_scale = scale instanceof CategoricalScale
 
       if (factor_range != categorical_scale) {
-        throw new Error(`Range ${range.type} is incompatible is Scale ${scale.type}`)
+        throw new Error(`'${range.type}' is incompatible '${scale.type}'`)
       }
 
       if (scale instanceof LogScale && range instanceof DataRange1d) {
@@ -78,7 +88,7 @@ export class CartesianFrame {
     return scales
   }
 
-  protected _configure_frame_ranges(): void {
+  protected _configure_ranges(): void {
     // data to/from screen space transform (left-bottom <-> left-top origin)
     const {bbox} = this
     this._x_target = new Range1d({start: bbox.left, end: bbox.right})
@@ -86,22 +96,30 @@ export class CartesianFrame {
   }
 
   protected _configure_scales(): void {
-    this._configure_frame_ranges()
+    const {x_range, y_range, extra_x_ranges, extra_y_ranges} = this.model
+    const {x_scale, y_scale, extra_x_scales, extra_y_scales} = this.model
 
-    this._x_ranges = this._get_ranges(this.x_range, this.extra_x_ranges)
-    this._y_ranges = this._get_ranges(this.y_range, this.extra_y_ranges)
+    assert(x_scale.properties.source_range.is_unset && x_scale.properties.target_range.is_unset)
+    assert(y_scale.properties.source_range.is_unset && y_scale.properties.target_range.is_unset)
 
-    this._x_scales = this._get_scales(this.in_x_scale, this.extra_x_scales, this._x_ranges, this._x_target)
-    this._y_scales = this._get_scales(this.in_y_scale, this.extra_y_scales, this._y_ranges, this._y_target)
-  }
+    this._configure_ranges()
 
-  configure_scales(): void {
-    this._configure_scales()
-    this.change.emit()
+    this._unregister_frame()
+    this._x_ranges = this._get_ranges(x_range, extra_x_ranges)
+    this._y_ranges = this._get_ranges(y_range, extra_y_ranges)
+    this._register_frame()
+
+    this._x_scales = this._get_scales(x_scale, extra_x_scales, this._x_ranges, this._x_target)
+    this._y_scales = this._get_scales(y_scale, extra_y_scales, this._y_ranges, this._y_target)
+
+    this._x_scale = this._x_scales.get("default")!
+    this._y_scale = this._y_scales.get("default")!
+
+    this.mark_finished()
   }
 
   protected _update_scales(): void {
-    this._configure_frame_ranges()
+    this._configure_ranges()
 
     for (const [, scale] of this._x_scales) {
       scale.target_range = this._x_target
@@ -112,9 +130,29 @@ export class CartesianFrame {
     }
   }
 
+  protected _register_frame(): void {
+    for (const range of this.ranges.values()) {
+      range.frames.add(this)
+    }
+  }
+
+  protected _unregister_frame(): void {
+    for (const range of this.ranges.values()) {
+      range.frames.delete(this)
+    }
+  }
+
   set_geometry(bbox: BBox): void {
     this._bbox = bbox
     this._update_scales()
+  }
+
+  get x_range(): Range {
+    return this.model.x_range
+  }
+
+  get y_range(): Range {
+    return this.model.y_range
   }
 
   get x_target(): Range1d {
@@ -150,15 +188,15 @@ export class CartesianFrame {
   }
 
   get x_scale(): Scale {
-    return this._x_scales.get("default")!
+    return this._x_scale
   }
 
   get y_scale(): Scale {
-    return this._y_scales.get("default")!
+    return this._y_scale
   }
 
-  // TODO remove this when CartesianFrameView is implemented
-  resolve_symbol(node: Node): XY | number {
+  // TODO remove this when bbox handling is unified
+  override resolve_symbol(node: Node): XY | number {
     const target = this
     const value = target.bbox.resolve(node.symbol)
     const {offset} = node
@@ -168,5 +206,58 @@ export class CartesianFrame {
       const {x, y} = value
       return {x: x + offset, y: y + offset}
     }
+  }
+}
+
+export namespace CartesianFrame {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = StyledElement.Props & {
+    x_range: p.Property<Range>
+    y_range: p.Property<Range>
+
+    x_scale: p.Property<Scale>
+    y_scale: p.Property<Scale>
+
+    extra_x_ranges: p.Property<Dict<Range>>
+    extra_y_ranges: p.Property<Dict<Range>>
+
+    extra_x_scales: p.Property<Dict<Scale>>
+    extra_y_scales: p.Property<Dict<Scale>>
+
+    match_aspect: p.Property<boolean>
+    aspect_scale: p.Property<number>
+  }
+}
+
+export interface CartesianFrame extends CartesianFrame.Attrs {}
+
+export class CartesianFrame extends StyledElement {
+  declare properties: CartesianFrame.Props
+  declare __view_type__: CartesianFrameView
+
+  constructor(attrs?: Partial<CartesianFrame.Attrs>) {
+    super(attrs)
+  }
+
+  static {
+    this.prototype.default_view = CartesianFrameView
+
+    this.define<CartesianFrame.Props>(({Bool, Float, Dict, Ref}) => ({
+      x_range:        [ Ref(Range), () => new DataRange1d() ],
+      y_range:        [ Ref(Range), () => new DataRange1d() ],
+
+      x_scale:        [ Ref(Scale), () => new LinearScale() ],
+      y_scale:        [ Ref(Scale), () => new LinearScale() ],
+
+      extra_x_ranges: [ Dict(Ref(Range)), {} ],
+      extra_y_ranges: [ Dict(Ref(Range)), {} ],
+
+      extra_x_scales: [ Dict(Ref(Scale)), {} ],
+      extra_y_scales: [ Dict(Ref(Scale)), {} ],
+
+      match_aspect:   [ Bool, false ],
+      aspect_scale:   [ Float, 1 ],
+    }))
   }
 }

--- a/bokehjs/src/lib/models/coordinates/coordinate_mapping.ts
+++ b/bokehjs/src/lib/models/coordinates/coordinate_mapping.ts
@@ -8,7 +8,7 @@ import {CompositeScale} from "../scales/composite_scale"
 import {Range} from "../ranges/range"
 import {DataRange1d} from "../ranges/data_range1d"
 import {FactorRange} from "../ranges/factor_range"
-import type {CartesianFrame} from "../canvas/cartesian_frame"
+import type {CartesianFrameView} from "../canvas/cartesian_frame"
 import type * as p from "core/properties"
 
 export class CoordinateTransform {
@@ -101,7 +101,7 @@ export class CoordinateMapping extends Model {
     return derived_scale
   }
 
-  get_transform(frame: CartesianFrame): CoordinateTransform {
+  get_transform(frame: CartesianFrameView): CoordinateTransform {
     const {x_source, x_scale, x_target} = this
     const x_source_scale = this._get_scale(x_source, x_scale, x_target)
 

--- a/bokehjs/src/lib/models/plots/range_manager.ts
+++ b/bokehjs/src/lib/models/plots/range_manager.ts
@@ -1,7 +1,7 @@
 import type {Range} from "../ranges/range"
 import type {Bounds} from "../ranges/data_range1d"
 import {DataRange1d} from "../ranges/data_range1d"
-import type {CartesianFrame} from "../canvas/cartesian_frame"
+import type {CartesianFrameView} from "../canvas/cartesian_frame"
 import type {CoordinateMapping} from "../coordinates/coordinate_mapping"
 import type {PlotView} from "./plot_canvas"
 import type {Interval} from "core/types"
@@ -23,7 +23,7 @@ export type RangeOptions = {
 export class RangeManager {
   constructor(readonly parent: PlotView) {}
 
-  get frame(): CartesianFrame {
+  get frame(): CartesianFrameView {
     return this.parent.frame
   }
 
@@ -78,7 +78,7 @@ export class RangeManager {
     this.update_dataranges()
   }
 
-  protected _update_dataranges(frame: CartesianFrame | CoordinateMapping): void {
+  protected _update_dataranges(frame: CartesianFrameView | CoordinateMapping): void {
     // Update any DataRange1ds here
     const bounds: Bounds = new Map()
     const log_bounds: Bounds = new Map()

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -103,7 +103,7 @@ export class DataRange1d extends DataRange {
   computed_renderers(): Renderer[] {
     // TODO (bev) check that renderers actually configured with this range
     const {renderers} = this
-    const all_renderers = flat_map(this.plots, (plot) => plot.auto_ranged_renderers.map((r) => r.model))
+    const all_renderers = flat_map(this.linked_plots, (plot) => plot.auto_ranged_renderers.map((r) => r.model))
     return compute_renderers(renderers.length == 0 ? "auto" : renderers, [...all_renderers])
   }
 

--- a/bokehjs/src/lib/models/ranges/range.ts
+++ b/bokehjs/src/lib/models/ranges/range.ts
@@ -1,7 +1,9 @@
 import {Model} from "../../model"
+import type {CartesianFrameView} from "../canvas/cartesian_frame"
 import type {PlotView} from "../plots/plot"
 import type * as p from "core/properties"
 import {Nullable, Or, Tuple, Float, Auto} from "core/kinds"
+import {map} from "core/util/iterator"
 
 const Bounds = Nullable(Or(Tuple(Nullable(Float), Nullable(Float)), Auto))
 type Bounds = typeof Bounds["__type__"]
@@ -65,6 +67,10 @@ export abstract class Range extends Model {
     return Math.abs(this.end - this.start)
   }
 
-  /** internal */
-  readonly plots = new Set<PlotView>()
+  /** @internal */
+  readonly frames = new Set<CartesianFrameView>()
+
+  get linked_plots(): ReadonlySet<PlotView> {
+    return new Set(map(this.frames, (frame) => frame.parent))
+  }
 }

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -86,7 +86,7 @@ export abstract class RendererView extends StyledElementView implements visuals.
 
     const {x_range_name, y_range_name} = this.model.properties
     this.on_change([x_range_name, y_range_name], () => delete this._coordinates)
-    this.connect(this.plot_view.frame.change, () => delete this._coordinates)
+    this.connect(this.plot_view.frame.model.change, () => delete this._coordinates)
   }
 
   protected _initialize_coordinates(): CoordinateTransform {

--- a/bokehjs/src/lib/models/tiles/tile_renderer.ts
+++ b/bokehjs/src/lib/models/tiles/tile_renderer.ts
@@ -4,7 +4,7 @@ import {TileSource} from "./tile_source"
 import {WMTSTileSource} from "./wmts_tile_source"
 import {Renderer, RendererView} from "../renderers/renderer"
 import type {Plot} from "../plots/plot"
-import type {CartesianFrame} from "../canvas/cartesian_frame"
+import type {CartesianFrameView} from "../canvas/cartesian_frame"
 import type {Range} from "../ranges/range"
 import {Range1d} from "../ranges/range1d"
 import {HTML} from "../dom/html"
@@ -72,7 +72,7 @@ export class TileRendererView extends RendererView {
     return this.layer.ctx
   }
 
-  private get map_frame(): CartesianFrame {
+  private get map_frame(): CartesianFrameView {
     return this.plot_view.frame
   }
 

--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -1,7 +1,7 @@
 import type {EventRole} from "../tool"
 import {GestureTool, GestureToolView} from "./gesture_tool"
 import {BoxAnnotation} from "../../annotations/box_annotation"
-import type {CartesianFrame} from "../../canvas/cartesian_frame"
+import type {CartesianFrameView} from "../../canvas/cartesian_frame"
 import type {RangeState} from "../../plots/range_manager"
 import type * as p from "core/properties"
 import type {PanEvent, KeyEvent, TapEvent} from "core/ui_events"
@@ -20,7 +20,7 @@ export class BoxZoomToolView extends GestureToolView {
 
   protected _base_point: Point | null = null
 
-  _match_aspect([bx, by]: Point, [cx, cy]: Point, frame: CartesianFrame): [Point, Point] {
+  _match_aspect([bx, by]: Point, [cx, cy]: Point, frame: CartesianFrameView): [Point, Point] {
     // aspect ratio of plot frame
     const a = frame.bbox.aspect
     const hend = frame.bbox.h_range.end

--- a/bokehjs/src/lib/models/tools/gestures/range_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/range_tool.ts
@@ -157,14 +157,14 @@ export class RangeTool extends Tool {
     if (x_range != null && this.x_interaction) {
       assert(isNumber(left) && isNumber(right))
       xrs.set(x_range, {start: left, end: right})
-      for (const plot of x_range.plots) {
+      for (const plot of x_range.linked_plots) {
         affected_plots.add(plot)
       }
     }
     if (y_range != null && this.y_interaction) {
       assert(isNumber(bottom) && isNumber(top))
       yrs.set(y_range, {start: bottom, end: top})
-      for (const plot of y_range.plots) {
+      for (const plot of y_range.linked_plots) {
         affected_plots.add(plot)
       }
     }

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -8,7 +8,7 @@ import type {MenuItem} from "core/util/menus"
 import {isString} from "core/util/types"
 import {Model} from "../../model"
 import type {Renderer} from "../renderers/renderer"
-import type {CartesianFrame} from "../canvas/cartesian_frame"
+import type {CartesianFrameView} from "../canvas/cartesian_frame"
 import type {EventType, PanEvent, PinchEvent, RotateEvent, ScrollEvent, TapEvent, MoveEvent, KeyEvent} from "core/ui_events"
 import type {ToolButton} from "./tool_button"
 
@@ -197,7 +197,7 @@ export abstract class Tool extends Model {
   // utility function to get limits along both dimensions, given
   // optional dimensional constraints
   _get_dim_limits([sx0, sy0]: [number, number], [sx1, sy1]: [number, number],
-      frame: CartesianFrame, dims: Dimensions): [[number, number], [number, number]] {
+      frame: CartesianFrameView, dims: Dimensions): [[number, number], [number, number]] {
 
     const hr = frame.bbox.h_range
     let sxlim: [number, number]

--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -250,9 +250,19 @@ function diff<T>(a: Set<T>, b: Set<T>): Set<T> {
 
 describe("Defaults", () => {
   const internal_models = new Set([
-    "Figure", "GMap", "Canvas", "LinearInterpolationScale", "ScanningColorMapper",
-    "ToolProxy", "CenterRotatable", "Spline", "ParkMillerLCG", "ToolButton",
-    "OnOffButton", "ClickButton",
+    "Canvas",
+    "CartesianFrame",
+    "CenterRotatable",
+    "ClickButton",
+    "Figure",
+    "GMap",
+    "LinearInterpolationScale",
+    "OnOffButton",
+    "ParkMillerLCG",
+    "ScanningColorMapper",
+    "Spline",
+    "ToolButton",
+    "ToolProxy",
   ])
 
   it("have bokehjs and bokeh implement the same set of models", () => {

--- a/bokehjs/test/unit/base.ts
+++ b/bokehjs/test/unit/base.ts
@@ -60,6 +60,7 @@ describe("default model resolver", () => {
       "CDSView",
       "Canvas",
       "CanvasTexture",
+      "CartesianFrame",
       "CategoricalAxis",
       "CategoricalColorMapper",
       "CategoricalMarkerMapper",

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -209,26 +209,26 @@ describe("Plot module", () => {
       const pv0 = view.owner.get_one(p0)
       const pv1 = view.owner.get_one(p1)
 
-      expect(x_range.plots.has(pv0)).to.be.true
-      expect(y_range.plots.has(pv0)).to.be.true
-      expect(x_range.plots.has(pv1)).to.be.true
-      expect(y_range.plots.has(pv1)).to.be.true
+      expect(x_range.linked_plots.has(pv0)).to.be.true
+      expect(y_range.linked_plots.has(pv0)).to.be.true
+      expect(x_range.linked_plots.has(pv1)).to.be.true
+      expect(y_range.linked_plots.has(pv1)).to.be.true
 
       row.children = [p1]
       await view.ready
 
-      expect(x_range.plots.has(pv0)).to.be.false
-      expect(y_range.plots.has(pv0)).to.be.false
-      expect(x_range.plots.has(pv1)).to.be.true
-      expect(y_range.plots.has(pv1)).to.be.true
+      expect(x_range.linked_plots.has(pv0)).to.be.false
+      expect(y_range.linked_plots.has(pv0)).to.be.false
+      expect(x_range.linked_plots.has(pv1)).to.be.true
+      expect(y_range.linked_plots.has(pv1)).to.be.true
 
       row.children = []
       await view.ready
 
-      expect(x_range.plots.has(pv0)).to.be.false
-      expect(y_range.plots.has(pv0)).to.be.false
-      expect(x_range.plots.has(pv1)).to.be.false
-      expect(y_range.plots.has(pv1)).to.be.false
+      expect(x_range.linked_plots.has(pv0)).to.be.false
+      expect(y_range.linked_plots.has(pv0)).to.be.false
+      expect(x_range.linked_plots.has(pv1)).to.be.false
+      expect(y_range.linked_plots.has(pv1)).to.be.false
     })
   })
 })


### PR DESCRIPTION
For now this is for the most part a structural change, in which `CartesianFrame` is converted from a regular class to a model/view. Ultimately range management logic should be moved to the new `CartesianFrameView`, so that we don't overburden `PlotView` with unrelated logic. Currently this new model isn't exposed in Python API, but it may be useful to do this at a later point.