### PR TITLE
Add missing release notes

### DIFF
--- a/docs/bokeh/source/docs/releases/3.4.1.rst
+++ b/docs/bokeh/source/docs/releases/3.4.1.rst
@@ -1,0 +1,21 @@
+.. _release-3-4-1:
+
+3.4.1
+=====
+
+Bokeh version ``3.4.1`` (April 2024) is a patch release that fixes a number of
+minor bugs/regressions and docs issues.
+
+Changes
+-------
+
+* Fixed configuration of secondary glyphs in ``GraphRendererView`` (:bokeh-pull:`13808`)
+* Allowed to update the order of ``LayoutDOM.children`` (:bokeh-pull:`13807`)
+* Allowed to update ``InputWidget.{title,description}`` (:bokeh-pull:`13805`)
+* Allowed ``DataRange1d`` to respect ``min_interval`` and ``max_interval`` (:bokeh-pull:`13819`)
+* Fixed WebGL scaling of anti-aliasing by pixel ratio (:bokeh-pull:`13783`)
+* Enabled RUF001 to lint confusable characters (:bokeh-pull:`13788`)
+* Removed references to Twitter from documentation (:bokeh-pull:`13775`)
+* Enabled documentation build on Windows (:bokeh-pull:`13776`)
+* Various fixes to documentation and docstrings (:bokeh-pull:`13793`, :bokeh-pull:`13798`,
+  :bokeh-pull:`13781`, :bokeh-pull:`13818`, :bokeh-pull:`13820`, :bokeh-pull:`13821`)

--- a/docs/bokeh/source/docs/releases/3.4.2.rst
+++ b/docs/bokeh/source/docs/releases/3.4.2.rst
@@ -1,0 +1,15 @@
+.. _release-3-4-2:
+
+3.4.2
+=====
+
+Bokeh version ``3.4.2`` (June 2024) is a patch release that fixes a number of
+minor bugs/regressions and docs issues.
+
+Changes
+-------
+
+* Added `"toggle"` select mode and made it the default in `TapTool` (:bokeh-pull:`13808`)
+* Made projection computations in glyphs aware of inherited properties (:bokeh-pull:`13832`)
+* Improvements to documentation and its infrastructure (:bokeh-pull:`13823`, :bokeh-pull:`13876`, :bokeh-pull:`13901` and :bokeh-pull:`13903`)
+* Robustified bokeh/bokehjs tests and their infrastructure (:bokeh-pull:`13843` and :bokeh-pull:`13851`)

--- a/docs/bokeh/source/docs/releases/3.4.3.rst
+++ b/docs/bokeh/source/docs/releases/3.4.3.rst
@@ -1,0 +1,19 @@
+.. _release-3-4-3:
+
+3.4.3
+=====
+
+Bokeh version ``3.4.3`` (July 2024) is a patch release that fixes a number of
+minor bugs/regressions and docs issues.
+
+Changes
+-------
+
+* Fixed performance regression related to inherited image data in ``Image``-like glyphs (:bokeh-pull:`13952`)
+* Fixed spurious warning about unknown bokeh version in the documentation (:bokeh-pull:`13949`)
+* Fixed handling of certain classes of objects in ``HasProps`` internals (:bokeh-pull:`13970`)
+* Restored support for ``BOKEH_MINIFIED=no`` in resources (:bokeh-pull:`13974`)
+* Updated the location of ``*.d.ts`` files in ``package.json`` (:bokeh-pull:`13975`)
+* Improved type hints of ``gridplot()`` (:bokeh-pull:`13914`)
+* Fixed merging of plots in grid plots when only one plot is involved (:bokeh-pull:`13978`)
+* Fixed indexing of categories in ``CategoricalSlider`` widget (:bokeh-pull:`13966`)


### PR DESCRIPTION
This PR adds the missing release notes for the 3.4.1 and 3.4.2 release.

I added `WIP` because I don't know if 3.4.3 will be released and needs to be added.