### PR TITLE
silence warning in `theme_glyphs.py`

### DIFF
--- a/examples/plotting/theme_glyphs.py
+++ b/examples/plotting/theme_glyphs.py
@@ -8,6 +8,7 @@
 '''
 import numpy as np
 
+from bokeh.core.properties import value
 from bokeh.io import curdoc, show
 from bokeh.models import (BasicTicker, BasicTickFormatter, ColumnDataSource, Ellipse,
                           HBar, Line, LinearAxis, Plot, Scatter, Text, Title)
@@ -31,7 +32,7 @@ theme_json = {
         "TextGlyph": {
             "text_color": "red",
             "text_font_style": "bold",
-            "text_font": "Helvetica",
+            "text_font": value("Helvetica"), # specify this is a Value and not a Field
         },
         "Ellipse": {"fill_color": "green", "line_color": "yellow", "fill_alpha": 0.2},
     },

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -106,7 +106,7 @@ class DataSpec(Either):
 
         glyph.x = 10
 
-    Alternatively, maybe the each glyph that gets drawn should have a
+    Alternatively, maybe each glyph that gets drawn should have a
     different location, according to the "pressure" column of a data
     source. In this case we would like to be able to write:
 
@@ -127,7 +127,7 @@ class DataSpec(Either):
 
         glyph.x = "pressure"  # => { 'field': 'pressure' }
 
-    When these underlying dictionary dictionary values are received in
+    When these underlying dictionary values are received in
     the browser, BokehJS knows how to interpret them and take the correct,
     expected action (i.e., draw the glyph at ``x=10``, or draw the glyph
     with ``x`` coordinates from the "pressure" column). In this way, both
@@ -288,8 +288,8 @@ class StringSpec(DataSpec):
 
     Because acceptable fixed values and field names are both strings, it can
     be necessary explicitly to disambiguate these possibilities. By default,
-    string values are interpreted as fields, but the |value| function can be
-    used to specify that a string should interpreted as a value:
+    string values are interpreted as fields, but you can use the |value| function
+    to specify that a string is interpreted as a value:
 
     .. code-block:: python
 
@@ -305,7 +305,7 @@ class FontSizeSpec(DataSpec):
     """ A |DataSpec| property that accepts font-size fixed values.
 
     The ``FontSizeSpec`` property attempts to first interpret string values as
-    font sizes (i.e. valid CSS length values). Otherwise string values are
+    font sizes (i.e. valid CSS length values). Otherwise, string values are
     interpreted as field names. For example:
 
     .. code-block:: python
@@ -363,7 +363,7 @@ class HatchPatternSpec(DataSpec):
     """ A |DataSpec| property that accepts hatch pattern types as fixed values.
 
     The ``HatchPatternSpec`` property attempts to first interpret string values
-    as hatch pattern types. Otherwise string values are interpreted as field
+    as hatch pattern types. Otherwise, string values are interpreted as field
     names. For example:
 
     .. code-block:: python
@@ -383,7 +383,7 @@ class MarkerSpec(DataSpec):
     """ A |DataSpec| property that accepts marker types as fixed values.
 
     The ``MarkerSpec`` property attempts to first interpret string values as
-    marker types. Otherwise string values are interpreted as field names.
+    marker types. Otherwise, string values are interpreted as field names.
     For example:
 
     .. code-block:: python

--- a/src/bokeh/themes/theme.py
+++ b/src/bokeh/themes/theme.py
@@ -71,7 +71,7 @@ class Theme:
     The ``Theme`` class can be constructed either from a YAML file or from a
     JSON dict (but not both). Examples of both formats are shown below.
 
-    The plotting API's defaults override some theme properties. Namely:
+    The plotting API defaults override some theme properties. Namely:
     `fill_alpha`, `fill_color`, `line_alpha`, `line_color`, `text_alpha` and
     `text_color`. Those properties should therefore be set explicitly when
     using the plotting API.
@@ -82,7 +82,7 @@ class Theme:
 
     Raises:
         ValueError
-            If neither ``filename`` or ``json`` is supplied.
+            If neither ``filename`` nor ``json`` is supplied.
 
     Examples:
 


### PR DESCRIPTION
This PR updates the example `theme_glyphe.py` to avoid the message

```
ERROR:bokeh.core.validation.check:E-1001 (BAD_COLUMN_NAME): Glyph refers to nonexistent column name. This could either be due to a misspelling or typo, or due to an expected column being missing. : text_font='Helvetica' [no close matches] {renderer: GlyphRenderer(id='p32875', ...)}
```

 during the docs build.

I also corrected a few typos.