### PR TITLE
improve session expiry error message

### DIFF
--- a/src/bokeh/server/views/ws.py
+++ b/src/bokeh/server/views/ws.py
@@ -146,7 +146,7 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
             raise ProtocolError("Session expiry has not been provided")
         elif now >= payload['session_expiry']:
             self.close()
-            raise ProtocolError("Token is expired.")
+            raise ProtocolError("Token is expired. Configure the app with a larger value for --session-token-expiration if necessary")
         elif not check_token_signature(token,
                                        signed=self.application.sign_sessions,
                                        secret_key=self.application.secret_key):


### PR DESCRIPTION
- [x] issues: fixes #12303

@jlstevens I opted not to display the current expiry value in order to avoid spilling details into the log. Presumably the app creator can figure out what to do with their own configuration. 