### PR TITLE
add release to project configuration

### DIFF
--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -25,8 +25,7 @@ copyright = f"©{year} {author}."
 
 project = "Bokeh"
 
-version = settings.docs_version() or __version__
-release = version
+release = version = settings.docs_version() or __version__
 
 # -- Sphinx configuration -----------------------------------------------------
 

--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -26,6 +26,7 @@ copyright = f"©{year} {author}."
 project = "Bokeh"
 
 version = settings.docs_version() or __version__
+release = version
 
 # -- Sphinx configuration -----------------------------------------------------
 


### PR DESCRIPTION
In this PR the missing value for the [release variable](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-release) is added to the `conf.py`. This sets DOCUMENTATION_OPTIONS.VERSION and enables a version check by the pydata-sphinx-theme version banner.

This is the local result.

![grafik](https://github.com/bokeh/bokeh/assets/68053396/6b8c0575-1628-4d82-b093-9db8d15b1109)

- [ ] issues: fixes #13948

To fix the version banner for https://docs.bokeh.org/en/latest/index.html no new release process is needed. It is enough to update the VERSION to '2.4.2' in https://docs.bokeh.org/en/latest/_static/documentation_options.js?v=5929fcd5. 

The version banner can inform about the development version for https://docs.bokeh.org/en/dev-3.5/index.html with an update of https://docs.bokeh.org/en/dev-3.5/_static/documentation_options.js?v=5929fcd5 of VERSION to '3.5.0'
 or '3.5.0.rc1'.