### PR TITLE
add ruff rules for numpy

### DIFF
--- a/examples/server/app/selection_histogram.py
+++ b/examples/server/app/selection_histogram.py
@@ -85,7 +85,7 @@ def update(attr, old, new):
         hhist1, hhist2 = hzeros, hzeros
         vhist1, vhist2 = vzeros, vzeros
     else:
-        neg_inds = np.ones_like(x, dtype=np.bool)
+        neg_inds = np.ones_like(x, dtype=bool)
         neg_inds[inds] = False
         hhist1, _ = np.histogram(x[inds], bins=hedges)
         vhist1, _ = np.histogram(y[inds], bins=vedges)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ lint.exclude = [
     'node_modules',
 ]
 lint.per-file-ignores = {"__init__.py" = ["F403"]}
-lint.select = ["B", "COM", "E", "F", "RUF", "TID", "UP", "W"]
+lint.select = ["B", "COM", "E", "F", "NPY", "RUF", "TID", "UP", "W"]
 lint.ignore = [
     'B005', # Using .strip() with multi-character strings is misleading the reader
     'B006', # Do not use mutable data structures for argument defaults
@@ -167,6 +167,7 @@ lint.ignore = [
     'E702', # Multiple statements on one line (semicolon)
     'E731', # Do not assign a lambda expression, use a def
     'E741', # Ambiguous variable name: I
+    'NPY002', # Replace legacy np.random.{method_name} call with np.random.Generator
     'UP035',  # Import from `collections.abc` instead: `Iterator`
     'RUF012', # Mutable class attributes should be annotated with `typing.ClassVar`
     'TID252', # Prefer absolute imports over relative imports from parent modules


### PR DESCRIPTION
This PR should finish the task for the Numpy 2.0 migration. Numpy offers [ruff-rules](https://docs.astral.sh/ruff/rules/#numpy-specific-rules-npy) and the most important one to migrate to Numpy 2.0 is [`NPY201`](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html). Running ruff resulted in one fixed file.

- [x] issues: fixes #13835

Since the one failling test mentioned in https://github.com/bokeh/bokeh/issues/13835#issuecomment-2077730436 was solved earlier in https://github.com/bokeh/bokeh/pull/13939, I think we can close the initial issue.