### PR TITLE
Implement data inheritance in `ImageBase._set_data()`

### DIFF
--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -317,7 +317,11 @@ export abstract class GlyphView extends DOMComponentView {
     })
   }
 
-  protected _can_inherit_from<T>(prop: p.Property<T>, base: this): boolean {
+  protected _can_inherit_from<T>(prop: p.Property<T>, base: this | null): boolean {
+    if (base == null) {
+      return false
+    }
+
     const base_prop = base.model.property(prop.attr)
 
     const value = prop.get_value()

--- a/bokehjs/src/lib/models/glyphs/image.ts
+++ b/bokehjs/src/lib/models/glyphs/image.ts
@@ -36,6 +36,11 @@ export class ImageView extends ImageBaseView {
     }
   }
 
+  protected override get _can_inherit_image_data(): boolean {
+    return super._can_inherit_image_data &&
+      this._can_inherit_from(this.model.properties.color_mapper, this.base)
+  }
+
   protected _flat_img_to_buf8(img: NDArrayType<number>): Uint8ClampedArray {
     const cmap = this.model.color_mapper.rgba_mapper
     return cmap.v_compute(img)

--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -114,8 +114,8 @@ export abstract class ImageBaseView extends XYGlyphView {
     if (!this._can_inherit_image_data) {
       if (typeof this.image_data === "undefined" || this.image_data.length != n) {
         this._define_attr<ImageBase.Data>("image_data", new Array(n).fill(null))
-        this._define_attr<ImageBase.Data>("_width", new Uint32Array(n))
-        this._define_attr<ImageBase.Data>("_height", new Uint32Array(n))
+        this._define_attr<ImageBase.Data>("image_width", new Uint32Array(n))
+        this._define_attr<ImageBase.Data>("image_height", new Uint32Array(n))
       }
 
       const {image_dimension} = this
@@ -129,16 +129,16 @@ export abstract class ImageBaseView extends XYGlyphView {
         assert(img.dimension == image_dimension, `expected a ${image_dimension}D array, not ${img.dimension}D`)
 
         const [height, width] = img.shape
-        this._width[i] = width
-        this._height[i] = height
+        this.image_width[i] = width
+        this.image_height[i] = height
 
         const buf8 = this._flat_img_to_buf8(img)
         this._set_image_data_from_buffer(i, buf8)
       }
     } else {
       this._inherit_attr<ImageBase.Data>("image_data")
-      this._inherit_attr<ImageBase.Data>("_width")
-      this._inherit_attr<ImageBase.Data>("_height")
+      this._inherit_attr<ImageBase.Data>("image_width")
+      this._inherit_attr<ImageBase.Data>("image_height")
     }
   }
 
@@ -171,13 +171,13 @@ export abstract class ImageBaseView extends XYGlyphView {
   protected _get_or_create_canvas(i: number): HTMLCanvasElement {
     assert(this.image_data != null)
     const image_data_i = this.image_data[i]
-    if (image_data_i != null && image_data_i.width  == this._width[i]
-                             && image_data_i.height == this._height[i]) {
+    if (image_data_i != null && image_data_i.width  == this.image_width[i]
+                             && image_data_i.height == this.image_height[i]) {
       return image_data_i
     } else {
       const canvas = document.createElement("canvas")
-      canvas.width = this._width[i]
-      canvas.height = this._height[i]
+      canvas.width = this.image_width[i]
+      canvas.height = this.image_height[i]
       return canvas
     }
   }
@@ -186,7 +186,7 @@ export abstract class ImageBaseView extends XYGlyphView {
     assert(this.image_data != null)
     const canvas = this._get_or_create_canvas(i)
     const ctx = canvas.getContext("2d")!
-    const image_data = ctx.getImageData(0, 0, this._width[i], this._height[i])
+    const image_data = ctx.getImageData(0, 0, this.image_width[i], this.image_height[i])
     image_data.data.set(buf8)
     ctx.putImageData(image_data, 0, 0)
     this.image_data[i] = canvas
@@ -220,8 +220,8 @@ export abstract class ImageBaseView extends XYGlyphView {
 
   protected _image_index(index: number, x: number, y: number): ImageIndex {
     const [l, r, t, b] = this._lrtb(index)
-    const width = this._width[index]
-    const height = this._height[index]
+    const width = this.image_width[index]
+    const height = this.image_height[index]
     const dx = (r - l) / width
     const dy = (t - b) / height
     const i = Math.floor((x - l) / dx)
@@ -270,11 +270,11 @@ export namespace ImageBase {
     image_data: Arrayable<ImageData> | undefined
     inherited_image_data: boolean
 
-    _width: Uint32Array
-    inherited__width: boolean
+    image_width: Uint32Array
+    inherited_image_width: boolean
 
-    _height: Uint32Array
-    inherited__height: boolean
+    image_height: Uint32Array
+    inherited_image_height: boolean
   }
 }
 

--- a/bokehjs/src/lib/models/glyphs/image_stack.ts
+++ b/bokehjs/src/lib/models/glyphs/image_stack.ts
@@ -39,6 +39,11 @@ export class ImageStackView extends ImageBaseView {
     }
   }
 
+  protected override get _can_inherit_image_data(): boolean {
+    return super._can_inherit_image_data &&
+      this._can_inherit_from(this.model.properties.color_mapper, this.base)
+  }
+
   protected _flat_img_to_buf8(img: NDArrayType<number>): Uint8ClampedArray {
     const cmap = this.model.color_mapper.rgba_mapper
     return cmap.v_compute(img)

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -18,8 +18,10 @@ import {
   CopyTool,
   CustomJS,
   DataRange1d,
+  EqHistColorMapper,
   GlyphRenderer,
   HoverTool,
+  Image,
   IndexFilter,
   Legend,
   LegendItem,
@@ -68,13 +70,14 @@ import type {DocJson, DocumentEvent} from "@bokehjs/document"
 import {Document, ModelChangedEvent, MessageSentEvent} from "@bokehjs/document"
 import {DocumentReady, RangesUpdate} from "@bokehjs/core/bokeh_events"
 import {gridplot} from "@bokehjs/api/gridplot"
-import {Spectral11, Viridis256} from "@bokehjs/api/palettes"
+import {Spectral11, Viridis11, Viridis256} from "@bokehjs/api/palettes"
 import {defer, paint, poll} from "@bokehjs/core/util/defer"
 import type {Field} from "@bokehjs/core/vectorization"
 
 import {UIElement, UIElementView} from "@bokehjs/models/ui/ui_element"
 import type {GlyphRendererView} from "@bokehjs/models/renderers/glyph_renderer"
 import {ImageURLView} from "@bokehjs/models/glyphs/image_url"
+import {ImageView} from "@bokehjs/models/glyphs/image"
 import {CopyToolView} from "@bokehjs/models/tools/actions/copy_tool"
 import {TableDataProvider, DataTable} from "@bokehjs/models/widgets/tables/data_table"
 import {TableColumn} from "@bokehjs/models/widgets/tables/table_column"
@@ -1550,7 +1553,7 @@ describe("Bug", () => {
   })
 
   describe("in issue #13831", () => {
-    it("allow addition of new indices to selection by default", async () => {
+    it("allows addition of new indices to selection by default", async () => {
       const tap_tool = new TapTool()
       const p = fig([200, 200], {tools: [tap_tool]})
       const cr = p.circle({x: [0, 1, 2, 3], y: [0, 1, 2, 3], radius: [0.5, 0.75, 1.0, 1.25], color: ["red", "green", "blue", "yellow"], alpha: 0.8})
@@ -1598,6 +1601,49 @@ describe("Bug", () => {
 
       await tap_at(2.5, 2.5) // deselect blue and select yellow
       expect(ds.selected.indices).to.be.equal([3])
+    })
+  })
+
+  describe("in issue #13951", () => {
+    it("doesn't allow inheriting image data in Image-like glyphs", async () => {
+      const p = fig([400, 400])
+
+      const color_mapper = new EqHistColorMapper({palette: Spectral11})
+      const gr = p.image({image: [scalar_image()], x: 0, y: 0, dw: 10, dh: 10, color_mapper})
+
+      const nonselection_color_mapper = new EqHistColorMapper({palette: Viridis11})
+      gr.nonselection_glyph = new Image({x: 0, y: 0, dw: 10, dh: 10, color_mapper: nonselection_color_mapper})
+
+      const {view} = await display(p)
+      const grv = view.views.get_one(gr)
+
+      expect_instanceof(grv.glyph, ImageView)
+      expect_instanceof(grv.selection_glyph, ImageView)
+      expect_instanceof(grv.nonselection_glyph, ImageView)
+      expect_instanceof(grv.decimated_glyph, ImageView)
+      expect_instanceof(grv.hover_glyph, ImageView)
+      expect_instanceof(grv.muted_glyph, ImageView)
+
+      expect(grv.glyph.inherited_image_data).to.be.false
+      expect(grv.selection_glyph.inherited_image_data).to.be.true
+      expect(grv.nonselection_glyph.inherited_image_data).to.be.false
+      expect(grv.decimated_glyph.inherited_image_data).to.be.true
+      expect(grv.hover_glyph.inherited_image_data).to.be.true
+      expect(grv.muted_glyph.inherited_image_data).to.be.true
+
+      expect(grv.glyph.inherited_image_width).to.be.false
+      expect(grv.selection_glyph.inherited_image_width).to.be.true
+      expect(grv.nonselection_glyph.inherited_image_width).to.be.false
+      expect(grv.decimated_glyph.inherited_image_width).to.be.true
+      expect(grv.hover_glyph.inherited_image_width).to.be.true
+      expect(grv.muted_glyph.inherited_image_width).to.be.true
+
+      expect(grv.glyph.inherited_image_height).to.be.false
+      expect(grv.selection_glyph.inherited_image_height).to.be.true
+      expect(grv.nonselection_glyph.inherited_image_height).to.be.false
+      expect(grv.decimated_glyph.inherited_image_height).to.be.true
+      expect(grv.hover_glyph.inherited_image_height).to.be.true
+      expect(grv.muted_glyph.inherited_image_height).to.be.true
     })
   })
 })


### PR DESCRIPTION
This implements data inheritance in `Image`-like glyphs (`Image`, `ImageRGBA` and `ImageStack`). This was overlooked in PR #13554 and any previous follow-ups to that PR.

I suppose this could be backported to 3.4, though 3.4.2 was just released, so we would have to do that as a part of 3.4.3.

fixes #13951