### PR TITLE
Remove `blob/main` and `tree/master` from references

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   </td>
 
   <td>
-    <a href="https://github.com/bokeh/bokeh/blob/main/LICENSE.txt">
+    <a href="https://github.com/bokeh/bokeh/blob/-/LICENSE.txt">
     <img src="https://img.shields.io/github/license/bokeh/bokeh.svg?color=ECD078&style=for-the-badge"
          alt="Bokeh license (BSD 3-clause)" />
     </a>

--- a/docs/bokeh/source/docs/gallery.json
+++ b/docs/bokeh/source/docs/gallery.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "transform_markers.py",
-      "alt": "Thumbnail link to the examples/basic/data/transform_markers.py example shows a scatter plot of the Palmer penuguins dataset, color- and marker-mapped by species. The x-axis is flipper length (mm) and the y-axis is body mass (g)."
+      "alt": "Thumbnail link to the examples/basic/data/transform_markers.py example shows a scatter plot of the Palmer penguins dataset, color- and marker-mapped by species. The x-axis is flipper length (mm) and the y-axis is body mass (g)."
     },
     {
       "name": "transform_jitter.py",
@@ -70,7 +70,7 @@
     },
     {
       "name": "intervals.py",
-      "alt": "Thumbnail link to the examples/basic/bars/intervals.py example shows an interval chart showing Olympic sprint time data as intervals using blue horizontal bars for times, with a bar for earch year on the y-axis."
+      "alt": "Thumbnail link to the examples/basic/bars/intervals.py example shows an interval chart showing Olympic sprint time data as intervals using blue horizontal bars for times, with a bar for each year on the y-axis."
     },
     {
       "name": "mixed.py",
@@ -78,7 +78,7 @@
     },
     {
       "name": "nested_colormapped.py",
-      "alt": "Thumbnail link to the examples/basic/bars/nested_colormapped.py example shows a grouped bar chart on a hierachical categorical axis of years for different categories of fruit. Each group has a silver, blue, and red bar corresponding to random values for years 2015, 2016 and 2017."
+      "alt": "Thumbnail link to the examples/basic/bars/nested_colormapped.py example shows a grouped bar chart on a hierarchical categorical axis of years for different categories of fruit. Each group has a silver, blue, and red bar corresponding to random values for years 2015, 2016 and 2017."
     },
     {
       "name": "pandas_groupby_colormapped.py",
@@ -98,7 +98,7 @@
     },
     {
       "name": "nested.py",
-      "alt": "Thumbnail link to the examples/basic/bars/nested.py example shows a grouped bar chart on a hierachical categorical axis of years for different categories of fruit. Each group has three blue bars corresponding to random values for years 2015, 2016 and 2017."
+      "alt": "Thumbnail link to the examples/basic/bars/nested.py example shows a grouped bar chart on a hierarchical categorical axis of years for different categories of fruit. Each group has three blue bars corresponding to random values for years 2015, 2016 and 2017."
     },
     {
       "name": "colors.py",
@@ -236,7 +236,7 @@
     },
     {
       "name": "image.py",
-      "alt": "Thumbnail link to the examples/topics/images/image.py example shows a plot with a colormapped two-dimensonal sine surface."
+      "alt": "Thumbnail link to the examples/topics/images/image.py example shows a plot with a colormapped two-dimensional sine surface."
     },
     {
       "name": "image_origin_anchor.py",
@@ -282,7 +282,7 @@
     },
     {
       "name": "slope_graph.py",
-      "alt": "Thumbnail link to the examples/topics/categorical/slope_graph.py example shows a slope graph of the CO2 emmisions of selected countries in the years 2000 and 2010."
+      "alt": "Thumbnail link to the examples/topics/categorical/slope_graph.py example shows a slope graph of the CO2 emissions of selected countries in the years 2000 and 2010."
     },
     {
       "name": "heatmap_unemployment.py",
@@ -364,7 +364,7 @@
     },
     {
       "name": "burtin.py",
-      "alt": "Thumbnail link to the examples/topics/pie/burtin.py example shows a reproduction of Burtin's hitorical antibiotics plot."
+      "alt": "Thumbnail link to the examples/topics/pie/burtin.py example shows a reproduction of Burtin's historical antibiotics plot."
     }
   ],
   "topics/stats": [
@@ -406,7 +406,7 @@
   "interaction/linking": [
     {
       "name": "linked_brushing.py",
-      "alt": "Thumbnail link to the examples/interaction/linking/linked_brushing.py example shows a two different scatter plots of the Palmer penuguin dataset with linked selections."
+      "alt": "Thumbnail link to the examples/interaction/linking/linked_brushing.py example shows a two different scatter plots of the Palmer penguin dataset with linked selections."
     },
     {
       "name": "linked_crosshair.py",
@@ -456,7 +456,7 @@
     },
     {
       "name": "date_picker.py",
-      "alt": "Thumbnail link to the examples/interaction/widgets/date_picker.py example shows a simple example of a widget for seleting dates and date ranges."
+      "alt": "Thumbnail link to the examples/interaction/widgets/date_picker.py example shows a simple example of a widget for selecting dates and date ranges."
     },
     {
       "name": "dropdown.py",
@@ -476,55 +476,55 @@
       "name": "movies",
       "url": "https://demo.bokeh.org/movies",
       "alt": "Thumbnail featuring an interactive query tool for a set of IMDB data. Tool features a default graph of the Tomato Meter (x-axis) against the number of reviews (y-axis). Graph can be refined using multiple variables including cast names, director name, number of Oscar wins, year released, end year released, genre, dollar at the box office, and more.",
-      "desc": "An interactive query tool for a set of IMDB data.(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/movies'>source code</a>)</em>"
+      "desc": "An interactive query tool for a set of IMDB data.(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/movies'>source code</a>)</em>"
     },
     {
       "name": "selection_histogram",
       "url": "https://demo.bokeh.org/selection_histogram",
       "alt": "Thumbnail featuring axis histograms for selected and non-selected points in a scatter plot. Axes unlabeled.",
-      "desc": "Shows axis histograms for selected <em>and</em> non-selected points in a scatter plot. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/selection_histogram.py'>source code</a>)</em>"
+      "desc": "Shows axis histograms for selected <em>and</em> non-selected points in a scatter plot. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/selection_histogram.py'>source code</a>)</em>"
     },
     {
       "name": "weather",
       "url": "https://demo.bokeh.org/weather",
       "alt": "Thumbnail featuring interactive weather statistics for three cities. Features drop down for city and distribution. X-axis features date, the y-axis features temperature.",
-      "desc": "Interactive weather statistics for three cities. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/weather'>source code</a>)</em>"
+      "desc": "Interactive weather statistics for three cities. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/weather'>source code</a>)</em>"
     },
     {
       "name": "sliders",
       "url": "https://demo.bokeh.org/sliders",
       "alt": "Thumbnail of plotted trigonometric function with sliders for offset, amplitude, phase, and frequency.",
-      "desc": "A basic demo that has sliders for controlling a plotted trigonometric function. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/sliders.py'>source code</a>)</em>"
+      "desc": "A basic demo that has sliders for controlling a plotted trigonometric function. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/sliders.py'>source code</a>)</em>"
     },
     {
       "name": "crossfilter",
       "url": "https://demo.bokeh.org/crossfilter",
       "alt": "Thumbnail of example scatter plot with drop downs for x-axis, y-axis, color, and size. Default graph features mpg on the x-axis, hp on the y-axis, and shows a downward exponential trend.",
-      "desc": "Explore the autompg data set by selecting and highlighting different dimensions. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/crossfilter'>source code</a>)</em>"
+      "desc": "Explore the autompg data set by selecting and highlighting different dimensions. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/crossfilter'>source code</a>)</em>"
     },
     {
       "name": "gapminder",
       "url": "https://demo.bokeh.org/gapminder",
       "alt": "Thumbnail of a page featuring a reproduction of the Gapminder demo and containing an embedded TED talk video added using a custom page template. Gapminder demo shows children per woman (x-axis), life expectancy at birth in years (y-axis), by nation, over the years (slider), and a play button that allows data to play across slider range of 1964 - 2012.",
-      "desc": "A reproduction of the famous Gapminder demo, with embedded video added using a custom page template. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/gapminder'>source code</a>)</em>"
+      "desc": "A reproduction of the famous Gapminder demo, with embedded video added using a custom page template. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/gapminder'>source code</a>)</em>"
     },
     {
       "name": "stocks",
       "url": "https://demo.bokeh.org/stocks",
       "alt": "Thumbnail image of linked plots, summary statistics, and correlations for market data. Contains two drop down selections for different investment options. Left features a scatterplot of option one's returns vs option two's returns. Below features a line plot of each individual option. Right shows basic statistics of each option and each option's returns.",
-      "desc": "Linked plots, summary statistics, and correlations for market data. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/stocks'>source code</a>)</em>"
+      "desc": "Linked plots, summary statistics, and correlations for market data. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/stocks'>source code</a>)</em>"
     },
     {
       "name": "surface3d",
       "url": "https://demo.bokeh.org/surface3d",
       "alt": "Thumbnail for surface3d example. Axes are rotated slightly and shown with perspective. A 3D surface is plotted, and colored with a heat map corresponding to z axis value.",
-      "desc": "An updating 3d plot that demonstrates using Bokeh custom extensions to wrap third-party JavaScript libraries. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/surface3d'>source code</a>)</em>"
+      "desc": "An updating 3d plot that demonstrates using Bokeh custom extensions to wrap third-party JavaScript libraries. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/surface3d'>source code</a>)</em>"
     },
     {
       "name": "export_csv",
       "url": "https://demo.bokeh.org/export_csv",
       "alt": "Thumbnail for export_csv example. Image shows an interface for filtering data with a slider widget, and writing the results by clicking a button.",
-      "desc": "Link sliders filter a data table that can be saved as a CSV. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/main/examples/server/app/export_csv'>source code</a>)</em>"
+      "desc": "Link sliders filter a data table that can be saved as a CSV. <em>(<a target='_blank' href='https://github.com/bokeh/bokeh/blob/-/examples/server/app/export_csv'>source code</a>)</em>"
     }
   ]
 }

