### PR TITLE
Fix HTML/CSS warning for palette group detail

### DIFF
--- a/src/bokeh/server/views/app_index.html
+++ b/src/bokeh/server/views/app_index.html
@@ -39,7 +39,7 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-light" id="main-menu">
 
       <a class="navbar-brand" href="//bokeh.org" id="logo">
-        <img src="https://static.bokeh.org/logos/logotype.svg" height="30" width="110" />
+        <img src="https://static.bokeh.org/logos/logotype.svg" alt="Logo" height="30" width="110" />
       </a>
 
       <button class="navbar-toggler ml-auto hidden-sm-up float-xs-left" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/src/bokeh/sphinxext/_templates/palette_group_detail.html
+++ b/src/bokeh/sphinxext/_templates/palette_group_detail.html
@@ -7,10 +7,10 @@
       {% for number in numbers %}
       <tr>
 
-        <td height='20px' width='30px'> {{ number }} </td>
+        <td style="height: 20px; width: 30px;"> {{ number }} </td>
 
         {% for color in palettes[number] %}
-        <td height="20px" width="20px" style="background-color: {{ color }};border: #444444 thin solid;"/>
+        <td style="height: 20px; width: 20px; background-color: {{ color }}; border: #444444 thin solid;"></td>
         {% endfor %}
 
       </tr>


### PR DESCRIPTION
Fix warning that HTML width attribute on table td is obsolete and follow recommendation to use CSS instead:
See https://www.w3.org/TR/2010/WD-html-markup-20100624/td.html

One thing I noticed at https://docs.bokeh.org/en/latest/docs/reference/palettes.html is that (with Chrome, Safari, Firefox all the same) I see for large palettes like `Category20c` or `Iridescent` that the widths are not equal when displayed. That's before this PR, i.e. unrelated.

<img width="1128" alt="Screenshot 2024-08-11 at 17 17 21" src="https://github.com/user-attachments/assets/95d71641-2a20-45fd-b44d-fd896a7cf58a">
