### PR TITLE
Add support for server sent bokeh/model/UI events

### DIFF
--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -5,8 +5,22 @@ import type {Class} from "./class"
 import type {KeyModifiers} from "./ui_gestures"
 import type {Serializable, Serializer} from "./serialization"
 import {serialize} from "./serialization"
+import {Deserializer} from "./serialization/deserializer"
 import type {Equatable, Comparator} from "./util/eq"
 import {equals} from "./util/eq"
+import type {InputWidget} from "../models/widgets/input_widget"
+
+Deserializer.register("event", (rep: BokehEventRep, deserializer: Deserializer): BokehEvent => {
+  switch (rep.name) {
+    case "clear_input": {
+      const {model} = deserializer.decode(rep.values) as {model: InputWidget}
+      return new ClearInput(model)
+    }
+    default: {
+      deserializer.error(`deserialization of '${rep.name}' event is not supported`)
+    }
+  }
+})
 
 export type BokehEventType =
   DocumentEventType |
@@ -54,6 +68,7 @@ export type PointEventType =
 
 export type BokehEventMap = {
   document_ready: DocumentReady
+  clear_input: ClearInput
   connection_lost: ConnectionLost
   button_click: ButtonClick
   menu_item_click: MenuItemClick
@@ -174,6 +189,18 @@ export class ValueSubmit extends ModelEvent {
   protected override get event_values(): Attrs {
     const {value} = this
     return {...super.event_values, value}
+  }
+}
+
+@event("clear_input")
+export class ClearInput extends ModelEvent {
+  constructor(readonly model: InputWidget) {
+    super()
+    this.origin = model
+  }
+
+  static {
+    this.prototype.publish = false
   }
 }
 

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -20,10 +20,12 @@ import {entries, dict} from "core/util/object"
 import * as sets from "core/util/set"
 import type {CallbackLike} from "core/util/callbacks"
 import {execute} from "core/util/callbacks"
+import {assert} from "core/util/assert"
 import {Model} from "model"
 import type {ModelDef} from "./defs"
 import {decode_def} from "./defs"
-import type {BokehEvent, BokehEventType, BokehEventMap, ModelEvent} from "core/bokeh_events"
+import type {BokehEvent, BokehEventType, BokehEventMap} from "core/bokeh_events"
+import {ModelEvent} from "core/bokeh_events"
 import {DocumentReady, LODStart, LODEnd} from "core/bokeh_events"
 import type {DocumentEvent, DocumentChangedEvent, Decoded, DocumentChanged} from "./events"
 import {DocumentEventBatch, RootRemovedEvent, TitleChangedEvent, MessageSentEvent, RootAddedEvent} from "./events"
@@ -120,6 +122,10 @@ export class Document implements Equatable {
     if (options.roots != null) {
       this._add_roots(...options.roots)
     }
+    this.on_message("bokeh_event", (event) => {
+      assert(event instanceof ModelEvent)
+      this.event_manager.trigger(event)
+    })
   }
 
   [equals](that: this, _cmp: Comparator): boolean {

--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -1,6 +1,7 @@
 import {InputWidget, InputWidgetView} from "./input_widget"
 import type {StyleSheetLike} from "core/dom"
 import {input} from "core/dom"
+import {ClearInput} from "core/bokeh_events"
 import {isString} from "core/util/types"
 import * as p from "core/properties"
 import * as inputs from "styles/widgets/inputs.css"
@@ -9,6 +10,19 @@ import buttons_css from "styles/buttons.css"
 export class FileInputView extends InputWidgetView {
   declare model: FileInput
   declare input_el: HTMLInputElement
+
+  override connect_signals(): void {
+    super.connect_signals()
+
+    this.model.on_event(ClearInput, () => {
+      this.model.setv({
+        value:     "", // p.unset,
+        mime_type: "", // p.unset,
+        filename:  "", // p.unset,
+      })
+      this.input_el.value = ""
+    })
+  }
 
   override stylesheets(): StyleSheetLike[] {
     return [...super.stylesheets(), buttons_css]

--- a/docs/bokeh/source/docs/releases/3.5.0.rst
+++ b/docs/bokeh/source/docs/releases/3.5.0.rst
@@ -11,3 +11,4 @@ Bokeh version ``3.5.0`` (May 2024) is a minor milestone of Bokeh project.
 * Added support for CSS variable based styling to plot renderers (:bokeh-pull:`13828`)
 * Added support for outline shapes to text-like glyphs (``Text``, ``TeX`` and ``MathML``) (:bokeh-pull:`13620`)
 * Added support for range setting gesture to ``RangeTool`` and allowed a choice of gesture (pan, tap or none) (:bokeh-pull:`13855`)
+* Added support for server-sent events, in particular for ``ClearInput`` event on input widgets (:bokeh-pull:`13890`)

--- a/examples/interaction/js_callbacks/doc_js_events.py
+++ b/examples/interaction/js_callbacks/doc_js_events.py
@@ -2,7 +2,8 @@
 
 from bokeh.events import Event
 from bokeh.io import curdoc
-from bokeh.models import Button, CustomJS
+from bokeh.layouts import column
+from bokeh.models import Button, CustomJS, FileInput
 
 
 def py_ready(event: Event):
@@ -27,16 +28,19 @@ document.body.insertAdjacentHTML("beforeend", html)
 curdoc().on_event("connection_lost", py_connection_lost)
 curdoc().js_on_event("connection_lost", js_connection_lost)
 
+file_input = FileInput()
+
 def py_clicked(event: Event):
     print("CLICKED!")
+    file_input.clear()
 
 js_clicked = CustomJS(code="""
 const html = "<div>CLICKED!</div>"
 document.body.insertAdjacentHTML("beforeend", html)
 """)
 
-button = Button(label="Click me")
-button.on_event("button_click", py_clicked)
+button = Button(label="Click me to clear the selected file")
+button.on_click(py_clicked) # or button.on_event("button_click", py_clicked)
 button.js_on_event("button_click", js_clicked)
 
-curdoc().add_root(button)
+curdoc().add_root(column(file_input, button))

--- a/src/bokeh/document/callbacks.py
+++ b/src/bokeh/document/callbacks.py
@@ -40,6 +40,7 @@ from ..models.callbacks import Callback as JSEventCallback
 from ..util.callback_manager import _check_callback
 from .events import (
     DocumentPatchedEvent,
+    MessageSentEvent,
     ModelChangedEvent,
     RootAddedEvent,
     RootRemovedEvent,
@@ -380,6 +381,14 @@ class DocumentCallbackManager:
 
         '''
         return tuple(self._change_callbacks.values())
+
+    def send_event(self, event: Event) -> None:
+        ''' Send a bokeh/model/UI event to the client.
+
+        '''
+        document = self._document()
+        if document is not None:
+            self.trigger_on_change(MessageSentEvent(document, "bokeh_event", event))
 
     def trigger_event(self, event: Event) -> None:
         # This is fairly gorpy, we are not being careful with model vs doc events, etc.

--- a/src/bokeh/models/widgets/inputs.py
+++ b/src/bokeh/models/widgets/inputs.py
@@ -51,6 +51,7 @@ from ...core.properties import (
     String,
     Tuple,
 )
+from ...events import ClearInput
 from ...util.deprecation import deprecated
 from ..dom import HTML
 from ..formatters import TickFormatter
@@ -117,7 +118,7 @@ class FileInput(InputWidget):
         super().__init__(*args, **kwargs)
 
     value = Readonly(Either(String, List(String)), help='''
-    The base64-enconded contents of the file or files that were loaded.
+    The base64-encoded contents of the file or files that were loaded.
 
     If `multiple` is set to False (default), this value is a single string with the contents
     of the single file that was chosen.
@@ -191,6 +192,13 @@ class FileInput(InputWidget):
     selection of more than one file at a time should be possible.
     """)
 
+    def clear(self) -> None:
+        """ Clear the contents of this file input widget.
+
+        """
+        doc = self.document
+        if doc is not None:
+            doc.callbacks.send_event(ClearInput(self))
 
 class NumericInput(InputWidget):
     ''' Numeric input widget.

--- a/tests/unit/bokeh/test_events.py
+++ b/tests/unit/bokeh/test_events.py
@@ -21,6 +21,7 @@ from bokeh.core.serialization import Deserializer
 from bokeh.models import (
     Button,
     Div,
+    FileInput,
     Plot,
     TextInput,
 )
@@ -62,6 +63,8 @@ def test_common_decode_json() -> None:
             model = Button()
         elif issubclass(event_cls, events.ValueSubmit):
             model = TextInput()
+        elif issubclass(event_cls, events.ClearInput):
+            model = FileInput()
         else:
             model = Plot()
 

--- a/tests/unit/bokeh/test_events.py
+++ b/tests/unit/bokeh/test_events.py
@@ -18,6 +18,8 @@ import pytest ; pytest
 
 # Bokeh imports
 from bokeh.core.serialization import Deserializer
+from bokeh.document import Document
+from bokeh.document.events import DocumentChangedEvent, MessageSentEvent
 from bokeh.models import (
     Button,
     Div,
@@ -380,6 +382,26 @@ def test_pinch_callbacks() -> None:
     plot._trigger_event(events.Pinch(plot, **payload))
     assert test_callback.event_name == events.Pinch.event_name
     assert test_callback.payload == payload
+
+def test_FileInput_clear() -> None:
+    file_input = FileInput()
+    doc = Document()
+    doc.add_root(file_input)
+
+    collected_events: list[DocumentChangedEvent] = []
+    def on_change(event: DocumentChangedEvent) -> None:
+        collected_events.append(event)
+    doc.on_change(on_change)
+
+    file_input.clear()
+
+    assert len(collected_events) == 1
+    [event] = collected_events
+
+    assert isinstance(event, MessageSentEvent)
+    assert event.msg_type == "bokeh_event"
+    assert isinstance(event.msg_data, events.ClearInput)
+    assert event.msg_data.model == file_input
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
Previously bokeh/model/UI events were only allowed to be sent from client to server. This PR allows the other direction, for events where it makes sense. In particular it adds `ClearInput` event that allows to clear the value of input widgets (those were the property or properties reporting input's value are read-only). This will be used in PR #13873 to replace the ad-hoc mechanism implemented in that PR.