### PR TITLE
Experiments with adding support for `int64` and `uint64` dtypes

### DIFF
--- a/bokehjs/src/lib/core/serialization/deserializer.ts
+++ b/bokehjs/src/lib/core/serialization/deserializer.ts
@@ -272,12 +272,13 @@ export class Deserializer {
       case "int16":   return new Int16Array(buffer)
       case "uint32":  return new Uint32Array(buffer)
       case "int32":   return new Int32Array(buffer)
-      // case "uint64": return new BigInt64Array(buffer)
-      // case "int64":  return new BigInt64Array(buffer)
+      case "uint64":  return new BigUint64Array(buffer)
+      case "int64":   return new BigInt64Array(buffer)
       case "float32": return new Float32Array(buffer)
       case "float64": return new Float64Array(buffer)
-      default:
+      default: {
         this.error(`unsupported dtype '${dtype}'`)
+      }
     }
   }
 

--- a/bokehjs/src/lib/core/serialization/serializer.ts
+++ b/bokehjs/src/lib/core/serialization/serializer.ts
@@ -183,18 +183,19 @@ export class Serializer {
 
     const dtype = (() => {
       switch (obj.constructor) {
-        case Uint8Array: return "uint8"
-        case Int8Array: return "int8"
-        case Uint16Array: return "uint16"
-        case Int16Array: return "int16"
-        case Uint32Array: return "uint32"
-        case Int32Array: return "int32"
-        // case BigUint64Array: return "uint64"
-        // case BigInt64Array: return "int64"
-        case Float32Array: return "float32"
-        case Float64Array: return "float64"
-        default:
+        case Uint8Array:     return "uint8"
+        case Int8Array:      return "int8"
+        case Uint16Array:    return "uint16"
+        case Int16Array:     return "int16"
+        case Uint32Array:    return "uint32"
+        case Int32Array:     return "int32"
+        case BigUint64Array: return "uint64"
+        case BigInt64Array:  return "int64"
+        case Float32Array:   return "float32"
+        case Float64Array:   return "float64"
+        default: {
           this.error(`can't serialize typed array of type '${obj[Symbol.toStringTag]}'`)
+        }
       }
     })()
 

--- a/bokehjs/src/lib/core/types.ts
+++ b/bokehjs/src/lib/core/types.ts
@@ -6,6 +6,7 @@ export const AsyncGeneratorFunction: AsyncGeneratorFunctionConstructor = Object.
 export type uint8  = number
 export type uint16 = number
 export type uint32 = number
+export type uint64 = bigint
 
 export type ByteOrder = "little" | "big"
 
@@ -19,14 +20,15 @@ export const ColorArray = Uint32Array
 export type RGBAArray = Uint8ClampedArray
 export const RGBAArray = Uint8ClampedArray
 
-export type DataType = "uint8" | "int8" | "uint16" | "int16" | "uint32" | "int32" /*"uint64" | "int64"*/ | "float32" | "float64"
+export type DataType = "uint8" | "int8" | "uint16" | "int16" | "uint32" | "int32" | "uint64" | "int64" | "float32" | "float64"
 export type NDDataType = "bool" | DataType | "object"
 
 export type TypedArray =
-  Uint8Array   | Int8Array    |
-  Uint16Array  | Int16Array   |
-  Uint32Array  | Int32Array   |
-  Float32Array | Float64Array
+  Uint8Array     | Int8Array     |
+  Uint16Array    | Int16Array    |
+  Uint32Array    | Int32Array    |
+  BigUint64Array | BigInt64Array |
+  Float32Array   | Float64Array
 
 export type FloatArray = Float32Array | Float64Array
 export type FloatArrayConstructor = Float32ArrayConstructor | Float64ArrayConstructor

--- a/bokehjs/src/lib/core/util/ndarray.ts
+++ b/bokehjs/src/lib/core/util/ndarray.ts
@@ -235,6 +235,64 @@ export class Int32NDArray extends Int32Array implements NDArrayType<number> {
   }
 }
 
