### PR TITLE
Add `size` to Scatter

### DIFF
--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -14,7 +14,7 @@ import type {Color} from "core/types"
 import {Indices} from "core/types"
 import type * as p from "core/properties"
 import {filter} from "core/util/arrayable"
-import {extend, clone, keys} from "core/util/object"
+import {extend, clone} from "core/util/object"
 import type {HitTestResult} from "core/hittest"
 import type {Geometry} from "core/geometry"
 import type {SelectionManager} from "core/selection_manager"
@@ -118,22 +118,7 @@ export class GlyphRendererView extends DataRendererView {
 
     function glyph_from_mode(defaults: Defaults, glyph?: Glyph | "auto" | null): typeof base_glyph {
       if (glyph instanceof Glyph) {
-        const attrs: any = clone(glyph_attrs)
-        const attrs_keys: any = keys(attrs)
-        const extra_glyph_attrs: any = clone({...glyph.attributes})
-        const extra_glyph_keys: any = keys(extra_glyph_attrs)
-        const default_glyph_attrs: any = clone({...new (glyph.constructor as any)().attributes})
-        for (const key of attrs_keys) {
-          if (key in extra_glyph_attrs === false) {
-            delete attrs[key]
-          }
-        }
-        for (const key of extra_glyph_keys) {
-          if (JSON.stringify(extra_glyph_attrs[key]) === JSON.stringify(default_glyph_attrs[key])) {
-            delete extra_glyph_attrs[key]
-          }
-        }
-        return new (glyph.constructor as any)({...attrs, ...extra_glyph_attrs})
+        return glyph
       } else if (glyph == "auto") {
         return mk_glyph(defaults)
       }

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -14,7 +14,7 @@ import type {Color} from "core/types"
 import {Indices} from "core/types"
 import type * as p from "core/properties"
 import {filter} from "core/util/arrayable"
-import {extend, clone} from "core/util/object"
+import {extend, clone, keys} from "core/util/object"
 import type {HitTestResult} from "core/hittest"
 import type {Geometry} from "core/geometry"
 import type {SelectionManager} from "core/selection_manager"
@@ -118,7 +118,22 @@ export class GlyphRendererView extends DataRendererView {
 
     function glyph_from_mode(defaults: Defaults, glyph?: Glyph | "auto" | null): typeof base_glyph {
       if (glyph instanceof Glyph) {
-        return glyph
+        const attrs: any = clone(glyph_attrs)
+        const attrs_keys: any = keys(attrs)
+        const extra_glyph_attrs: any = clone({...glyph.attributes})
+        const extra_glyph_keys: any = keys(extra_glyph_attrs)
+        const default_glyph_attrs: any = clone({...new (glyph.constructor as any)().attributes})
+        for (const key of attrs_keys) {
+          if (key in extra_glyph_attrs === false) {
+            delete attrs[key]
+          }
+        }
+        for (const key of extra_glyph_keys) {
+          if (JSON.stringify(extra_glyph_attrs[key]) === JSON.stringify(default_glyph_attrs[key])) {
+            delete extra_glyph_attrs[key]
+          }
+        }
+        return new (glyph.constructor as any)({...attrs, ...extra_glyph_attrs})
       } else if (glyph == "auto") {
         return mk_glyph(defaults)
       }

--- a/examples/advanced/extensions/parallel_plot/parallel_plot.py
+++ b/examples/advanced/extensions/parallel_plot/parallel_plot.py
@@ -3,7 +3,7 @@ import numpy as np
 from bokeh.layouts import column
 from bokeh.models import (BasicTickFormatter, ColumnDataSource,
                           CustomJSTickFormatter, Div, FixedTicker,
-                          LinearAxis, LinearColorMapper, MultiLine, Range1d)
+                          LinearAxis, LinearColorMapper, Range1d)
 from bokeh.plotting import figure
 from bokeh.sampledata.autompg import autompg_clean as df
 
@@ -34,9 +34,9 @@ def parallel_plot(df, color=None, palette=None):
     p = figure(x_range=(-1, ndims),
                y_range=(0, 1),
                width=1000,
-               tools="pan, box_zoom")
+               tools="pan,box_zoom,tap")
 
-    # Create x axis ticks from columns contained in dataframe
+    # Create x-axis ticks from columns contained in dataframe
     fixed_x_ticks = FixedTicker(
         ticks=np.arange(ndims), minor_ticks=[])
     formatter_x_ticks = CustomJSTickFormatter(
@@ -47,7 +47,7 @@ def parallel_plot(df, color=None, palette=None):
     p.yaxis.visible = False
     p.y_range.start = 0
     p.y_range.end = 1
-    p.y_range.bounds = (-0.1, 1.1) # add a little padding around y axis
+    p.y_range.bounds = (-0.1, 1.1)  # add a little padding around y-axis
     p.xgrid.visible = False
     p.ygrid.visible = False
 
@@ -67,23 +67,16 @@ def parallel_plot(df, color=None, palette=None):
         p.add_layout(LinearAxis(fixed_location=index, y_range_name=col,
                                 ticker=fixedticks, formatter=tickformatter), 'right')
 
-    # create the data renderer ( MultiLine )
-    # specify selected and non selected style
+    # create the data renderer (MultiLine)
+    # specify selected and non-selected style
     non_selected_line_style = dict(line_color='grey', line_width=0.1, line_alpha=0.5)
 
     selected_line_style = dict(line_color={'field': 'color', 'transform': cmap}, line_width=1)
 
-    parallel_renderer = p.multi_line(
-        xs="xs", ys="ys", source=data_source, **non_selected_line_style)
+    parallel_renderer = p.multi_line(xs="xs", ys="ys", source=data_source, **non_selected_line_style)
 
-    # Specify selection style
-    selected_lines = MultiLine(**selected_line_style)
-
-    # Specify non selection style
-    nonselected_lines = MultiLine(**non_selected_line_style)
-
-    parallel_renderer.selection_glyph = selected_lines
-    parallel_renderer.nonselection_glyph = nonselected_lines
+    parallel_renderer.selection_glyph = parallel_renderer.glyph.clone(**selected_line_style)
+    parallel_renderer.nonselection_glyph = parallel_renderer.glyph.clone(**non_selected_line_style)
     p.y_range.start = p.y_range.bounds[0]
     p.y_range.end = p.y_range.bounds[1]
 
@@ -106,12 +99,13 @@ def parallel_plot(df, color=None, palette=None):
     p.toolbar.active_drag = selection_tool
     return p
 
+
 if __name__ == '__main__':
     from bokeh.io import show
     from bokeh.palettes import Viridis256
     del df['origin']
     del df['mfr']
     del df['name']
-    p = parallel_plot(df=df, color=df[df.columns[0]], palette=Viridis256)
+    plot = parallel_plot(df=df, color=df[df.columns[0]], palette=Viridis256)
     div = Div(text="Select up and down column grid lines to define filters. Double click a filter to reset it.")
-    show(column(div, p))
+    show(column(div, plot))

--- a/examples/advanced/extensions/parallel_plot/parallel_plot.py
+++ b/examples/advanced/extensions/parallel_plot/parallel_plot.py
@@ -1,9 +1,8 @@
 import numpy as np
 
 from bokeh.layouts import column
-from bokeh.models import (BasicTickFormatter, ColumnDataSource,
-                          CustomJSTickFormatter, Div, FixedTicker,
-                          LinearAxis, LinearColorMapper, Range1d)
+from bokeh.models import (BasicTickFormatter, ColumnDataSource, CustomJSTickFormatter,
+                          Div, FixedTicker, LinearAxis, LinearColorMapper, Range1d)
 from bokeh.plotting import figure
 from bokeh.sampledata.autompg import autompg_clean as df
 

--- a/examples/advanced/extensions/parallel_plot/parallel_selection_tool.py
+++ b/examples/advanced/extensions/parallel_plot/parallel_selection_tool.py
@@ -6,7 +6,7 @@ class ParallelSelectionTool(BoxSelectTool):
     """ Selection tool for parallel plot
     To create a selection box, drag the selection around an axe
     When hovering a selection the box can be dragged upside-down
-    Double click on a selection to remove it
+    Doubleclick on a selection to remove it
     Escape key remove all selections
     """
 

--- a/examples/interaction/js_callbacks/customjs_for_tools.py
+++ b/examples/interaction/js_callbacks/customjs_for_tools.py
@@ -8,7 +8,7 @@ callback = CustomJS(args=dict(source=source), code="""
     const geometry = cb_obj.geometry
     const data = source.data
 
-    // quad is forgiving if left/right or top/bottom are swappeed
+    // quad is forgiving if left/right or top/bottom are swapped
     source.data = {
         left: data.left.concat([geometry.x0]),
         right: data.right.concat([geometry.x1]),
@@ -21,10 +21,15 @@ p = figure(width=400, height=400, title="Select below to draw rectangles",
            tools="box_select", x_range=(0, 1), y_range=(0, 1))
 
 # using Quad model directly to control (non)selection glyphs more carefully
-quad = Quad(left='left', right='right',top='top', bottom='bottom',
+quad = Quad(left='left', right='right', top='top', bottom='bottom',
             fill_alpha=0.3, fill_color='#009933')
 
-p.add_glyph(source, quad, selection_glyph=quad, nonselection_glyph=quad)
+p.add_glyph(
+    source,
+    quad,
+    selection_glyph=quad.clone(fill_color='blue'),
+    nonselection_glyph=quad.clone(fill_color='gray')
+)
 
 p.js_on_event(SelectionGeometry, callback)
 

--- a/examples/interaction/js_callbacks/customjs_for_tools.py
+++ b/examples/interaction/js_callbacks/customjs_for_tools.py
@@ -28,7 +28,7 @@ p.add_glyph(
     source,
     quad,
     selection_glyph=quad.clone(fill_color='blue'),
-    nonselection_glyph=quad.clone(fill_color='gray')
+    nonselection_glyph=quad.clone(fill_color='gray'),
 )
 
 p.js_on_event(SelectionGeometry, callback)

--- a/examples/models/graphs.py
+++ b/examples/models/graphs.py
@@ -58,7 +58,7 @@ plot_3.title.text = "Random Layout (EdgesAndLinkedNodes inspection policy)"
 plot_3.add_tools(HoverTool(tooltips=None))
 
 plot_4 = create_graph(
-    nx.fruchterman_reingold_layout, selection_policy=EdgesAndLinkedNodes(), scale=2, center=(0, 0), dim=2
+    nx.fruchterman_reingold_layout, selection_policy=EdgesAndLinkedNodes(), scale=2, center=(0, 0), dim=2,
 )
 plot_4.title.text = "FR Layout (EdgesAndLinkedNodes selection policy)"
 plot_4.add_tools(TapTool())
@@ -68,7 +68,7 @@ plot_5.title.text = "Circular Layout (NodesAndAdjacentNodes inspection policy)"
 plot_5.add_tools(HoverTool(tooltips=None))
 
 plot_6 = create_graph(
-    nx.fruchterman_reingold_layout, selection_policy=NodesAndAdjacentNodes(), scale=2, center=(0, 0), dim=2
+    nx.fruchterman_reingold_layout, selection_policy=NodesAndAdjacentNodes(), scale=2, center=(0, 0), dim=2,
 )
 plot_6.title.text = "FR Layout (NodesAndAdjacentNodes selection policy)"
 plot_6.add_tools(TapTool())

--- a/examples/models/graphs.py
+++ b/examples/models/graphs.py
@@ -19,19 +19,21 @@ from bokeh.plotting import from_networkx
 
 G = nx.karate_club_graph()
 
+
 def create_graph(layout_func, inspection_policy=None, selection_policy=None, **kwargs):
 
-    plot = Plot(width=400, height=400,
-                x_range=Range1d(-1.1,1.1), y_range=Range1d(-1.1,1.1))
+    plot = Plot(width=400, height=400, x_range=Range1d(-1.1, 1.1), y_range=Range1d(-1.1, 1.1))
     graph_renderer = from_networkx(G, layout_func, **kwargs)
 
-    graph_renderer.node_renderer.glyph = Scatter(size=15, fill_color=Spectral4[0])
-    graph_renderer.node_renderer.selection_glyph = Scatter(size=15, fill_color=Spectral4[2])
-    graph_renderer.node_renderer.hover_glyph = Scatter(size=15, fill_color=Spectral4[1])
+    scatter_glyph = Scatter(size=15, fill_color=Spectral4[0])
+    graph_renderer.node_renderer.glyph = scatter_glyph
+    graph_renderer.node_renderer.selection_glyph = scatter_glyph.clone(fill_color=Spectral4[2])
+    graph_renderer.node_renderer.hover_glyph = scatter_glyph.clone(fill_color=Spectral4[1])
 
-    graph_renderer.edge_renderer.glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
-    graph_renderer.edge_renderer.selection_glyph = MultiLine(line_color=Spectral4[2], line_width=5)
-    graph_renderer.edge_renderer.hover_glyph = MultiLine(line_color=Spectral4[1], line_width=5)
+    ml_glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
+    graph_renderer.edge_renderer.glyph = ml_glyph
+    graph_renderer.edge_renderer.selection_glyph = ml_glyph.clone(line_color=Spectral4[2], line_alpha=1)
+    graph_renderer.edge_renderer.hover_glyph = ml_glyph.clone(line_color=Spectral4[1], line_alpha=1)
 
     if inspection_policy is not None:
         graph_renderer.inspection_policy = inspection_policy
@@ -42,27 +44,32 @@ def create_graph(layout_func, inspection_policy=None, selection_policy=None, **k
 
     return plot
 
-plot_1 = create_graph(nx.circular_layout, inspection_policy=NodesAndLinkedEdges(), scale=1, center=(0,0))
+
+plot_1 = create_graph(nx.circular_layout, inspection_policy=NodesAndLinkedEdges(), scale=1, center=(0, 0))
 plot_1.title.text = "Circular Layout (NodesAndLinkedEdges inspection policy)"
 plot_1.add_tools(HoverTool(tooltips=None))
 
-plot_2 = create_graph(nx.spring_layout, selection_policy=NodesAndLinkedEdges(), scale=2, center=(0,0))
+plot_2 = create_graph(nx.spring_layout, selection_policy=NodesAndLinkedEdges(), scale=2, center=(0, 0))
 plot_2.title.text = "Spring Layout (NodesAndLinkedEdges selection policy)"
 plot_2.add_tools(TapTool(), BoxSelectTool())
 
-plot_3 = create_graph(nx.random_layout, inspection_policy=EdgesAndLinkedNodes(), center=(0,0))
+plot_3 = create_graph(nx.random_layout, inspection_policy=EdgesAndLinkedNodes(), center=(0, 0))
 plot_3.title.text = "Random Layout (EdgesAndLinkedNodes inspection policy)"
 plot_3.add_tools(HoverTool(tooltips=None))
 
-plot_4 = create_graph(nx.fruchterman_reingold_layout, selection_policy=EdgesAndLinkedNodes(), scale=2, center=(0,0), dim=2)
+plot_4 = create_graph(
+    nx.fruchterman_reingold_layout, selection_policy=EdgesAndLinkedNodes(), scale=2, center=(0, 0), dim=2
+)
 plot_4.title.text = "FR Layout (EdgesAndLinkedNodes selection policy)"
 plot_4.add_tools(TapTool())
 
-plot_5 = create_graph(nx.circular_layout, inspection_policy=NodesAndAdjacentNodes(), scale=1, center=(0,0))
+plot_5 = create_graph(nx.circular_layout, inspection_policy=NodesAndAdjacentNodes(), scale=1, center=(0, 0))
 plot_5.title.text = "Circular Layout (NodesAndAdjacentNodes inspection policy)"
 plot_5.add_tools(HoverTool(tooltips=None))
 
-plot_6 = create_graph(nx.fruchterman_reingold_layout, selection_policy=NodesAndAdjacentNodes(), scale=2, center=(0,0), dim=2)
+plot_6 = create_graph(
+    nx.fruchterman_reingold_layout, selection_policy=NodesAndAdjacentNodes(), scale=2, center=(0, 0), dim=2
+)
 plot_6.title.text = "FR Layout (NodesAndAdjacentNodes selection policy)"
 plot_6.add_tools(TapTool())
 

--- a/examples/styling/plots/glyph_non_visual.py
+++ b/examples/styling/plots/glyph_non_visual.py
@@ -19,7 +19,7 @@ p = figure(tools=["hover", "box_select"], active_drag="box_select")
 cr = p.circle(
     x, y, radius=radii,
     fill_color=colors, fill_alpha=0.8, line_color=None,
-    hover_fill_alpha=0.5, # mix `hover_` attributes with manual setup below
+    hover_fill_alpha=0.5,  # mix `hover_` attributes with manual setup below
 )
 
 # there is no `hover_radius` so we have set things manually

--- a/examples/styling/plots/glyph_selection_models.py
+++ b/examples/styling/plots/glyph_selection_models.py
@@ -4,10 +4,7 @@ from bokeh.plotting import figure, show
 plot = figure(width=400, height=400, tools="tap", title="Select a circle")
 renderer = plot.scatter([1, 2, 3, 4, 5], [2, 5, 8, 2, 7], size=50)
 
-selected_scatter = Scatter(fill_alpha=1, fill_color="firebrick", line_color=None)
-nonselected_scatter = Scatter(fill_alpha=0.2, fill_color="blue", line_color="firebrick")
-
-renderer.selection_glyph = selected_scatter
-renderer.nonselection_glyph = nonselected_scatter
+renderer.selection_glyph = renderer.glyph.clone(fill_alpha=1, fill_color="firebrick", line_color=None)
+renderer.nonselection_glyph = renderer.glyph.clone(fill_alpha=0.2, fill_color="blue", line_color="firebrick")
 
 show(plot)

--- a/examples/styling/plots/glyph_selection_models.py
+++ b/examples/styling/plots/glyph_selection_models.py
@@ -4,8 +4,8 @@ from bokeh.plotting import figure, show
 plot = figure(width=400, height=400, tools="tap", title="Select a circle")
 renderer = plot.scatter([1, 2, 3, 4, 5], [2, 5, 8, 2, 7], size=50)
 
-selected_scatter = Scatter(fill_alpha=1, fill_color="firebrick", line_color=None, size=50)
-nonselected_scatter = Scatter(fill_alpha=0.2, fill_color="blue", line_color="firebrick", size=50)
+selected_scatter = Scatter(fill_alpha=1, fill_color="firebrick", line_color=None)
+nonselected_scatter = Scatter(fill_alpha=0.2, fill_color="blue", line_color="firebrick")
 
 renderer.selection_glyph = selected_scatter
 renderer.nonselection_glyph = nonselected_scatter

--- a/examples/styling/plots/glyph_selection_models.py
+++ b/examples/styling/plots/glyph_selection_models.py
@@ -1,4 +1,3 @@
-from bokeh.models import Scatter
 from bokeh.plotting import figure, show
 
 plot = figure(width=400, height=400, tools="tap", title="Select a circle")

--- a/examples/styling/plots/glyph_selection_models.py
+++ b/examples/styling/plots/glyph_selection_models.py
@@ -4,8 +4,8 @@ from bokeh.plotting import figure, show
 plot = figure(width=400, height=400, tools="tap", title="Select a circle")
 renderer = plot.scatter([1, 2, 3, 4, 5], [2, 5, 8, 2, 7], size=50)
 
-selected_scatter = Scatter(fill_alpha=1, fill_color="firebrick", line_color=None)
-nonselected_scatter = Scatter(fill_alpha=0.2, fill_color="blue", line_color="firebrick")
+selected_scatter = Scatter(fill_alpha=1, fill_color="firebrick", line_color=None, size=50)
+nonselected_scatter = Scatter(fill_alpha=0.2, fill_color="blue", line_color="firebrick", size=50)
 
 renderer.selection_glyph = selected_scatter
 renderer.nonselection_glyph = nonselected_scatter

--- a/examples/topics/graph/graph_interaction.py
+++ b/examples/topics/graph/graph_interaction.py
@@ -8,20 +8,22 @@ from bokeh.plotting import from_networkx, show
 G = nx.karate_club_graph()
 
 plot = Plot(width=400, height=400,
-            x_range=Range1d(-1.1,1.1), y_range=Range1d(-1.1,1.1))
+            x_range=Range1d(-1.1, 1.1), y_range=Range1d(-1.1, 1.1))
 plot.title.text = "Graph Interaction Demonstration"
 
 plot.add_tools(HoverTool(tooltips=None), TapTool(), BoxSelectTool())
 
-graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0,0))
+graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0, 0))
 
-graph_renderer.node_renderer.glyph = Scatter(size=15, fill_color=Spectral4[0])
-graph_renderer.node_renderer.selection_glyph = Scatter(size=15, fill_color=Spectral4[2])
-graph_renderer.node_renderer.hover_glyph = Scatter(size=15, fill_color=Spectral4[1])
+scatter_glyph = Scatter(size=15, fill_color=Spectral4[0])
+graph_renderer.node_renderer.glyph = scatter_glyph
+graph_renderer.node_renderer.selection_glyph = scatter_glyph.clone(fill_color=Spectral4[2])
+graph_renderer.node_renderer.hover_glyph = scatter_glyph.clone(fill_color=Spectral4[1])
 
-graph_renderer.edge_renderer.glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
-graph_renderer.edge_renderer.selection_glyph = MultiLine(line_color=Spectral4[2], line_width=5)
-graph_renderer.edge_renderer.hover_glyph = MultiLine(line_color=Spectral4[1], line_width=5)
+ml_glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
+graph_renderer.edge_renderer.glyph = ml_glyph
+graph_renderer.edge_renderer.selection_glyph = ml_glyph.clone(line_color=Spectral4[2], line_alpha=1)
+graph_renderer.edge_renderer.hover_glyph = ml_glyph.clone(line_color=Spectral4[1], line_width=1)
 
 graph_renderer.selection_policy = NodesAndLinkedEdges()
 graph_renderer.inspection_policy = EdgesAndLinkedNodes()

--- a/examples/topics/graph/interaction_edgeslinkednodes.py
+++ b/examples/topics/graph/interaction_edgeslinkednodes.py
@@ -7,13 +7,12 @@ from bokeh.plotting import from_networkx, show
 
 G = nx.karate_club_graph()
 
-plot = Plot(width=400, height=400,
-            x_range=Range1d(-1.1,1.1), y_range=Range1d(-1.1,1.1))
+plot = Plot(width=400, height=400, x_range=Range1d(-1.1, 1.1), y_range=Range1d(-1.1, 1.1))
 plot.title.text = "Graph Interaction Demonstration"
 
 plot.add_tools(HoverTool(tooltips=None), TapTool(), BoxSelectTool())
 
-graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0,0))
+graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0, 0))
 
 scatter_glyph = Scatter(size=15, fill_color=Spectral4[0])
 graph_renderer.node_renderer.glyph = scatter_glyph

--- a/examples/topics/graph/interaction_edgeslinkednodes.py
+++ b/examples/topics/graph/interaction_edgeslinkednodes.py
@@ -15,13 +15,15 @@ plot.add_tools(HoverTool(tooltips=None), TapTool(), BoxSelectTool())
 
 graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0,0))
 
-graph_renderer.node_renderer.glyph = Scatter(size=15, fill_color=Spectral4[0])
-graph_renderer.node_renderer.selection_glyph = Scatter(size=15, fill_color=Spectral4[2])
-graph_renderer.node_renderer.hover_glyph = Scatter(size=15, fill_color=Spectral4[1])
+scatter_glyph = Scatter(size=15, fill_color=Spectral4[0])
+graph_renderer.node_renderer.glyph = scatter_glyph
+graph_renderer.node_renderer.selection_glyph = scatter_glyph.clone(fill_color=Spectral4[2])
+graph_renderer.node_renderer.hover_glyph = scatter_glyph.clone(fill_color=Spectral4[1])
 
-graph_renderer.edge_renderer.glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
-graph_renderer.edge_renderer.selection_glyph = MultiLine(line_color=Spectral4[2], line_width=5)
-graph_renderer.edge_renderer.hover_glyph = MultiLine(line_color=Spectral4[1], line_width=5)
+ml_glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
+graph_renderer.edge_renderer.glyph = ml_glyph
+graph_renderer.edge_renderer.selection_glyph = ml_glyph.clone(line_color=Spectral4[2], line_alpha=1)
+graph_renderer.edge_renderer.hover_glyph = ml_glyph.clone(line_color=Spectral4[1], line_width=1)
 
 graph_renderer.selection_policy = EdgesAndLinkedNodes()
 graph_renderer.inspection_policy = EdgesAndLinkedNodes()

--- a/examples/topics/graph/interaction_nodesadjacentnodes.py
+++ b/examples/topics/graph/interaction_nodesadjacentnodes.py
@@ -7,8 +7,7 @@ from bokeh.plotting import from_networkx, show
 
 G = nx.karate_club_graph()
 
-plot = Plot(width=400, height=400,
-            x_range=Range1d(-1.1,1.1), y_range=Range1d(-1.1, 1.1))
+plot = Plot(width=400, height=400, x_range=Range1d(-1.1, 1.1), y_range=Range1d(-1.1, 1.1))
 plot.title.text = "Graph Interaction Demonstration"
 
 plot.add_tools(HoverTool(tooltips=None), TapTool(), BoxSelectTool())

--- a/examples/topics/graph/interaction_nodesadjacentnodes.py
+++ b/examples/topics/graph/interaction_nodesadjacentnodes.py
@@ -8,20 +8,22 @@ from bokeh.plotting import from_networkx, show
 G = nx.karate_club_graph()
 
 plot = Plot(width=400, height=400,
-            x_range=Range1d(-1.1,1.1), y_range=Range1d(-1.1,1.1))
+            x_range=Range1d(-1.1,1.1), y_range=Range1d(-1.1, 1.1))
 plot.title.text = "Graph Interaction Demonstration"
 
 plot.add_tools(HoverTool(tooltips=None), TapTool(), BoxSelectTool())
 
-graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0,0))
+graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0, 0))
 
-graph_renderer.node_renderer.glyph = Scatter(size=15, fill_color=Spectral4[0])
-graph_renderer.node_renderer.selection_glyph = Scatter(size=15, fill_color=Spectral4[2])
-graph_renderer.node_renderer.hover_glyph = Scatter(size=15, fill_color=Spectral4[1])
+scatter_glyph = Scatter(size=15, fill_color=Spectral4[0])
+graph_renderer.node_renderer.glyph = scatter_glyph
+graph_renderer.node_renderer.selection_glyph = scatter_glyph.clone(fill_color=Spectral4[2])
+graph_renderer.node_renderer.hover_glyph = scatter_glyph.clone(fill_color=Spectral4[1])
 
-graph_renderer.edge_renderer.glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
-graph_renderer.edge_renderer.selection_glyph = MultiLine(line_color=Spectral4[2], line_width=5)
-graph_renderer.edge_renderer.hover_glyph = MultiLine(line_color=Spectral4[1], line_width=5)
+ml_glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
+graph_renderer.edge_renderer.glyph = ml_glyph
+graph_renderer.edge_renderer.selection_glyph = ml_glyph.clone(line_color=Spectral4[2], line_alpha=1)
+graph_renderer.edge_renderer.hover_glyph = ml_glyph.clone(line_color=Spectral4[1], line_width=1)
 
 graph_renderer.selection_policy = NodesAndAdjacentNodes()
 graph_renderer.inspection_policy = NodesAndAdjacentNodes()

--- a/examples/topics/graph/interaction_nodeslinkededges.py
+++ b/examples/topics/graph/interaction_nodeslinkededges.py
@@ -15,13 +15,15 @@ plot.add_tools(HoverTool(tooltips=None), TapTool(), BoxSelectTool())
 
 graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0,0))
 
-graph_renderer.node_renderer.glyph = Scatter(size=15, fill_color=Spectral4[0])
-graph_renderer.node_renderer.selection_glyph = Scatter(size=15, fill_color=Spectral4[2])
-graph_renderer.node_renderer.hover_glyph = Scatter(size=15, fill_color=Spectral4[1])
+scatter_glyph = Scatter(size=15, fill_color=Spectral4[0])
+graph_renderer.node_renderer.glyph = scatter_glyph
+graph_renderer.node_renderer.selection_glyph = scatter_glyph.clone(fill_color=Spectral4[2])
+graph_renderer.node_renderer.hover_glyph = scatter_glyph.clone(fill_color=Spectral4[1])
 
-graph_renderer.edge_renderer.glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
-graph_renderer.edge_renderer.selection_glyph = MultiLine(line_color=Spectral4[2], line_width=5)
-graph_renderer.edge_renderer.hover_glyph = MultiLine(line_color=Spectral4[1], line_width=5)
+ml_glyph = MultiLine(line_color="#CCCCCC", line_alpha=0.8, line_width=5)
+graph_renderer.edge_renderer.glyph = ml_glyph
+graph_renderer.edge_renderer.selection_glyph = ml_glyph.clone(line_color=Spectral4[2], line_alpha=1)
+graph_renderer.edge_renderer.hover_glyph = ml_glyph.clone(line_color=Spectral4[1], line_width=1)
 
 graph_renderer.selection_policy = NodesAndLinkedEdges()
 graph_renderer.inspection_policy = NodesAndLinkedEdges()

--- a/examples/topics/graph/interaction_nodeslinkededges.py
+++ b/examples/topics/graph/interaction_nodeslinkededges.py
@@ -7,13 +7,12 @@ from bokeh.plotting import from_networkx, show
 
 G = nx.karate_club_graph()
 
-plot = Plot(width=400, height=400,
-            x_range=Range1d(-1.1,1.1), y_range=Range1d(-1.1,1.1))
+plot = Plot(width=400, height=400, x_range=Range1d(-1.1, 1.1), y_range=Range1d(-1.1, 1.1))
 plot.title.text = "Graph Interaction Demonstration"
 
 plot.add_tools(HoverTool(tooltips=None), TapTool(), BoxSelectTool())
 
-graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0,0))
+graph_renderer = from_networkx(G, nx.circular_layout, scale=1, center=(0, 0))
 
 scatter_glyph = Scatter(size=15, fill_color=Spectral4[0])
 graph_renderer.node_renderer.glyph = scatter_glyph

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -369,7 +369,7 @@ class figure(Plot, GlyphAPI):
         Examples:
 
             Assuming a ``ColumnDataSource`` named ``source`` with columns
-            *2016* and *2017*, then the following call to ``harea_stack`` will
+            *2016* and *2017*, then the following call to ``harea_stack``
             will create two ``HArea`` renderers that stack:
 
             .. code-block:: python
@@ -410,7 +410,7 @@ class figure(Plot, GlyphAPI):
         Examples:
 
             Assuming a ``ColumnDataSource`` named ``source`` with columns
-            *2016* and *2017*, then the following call to ``hbar_stack`` will
+            *2016* and *2017*, then the following call to ``hbar_stack``
             will create two ``HBar`` renderers that stack:
 
             .. code-block:: python
@@ -454,7 +454,7 @@ class figure(Plot, GlyphAPI):
 
             Assuming a ``ColumnDataSource`` named ``source`` with columns
             *2016* and *2017*, then the following call to ``line_stack`` with
-            stackers for the y-coordinates will will create two ``Line``
+            stackers for the y-coordinates will create two ``Line``
             renderers that stack:
 
             .. code-block:: python
@@ -510,7 +510,7 @@ class figure(Plot, GlyphAPI):
 
             Assuming a ``ColumnDataSource`` named ``source`` with columns
             *2016* and *2017*, then the following call to ``hline_stack`` with
-            stackers for the x-coordinates will will create two ``Line``
+            stackers for the x-coordinates will create two ``Line``
             renderers that stack:
 
             .. code-block:: python
@@ -549,7 +549,7 @@ class figure(Plot, GlyphAPI):
         Examples:
 
             Assuming a ``ColumnDataSource`` named ``source`` with columns
-            *2016* and *2017*, then the following call to ``varea_stack`` will
+            *2016* and *2017*, then the following call to ``varea_stack``
             will create two ``VArea`` renderers that stack:
 
             .. code-block:: python
@@ -591,7 +591,7 @@ class figure(Plot, GlyphAPI):
         Examples:
 
             Assuming a ``ColumnDataSource`` named ``source`` with columns
-            *2016* and *2017*, then the following call to ``vbar_stack`` will
+            *2016* and *2017*, then the following call to ``vbar_stack``
             will create two ``VBar`` renderers that stack:
 
             .. code-block:: python
@@ -633,7 +633,7 @@ class figure(Plot, GlyphAPI):
 
             Assuming a ``ColumnDataSource`` named ``source`` with columns
             *2016* and *2017*, then the following call to ``vline_stack`` with
-            stackers for the y-coordinates will will create two ``Line``
+            stackers for the y-coordinates will create two ``Line``
             renderers that stack:
 
             .. code-block:: python
@@ -703,7 +703,7 @@ class figure(Plot, GlyphAPI):
 
             z (array-like[float] of shape (ny, nx)) :
                 A 2D NumPy array of gridded values to calculate the contours
-                of.  May be a masked array, and any invalid values (``np.inf``
+                of.  It may be a masked array, and any invalid values (``np.inf``
                 or ``np.nan``) will also be masked out.
 
             levels (array-like[float]) :


### PR DESCRIPTION
This PR fixes the [explicit selection glyph example](https://docs.bokeh.org/en/latest/docs/examples/styling/plots/glyph_selection_models.html) by adding size parameter to the Scatter model, which is by default 4.

- [ ] issues: fixes #13957

Here the result with the fix using bokeh 3.4.2 in a jupyter notebook after a click.

![grafik](https://github.com/bokeh/bokeh/assets/68053396/71644297-48d3-40b9-8025-fd5395058e29)