--- a/docs/bokeh/source/docs/gallery.rst
+++ b/docs/bokeh/source/docs/gallery.rst
@@ -53,7 +53,7 @@ code and interact with a live plot.
 
     .. tab-item:: Interaction
 
-        Bokeh has many interative tools and widgets. Only a subset have
+        Bokeh has many interactive tools and widgets. Only a subset have
         thumbnails here. For more information see the :ref:`ug_interaction`
         chapter of the users guide.
 

--- a/examples/server/app/README.md
+++ b/examples/server/app/README.md
@@ -16,85 +16,85 @@ The demos container here are:
 
   <tr><td colspan="2">clustering</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/clustering"><img src="https://docs.bokeh.org/static/clustering_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/clustering"><img src="https://docs.bokeh.org/static/clustering_t.png" width=400></a></td>
     <td>Demonstrates different <a href=http://scikit-learn.org/stable>scikit-learn</a> clustering algorithms on a few different data sets.</td>
   </tr>
 
   <tr><td colspan="2">contour_animated</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/contour_animated.py"><img src="https://docs.bokeh.org/static/contour_animated_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/contour_animated.py"><img src="https://docs.bokeh.org/static/contour_animated_t.png" width=400></a></td>
     <td>Using a Python callback to animate a contour plot.</td>
   </tr>
 
   <tr><td colspan="2">crossfilter</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/crossfilter"><img src="https://docs.bokeh.org/static/crossfilter_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/crossfilter"><img src="https://docs.bokeh.org/static/crossfilter_t.png" width=400></a></td>
     <td>Explore the "autompg" data set by selecting and highlighting different dimensions</td>
   </tr>
 
   <tr><td colspan="2">dash</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/dash"><img src="https://docs.bokeh.org/static/dash_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/dash"><img src="https://docs.bokeh.org/static/dash_t.png" width=400></a></td>
     <td>Demonstrates use of custom Bootstrap template with a Bokeh application</td>
   </tr>
 
   <tr><td colspan="2">export_csv</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/export_csv"><img src="https://docs.bokeh.org/static/export_csv_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/export_csv"><img src="https://docs.bokeh.org/static/export_csv_t.png" width=400></a></td>
     <td>Query a data table and save the results to a CSV file</td>
   </tr>
 
   <tr><td colspan="2">fourier_animated</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/fourier_animated.py"><img src="https://docs.bokeh.org/static/fourier_animated_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/fourier_animated.py"><img src="https://docs.bokeh.org/static/fourier_animated_t.png" width=400></a></td>
     <td>A continuously updating demonstration of Fourier synthesis using periodic callbacks</td>
   </tr>
 
   <tr><td colspan="2">gapminder</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/gapminder"><img src="https://docs.bokeh.org/static/gapminder_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/gapminder"><img src="https://docs.bokeh.org/static/gapminder_t.png" width=400></a></td>
     <td>A reproduction of the famous Gapminder demo, with embedded video added using a custom page template</td>
   </tr>
 
   <tr><td colspan="2">movies</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/movies"><img src="https://docs.bokeh.org/static/movies_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/movies"><img src="https://docs.bokeh.org/static/movies_t.png" width=400></a></td>
     <td>An interactive query tool for a set of IMDB data</td>
   </tr>
 
   <tr><td colspan="2">ohlc</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/ohlc"><img src="https://docs.bokeh.org/static/ohlc_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/ohlc"><img src="https://docs.bokeh.org/static/ohlc_t.png" width=400></a></td>
     <td>A simulated streaming <a href=https://en.wikipedia.org/wiki/Open-high-low-close_chart>OHLC chart</a> with <a href=https://en.wikipedia.org/wiki/MACD>MACD indicator</a> and selectable moving averages using periodic callbacks and the efficient streaming API</td>
   </tr>
 
   <tr><td colspan="2">selection_histogram</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/selection_histogram.py"><img src="https://docs.bokeh.org/static/selection_histogram_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/selection_histogram.py"><img src="https://docs.bokeh.org/static/selection_histogram_t.png" width=400></a></td>
     <td>Shows axis histograms for selected <em>and</em> unselected points in a scatter plot</td>
   </tr>
 
   <tr><td colspan="2">sliders</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/sliders.py"><img src="https://docs.bokeh.org/static/sliders_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/sliders.py"><img src="https://docs.bokeh.org/static/sliders_t.png" width=400></a></td>
     <td>A basic demo that has sliders for controlling a plotted trigonometric function</td>
   </tr>
 
   <tr><td colspan="2">spectrogram</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/spectrogram"><img src="https://docs.bokeh.org/static/spectrogram_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/spectrogram"><img src="https://docs.bokeh.org/static/spectrogram_t.png" width=400></a></td>
     <td>A live audio spectrogram that connects NumPy to interactive web visualizations</td>
   </tr>
 
   <tr><td colspan="2">stocks</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/stocks"><img src="https://docs.bokeh.org/static/stocks_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/stocks"><img src="https://docs.bokeh.org/static/stocks_t.png" width=400></a></td>
     <td>Linked plots, summary statistics, and correlations for market data </td>
   </tr>
 
   <tr><td colspan="2">surface3d</td></tr>
   <tr>
