### PR TITLE
Use non-deprecated argument in pytest hook

### DIFF
--- a/tests/support/plugins/selenium.py
+++ b/tests/support/plugins/selenium.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import pathlib
 from shutil import which
 from typing import (
     TYPE_CHECKING,
@@ -34,7 +35,6 @@ from warnings import warn
 import pytest
 
 if TYPE_CHECKING:
-    import py
     from _pytest import config, nodes
     from selenium.webdriver.remote.webdriver import WebDriver
 
@@ -52,7 +52,7 @@ __all__ = (
 # General API
 #-----------------------------------------------------------------------------
 
-def pytest_report_collectionfinish(config: config.Config, startdir: py.path.local, items: Sequence[nodes.Item]) -> list[str]:
+def pytest_report_collectionfinish(config: config.Config, start_path: pathlib.Path, items: Sequence[nodes.Item]) -> list[str]:
     '''
 
     '''


### PR DESCRIPTION
pytest_report_collectionfinish()'s startdir argument has been deprecated since 7.0, and with pytest 8.2 now raises a deprecation warning that it will be removed in 9.0. Switch to the new start_path argument.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #13984
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
