### PR TITLE
correct version string to match dev name from switcher.json

### DIFF
--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -38,7 +38,7 @@ dependencies:
   - pip:
     # docs
     - bokeh_sampledata
-    - pydata_sphinx_theme==0.15.2
+    - pydata_sphinx_theme
     - sphinx >= 7.1.0
     - sphinx-copybutton
     - sphinx-design

--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -7,6 +7,7 @@
 
 # Standard library imports
 import os
+import re
 from datetime import date
 
 from sphinx.util import logging
@@ -175,7 +176,7 @@ if "BOKEH_DOCS_VERSION" in os.environ:
 else:
     json_url = "../switcher.json"
 if "dev" in version or "rc" in version:
-    version_match = f"dev-{version[:3]}"
+    version_match = "dev-" + re.match(r"\d\.\d+", version).group()
 else:
     version_match = version
 

--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -174,6 +174,10 @@ if "BOKEH_DOCS_VERSION" in os.environ:
     json_url = "https://docs.bokeh.org/switcher.json"
 else:
     json_url = "../switcher.json"
+if "dev" in version or "rc" in version:
+    version_match = f"dev-{version[:3]}"
+else:
+    version_match = version
 
 # html_logo configured in navbar-logo.html
 
@@ -196,7 +200,7 @@ html_theme_options = {
     "show_toc_level": 1,
     "switcher": {
         "json_url": json_url,
-        "version_match": version,
+        "version_match": version_match,
     },
     "use_edit_page_button": False,
     "show_version_warning_banner": True,

--- a/tests/unit/bokeh/core/property/test_validation__property.py
+++ b/tests/unit/bokeh/core/property/test_validation__property.py
@@ -131,7 +131,7 @@ class TestValidateDetailDefault:
         p = Bool()
         with pytest.raises(ValueError) as e:
             p.validate("junk")
-        assert matches(str(e.value), r"expected a value of type bool or bool_, got junk of type str")
+        assert matches(str(e.value), r"expected a value of type bool or bool_?, got junk of type str")
     def test_Complex(self) -> None:
         p = Complex()
         with pytest.raises(ValueError) as e:


### PR DESCRIPTION
This PR removes the string `"Choose version"` from the switcher field for development docs and shows the `"name"` field from the `switcher.json`.

https://github.com/bokeh/bokeh/blob/c93d8083c93a43781b6acaf0ccad165faef8ea5b/docs/bokeh/switcher.json#L25-L27

To have a presice string for "dev" or "rc" versions, the `switcher.json` has to be updated and uploaded for each new developemnt stage.

With the latest version of the `switcher.json` the results on my local build looks like below.

![Switcher with DEV name](https://github.com/bokeh/bokeh/assets/68053396/c92c0f64-ae9c-44d1-a65c-a2c920784937)

- [x] issues: adresses #13477

