### PR TITLE
Allow values of any type in ``GroupFilter.group``

### DIFF
--- a/bokehjs/src/lib/models/filters/group_filter.ts
+++ b/bokehjs/src/lib/models/filters/group_filter.ts
@@ -2,6 +2,7 @@ import {Filter} from "./filter"
 import type * as p from "core/properties"
 import {Indices} from "core/types"
 import {logger} from "core/logging"
+import {Comparator} from "core/util/eq"
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 
 export namespace GroupFilter {
@@ -9,7 +10,7 @@ export namespace GroupFilter {
 
   export type Props = Filter.Props & {
     column_name: p.Property<string>
-    group: p.Property<string>
+    group: p.Property<unknown>
   }
 }
 
@@ -23,9 +24,9 @@ export class GroupFilter extends Filter {
   }
 
   static {
-    this.define<GroupFilter.Props>(({Str}) => ({
+    this.define<GroupFilter.Props>(({Str, Unknown}) => ({
       column_name: [ Str ],
-      group:       [ Str ],
+      group:       [ Unknown ],
     }))
   }
 
@@ -37,8 +38,9 @@ export class GroupFilter extends Filter {
       return Indices.all_set(size)
     } else {
       const indices = new Indices(size, 0)
+      const cmp = new Comparator()
       for (let i = 0; i < indices.size; i++) {
-        if (column[i] === this.group) {
+        if (cmp.eq(column[i], this.group)) {
           indices.set(i)
         }
       }

--- a/bokehjs/test/unit/models/filters/group_filter.ts
+++ b/bokehjs/test/unit/models/filters/group_filter.ts
@@ -7,6 +7,7 @@ describe("GroupFilter", () => {
   const cds = new ColumnDataSource({
     data: {
       x: ["a", "a", "b", "b", "b"],
+      y: [0.0, NaN, Infinity, NaN, 1.0],
     },
   })
 
@@ -22,8 +23,13 @@ describe("GroupFilter", () => {
       expect([...group_filter.compute_indices(cds)]).to.be.equal([])
     })
 
+    it("returns correct indices when group is NaN", () => {
+      const group_filter = new GroupFilter({column_name: "y", group: NaN})
+      expect([...group_filter.compute_indices(cds)]).to.be.equal([1, 3])
+    })
+
     it("returns null when column_name is not in the data source", () => {
-      const group_filter = new GroupFilter({column_name: "y", group: "c"})
+      const group_filter = new GroupFilter({column_name: "z", group: "c"})
       expect([...group_filter.compute_indices(cds)]).to.be.equal([0, 1, 2, 3, 4])
     })
   })

--- a/docs/bokeh/source/docs/releases/3.6.0.rst
+++ b/docs/bokeh/source/docs/releases/3.6.0.rst
@@ -7,3 +7,4 @@ Bokeh version ``3.6.0`` (??? 2024) is a minor milestone of Bokeh project.
 
 * Improved streaming corner cases and added NumPy to ``bokeh info`` (:bokeh-pull:`14007`)
 * Added support for "open in a new tab" mode to ``SaveTool`` (:bokeh-pull:`14031`)
+* Allowed values of any type in ``GroupFilter.group`` and improved equality checking (:bokeh-pull:`14034`)

--- a/src/bokeh/models/filters.py
+++ b/src/bokeh/models/filters.py
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
+    Any,
     AnyRef,
     Bool,
     Instance,
@@ -168,15 +169,15 @@ class BooleanFilter(Filter):
         super().__init__(**kwargs)
 
 class GroupFilter(Filter):
-    ''' A ``GroupFilter`` represents the rows of a ``ColumnDataSource`` where the values of the categorical
-    column column_name match the group variable.
+    ''' A ``GroupFilter`` represents the rows of a ``ColumnDataSource`` where the
+    values of the column indicated by ``column_name`` match the ``group`` variable.
     '''
 
     column_name = Required(String, help="""
     The name of the column to perform the group filtering operation on.
     """)
 
-    group = Required(String, help="""
+    group = Required(Any, help="""
     The value of the column indicating the rows of data to keep.
     """)
 


### PR DESCRIPTION
Also switches from using `===` for value equality to `is_equals()`, which allows handling of NaN, arrays and other complex or unusual types. Performance hit should be minimal for primitives, because `is_equal()` has hot paths for these. In the future, this will also allow us to implement inexact equality for floats.

fixes #7524 