### PR TITLE
Contain all rendering related tasks in `DOMView.render()`

### DIFF
--- a/bokehjs/src/lib/core/dom_view.ts
+++ b/bokehjs/src/lib/core/dom_view.ts
@@ -1,7 +1,7 @@
 import {View} from "./view"
 import type {SerializableState} from "./view"
 import type {StyleSheet, StyleSheetLike} from "./dom"
-import {create_element, empty, InlineStyleSheet, ClassList} from "./dom"
+import {create_element, InlineStyleSheet, ClassList} from "./dom"
 import {isString} from "./util/types"
 import {assert} from "./util/assert"
 import type {BBox} from "./util/bbox"
@@ -16,7 +16,12 @@ export abstract class DOMView extends View {
 
   static tag_name: keyof HTMLElementTagNameMap = "div"
 
-  el: ChildNode
+  protected _el: ChildNode | null = null
+  get el(): ChildNode {
+    assert(this._el != null, "not rendered")
+    return this._el
+  }
+
   shadow_el?: ShadowRoot
 
   get bbox(): BBox | undefined {
@@ -29,17 +34,8 @@ export abstract class DOMView extends View {
     return bbox != null ? {...state, bbox: bbox.round()} : state
   }
 
-  get children_el(): Node {
-    return this.shadow_el ?? this.el
-  }
-
-  override initialize(): void {
-    super.initialize()
-    this.el = this._create_element()
-  }
-
   override remove(): void {
-    this.el.remove()
+    this._el?.remove()
     super.remove()
   }
 
@@ -51,7 +47,13 @@ export abstract class DOMView extends View {
     return []
   }
 
-  abstract render(): void
+  render(): void {
+    const el = this._create_element()
+    if (this._el != null) {
+      this._el.replaceWith(el)
+    }
+    this._el = el
+  }
 
   render_to(target: Node): void {
     this.render()
@@ -92,12 +94,15 @@ export abstract class DOMView extends View {
 }
 
 export abstract class DOMElementView extends DOMView {
-  declare el: HTMLElement
+  declare protected _el: HTMLElement
+  override get el(): HTMLElement {
+    return super.el as HTMLElement
+  }
 
   class_list: ClassList
 
-  override initialize(): void {
-    super.initialize()
+  override render(): void {
+    super.render()
     this.class_list = new ClassList(this.el.classList)
   }
 }
@@ -108,24 +113,15 @@ export abstract class DOMComponentView extends DOMElementView {
 
   declare shadow_el: ShadowRoot
 
-  override initialize(): void {
-    super.initialize()
-    this.shadow_el = this.el.attachShadow({mode: "open"})
-  }
-
   override stylesheets(): StyleSheetLike[] {
     return [...super.stylesheets(), base_css]
   }
 
-  empty(): void {
-    empty(this.shadow_el)
-    this.class_list.clear()
+  override render(): void {
+    super.render()
+    this.shadow_el = this.el.attachShadow({mode: "open"})
     this._applied_css_classes = []
     this._applied_stylesheets = []
-  }
-
-  render(): void {
-    this.empty()
     this._update_stylesheets()
     this._update_css_classes()
     this._update_css_variables()

--- a/bokehjs/src/lib/core/visuals/index.ts
+++ b/bokehjs/src/lib/core/visuals/index.ts
@@ -49,11 +49,6 @@ export class Visuals {
             throw new Error("unknown visual")
         }
       })()
-
-      if (visual instanceof VisualProperties) {
-        visual.update()
-      }
-
       this._visuals.push(visual)
 
       Object.defineProperty(this, prefix + visual.type, {
@@ -63,6 +58,12 @@ export class Visuals {
         configurable: false,
         enumerable: true,
       })
+    }
+  }
+
+  update(): void {
+    for (const visual of this) {
+      visual.update()
     }
   }
 }

--- a/bokehjs/src/lib/models/annotations/data_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/data_annotation.ts
@@ -50,9 +50,7 @@ export abstract class DataAnnotationView extends AnnotationView {
       }
     }
 
-    for (const visual of this.visuals) {
-      visual.update()
-    }
+    this.visuals.update()
   }
 
   abstract map_data(): void

--- a/bokehjs/src/lib/models/dom/dom_element.ts
+++ b/bokehjs/src/lib/models/dom/dom_element.ts
@@ -5,7 +5,6 @@ import type {ViewStorage, IterViews} from "core/build_views"
 import {build_views, remove_views} from "core/build_views"
 import {isString} from "core/util/types"
 import {apply_styles} from "core/css"
-import {empty} from "core/dom"
 import type * as p from "core/properties"
 
 export abstract class DOMElementView extends DOMNodeView {
@@ -31,7 +30,7 @@ export abstract class DOMElementView extends DOMNodeView {
   }
 
   override render(): void {
-    empty(this.el)
+    super.render()
     apply_styles(this.el.style, this.model.style)
 
     for (const child of this.model.children) {

--- a/bokehjs/src/lib/models/dom/html.ts
+++ b/bokehjs/src/lib/models/dom/html.ts
@@ -2,7 +2,7 @@ import {DOMNode, DOMNodeView} from "./dom_node"
 import {UIElement} from "../ui/ui_element"
 import type {ViewStorage, IterViews} from "core/build_views"
 import {build_views, remove_views} from "core/build_views"
-import {empty, span} from "core/dom"
+import {span} from "core/dom"
 import {assert} from "core/util/assert"
 import {isString, isArray} from "core/util/types"
 import type * as p from "core/properties"
@@ -43,8 +43,8 @@ export class HTMLView extends DOMNodeView {
     super.remove()
   }
 
-  render(): void {
-    empty(this.el)
+  override render(): void {
+    super.render()
 
     const html = (() => {
       const {html} = this.model

--- a/bokehjs/src/lib/models/dom/placeholder.ts
+++ b/bokehjs/src/lib/models/dom/placeholder.ts
@@ -7,10 +7,6 @@ export abstract class PlaceholderView extends DOMNodeView {
   declare model: Placeholder
   static override tag_name = "span" as const
 
-  override render(): void {
-    // XXX: no implementation?
-  }
-
   abstract update(source: ColumnarDataSource, i: DataIndex | null, vars: object/*, formatters?: Formatters*/): void
 }
 

--- a/bokehjs/src/lib/models/dom/text.ts
+++ b/bokehjs/src/lib/models/dom/text.ts
@@ -6,6 +6,7 @@ export class TextView extends DOMNodeView {
   declare el: globalThis.Text
 
   override render(): void {
+    super.render()
     this.el.textContent = this.model.content
   }
 

--- a/bokehjs/src/lib/models/dom/value_of.ts
+++ b/bokehjs/src/lib/models/dom/value_of.ts
@@ -1,6 +1,5 @@
 import {DOMNode, DOMNodeView} from "./dom_node"
 import {HasProps} from "core/has_props"
-import {empty} from "core/dom"
 import {to_string} from "core/util/pretty"
 import type * as p from "core/properties"
 
@@ -17,8 +16,8 @@ export class ValueOfView extends DOMNodeView {
     }
   }
 
-  render(): void {
-    empty(this.el)
+  override render(): void {
+    super.render()
     this.el.style.display = "contents"
 
     const text = (() => {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -350,10 +350,7 @@ export abstract class GlyphView extends DOMComponentView {
       }
     }
 
-    for (const visual of this.visuals) {
-      visual.update()
-    }
-
+    this.visuals.update()
     this.glglyph?.set_visuals_changed()
   }
 

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -71,13 +71,6 @@ export abstract class LayoutDOMView extends PaneView {
   override connect_signals(): void {
     super.connect_signals()
 
-    this.el.addEventListener("mouseenter", (event) => {
-      this.mouseenter.emit(event)
-    })
-    this.el.addEventListener("mouseleave", (event) => {
-      this.mouseleave.emit(event)
-    })
-
     if (this.parent instanceof LayoutDOMView) {
       this.connect(this.parent.disabled, (disabled) => {
         this.disabled.emit(disabled || this.model.disabled)
@@ -122,16 +115,7 @@ export abstract class LayoutDOMView extends PaneView {
   }
 
   async build_child_views(): Promise<UIElementView[]> { // TODO BuildResult<UIElement>
-    const {created, removed} = await build_views(this._child_views, this.child_models, {parent: this})
-
-    for (const view of removed) {
-      this._resize_observer.unobserve(view.el)
-    }
-
-    for (const view of created) {
-      this._resize_observer.observe(view.el, {box: "border-box"})
-    }
-
+    const {created} = await build_views(this._child_views, this.child_models, {parent: this})
     return created
   }
 
@@ -141,6 +125,13 @@ export abstract class LayoutDOMView extends PaneView {
     for (const child_view of this.child_views) {
       child_view.render_to(this.shadow_el)
     }
+
+    this.el.addEventListener("mouseenter", (event) => {
+      this.mouseenter.emit(event)
+    })
+    this.el.addEventListener("mouseleave", (event) => {
+      this.mouseleave.emit(event)
+    })
   }
 
   protected _update_children(): void {}
@@ -443,6 +434,12 @@ export abstract class LayoutDOMView extends PaneView {
 
   override _after_render(): void {
     // XXX no super
+    this._resize_observer.disconnect()
+
+    for (const child_view of this.child_views) {
+      this._resize_observer.observe(child_view.el, {box: "border-box"})
+    }
+
     if (!this.is_managed) {
       this.invalidate_layout()
     }

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -167,6 +167,11 @@ export abstract class RendererView extends StyledElementView implements visuals.
     return true
   }
 
+  override render(): void {
+    super.render()
+    this.visuals.update()
+  }
+
   paint(): void {
     // It would be better to update geometry (the internal layout) only when
     // necessary, but conditions for that are not clear, so for now update

--- a/bokehjs/src/lib/models/tools/tool_button.ts
+++ b/bokehjs/src/lib/models/tools/tool_button.ts
@@ -23,9 +23,23 @@ export abstract class ToolButtonView extends UIElementView {
   protected _menu: ContextMenu
   protected _ui_gestures: UIGestures
 
-  override initialize(): void {
-    super.initialize()
+  override connect_signals(): void {
+    super.connect_signals()
+    this.connect(this.model.change, () => this.render())
+    this.connect(this.model.tool.change as Signal0<Tool>, () => this.render())
+  }
 
+  override remove(): void {
+    this._ui_gestures.remove()
+    this._menu.remove()
+    super.remove()
+  }
+
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), tool_button_css, icons_css]
+  }
+
+  protected _build_menu(): void {
     const {location} = this.parent.model
     const reverse = location == "left" || location == "above"
     const orientation = this.parent.model.horizontal ? "vertical" : "horizontal"
@@ -37,6 +51,12 @@ export abstract class ToolButtonView extends UIElementView {
         return event.composedPath().includes(this.el)
       },
     })
+  }
+
+  override render(): void {
+    super.render()
+
+    this._build_menu()
 
     this._ui_gestures = new UIGestures(this.el, {
       on_tap: (event: TapEvent) => {
@@ -52,6 +72,7 @@ export abstract class ToolButtonView extends UIElementView {
         this._pressed()
       },
     })
+    this._ui_gestures.connect_signals()
 
     this.el.addEventListener("keydown", (event) => {
       switch (event.key as Keys) {
@@ -66,27 +87,6 @@ export abstract class ToolButtonView extends UIElementView {
         default:
       }
     })
-  }
-
-  override connect_signals(): void {
-    super.connect_signals()
-    this._ui_gestures.connect_signals()
-    this.connect(this.model.change, () => this.render())
-    this.connect(this.model.tool.change as Signal0<Tool>, () => this.render())
-  }
-
-  override remove(): void {
-    this._ui_gestures.remove()
-    this._menu.remove()
-    super.remove()
-  }
-
-  override stylesheets(): StyleSheetLike[] {
-    return [...super.stylesheets(), tool_button_css, icons_css]
-  }
-
-  override render(): void {
-    super.render()
 
     this.class_list.add(tool_button[this.parent.model.location])
     if (this.model.tool.disabled) {

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -68,9 +68,7 @@ export class ToolbarView extends UIElementView {
     return true
   }
 
-  override initialize(): void {
-    super.initialize()
-
+  protected _build_overflow_menu(): void {
     const {location} = this.model
     const reversed = location == "left" || location == "above"
     const orientation = this.model.horizontal ? "vertical" : "horizontal"
@@ -113,6 +111,7 @@ export class ToolbarView extends UIElementView {
 
   override remove(): void {
     remove_views(this._tool_button_views)
+    this._overflow_menu.remove()
     super.remove()
   }
 
@@ -171,6 +170,8 @@ export class ToolbarView extends UIElementView {
 
   override render(): void {
     super.render()
+
+    this._build_overflow_menu()
 
     this.el.classList.add(toolbars[this.model.location])
     this.el.classList.toggle(toolbars.inner, this.model.inner)

--- a/bokehjs/src/lib/models/ui/tooltip.ts
+++ b/bokehjs/src/lib/models/ui/tooltip.ts
@@ -29,15 +29,15 @@ export class TooltipView extends UIElementView {
   protected content_el: HTMLElement
   protected _observer: ResizeObserver
 
-  private _target: Element
+  private _target: Element | null = null
   get target(): Element {
-    return this._target
+    return this._target ?? (this._target = this._get_target())
   }
   set target(el: Element) {
     this._target = el
   }
 
-  protected _init_target(): void {
+  protected _get_target(): Element {
     const {target} = this.model
     const el = (() => {
       if (target instanceof UIElement) {
@@ -53,16 +53,11 @@ export class TooltipView extends UIElementView {
     })()
 
     if (el instanceof Element) {
-      this._target = el
+      return el
     } else {
       logger.warn(`unable to resolve target '${target}' for '${this}'`)
-      this._target = document.body
+      return document.body
     }
-  }
-
-  override initialize(): void {
-    super.initialize()
-    this._init_target()
   }
 
   protected _element_view: ViewOf<DOMNode | UIElement> | null = null
@@ -91,7 +86,7 @@ export class TooltipView extends UIElementView {
     this._observer = new ResizeObserver(() => {
       this._reposition()
     })
-    this._observer.observe(this.target)
+    //this._observer.observe(this.target)
 
     let throttle = false
     document.addEventListener("scroll", this._scroll_listener = () => {
@@ -107,7 +102,7 @@ export class TooltipView extends UIElementView {
 
     const {target, content, closable, interactive, position, attachment, visible} = this.model.properties
     this.on_change(target, () => {
-      this._init_target()
+      this._target = this._get_target()
       this._observer.disconnect()
       this._observer.observe(this.target)
       this.render()

--- a/bokehjs/src/lib/models/ui/ui_element.ts
+++ b/bokehjs/src/lib/models/ui/ui_element.ts
@@ -111,9 +111,7 @@ export abstract class UIElementView extends StyledElementView {
 
   override initialize(): void {
     super.initialize()
-
     this._resize_observer = new ResizeObserver((_entries) => this.after_resize())
-    this._resize_observer.observe(this.el, {box: "border-box"})
   }
 
   override async lazy_initialize(): Promise<void> {
@@ -129,8 +127,6 @@ export abstract class UIElementView extends StyledElementView {
 
     const {visible} = this.model.properties
     this.on_change(visible, () => this._update_visible())
-
-    this.el.addEventListener("contextmenu", (event) => this.show_context_menu(event))
   }
 
   get_context_menu(_xy: XY): ViewOf<Menu> | null {
@@ -172,6 +168,9 @@ export abstract class UIElementView extends StyledElementView {
 
   override render(): void {
     super.render()
+    this._resize_observer.disconnect()
+    this._resize_observer.observe(this.el, {box: "border-box"})
+    this.el.addEventListener("contextmenu", (event) => this.show_context_menu(event))
     this._apply_visible()
   }
 

--- a/bokehjs/test/unit/embed.ts
+++ b/bokehjs/test/unit/embed.ts
@@ -8,7 +8,8 @@ import {DOMElementView} from "@bokehjs/core/dom_view"
 import {is_equal} from "@bokehjs/core/util/eq"
 
 class SomeView extends DOMElementView {
-  render(): void {
+  override render(): void {
+    super.render()
     this.el.style.width = "100px"
     this.el.style.height = "100px"
     this.el.style.backgroundColor = "red"


### PR DESCRIPTION
Currently rendering is spread in multiple places, including `initialize()`, `connect_signals()` and `render()`. When re-rendering `this.el` (the root element of a component) never gets recreated. It's "emptied" instead, but that doesn't really clear all the associated state with that element, which can cause issues when calling `render()` multiple times.

This PR moves all rendering related tasks to `render()` method, including creation of `this.el`. If re-rendering, then `render()` will create a new DOM element and then use `replaceWith` to efficiently replace it in the existing DOM hierarchy. This makes re-rendering much more predictable. Re-rendering, especially unnecessary re-rendering, is not advised, but sometimes necessary. 