### PR TITLE
Fix ValueError in get_graph_kwargs

### DIFF
--- a/src/bokeh/plotting/_graph.py
+++ b/src/bokeh/plotting/_graph.py
@@ -51,11 +51,10 @@ RENDERER_ARGS = ['name', 'level', 'visible', 'x_range_name', 'y_range_name',
 # Dev API
 #-----------------------------------------------------------------------------
 
-def get_graph_kwargs(node_source: ColumnDataSource, edge_source: ColumnDataSource, **kwargs):
+def get_graph_kwargs(node_source: ColumnDataSource, edge_source: ColumnDataSource, **kwargs) -> dict:
 
     if not isinstance(node_source, ColumnarDataSource):
         try:
-            # try converting the source to ColumnDataSource
             node_source = ColumnDataSource(node_source)
         except ValueError as err:
             msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err}"
@@ -63,7 +62,6 @@ def get_graph_kwargs(node_source: ColumnDataSource, edge_source: ColumnDataSourc
 
     if not isinstance(edge_source, ColumnarDataSource):
         try:
-            # try converting the source to ColumnDataSource
             edge_source = ColumnDataSource(edge_source)
         except ValueError as err:
             msg = f"Failed to auto-convert {type(edge_source)} to ColumnDataSource.\n Original error: {err}"

--- a/src/bokeh/plotting/_graph.py
+++ b/src/bokeh/plotting/_graph.py
@@ -58,7 +58,7 @@ def get_graph_kwargs(node_source: ColumnDataSource, edge_source: ColumnDataSourc
             # try converting the source to ColumnDataSource
             node_source = ColumnDataSource(node_source)
         except ValueError as err:
-            msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err.message}"
+            msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err}"
             raise ValueError(msg).with_traceback(sys.exc_info()[2])
 
     if not isinstance(edge_source, ColumnarDataSource):
@@ -66,7 +66,7 @@ def get_graph_kwargs(node_source: ColumnDataSource, edge_source: ColumnDataSourc
             # try converting the source to ColumnDataSource
             edge_source = ColumnDataSource(edge_source)
         except ValueError as err:
-            msg = f"Failed to auto-convert {type(edge_source)} to ColumnDataSource.\n Original error: {err.message}"
+            msg = f"Failed to auto-convert {type(edge_source)} to ColumnDataSource.\n Original error: {err}"
             raise ValueError(msg).with_traceback(sys.exc_info()[2])
 
     marker = kwargs.pop('node_marker', None)

--- a/tests/unit/bokeh/plotting/test__graph.py
+++ b/tests/unit/bokeh/plotting/test__graph.py
@@ -130,6 +130,14 @@ class Test_get_graph_kwargs:
         assert r.muted_glyph.line_alpha == 0.2
         assert r.muted_glyph.line_color == "blue"
 
+    def test_bad_input(self) -> None:
+        msg = "Failed to auto-convert <class 'int'> to ColumnDataSource.\n Original error: expected a dict or pandas.DataFrame, got 42"
+        with pytest.raises(ValueError, match=msg):
+            bpg.get_graph_kwargs(42, {})
+
+        with pytest.raises(ValueError, match=msg):
+            bpg.get_graph_kwargs({}, 42)
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the warning I see in PyCharm static code analysis:

> Unresolved attribute reference 'message' for class 'ValueError'

This seems to work:

```
In [6]: import sys

In [7]: node_source = "my node source"

In [8]: try:
   ...:     raise ValueError("spam alot")
   ...: except ValueError as err:
   ...:     msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err.message}"
   ...:     raise ValueError(msg).with_traceback(sys.exc_info()[2])
   ...: 
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[8], line 2
      1 try:
----> 2     raise ValueError("spam alot")
      3 except ValueError as err:

ValueError: spam alot

During handling of the above exception, another exception occurred:

AttributeError                            Traceback (most recent call last)
Cell In[8], line 4
      2     raise ValueError("spam alot")
      3 except ValueError as err:
----> 4     msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err.message}"
      5     raise ValueError(msg).with_traceback(sys.exc_info()[2])

AttributeError: 'ValueError' object has no attribute 'message'

In [9]: try:
   ...:     raise ValueError("spam alot")
   ...: except ValueError as err:
   ...:     msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err}"
   ...:     raise ValueError(msg).with_traceback(sys.exc_info()[2])
   ...: 
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[9], line 2
      1 try:
----> 2     raise ValueError("spam alot")
      3 except ValueError as err:

ValueError: spam alot

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
Cell In[9], line 5
      3 except ValueError as err:
      4     msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err}"
----> 5     raise ValueError(msg).with_traceback(sys.exc_info()[2])

Cell In[9], line 2
      1 try:
----> 2     raise ValueError("spam alot")
      3 except ValueError as err:
      4     msg = f"Failed to auto-convert {type(node_source)} to ColumnDataSource.\n Original error: {err}"

ValueError: Failed to auto-convert <class 'str'> to ColumnDataSource.
 Original error: spam alot

```

Is it really useful to catch a ValueError and raise another?
Apply this fix here or instead remove the whole try/except?