### PR TITLE
Python docstring argument fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@
 .sw[nop]
 *.tmp
 .vscode
+.idea
 
 # compressed / binary files
 *.bz2

--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -218,11 +218,10 @@ def enumeration(*values: Any, case_sensitive: bool = True, quote: bool = False) 
             first element will be considered the default value when used
             to create |Enum| properties.
 
-    Keyword Args:
         case_sensitive (bool, optional) :
             Whether validation should consider case or not (default: True)
 
-        quote (bool, optional):
+        quote (bool, optional) :
             Whether values should be quoted in the string representations
             (default: False)
 

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -424,15 +424,9 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         ''' Set a property value on this object from JSON.
 
         Args:
-            name: (str) : name of the attribute to set
+            name (str) : name of the attribute to set
 
-            json: (JSON-value) : value to set to the attribute to
-
-            models (dict or None, optional) :
-                Mapping of model ids to models (default: None)
-
-                This is needed in cases where the attributes to update also
-                have values that have references.
+            value (JSON-value) : value to set to the attribute to
 
             setter(ClientSession or ServerSession or None, optional) :
                 This is used to prevent "boomerang" updates to Bokeh apps.

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -447,7 +447,7 @@ class UnitsSpec(NumberSpec):
         property as well as the associated units property are returned.
 
         Args:
-            name (str) : the name of the property these descriptors are for
+            base_name (str) : the name of the property these descriptors are for
 
         Returns:
             list[PropertyDescriptor]

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -398,13 +398,7 @@ class PropertyDescriptor(Generic[T]):
         Args:
             obj: (HasProps) : instance to set the property value on
 
-            json: (JSON-value) : value to set to the attribute to
-
-            models (dict or None, optional) :
-                Mapping of model ids to models (default: None)
-
-                This is needed in cases where the attributes to update also
-                have values that have references.
+            value: (JSON-value) : value to set to the attribute to
 
             setter (ClientSession or ServerSession or None, optional) :
                 This is used to prevent "boomerang" updates to Bokeh apps.
@@ -786,9 +780,7 @@ class DataSpecPropertyDescriptor(PropertyDescriptor):
         Args:
             obj (HasProps) :
 
-            json (JSON-dict) :
-
-            models(seq[Model], optional) :
+            value (JSON-dict) :
 
             setter (ClientSession or ServerSession or None, optional) :
                 This is used to prevent "boomerang" updates to Bokeh apps.

--- a/src/bokeh/core/property/wrappers.py
+++ b/src/bokeh/core/property/wrappers.py
@@ -214,7 +214,7 @@ class PropertyValueList(PropertyValueContainer, list[T]):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        return super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _saved_copy(self) -> list[T]:
         return list(self)
@@ -274,7 +274,7 @@ class PropertyValueSet(PropertyValueContainer, set[T]):
     """
 
     def __init__(self, *args, **kwargs) -> None:
-        return super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _saved_copy(self) -> set[T]:
         return set(self)
@@ -348,7 +348,7 @@ class PropertyValueDict(PropertyValueContainer, dict[str, T_Val]):
 
     """
     def __init__(self, *args, **kwargs) -> None:
-        return super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _saved_copy(self):
         return dict(self)

--- a/src/bokeh/core/query.py
+++ b/src/bokeh/core/query.py
@@ -62,7 +62,7 @@ def find(objs: Iterable[Model], selector: SelectorType) -> Iterable[Model]:
     a selector.
 
     Args:
-        obj (Model) : object to test
+        objs (Iterable[Model]) : model objects to test
         selector (JSON-like) : query selector
 
     Yields:

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -350,7 +350,7 @@ class Document:
         ''' Apply a JSON patch object and process any resulting events.
 
         Args:
-            patch (JSON-data) :
+            patch_json (JSON-data) :
                 The JSON-object containing the patch to apply.
 
             setter (ClientSession or ServerSession or None, optional) :
@@ -496,7 +496,7 @@ side of a communications channel while it was being removed on the other end.\
         hold will be applied according to the hold policy.
 
         Args:
-            hold ('combine' or 'collect', optional)
+            policy ('combine' or 'collect', optional)
                 Whether events collected during a hold should attempt to be
                 combined (default: 'combine')
 
@@ -716,7 +716,7 @@ side of a communications channel while it was being removed on the other end.\
         Args:
             selector (JSON-like query dictionary) : you can query by type or by
                 name,i e.g. ``{"type": HoverTool}``, ``{"name": "mycircle"}``
-                updates (dict) :
+            updates (dict) :
 
         Returns:
             None

--- a/src/bokeh/driving.py
+++ b/src/bokeh/driving.py
@@ -145,7 +145,7 @@ def linear(m: float = 1, b: float = 0) -> partial[Callable[[], None]]:
 
     Args:
         m (float) : a slope for the linear driver
-        x (float) : an offset for the linear driver
+        b (float) : an offset for the linear driver
 
     '''
     def f(i: float) -> float:

--- a/src/bokeh/plotting/_tools.py
+++ b/src/bokeh/plotting/_tools.py
@@ -79,7 +79,7 @@ def process_active_tools(toolbar: Toolbar, tool_map: dict[str, Tool],
 
     Args:
         toolbar (Toolbar): instance of a Toolbar object
-        tools_map (dict[str]): tool_map from _process_tools_arg
+        tool_map (dict[str]): tool_map from _process_tools_arg
         active_drag (str, None, "auto" or Tool): the tool to set active for drag
         active_inspect (str, None, "auto", Tool or Tool[]): the tool to set active for inspect
         active_scroll (str, None, "auto" or Tool): the tool to set active for scroll

--- a/src/bokeh/protocol/message.py
+++ b/src/bokeh/protocol/message.py
@@ -208,8 +208,7 @@ class Message(Generic[Content]):
         ''' Associate a buffer header and payload with this message.
 
         Args:
-            buf_header (``JSON``) : a buffer header
-            buf_payload (``JSON`` or bytes) : a buffer payload
+            buffer (Buffer) : a buffer
 
         Returns:
             None

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -157,7 +157,7 @@ class BaseServer:
         as stops the ``HTTPServer`` that this instance was configured with.
 
         Args:
-            fast (bool):
+            wait (bool):
                 Whether to wait for orderly cleanup (default: True)
 
         Returns:

--- a/src/bokeh/util/callback_manager.py
+++ b/src/bokeh/util/callback_manager.py
@@ -166,15 +166,6 @@ class PropertyCallbackManager:
     def trigger(self, attr: str, old: Any, new: Any,
             hint: DocumentPatchedEvent | None = None, setter: Setter | None = None) -> None:
         ''' Trigger callbacks for ``attr`` on this object.
-
-        Args:
-            attr (str) :
-            old (object) :
-            new (object) :
-
-        Returns:
-            None
-
         '''
         def invoke() -> None:
             callbacks = self._callbacks.get(attr)


### PR DESCRIPTION
Fix some small warnings pointed out by PyCharm. No code changes except removing some redundant `return` statements in `__init__` methods in `src/bokeh/core/property/wrappers.py`.
