### PR TITLE
Always proxy tools (even if only one) when merging toolbars

### DIFF
--- a/src/bokeh/layouts.py
+++ b/src/bokeh/layouts.py
@@ -219,15 +219,16 @@ def gridplot(
 
 
 def gridplot(
-        children: list[UIElement | None] | list[list[UIElement | None]],
-        *,
-        sizing_mode: SizingModeType | None = None,
-        toolbar_location: LocationType | None = "above",
-        ncols: int | None = None,
-        width: int | None = None,
-        height: int | None = None,
-        toolbar_options: dict[ToolbarOptions, Any] | None = None,
-        merge_tools: bool = True) -> GridPlot:
+    children: list[UIElement | None] | list[list[UIElement | None]],
+    *,
+    sizing_mode: SizingModeType | None = None,
+    toolbar_location: LocationType | None = "above",
+    ncols: int | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    toolbar_options: dict[ToolbarOptions, Any] | None = None,
+    merge_tools: bool = True,
+) -> GridPlot:
     ''' Create a grid of plots rendered on separate canvases.
 
     The ``gridplot`` function builds a single toolbar for all the plots in the
@@ -636,9 +637,7 @@ def group_tools(tools: list[Tool | ToolProxy], *, merge: MergeFn[Tool] | None = 
                     entries.remove(item)
             entries.remove(head)
 
-            if len(group) == 1:
-                computed.append(group[0])
-            elif merge is not None and (tool := merge(cls, group)) is not None:
+            if merge is not None and (tool := merge(cls, group)) is not None:
                 computed.append(tool)
             else:
                 computed.append(ToolProxy(tools=group))

--- a/tests/unit/bokeh/test_layouts.py
+++ b/tests/unit/bokeh/test_layouts.py
@@ -291,18 +291,18 @@ def test_group_tools() -> None:
 
     assert isinstance(t0, ToolProxy)
     assert isinstance(t1, ToolProxy)
-    assert isinstance(t2, PanTool)
+    assert isinstance(t2, ToolProxy)
     assert isinstance(t3, ToolProxy)
-    assert isinstance(t4, TapTool)
+    assert isinstance(t4, ToolProxy)
     assert isinstance(t5, SaveTool)
     assert isinstance(t6, ToolProxy)
     assert isinstance(t7, ToolProxy)
 
     assert t0.tools == [pan0, pan1]
     assert t1.tools == [pan2, pan4, pan3]
-    assert t2 == pan5
+    assert t2.tools == [pan5]
     assert t3.tools == [tap0, tap1]
-    assert t4 == tap2
+    assert t4.tools == [tap2]
     assert t5 != save0 and t5 != save1 and t5.filename is None
     assert t6.tools == [select0, select1, select2]
     assert t7.tools == [hover0, hover1, hover2]


### PR DESCRIPTION
Otherwise two `ResetToolView` instances are built for a single `ResetTool` model, one for the plot and one for the grid plot. Grid plot doesn't support `reset()` method, so things fail, and even if it did, then the work would be duplicated. So now `ToolProxy` is created in all cases.

fixes #13959