### PR TITLE
enable pydata_sphinx_theme version banner

### DIFF
--- a/docs/bokeh/Makefile
+++ b/docs/bokeh/Makefile
@@ -18,7 +18,6 @@ clean:
 	-rm -rf source/docs/gallery/*
 	-rm -rf source/docs/examples/*
 
-# XXX -W was removed due to issue https://github.com/bokeh/bokeh/issues/13156
 html:
 	@start=$$(date +%s) \
 	; sphinx-build -W -b html -d $(BUILDDIR)/doctrees $(SPHINXOPTS) source $(BUILDDIR)/html \

--- a/docs/bokeh/docserver.py
+++ b/docs/bokeh/docserver.py
@@ -14,7 +14,7 @@ This script can be run manually:
     python docserver.py
 
 or more commonly via executing ``make serve`` in this directory. It is possible
-to combine this usage with other make targets in a single invovation, e.g.
+to combine this usage with other make targets in a single invocation, e.g.
 
     make clean html serve
 
@@ -34,7 +34,7 @@ import webbrowser
 from pathlib import Path
 
 import flask
-from flask import redirect, url_for
+from flask import redirect
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 from tornado.wsgi import WSGIContainer
@@ -52,12 +52,12 @@ app = flask.Flask(__name__, static_folder="/unused")
 
 @app.route("/")
 def root():
-    return redirect(url_for("en/latest/index.html"))
+    return redirect("en/latest/index.html")
 
 
 @app.route("/switcher.json")
 def switcher():
-    return flask.send_from_directory(SPHINX_TOP, "switcher.json")
+    return flask.send_from_directory(SPHINX_TOP / "build" / "html" / "_static", "switcher.json")
 
 
 @app.route("/en/latest/<path:filename>")

--- a/docs/bokeh/source/_static/custom.css
+++ b/docs/bokeh/source/_static/custom.css
@@ -105,24 +105,6 @@ img.image-border {
 .bd-footer .btn-primary { filter: brightness(90%); background-color: #C02942; border-color: #C02942; }
 .bd-footer .btn-primary:hover { filter: brightness(100%); background-color: #C02942; border-color: #C02942; }
 
-/* CSS for our custom version warning banner */
-.version-alert a {
-  text-decoration: underline;
-  color: #ddd;
-}
-
-#banner .version-alert {
-  background-color: #CF462A;
-  padding: 1em;
-  color: #fff;
-  font-weight: 600; font-size: 16px;
-}
-
-.version-alert a {
-  text-decoration: underline;
-  color: #ddd;
-}
-
 /* CSS for our custom gallery */
 div.bk-gallery {
     width: 100%;

--- a/docs/bokeh/source/_static/custom.js
+++ b/docs/bokeh/source/_static/custom.js
@@ -6,21 +6,3 @@ window.addEventListener('DOMContentLoaded', function () {
     });
   }
 })
-
-// Display a version warning banner if necessary
-$(document).ready(function () {
-  const randid = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
-  $.getJSON('/switcher.json?v=' + randid , function (data) {
-    // old versions have a unified latest/x.y.z, things are split starting with 3.0
-    if (BOKEH_CURRENT_VERSION != data[1].version) {
-      let msg
-      if (data.findIndex((elt) => elt.version == BOKEH_CURRENT_VERSION) < 0 ) {
-        msg = "DEVELOPMENT / PRE-RELEASE"
-      } else {
-        msg = "PREVIOUS RELEASE"
-      }
-      const content = $('<div class="version-alert">This page is documentation for a ' + msg + ' version. For the latest release, go to <a href="https://docs.bokeh.org/en/latest/">https://docs.bokeh.org/en/latest/</a></div>')
-      $('#banner').append(content);
-    }
-  })
-})

--- a/docs/bokeh/source/_static/switcher.json
+++ b/docs/bokeh/source/_static/switcher.json
@@ -6,10 +6,6 @@
     "preferred": true
   },
   {
-    "version": "3.4.0",
-    "url": "https://docs.bokeh.org/en/3.4.0/"
-  },
-  {
     "version": "3.3.0",
     "url": "https://docs.bokeh.org/en/3.3.0/"
   },

--- a/docs/bokeh/source/_static/switcher.json
+++ b/docs/bokeh/source/_static/switcher.json
@@ -1,7 +1,9 @@
 [
   {
     "name": "latest",
-    "url": "https://docs.bokeh.org/en/latest/"
+    "version": "3.4.1",
+    "url": "https://docs.bokeh.org/en/latest/",
+    "preferred": true
   },
   {
     "version": "3.4.0",
@@ -25,6 +27,7 @@
   },
   {
     "name": "dev (3.5)",
+    "version": "dev-3.5",
     "url": "https://docs.bokeh.org/en/dev-3.5/"
   }
 ]

