### PR TITLE
update path in readme for server examples 

### DIFF
--- a/examples/server/app/clustering/README.md
+++ b/examples/server/app/clustering/README.md
@@ -19,7 +19,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show clustering

--- a/examples/server/app/crossfilter/README.md
+++ b/examples/server/app/crossfilter/README.md
@@ -20,7 +20,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show crossfilter

--- a/examples/server/app/dash/README.md
+++ b/examples/server/app/dash/README.md
@@ -11,7 +11,7 @@ No additional packages or steps are required to run this example.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command
 
     bokeh serve --show dash

--- a/examples/server/app/export_csv/README.md
+++ b/examples/server/app/export_csv/README.md
@@ -19,7 +19,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show export_csv

--- a/examples/server/app/faces/README.md
+++ b/examples/server/app/faces/README.md
@@ -15,7 +15,7 @@ install OpenCV using conda, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show faces

--- a/examples/server/app/gapminder/README.md
+++ b/examples/server/app/gapminder/README.md
@@ -18,7 +18,7 @@ directory.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show gapminder

--- a/examples/server/app/movies/README.md
+++ b/examples/server/app/movies/README.md
@@ -28,7 +28,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app), and
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app), and
 execute the command:
 
     bokeh serve --show movies

--- a/examples/server/app/ohlc/README.md
+++ b/examples/server/app/ohlc/README.md
@@ -12,7 +12,7 @@ No additional packages or steps are required to run this example.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show ohlc

--- a/examples/server/app/simple_hdf5/README.md
+++ b/examples/server/app/simple_hdf5/README.md
@@ -25,7 +25,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show simple_hdf5

--- a/examples/server/app/spectrogram/README.md
+++ b/examples/server/app/spectrogram/README.md
@@ -27,7 +27,7 @@ If pyaudio is not installed, this example will use simulated audio data.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show spectrogram

--- a/examples/server/app/stocks/README.md
+++ b/examples/server/app/stocks/README.md
@@ -7,7 +7,7 @@ Create a simple stocks correlation dashboard.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/tree/branch-3.0/examples/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show stocks

--- a/examples/server/app/surface3d/README.md
+++ b/examples/server/app/surface3d/README.md
@@ -13,7 +13,7 @@ No additional packages or steps are required to run this example.
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show surface3d

--- a/examples/server/app/weather/README.md
+++ b/examples/server/app/weather/README.md
@@ -23,7 +23,7 @@ To install using pip, execute the command:
 ## Running
 
 To view the app directly from a Bokeh server, navigate to the parent directory
-[`examples/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
+[`examples/server/app`](https://github.com/bokeh/bokeh/blob/-/examples/server/app),
 and execute the command:
 
     bokeh serve --show weather


### PR DESCRIPTION
I merged #13926 a bit to early. Here I correct the path `examples/app` to  `examples/server/app` for the server examples and I remove a `tree/branch-3.0` and replace it with `blob/-`