### PR TITLE
Fix ValueError check in ColumnDataSource.patch

### DIFF
--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -703,7 +703,7 @@ class ColumnDataSource(ColumnarDataSource):
                         raise ValueError(f"Initial patch sub-index may only be integer, got: {ind_0}")
 
                     if ind_0 > col_len or ind_0 < 0:
-                        raise ValueError("Out-of bounds initial sub-index (%d) in patch for column: %s" % (ind, name))
+                        raise ValueError("Out-of bounds initial sub-index (%d) in patch for column: %s" % (ind_0, name))
 
                     if not isinstance(self.data[name][ind_0], np.ndarray):
                         raise ValueError("Can only sub-patch into columns with NumPy array items")
@@ -714,7 +714,7 @@ class ColumnDataSource(ColumnarDataSource):
                     elif isinstance(ind_0, slice):
                         _check_slice(ind_0)
                         if ind_0.stop is not None and ind_0.stop > col_len:
-                            raise ValueError("Out-of bounds initial slice sub-index stop (%d) in patch for column: %s" % (ind.stop, name))
+                            raise ValueError("Out-of bounds initial slice sub-index stop (%d) in patch for column: %s" % (ind_0.stop, name))
 
                     # Note: bounds of sub-indices after the first are not checked!
                     for subind in ind[1:]:

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -682,13 +682,13 @@ class ColumnDataSource(ColumnarDataSource):
                 # integer index, patch single value of 1d column
                 if isinstance(ind, int):
                     if ind > col_len or ind < 0:
-                        raise ValueError("Out-of bounds index (%d) in patch for column: %s" % (ind, name))
+                        raise ValueError(f"Out-of bounds index ({ind}) in patch for column: {name}")
 
                 # slice index, patch multiple values of 1d column
                 elif isinstance(ind, slice):
                     _check_slice(ind)
                     if ind.stop is not None and ind.stop > col_len:
-                        raise ValueError("Out-of bounds slice index stop (%d) in patch for column: %s" % (ind.stop, name))
+                        raise ValueError(f"Out-of bounds slice index stop ({ind.stop}) in patch for column: {name}")
 
                 # multi-index, patch sub-regions of "n-d" column
                 elif isinstance(ind, list | tuple):
@@ -703,7 +703,7 @@ class ColumnDataSource(ColumnarDataSource):
                         raise ValueError(f"Initial patch sub-index may only be integer, got: {ind_0}")
 
                     if ind_0 > col_len or ind_0 < 0:
-                        raise ValueError("Out-of bounds initial sub-index (%d) in patch for column: %s" % (ind_0, name))
+                        raise ValueError(f"Out-of bounds initial sub-index ({ind_0}) in patch for column: {name}")
 
                     if not isinstance(self.data[name][ind_0], np.ndarray):
                         raise ValueError("Can only sub-patch into columns with NumPy array items")
@@ -714,7 +714,7 @@ class ColumnDataSource(ColumnarDataSource):
                     elif isinstance(ind_0, slice):
                         _check_slice(ind_0)
                         if ind_0.stop is not None and ind_0.stop > col_len:
-                            raise ValueError("Out-of bounds initial slice sub-index stop (%d) in patch for column: %s" % (ind_0.stop, name))
+                            raise ValueError(f"Out-of bounds initial slice sub-index stop ({ind_0.stop}) in patch for column: {name}")
 
                     # Note: bounds of sub-indices after the first are not checked!
                     for subind in ind[1:]:

--- a/tests/unit/bokeh/models/test_sources.py
+++ b/tests/unit/bokeh/models/test_sources.py
@@ -742,6 +742,20 @@ Lime,Green,99,$0.39
         with pytest.raises(ValueError, match=r"Patch slices must have non-negative \(start, stop, step\) values, got slice\(1, 10, -1\)"):
             ds.patch(dict(a=[(slice(1, 10, -1), list(range(10)))]))
 
+    def test_bad_multi_index(self) -> None:
+        ds = ColumnDataSource(data=dict(foo=[1]))
+        with pytest.raises(ValueError, match=r"Empty \(length zero\) patch multi-index"):
+            ds.patch(dict(foo=[[[], 5]]))
+        with pytest.raises(ValueError, match=r"Patch multi-index must contain more than one subindex"):
+            ds.patch(dict(foo=[[[2], 5]]))
+        with pytest.raises(ValueError, match=r"Initial patch sub-index may only be integer, got: spam"):
+            ds.patch(dict(foo=[[["spam", 3], 5]]))
+        with pytest.raises(ValueError, match=r"Out-of bounds initial sub-index \(-1\) in patch for column: foo"):
+            ds.patch(dict(foo=[[[-1, 3], 5]]))
+        with pytest.raises(ValueError, match=r"Can only sub-patch into columns with NumPy array items"):
+            ds.patch(dict(foo=[[[0, 3], 5]]))
+        with pytest.raises(ValueError, match=r"Invalid patch index: {}"):
+            ds.patch(dict(foo=[[{}, 5]]))
 
     def test_patch_good_slice_indices(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10, 11, 12, 13, 14, 15], b=[20, 21, 22, 23, 24, 25]))


### PR DESCRIPTION
Fix an error where ColumnDataSource.patch was doing some ValueError reporting but trying to format a list `ind` as a int `%d` which when executed would raise TypeError. I'm not familiar with the code (was just pointed out by PyCharm) but I suppose using the int `ind_0` was intended?
