### PR TITLE
add new line to raw directive 

### DIFF
--- a/docs/bokeh/source/index.rst
+++ b/docs/bokeh/source/index.rst
@@ -12,6 +12,7 @@ to complex dashboards with streaming datasets. With Bokeh, you can create
 JavaScript-powered visualizations without writing any JavaScript yourself.
 
 .. raw:: html
+
     <div>
         <form class="bd-search align-items-center" action="search.html" method="get">
           <input type="search" class="form-control search-front-page" name="q" id="search-input" placeholder="&#128269; Search the docs ..." aria-label="Search the docs ..." autocomplete="off">


### PR DESCRIPTION
This PR adds a simple line to avoid an error message from Sphinx.

```
~\bokeh\docs\bokeh\source\index.rst:14: ERROR: Content block expected for the "raw" directive; none found.
```
