### PR TITLE
Update setup and testing docs dev guide

### DIFF
--- a/docs/bokeh/source/docs/dev_guide/setup.rst
+++ b/docs/bokeh/source/docs/dev_guide/setup.rst
@@ -283,6 +283,10 @@ You will not see any effects of your local changes to BokehJS unless you
 configure Bokeh to use your local version of BokehJS instead of the default
 version from the CDN.
 
+Note that ``BOKEH_RESOURCES`` should only be set when running examples.
+When you run tests or build the docs, you should not set this variable
+(or unset it if it is already set) or you might get an error.
+
 You have the following three options to use your local version of BokehJS:
 
 Use ``absolute-dev``

--- a/docs/bokeh/source/docs/dev_guide/setup.rst
+++ b/docs/bokeh/source/docs/dev_guide/setup.rst
@@ -258,10 +258,6 @@ different local version instead, set the ``BOKEHJS_ACTION`` environment variable
     :ref:`contributor_guide_setup_installing_node_packages` section above before
     rebuilding BokehJS.
 
-    In case you **update from a development environment based on Bokeh 2.3 or
-    older**, you most likely also need to delete the ``bokehjs/build`` folder in
-    your local environment before building and installing a fresh BokehJS.
-
 .. _contributor_guide_setup_environment_variables:
 
 7. Set environment variables

--- a/docs/bokeh/source/docs/dev_guide/testing.rst
+++ b/docs/bokeh/source/docs/dev_guide/testing.rst
@@ -155,24 +155,23 @@ Unit tests
 
 Code coverage (Python unit tests)
     To create a coverage report for Python unit tests, use ``pytest`` with the
-    command-line options ``--cov=bokeh`` and ``--cov-config=tests/.coveragerc``:
+    command-line option ``--cov=bokeh``:
 
     .. code-block:: sh
 
-        pytest --cov=bokeh --cov-config=tests/.coveragerc
+        pytest --cov=bokeh
 
     Coverage with Bokeh's Python unit tests should be around 90%. Coverage
     reports are only relevant for Python unit tests. There are no coverage
     reports for other Python tests or for any of the JavaScript code of BokehJS.
 
-    You also have the option to add
-    ``--cov=bokeh --cov-config=tests/.coveragerc`` when running a specific
+    You also have the option to add ``--cov=bokeh`` when running a specific
     subset of Python unit tests. This adds a coverage report to the test
     results. For example:
 
     .. code-block:: sh
 
-        pytest --cov=bokeh --cov-config=tests/.coveragerc -m "not selenium" tests/unit/bokeh/test_objects.py
+        pytest --cov=bokeh --cov-report=html -m "not selenium" tests/unit/bokeh/test_objects.py
 
     .. seealso::
         Coverage reports use the pytest plugin `pytest-cov`_. For more

--- a/docs/bokeh/source/docs/dev_guide/testing.rst
+++ b/docs/bokeh/source/docs/dev_guide/testing.rst
@@ -124,7 +124,7 @@ when working with Bokeh's pytest-based tests:
 * ``-v``: Run test with more verbose output.
 * ``--driver``: Use a specific web driver for Selenium-based tests
   (``"chrome"``, ``"firefox"``, or ``"safari"``). For example:
-  ``pytest --driver="firefox" tests/integration/``.
+  ``pytest --driver="firefox" tests/unit/``.
 * ``--no-js``: Skip any JavaScript code and only test Python code.
 
 See the `pytest documentation`_ for more options.
@@ -180,14 +180,8 @@ Code coverage (Python unit tests)
 
 .. _contributor_guide_testing_local_python_integration:
 
-Integration tests
-    The Python-focused integration tests that simulate UI interactions
-    are currently removed until a more maintainable way is found to run
-    them via `Chrome`_ or `Chromium`_ and `Selenium`_ with the
-    `ChromeDriver`_ web driver.
-
 Cross integration tests
-    This is a variant of integration tests where on Bokeh's side a Python
+    There are some Python to JS interface tests where on Bokeh's side a Python
     code sample (a test case) is run, which produces JSON output with the
     serialized document. That JSON is then stored in the repository under
     ``tests/baselines/cross``. When adding a new test case, run:

--- a/docs/bokeh/source/docs/dev_guide/testing.rst
+++ b/docs/bokeh/source/docs/dev_guide/testing.rst
@@ -181,16 +181,10 @@ Code coverage (Python unit tests)
 .. _contributor_guide_testing_local_python_integration:
 
 Integration tests
-    To run Bokeh's Python-focused integration tests, use this command from the
-    top level of the repository:
-
-    .. code-block:: sh
-
-        pytest tests/integration
-
-    These tests mostly simulate UI interactions. Therefore, they require
-    `Chrome`_ or `Chromium`_ and `Selenium`_ with the `ChromeDriver`_ web
-    driver.
+    The Python-focused integration tests that simulate UI interactions
+    are currently removed until a more maintainable way is found to run
+    them via `Chrome`_ or `Chromium`_ and `Selenium`_ with the
+    `ChromeDriver`_ web driver.
 
 Cross integration tests
     This is a variant of integration tests where on Bokeh's side a Python


### PR DESCRIPTION
Follow-up to #13992 to remove the `pytest tests/integration` instruction in the dev docs which doesn't exist any more.



