### PR TITLE
Add support for user defined server-sent events

### DIFF
--- a/bokehjs/src/lib/models/widgets/file_input.ts
+++ b/bokehjs/src/lib/models/widgets/file_input.ts
@@ -1,7 +1,6 @@
-import {InputWidget, InputWidgetView} from "./input_widget"
+import {InputWidget, InputWidgetView, ClearInput} from "./input_widget"
 import type {StyleSheetLike} from "core/dom"
 import {input} from "core/dom"
-import {ClearInput} from "core/bokeh_events"
 import {isString} from "core/util/types"
 import * as p from "core/properties"
 import * as inputs from "styles/widgets/inputs.css"

--- a/bokehjs/src/lib/models/widgets/input_widget.ts
+++ b/bokehjs/src/lib/models/widgets/input_widget.ts
@@ -10,11 +10,25 @@ import type {StyleSheetLike} from "core/dom"
 import {div, label} from "core/dom"
 import {View} from "core/view"
 import type * as p from "core/properties"
+import {server_event, ModelEvent} from "core/bokeh_events"
 
 import inputs_css, * as inputs from "styles/widgets/inputs.css"
 import icons_css from "styles/icons.css"
 
 export type HTMLInputElementLike = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+
+@server_event("clear_input")
+export class ClearInput extends ModelEvent {
+  constructor(readonly model: InputWidget) {
+    super()
+    this.origin = model
+  }
+
+  static override from_values(values: object): ClearInput {
+    const {model} = values as {model: InputWidget}
+    return new ClearInput(model)
+  }
+}
 
 export abstract class InputWidgetView extends ControlView {
   declare model: InputWidget

--- a/bokehjs/test/unit/core/bokeh_events.ts
+++ b/bokehjs/test/unit/core/bokeh_events.ts
@@ -1,0 +1,63 @@
+import {expect, expect_instanceof} from "assertions"
+import {display} from "../_util"
+
+import {Serializer} from "@bokehjs/core/serialization"
+import type {BokehEvent} from "@bokehjs/core/bokeh_events"
+import {server_event, UserEvent} from "@bokehjs/core/bokeh_events"
+import type {Model} from "@bokehjs/model"
+import type {MessageSent, Patch} from "@bokehjs/document"
+import {TextInput} from "@bokehjs/models/widgets"
+
+@server_event("some_library.do_something")
+class DoSomething extends UserEvent {
+  constructor(override readonly values: {target: Model, action: "do_this" | "do_that"}) {
+    super(values)
+  }
+}
+
+describe("BokehEvent", () => {
+  it("should support user defined events", async () => {
+    const collected_events: BokehEvent[] = []
+
+    const widget = new TextInput()
+    widget.on_event(DoSomething, (event) => {
+      collected_events.push(event)
+    })
+
+    const {view, doc} = await display(widget, null)
+
+    const new_event = new DoSomething({target: widget, action: "do_that"})
+
+    const serializer = new Serializer({references: new Map([[widget, widget.ref()]])})
+    const new_rep = serializer.encode(new_event)
+    expect(new_rep).to.be.equal({
+      type: "event",
+      name: "some_library.do_something",
+      values: {
+        type: "map",
+        entries: [
+          ["model", null],
+          ["target", widget.ref()],
+          ["action", "do_that"],
+        ],
+      },
+    })
+
+    const msg: MessageSent = {
+      kind: "MessageSent",
+      msg_type: "bokeh_event",
+      msg_data: new_rep,
+    }
+    const patch: Patch = {events: [msg]}
+    doc.apply_json_patch(patch)
+    await view.ready
+
+    expect(collected_events.length).to.be.equal(1)
+
+    const [event] = collected_events
+    expect_instanceof(event, DoSomething)
+
+    expect(event.origin).to.be.null
+    expect(event.values).to.be.equal({target: widget, action: "do_that"})
+  })
+})

--- a/src/bokeh/events.py
+++ b/src/bokeh/events.py
@@ -84,7 +84,7 @@ if TYPE_CHECKING:
     from .models.annotations import Legend, LegendItem
     from .models.plots import Plot
     from .models.widgets.buttons import AbstractButton
-    from .models.widgets.inputs import InputWidget, TextInput
+    from .models.widgets.inputs import TextInput
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -92,7 +92,6 @@ if TYPE_CHECKING:
 
 __all__ = (
     'ButtonClick',
-    'ClearInput',
     'ConnectionLost',
     'DocumentEvent',
     'DocumentReady',
@@ -324,19 +323,6 @@ class ValueSubmit(ModelEvent):
             raise ValueError(f"{clsname} event only applies to text input models")
         super().__init__(model=model)
         self.value = value
-
-# TODO mark this as a one way event from server to client
-class ClearInput(ModelEvent):
-    '''
-
-    '''
-    event_name = 'clear_input'
-
-    def __init__(self, model: InputWidget) -> None:
-        from .models.widgets import InputWidget
-        if not isinstance(model, InputWidget):
-            raise ValueError(f"{self.__class__.__name__} event only applies to input models")
-        super().__init__(model=model)
 
 class PlotEvent(ModelEvent):
     ''' The base class for all events applicable to Plot models.

--- a/src/bokeh/models/widgets/inputs.py
+++ b/src/bokeh/models/widgets/inputs.py
@@ -51,7 +51,7 @@ from ...core.properties import (
     String,
     Tuple,
 )
-from ...events import ClearInput
+from ...events import ModelEvent
 from ...util.deprecation import deprecated
 from ..dom import HTML
 from ..formatters import TickFormatter
@@ -85,7 +85,6 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-
 @abstract
 class InputWidget(Widget):
     ''' Abstract base class for input widgets.
@@ -107,6 +106,22 @@ class InputWidget(Widget):
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+# TODO mark this as a one way event from server to client
+class ClearInput(ModelEvent):
+    """
+    Notifies the input widget that its input/value needs to be cleared.
+
+    This is specially useful for widgets whose value can't be simply cleared by
+    assigning to ``value`` (or equivalent) property.
+
+    """
+    event_name = "clear_input"
+
+    def __init__(self, model: InputWidget) -> None:
+        if not isinstance(model, InputWidget):
+            raise ValueError(f"{self.__class__.__name__} event only applies to input models, i.e. instances of bokeh.models.widgets.InputWidget")
+        super().__init__(model=model)
 
 class FileInput(InputWidget):
     ''' Present a file-chooser dialog to users and return the contents of the

--- a/tests/unit/bokeh/test_events.py
+++ b/tests/unit/bokeh/test_events.py
@@ -29,6 +29,7 @@ from bokeh.models import (
     Plot,
     TextInput,
 )
+from bokeh.models.widgets.inputs import ClearInput
 
 # Module under test
 from bokeh import events # isort:skip
@@ -71,7 +72,7 @@ def test_common_decode_json() -> None:
             model = Legend(items=[legend_item])
         elif issubclass(event_cls, events.ValueSubmit):
             model = TextInput()
-        elif issubclass(event_cls, events.ClearInput):
+        elif issubclass(event_cls, ClearInput):
             model = FileInput()
         else:
             model = Plot()
@@ -408,7 +409,7 @@ def test_FileInput_clear() -> None:
 
     assert isinstance(event, MessageSentEvent)
     assert event.msg_type == "bokeh_event"
-    assert isinstance(event.msg_data, events.ClearInput)
+    assert isinstance(event.msg_data, ClearInput)
     assert event.msg_data.model == file_input
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This allows users to define their own server-sent events, like this:

```ts
import {server_event, UserEvent} from "@bokehjs/core/bokeh_events"

@server_event("some_library.do_something")
class DoSomething extends UserEvent {
  constructor(override readonly values: {target: Model, action: "do_this" | "do_that"}) {
    super(values)
  }
}
```

fixes #13935