-    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/surface3d"><img src="https://docs.bokeh.org/static/surface3d_t.png" width=400></img></a></td>
+    <td><a href="https://github.com/bokeh/bokeh/blob/-/examples/server/app/surface3d"><img src="https://docs.bokeh.org/static/surface3d_t.png" width=400></a></td>
     <td> An updating 3d plot that demonstrates using Bokeh custom extensions to wrap third-party JavaScript libraries</td>
   </tr>
 

--- a/examples/server/app/clustering/README.md
+++ b/examples/server/app/clustering/README.md
@@ -19,7 +19,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show clustering

--- a/examples/server/app/crossfilter/README.md
+++ b/examples/server/app/crossfilter/README.md
@@ -20,7 +20,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show crossfilter

--- a/examples/server/app/dash/README.md
+++ b/examples/server/app/dash/README.md
@@ -11,7 +11,7 @@ No additional packages or steps are required to run this example.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command
 
     bokeh serve --show dash

--- a/examples/server/app/export_csv/README.md
+++ b/examples/server/app/export_csv/README.md
@@ -19,7 +19,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show export_csv

--- a/examples/server/app/faces/README.md
+++ b/examples/server/app/faces/README.md
@@ -15,7 +15,7 @@ install OpenCV using conda, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show faces

--- a/examples/server/app/gapminder/README.md
+++ b/examples/server/app/gapminder/README.md
@@ -18,7 +18,7 @@ directory.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show gapminder

