### PR TITLE
fix indentation in `offset` parameter for `Title`

### DIFF
--- a/src/bokeh/models/annotations/labels.py
+++ b/src/bokeh/models/annotations/labels.py
@@ -316,10 +316,10 @@ class Title(TextAnnotation):
     Offset the text by a number of pixels (can be positive or negative). Shifts the text in
     different directions based on the location of the title:
 
-        * above: shifts title right
-        * right: shifts title down
-        * below: shifts title right
-        * left: shifts title up
+    * above: shifts title right
+    * right: shifts title down
+    * below: shifts title right
+    * left: shifts title up
 
     """)
 


### PR DESCRIPTION
This PR solves an indentation problem, see [bokeh.models.Title.offset](https://docs.bokeh.org/en/latest/docs/reference/models/annotations.html#bokeh.models.Title.offset).

|**actual**|**suggested**|
|--|--|
|![broken_title_offset](https://github.com/bokeh/bokeh/assets/68053396/a16f36fd-caac-4c32-a389-cec3a146450b)|![fix_title_offset](https://github.com/bokeh/bokeh/assets/68053396/90b94934-f226-4459-9fdb-b8ab971f0aac)|
