### PR TITLE
Remove Step 7 (download sample data) from setup docs

### DIFF
--- a/docs/bokeh/source/docs/dev_guide/documentation.rst
+++ b/docs/bokeh/source/docs/dev_guide/documentation.rst
@@ -130,13 +130,6 @@ root level of your *source checkout* directory to update ``bkdev``:
 
 using the environment file you originally used to create ``bkdev``.
 
-Some of the examples in the documentation require additional sample data. Use
-this command to automatically download and install the necessary package:
-
-.. code-block:: sh
-
-    pip install bokeh_sampledata
-
 2. Set environment variable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/bokeh/source/docs/dev_guide/setup.rst
+++ b/docs/bokeh/source/docs/dev_guide/setup.rst
@@ -262,22 +262,9 @@ different local version instead, set the ``BOKEHJS_ACTION`` environment variable
     older**, you most likely also need to delete the ``bokehjs/build`` folder in
     your local environment before building and installing a fresh BokehJS.
 
-.. _contributor_guide_setup_sample_data:
-
-7. Download sample data
------------------------
-
-Several tests and examples require Bokeh's sample data to be available on your
-hard drive. After :ref:`installing <contributor_guide_setup_install_locally>`
-Bokeh, use the following command to download and install the data:
-
-.. code-block:: sh
-
-    pip install bokeh_sampledata
-
 .. _contributor_guide_setup_environment_variables:
 
-8. Set environment variables
+7. Set environment variables
 ----------------------------
 
 Bokeh uses :ref:`environment variables <ug_settings>` to control several
@@ -480,7 +467,7 @@ is called.
 
 .. _contributor_guide_setup_test_setup:
 
-9. Test your local setup
+8. Test your local setup
 ------------------------
 
 Run the following tests to check that everything is installed and set up

--- a/src/bokeh/sampledata/__init__.py
+++ b/src/bokeh/sampledata/__init__.py
@@ -5,6 +5,13 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 '''
+The ``bokeh.sampledata`` module exposes datasets that are used in examples and
+documentation. Some datasets require separate installation. To install those
+using ``pip``, execute the command:
+
+.. code-block:: sh
+
+    pip install bokeh_sampledata
 
 '''
 


### PR DESCRIPTION
This PR fixes #13960.

As @pavithraes mentioned, since Sample data was moved to a package that gets installed with the environment setup, it's no longer necessary in the setup guide, and can be a bit misleading if left as is.