### PR TITLE
Add `http://` to devtools server

### DIFF
--- a/bokehjs/test/devtools/server.ts
+++ b/bokehjs/test/devtools/server.ts
@@ -254,7 +254,7 @@ const {host, port} = argv
 const server = app.listen(port, host)
 
 server.on("listening", () => {
-  console.log(`listening on ${host}:${port}`)
+  console.log(`listening on http://${host}:${port}`)
   process.send?.("ready")
 })
 server.on("error", (error) => {


### PR DESCRIPTION
Making it possible to click on the link when running `node test/devtools server`

![image](https://github.com/bokeh/bokeh/assets/19758978/fcff0ae2-ce77-4fc6-9f4c-882f1f88054b)