+export class Uint64NDArray extends BigUint64Array implements NDArrayType<bigint> {
+  readonly [__ndarray__] = true
+  readonly dtype: "uint64" = "uint64"
+  readonly shape: number[]
+  readonly dimension: number
+
+  constructor(init: Init<bigint>, shape?: number[]) {
+    super(init as any) // XXX: typescript bug?
+    this.shape = shape ?? (is_NDArray(init) ? init.shape : [this.length])
+    this.dimension = this.shape.length
+  }
+
+  [equals](that: this, cmp: Comparator): boolean {
+    return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
+  }
+
+  [clone](cloner: Cloner): this {
+    return new Uint64NDArray(this, cloner.clone(this.shape)) as this
+  }
+
+  [serialize](serializer: Serializer): unknown {
+    return encode_NDArray(this, serializer)
+  }
+
+  get(i: number): bigint {
+    return this[i]
+  }
+}
+
+export class Int64NDArray extends BigInt64Array implements NDArrayType<bigint> {
+  readonly [__ndarray__] = true
+  readonly dtype: "int64" = "int64"
+  readonly shape: number[]
+  readonly dimension: number
+
+  constructor(init: Init<bigint>, shape?: number[]) {
+    super(init as any) // XXX: typescript bug?
+    this.shape = shape ?? (is_NDArray(init) ? init.shape : [this.length])
+    this.dimension = this.shape.length
+  }
+
+  [equals](that: this, cmp: Comparator): boolean {
+    return cmp.eq(this.shape, that.shape) && cmp.arrays(this, that)
+  }
+
+  [clone](cloner: Cloner): this {
+    return new Int64NDArray(this, cloner.clone(this.shape)) as this
+  }
+
+  [serialize](serializer: Serializer): unknown {
+    return encode_NDArray(this, serializer)
+  }
+
+  get(i: number): bigint {
+    return this[i]
+  }
+}
+
 export class Float32NDArray extends Float32Array implements NDArrayType<number> {
   readonly [__ndarray__] = true
   readonly dtype: "float32" = "float32"
@@ -344,6 +402,7 @@ export type NDArray =
   Uint8NDArray   | Int8NDArray    |
   Uint16NDArray  | Int16NDArray   |
   Uint32NDArray  | Int32NDArray   |
+  Uint64NDArray  | Int64NDArray   |
   Float32NDArray | Float64NDArray |
   ObjectNDArray
 
@@ -352,16 +411,18 @@ export function is_NDArray(v: unknown): v is NDArray {
 }
 
 export type NDArrayTypes = {
-  bool:    {array: Uint8Array,   ndarray: BoolNDArray}
-  uint8:   {array: Uint8Array,   ndarray: Uint8NDArray}
-  int8:    {array: Int8Array,    ndarray: Int8NDArray}
-  uint16:  {array: Uint16Array,  ndarray: Uint16NDArray}
-  int16:   {array: Int16Array,   ndarray: Int16NDArray}
-  uint32:  {array: Uint32Array,  ndarray: Uint32NDArray}
-  int32:   {array: Int32Array,   ndarray: Int32NDArray}
-  float32: {array: Float32Array, ndarray: Float32NDArray}
-  float64: {array: Float64Array, ndarray: Float64NDArray}
-  object:  {array: unknown[],    ndarray: ObjectNDArray}
+  bool:    {array: Uint8Array,     ndarray: BoolNDArray}
+  uint8:   {array: Uint8Array,     ndarray: Uint8NDArray}
+  int8:    {array: Int8Array,      ndarray: Int8NDArray}
+  uint16:  {array: Uint16Array,    ndarray: Uint16NDArray}
+  int16:   {array: Int16Array,     ndarray: Int16NDArray}
+  uint32:  {array: Uint32Array,    ndarray: Uint32NDArray}
+  int32:   {array: Int32Array,     ndarray: Int32NDArray}
+  uint64:  {array: BigUint64Array, ndarray: Uint64NDArray}
+  int64:   {array: BigInt64Array,  ndarray: Int64NDArray}
+  float32: {array: Float32Array,   ndarray: Float32NDArray}
+  float64: {array: Float64Array,   ndarray: Float64NDArray}
+  object:  {array: unknown[],      ndarray: ObjectNDArray}
 }
 
 type ArrayNd<S extends number[]> = {dimension: S["length"], shape: S}
@@ -390,6 +451,8 @@ export function ndarray(init: number | ArrayBuffer | ArrayLike<unknown>, {dtype,
         case init instanceof Int16Array:   return "int16"
         case init instanceof Uint32Array:  return "uint32"
         case init instanceof Int32Array:   return "int32"
+        case init instanceof Uint32Array:  return "uint32"
+        case init instanceof Int32Array:   return "int32"
         case init instanceof Float32Array: return "float32"
         case init instanceof ArrayBuffer:
         case init instanceof Float64Array: return "float64"
@@ -406,6 +469,8 @@ export function ndarray(init: number | ArrayBuffer | ArrayLike<unknown>, {dtype,
     case "int16":   return new Int16NDArray(init as Init<number>, shape)
     case "uint32":  return new Uint32NDArray(init as Init<number>, shape)
     case "int32":   return new Int32NDArray(init as Init<number>, shape)
+    case "uint64":  return new Uint64NDArray(init as Init<bigint>, shape)
+    case "int64":   return new Int64NDArray(init as Init<bigint>, shape)
     case "float32": return new Float32NDArray(init as Init<number>, shape)
     case "float64": return new Float64NDArray(init as Init<number>, shape)
     case "object":  return new ObjectNDArray(init, shape)

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -146,7 +146,7 @@ ModelRep = ObjectRefRep
 
 ByteOrder: TypeAlias = Literal["little", "big"]
 
-DataType: TypeAlias = Literal["uint8", "int8", "uint16", "int16", "uint32", "int32", "float32", "float64"] # "uint64", "int64"
+DataType: TypeAlias = Literal["uint8", "int8", "uint16", "int16", "uint32", "int32", "uint64", "int64", "float32", "float64"]
 NDDataType: TypeAlias = Literal["bool"] | DataType | Literal["object"]
 
 class TypedArrayRep(TypedDict):
@@ -402,13 +402,13 @@ class Serializer:
                         case 1: return "uint8"
                         case 2: return "uint16"
                         case 4: return "uint32"
-                        #case 8: return "uint64"
+                        case 8: return "uint64"
                 case "b" | "h" | "i" | "l" | "q":
                     match obj.itemsize:
                         case 1: return "int8"
                         case 2: return "int16"
                         case 4: return "int32"
-                        #case 8: return "int64"
+                        case 8: return "int64"
             self.error(f"can't serialize array with items of type '{typecode}@{itemsize}'")
 
         return TypedArrayRep(
@@ -637,8 +637,8 @@ class Deserializer:
             int16="h",
             uint32="I",
             int32="i",
-            #uint64="Q",
-            #int64="q",
+            uint64="Q",
+            int64="q",
             float32="f",
             float64="d",
         )

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -74,8 +74,8 @@ BINARY_ARRAY_TYPES = {
     np.dtype(np.int16),
     np.dtype(np.uint32),
     np.dtype(np.int32),
-    #np.dtype(np.uint64),
-    #np.dtype(np.int64),
+    np.dtype(np.uint64),
+    np.dtype(np.int64),
     np.dtype(np.float32),
     np.dtype(np.float64),
 }
@@ -346,11 +346,6 @@ def transform_array(array: npt.NDArray[Any]) -> npt.NDArray[Any]:
             return array
         else:
             return array.astype(dtype, casting="unsafe")
-
-    if array.dtype == np.dtype(np.int64):
-        array = _cast_if_can(array, np.int32)
-    elif array.dtype == np.dtype(np.uint64):
-        array = _cast_if_can(array, np.uint32)
 
     if isinstance(array, np.ma.MaskedArray):
         array = array.filled(np.nan)  # type: ignore # filled is untyped

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -468,20 +468,18 @@ class TestSerializer:
 
         assert rep7 == NDArrayRep(
             type="ndarray",
-            array=BytesRep(type="bytes", data=Buffer(encoder.buffers[7].id, encoder.buffers[5].data)), # encoder.buffers[7]),
+            array=BytesRep(type="bytes", data=encoder.buffers[7]),
             order=sys.byteorder,
             shape=[2, 3],
-            dtype="uint32",
-            #dtype="uint64",
+            dtype="uint64",
         )
 
         assert rep8 == NDArrayRep(
             type="ndarray",
-            array=BytesRep(type="bytes", data=Buffer(encoder.buffers[8].id, encoder.buffers[6].data)), # encoder.buffers[8]),
+            array=BytesRep(type="bytes", data=encoder.buffers[8]),
             order=sys.byteorder,
             shape=[2, 3],
-            dtype="int32",
-            #dtype="int64",
+            dtype="int64",
         )
 
         assert rep9 == NDArrayRep(
@@ -549,15 +547,15 @@ class TestSerializer:
         rep2 = encoder.encode(val2)
         rep3 = encoder.encode(val3)
 
-        assert len(encoder.buffers) == 2
-        [buf0, buf1] = encoder.buffers
+        assert len(encoder.buffers) == 4
+        [buf0, buf1, buf2, buf3] = encoder.buffers
 
         assert rep0 == NDArrayRep(
             type="ndarray",
             array=BytesRep(type="bytes", data=buf0),
             order=sys.byteorder,
             shape=[1],
-            dtype="int32",
+            dtype="int64",
         )
 
         assert rep1 == NDArrayRep(
@@ -565,23 +563,23 @@ class TestSerializer:
             array=BytesRep(type="bytes", data=buf1),
             order=sys.byteorder,
             shape=[1],
-            dtype="uint32",
+            dtype="uint64",
         )
 
         assert rep2 == NDArrayRep(
             type="ndarray",
-            array=[-2**36],
+            array=BytesRep(type="bytes", data=buf2),
             order=sys.byteorder,
             shape=[1],
-            dtype="object",
+            dtype="int64",
         )
 
         assert rep3 == NDArrayRep(
             type="ndarray",
-            array=[2**36],
+            array=BytesRep(type="bytes", data=buf3),
             order=sys.byteorder,
             shape=[1],
-            dtype="object",
+            dtype="uint64",
         )
 
     def test_ndarray_zero_dimensional(self):

--- a/tests/unit/bokeh/util/test_util__serialization.py
+++ b/tests/unit/bokeh/util/test_util__serialization.py
@@ -84,8 +84,8 @@ def test_binary_array_types() -> None:
         np.dtype(np.int16),
         np.dtype(np.uint32),
         np.dtype(np.int32),
-        #np.dtype(np.uint64),
-        #np.dtype(np.int64),
+        np.dtype(np.uint64),
+        np.dtype(np.int64),
         np.dtype(np.float32),
         np.dtype(np.float64),
     ]


### PR DESCRIPTION
This PR is an experiment and is very unlikely to be successful, due to JS limitations outlined in issue #13573. However, I wanted to see exactly how bad it would be and yes, it's pretty bad. The main reason for this is that `BigInt64Array` (same for unsigned) produces `bigint` numbers, which can represent 64bit integers and arbitrary sized integers. This new type comes with a new syntax (`0n` for 0 `bigint`) and semantics, where you can't mix regular `number` values, even if they represent integers, with `bigint`. This results in us having to implement code paths for both everywhere a `bigint` may appear. Not event a simple `0n + 1` or `2*0n` is allowed. Thus it's much more likely that support for 64bit integers will arrive via WASM, in one form of another. Some preliminary integration work was started in PR #12961.

addresses #13573