### PR TITLE
Remove explanation from the code block and handle backslahes as raw

### DIFF
--- a/src/bokeh/sphinxext/bokeh_plot.py
+++ b/src/bokeh/sphinxext/bokeh_plot.py
@@ -362,6 +362,8 @@ def _evaluate_source(source: str, filename: str, env):
 def _remove_module_docstring(source, docstring):
     if docstring is None:
         return source
+    # escape backslashes, see https://docs.python.org/3/library/re.html#re.escape
+    docstring = docstring.replace("\\", r"\\")
     return re.sub(rf'(\'\'\'|\"\"\")\s*{re.escape(docstring)}\s*(\'\'\'|\"\"\")', "", source)
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR solves a problem in the bokeh code block for examples.

The issue was that the number of backslashes `\` in the regular expression did not match the number in the source and the substitution was not working. With the one added line, two backslahes are replaced two raw ones, which results in the correct regular expression.

|**current**|**changed**|
|--|--|
|![current](https://github.com/bokeh/bokeh/assets/68053396/b195c5fa-fe01-42e2-9518-fa223c9d2315)|![new](https://github.com/bokeh/bokeh/assets/68053396/e44f5e3c-c60b-44af-a7c3-53bfeeeea181)|

- [ ] issues: fixes #13720