### PR TITLE
Remove outdated known issues list from BokehJS docs

### DIFF
--- a/docs/bokeh/source/docs/user_guide/advanced/bokehjs.rst
+++ b/docs/bokeh/source/docs/user_guide/advanced/bokehjs.rst
@@ -278,17 +278,6 @@ and hover policy. Here is an example of a ``bar`` chart and the plot it generate
 
     plt.show(plt.gridplot([[p1, p2], [p3, p4]], {width: 350, height: 350}));
 
-.. _ug_advanced_bokehjs_issues:
-
-Known Issues
-------------
-
-* :bokeh-issue:`11016` figure name passed to `renderer.glyph.name` but not `renderer.name`
-* :bokeh-issue:`11034` Palettes not accessible by name for `ColorMapper` objects in BokehJS
-* :bokeh-issue:`11035` `Bokeh.Widgets.Div()` missing `tools`, required by `Bokeh.Plotting.gridplot()`
-* :bokeh-issue:`11036` Making axis range padding persistent requires changing `._initial_range_padding` as well
-* :bokeh-issue:`11037` Using `sizing_mode` in gridplot layouts requires explicit assignment
-* :bokeh-issue:`11038` Calling `figure({title:"some title"})` replaces Title object with string, prevents subsequent updates to title text
 
 Minimal example
 ---------------


### PR DESCRIPTION
For some reason the Advanced BokehJS docs page had a list of known issues pointing to Github.

Almost all of them have been resolved in the past years.

Plus it's hard to maintain such a manual list.

So this PR simply removes that section.


<img width="1308" alt="Screenshot 2024-08-11 at 18 10 46" src="https://github.com/user-attachments/assets/86978ff8-52ea-43d1-8466-26e5aa7459b5">