--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -169,6 +169,12 @@ html_theme ="pydata_sphinx_theme"
 
 html_title = f"{project} {version} Documentation"
 
+# avoid CORS error on local docs build for the switcher.json file
+if 'dev' in version:
+    json_url = "_static/switcher.json"
+else:
+    json_url = "https://docs.bokeh.org/switcher.json"
+
 # html_logo configured in navbar-logo.html
 
 html_theme_options = {
@@ -189,10 +195,11 @@ html_theme_options = {
     "show_nav_level": 2,
     "show_toc_level": 1,
     "switcher": {
-        "json_url": "https://docs.bokeh.org/switcher.json",
+        "json_url": json_url,
         "version_match": version,
     },
     "use_edit_page_button": False,
+    "show_version_warning_banner": True,
     "header_links_before_dropdown": 8,
 }
 

--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -170,10 +170,10 @@ html_theme ="pydata_sphinx_theme"
 html_title = f"{project} {version} Documentation"
 
 # avoid CORS error on local docs build for the switcher.json file
-if 'dev' in version:
-    json_url = "_static/switcher.json"
-else:
+if "BOKEH_DOCS_RELEASE" in os.environ:
     json_url = "https://docs.bokeh.org/switcher.json"
+else:
+    json_url = "_static/switcher.json"
 
 # html_logo configured in navbar-logo.html
 

--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -170,7 +170,7 @@ html_theme ="pydata_sphinx_theme"
 html_title = f"{project} {version} Documentation"
 
 # avoid CORS error on local docs build for the switcher.json file
-if "BOKEH_DOCS_RELEASE" in os.environ:
+if "BOKEH_DOCS_VERSION" in os.environ:
     json_url = "https://docs.bokeh.org/switcher.json"
 else:
     json_url = "_static/switcher.json"

--- a/release/build.py
+++ b/release/build.py
@@ -69,12 +69,7 @@ def build_conda_packages(config: Config, system: System) -> ActionReturn:
 def build_docs(config: Config, system: System) -> ActionReturn:
     try:
         system.cd("docs/bokeh")
-        system.run(
-            "make clean all SPHINXOPTS=-v",
-            BOKEH_DOCS_CDN=config.version,
-            BOKEH_DOCS_VERSION=config.version,
-            BOKEH_DOCS_RELEASE=config.version,
-        )
+        system.run("make clean all SPHINXOPTS=-v", BOKEH_DOCS_CDN=config.version, BOKEH_DOCS_VERSION=config.version)
         system.cd("../..")
         return PASSED("Docs build succeeded")
     except RuntimeError as e:

--- a/release/build.py
+++ b/release/build.py
@@ -69,7 +69,12 @@ def build_conda_packages(config: Config, system: System) -> ActionReturn:
 def build_docs(config: Config, system: System) -> ActionReturn:
     try:
         system.cd("docs/bokeh")
-        system.run("make clean all SPHINXOPTS=-v", BOKEH_DOCS_CDN=config.version, BOKEH_DOCS_VERSION=config.version)
+        system.run(
+            "make clean all SPHINXOPTS=-v",
+            BOKEH_DOCS_CDN=config.version,
+            BOKEH_DOCS_VERSION=config.version,
+            BOKEH_DOCS_RELEASE=config.version,
+        )
         system.cd("../..")
         return PASSED("Docs build succeeded")
     except RuntimeError as e:


### PR DESCRIPTION
This PR activates the version banner from pydata-sphinx-theme, removes the old version banner (js and css). The switcher.json in also adapted to silence a warning.

- [ ] issues: fixes #13824

After running `make clean html serve` on my local machine this is the result.

![version_banner](https://github.com/bokeh/bokeh/assets/68053396/70fbcb60-b8d7-4cfd-b87f-ffcfe10136f8)


For the older versions 

*    https://docs.bokeh.org/en/3.2.2/
*    https://docs.bokeh.org/en/3.3.0/
*    https://docs.bokeh.org/en/3.4.0/

it is suggested to add the code below to all existing html pages to enable the banner.

```

<div style="background-color: rgb(248, 215, 218); color: rgb(114, 28, 36); text-align: center;">
  <div>
    <div>This is documentation for <strong>an old version</strong>.
      <a href="https://docs.bokeh.org/en/latest/index.html" style="background-color: rgb(220, 53, 69); color: rgb(255, 255, 255); margin: 1rem; padding: 0.375rem 0.75rem; border-radius: 4px; display: inline-block; text-align: center;">Switch to stable version</a>
    </div>
  </div>
</div>
```

I don't know how to do this.