--- a/examples/server/app/movies/README.md
+++ b/examples/server/app/movies/README.md
@@ -28,7 +28,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app), and
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app), and
 execute the command:
 
     bokeh serve --show movies

--- a/examples/server/app/ohlc/README.md
+++ b/examples/server/app/ohlc/README.md
@@ -12,7 +12,7 @@ No additional packages or steps are required to run this example.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show ohlc

--- a/examples/server/app/simple_hdf5/README.md
+++ b/examples/server/app/simple_hdf5/README.md
@@ -25,7 +25,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show simple_hdf5

--- a/examples/server/app/spectrogram/README.md
+++ b/examples/server/app/spectrogram/README.md
@@ -27,7 +27,7 @@ If pyaudio is not installed, this example will use simulated audio data.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show spectrogram

--- a/examples/server/app/surface3d/README.md
+++ b/examples/server/app/surface3d/README.md
@@ -13,7 +13,7 @@ No additional packages or steps are required to run this example.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show surface3d

--- a/examples/server/app/weather/README.md
+++ b/examples/server/app/weather/README.md
@@ -23,7 +23,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/master/examples/app),
+[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show weather

--- a/src/bokeh/sphinxext/bokeh_gallery.py
+++ b/src/bokeh/sphinxext/bokeh_gallery.py
@@ -143,7 +143,7 @@ def config_inited_handler(app, config):
         if detail_file_path in extras:
             extras.remove(detail_file_path)
 
-        # if the gallery detail file is newer than the gallery file, assume it is up to date
+        # if the gallery detail file is newer than the gallery file, assume it is up-to-date
         if exists(detail_file_path) and getmtime(detail_file_path) > gallery_file_mtime:
             continue
 


### PR DESCRIPTION
The main goal of this PR is to update some references to the github respository. They should always point to the default branch.
I removes `blob/main` and `tree/master` with `blob/-`. I also corrected some typos.
