### PR TITLE
Fix broken example in user guide advanced bokehjs

### DIFF
--- a/docs/bokeh/source/docs/user_guide/advanced/bokehjs.rst
+++ b/docs/bokeh/source/docs/user_guide/advanced/bokehjs.rst
@@ -113,10 +113,9 @@ The JavaScript sample below is very similar to the Python code in
             xx.push(x);
             yy.push(y);
             colors.push(plt.color([50+2*x, 30+2*y, 150]));
-            radii.push(Math.random() * 0.4 + 1.7)
+            radii.push(Math.random() * 0.4 + 1.7);
         }
     }
-
     // create a data source
     const source = new Bokeh.ColumnDataSource({
         data: { x: xx, y: yy, radius: radii, colors: colors }
@@ -127,12 +126,11 @@ The JavaScript sample below is very similar to the Python code in
     const p = plt.figure({ title: "Colorful Scatter", tools: tools });
 
     // call the circle glyph method to add some circle glyphs
-    const circles = p.circle({ field: "x" }, { field: "y" }, {
+    const circles = p.circle({ field: "x" }, { field: "y" }, {field: "radius"}, {
         source: source,
-        radius: radii,
         fill_color: { field: "colors" },
         fill_alpha: 0.6,
-        line_color: null
+        line_color: null,
     });
 
     // show the plot

--- a/docs/bokeh/source/docs/user_guide/advanced/bokehjs.rst
+++ b/docs/bokeh/source/docs/user_guide/advanced/bokehjs.rst
@@ -113,7 +113,7 @@ The JavaScript sample below is very similar to the Python code in
             xx.push(x);
             yy.push(y);
             colors.push(plt.color([50+2*x, 30+2*y, 150]));
-            radii.push(Math.random() * 0.4 + 1.7);
+            radii.push(Math.random() * 5);
         }
     }
     // create a data source

--- a/docs/bokeh/source/docs/user_guide/advanced/bokehjs.rst
+++ b/docs/bokeh/source/docs/user_guide/advanced/bokehjs.rst
@@ -113,7 +113,7 @@ The JavaScript sample below is very similar to the Python code in
             xx.push(x);
             yy.push(y);
             colors.push(plt.color([50+2*x, 30+2*y, 150]));
-            radii.push(Math.random() * 5);
+            radii.push(Math.random() * 1.5);
         }
     }
     // create a data source

--- a/src/bokeh/sphinxext/bokehjs_content.py
+++ b/src/bokeh/sphinxext/bokehjs_content.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 # -----------------------------------------------------------------------------
-""" Make javascript code blocks also include a live link to codepen.io for instant experiementation.
+""" Make javascript code blocks also include a live link to codepen.io for instant experimentation.
 
 This directive takes a title to use for the codepen example:
 
@@ -26,7 +26,7 @@ include_html: string
     if present, this code block will be emitted as a complete HTML template with
     js inside a script block
 disable_codepen: string
-    if present, this code block will not have a 'try on codepen' button.  Currently
+    if present, this code block will not have a 'try on codepen' button. Currently
     necessary when 'include_html' is turned on.
 
 Examples
@@ -235,7 +235,7 @@ class BokehJSContent(CodeBlock):
             # we only want to inject the CODEPEN_INIT on one
             # bokehjs-content block per page, here we check to see if
             # bjs_seen exists, if not set it to true, and set
-            # node['include_bjs_header'] to true.  This way the
+            # node['include_bjs_header'] to true. This way the
             # CODEPEN_INIT is only injected once per document (html
             # page)
             source_doc.bjs_seen = True


### PR DESCRIPTION
At the moment the [`Bokeh.plotting` example](https://docs.bokeh.org/en/latest/docs/user_guide/advanced/bokehjs.html#bokeh-plotting) is broken and will be fixed by this PR. The example is not valid anymore. I opend #13878 to document the change.

- [ ] issues: adresses #13867