### PR TITLE
Make clear_extensions API public

### DIFF
--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -234,6 +234,18 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
     # Public methods ----------------------------------------------------------
 
     @classmethod
+    def clear_extensions(cls) -> None:
+        """ Clear any currently defined custom extensions.
+
+        Serialization calls will result in any currently defined custom
+        extensions being included with the generated Document, whether or not
+        there are utlized. This method can be used to clear out all existing
+        custom extension definitions.
+
+        """
+        _default_resolver.clear_extensions()
+
+    @classmethod
     @without_property_validation
     def parameters(cls: type[Model]) -> list[Parameter]:
         ''' Generate Python ``Parameter`` values suitable for functions that are
@@ -586,10 +598,6 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
         doc.theme.apply_to_model(self)
         self.document = doc
         self._update_event_callbacks()
-
-    @classmethod
-    def _clear_extensions(cls) -> None:
-        _default_resolver.clear_extensions()
 
     def _detach_document(self) -> None:
         ''' Detach a model from a Bokeh |Document|.

--- a/src/bokeh/sphinxext/bokeh_plot.py
+++ b/src/bokeh/sphinxext/bokeh_plot.py
@@ -233,7 +233,7 @@ class BokehPlotDirective(BokehDirective):
             raise SphinxError(f"bokeh-plot:: error reading {path!r} for {self.env.docname!r}: {e!r}")
 
     def process_source(self, source, path, js_filename):
-        Model._clear_extensions()
+        Model.clear_extensions()
 
         root, docstring = _evaluate_source(source, path, self.env)
 

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -279,6 +279,43 @@ def test_args_pass_through():
     with pytest.raises(ValueError, match=r"positional arguments are not allowed"):
         SomeModel(1, b="a")
 
+class Test_clear_extensions:
+    def test_ext_with___css__(self):
+        assert not any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
+        class Custom(Model):
+            __css__ = "stuff"
+
+        assert any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
+        Model.clear_extensions()
+
+        assert not any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
+    def test_ext_with___implementation__(self):
+        assert not any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
+        class Custom(Model):
+            __implementation__ = "stuff"
+
+        assert any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
+        Model.clear_extensions()
+
+        assert not any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
+    def test_ext_with___javascript__(self):
+        assert not any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
+        class Custom(Model):
+            __javascript__ = "stuff"
+
+        assert any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
+        Model.clear_extensions()
+
+        assert not any(x.endswith(".Custom") for x in Model.model_class_reverse_map)
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -49,7 +49,7 @@ LOG_LEVELS: list[LogLevel] = ["trace", "debug", "info", "warn", "error", "fatal"
 DEFAULT_LOG_JS_RAW = 'Bokeh.set_log_level("info");'
 
 def teardown_module() -> None:
-    Model._clear_extensions()
+    Model.clear_extensions()
 
 # -----------------------------------------------------------------------------
 # General API


### PR DESCRIPTION
- [x] issues: fixes #4951
- [x] tests added

This does not preclude doing something more sophisticated, e.g. auto-pruning extensions that are not explicitly included in a  Document, but let's make a new issue, at this point, if there is interest in that. 

