### PR TITLE
Add AxisClick event

### DIFF
--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -12,7 +12,9 @@ import {Deserializer} from "./serialization/deserializer"
 import type {Equatable, Comparator} from "./util/eq"
 import {equals} from "./util/eq"
 import type {Legend} from "../models/annotations/legend"
+import type {Axis} from "../models/axes/axis"
 import type {LegendItem} from "../models/annotations/legend_item"
+import type {Factor} from "../models/ranges/factor_range"
 import type {ClearInput} from "../models/widgets/input_widget"
 
 Deserializer.register("event", (rep: BokehEventRep, deserializer: Deserializer): BokehEvent => {
@@ -38,6 +40,7 @@ export type ConnectionEventType =
   "connection_lost"
 
 export type ModelEventType =
+  "axis_click" |
   "button_click" |
   "legend_item_click" |
   "menu_item_click" |
@@ -76,35 +79,36 @@ export type PointEventType =
  * Other events, including user defined events, can be referred to by event's class object.
  */
 export type BokehEventMap = {
-  document_ready: DocumentReady
+  axis_click: AxisClick
+  button_click: ButtonClick
   clear_input: ClearInput
   connection_lost: ConnectionLost
-  button_click: ButtonClick
+  document_ready: DocumentReady
+  doubletap: DoubleTap
   legend_item_click: LegendItemClick
-  menu_item_click: MenuItemClick
-  value_submit: ValueSubmit
-  lodstart: LODStart
   lodend: LODEnd
-  rangesupdate: RangesUpdate
-  selectiongeometry: SelectionGeometry
-  reset: Reset
-  pan: Pan
-  pinch: Pinch
-  rotate: Rotate
-  wheel: MouseWheel
-  mousemove: MouseMove
+  lodstart: LODStart
+  menu_item_click: MenuItemClick
   mouseenter: MouseEnter
   mouseleave: MouseLeave
-  tap: Tap
-  doubletap: DoubleTap
+  mousemove: MouseMove
+  pan: Pan
+  panend: PanEnd
+  panstart: PanStart
+  pinch: Pinch
+  pinchend: PinchEnd
+  pinchstart: PinchStart
   press: Press
   pressup: PressUp
-  panstart: PanStart
-  panend: PanEnd
-  pinchstart: PinchStart
-  pinchend: PinchEnd
-  rotatestart: RotateStart
+  rangesupdate: RangesUpdate
+  reset: Reset
+  rotate: Rotate
   rotateend: RotateEnd
+  rotatestart: RotateStart
+  selectiongeometry: SelectionGeometry
+  tap: Tap
+  value_submit: ValueSubmit
+  wheel: MouseWheel
 }
 
 export type BokehEventRep = {
@@ -214,6 +218,19 @@ export class ConnectionLost extends ConnectionEvent {
   static {
     this.prototype.event_name = "connection_lost"
     this.prototype.publish = false
+  }
+}
+
+@event("axis_click")
+export class AxisClick extends ModelEvent {
+
+  constructor(readonly model: Axis, readonly value: number | Factor) {
+    super()
+  }
+
+  protected override get event_values(): Attrs {
+    const {value} = this
+    return {...super.event_values, value}
   }
 }
 

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -157,15 +157,15 @@ export abstract class AxisView extends GuideRendererView {
     return super.is_renderable && range.is_valid && cross_range.is_valid && range.span > 0 && cross_range.span > 0
   }
 
-  protected abstract _hit_value(sx: number, sy: number): any | null
+  protected abstract _hit_value(sx: number, sy: number): number | Factor | null
 
   override interactive_hit(sx: number, sy: number): boolean {
     return this.bbox.contains(sx, sy)
   }
 
   override on_hit(sx: number, sy: number): boolean {
-
     const value = this._hit_value(sx, sy)
+
     if (value != null) {
       this.model.trigger_event(new AxisClick(this.model, value))
       return true

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -4,6 +4,7 @@ import {TickFormatter} from "../formatters/tick_formatter"
 import type {DistanceMeasure} from "../policies/labeling"
 import {LabelingPolicy, AllLabels} from "../policies/labeling"
 import type {Range} from "../ranges/range"
+import {AxisClick} from "core/bokeh_events"
 import type * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import type * as p from "core/properties"
@@ -154,6 +155,23 @@ export abstract class AxisView extends GuideRendererView {
   override get is_renderable(): boolean {
     const [range, cross_range] = this.ranges
     return super.is_renderable && range.is_valid && cross_range.is_valid && range.span > 0 && cross_range.span > 0
+  }
+
+  protected abstract _hit_value(sx: number, sy: number): any | null
+
+  override interactive_hit(sx: number, sy: number): boolean {
+    return this.bbox.contains(sx, sy)
+  }
+
+  override on_hit(sx: number, sy: number): boolean {
+
+    const value = this._hit_value(sx, sy)
+    if (value != null) {
+      this.model.trigger_event(new AxisClick(this.model, value))
+      return true
+    }
+
+    return false
   }
 
   protected _paint(): void {

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -26,6 +26,21 @@ export class CategoricalAxisView extends AxisView {
 
   declare readonly RangeType: FactorRange
 
+  protected  _hit_value(sx: number, sy: number): any | null {
+    const [range] = this.ranges as [FactorRange, FactorRange]
+    const {start, end, span} = range
+    switch (this.dimension) {
+      case 0: {
+        const {x0, width} = this.bbox
+        return range.factor(span * (sx - x0) / width + start)
+      }
+      case 1: {
+        const {y0, height} = this.bbox
+        return range.factor(end - span * (sy - y0) / height)
+      }
+    }
+  }
+
   protected override _paint(): void {
     const {tick_coords, extents} = this
     const ctx = this.layer.ctx

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -27,7 +27,7 @@ export class CategoricalAxisView extends AxisView {
   declare readonly RangeType: FactorRange
 
   protected _hit_value(sx: number, sy: number): Factor | null {
-    const [range] = this.ranges as [FactorRange, FactorRange]
+    const [range] = this.ranges
     const {start, end, span} = range
     switch (this.dimension) {
       case 0: {

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -26,7 +26,7 @@ export class CategoricalAxisView extends AxisView {
 
   declare readonly RangeType: FactorRange
 
-  protected  _hit_value(sx: number, sy: number): any | null {
+  protected _hit_value(sx: number, sy: number): Factor | null {
     const [range] = this.ranges as [FactorRange, FactorRange]
     const {start, end, span} = range
     switch (this.dimension) {

--- a/bokehjs/src/lib/models/axes/continuous_axis.ts
+++ b/bokehjs/src/lib/models/axes/continuous_axis.ts
@@ -3,6 +3,21 @@ import type * as p from "core/properties"
 
 export abstract class ContinuousAxisView extends AxisView {
   declare model: ContinuousAxis
+
+  protected  _hit_value(sx: number, sy: number): any | null {
+    const [range] = this.ranges
+    const {start, end, span} = range
+    switch (this.dimension) {
+      case 0: {
+        const {x0, width} = this.bbox
+        return span * (sx - x0) / width + start
+      }
+      case 1: {
+        const {y0, height} = this.bbox
+        return end - span * (sy - y0) / height
+      }
+    }
+  }
 }
 
 export namespace ContinuousAxis {

--- a/bokehjs/src/lib/models/axes/continuous_axis.ts
+++ b/bokehjs/src/lib/models/axes/continuous_axis.ts
@@ -4,7 +4,7 @@ import type * as p from "core/properties"
 export abstract class ContinuousAxisView extends AxisView {
   declare model: ContinuousAxis
 
-  protected  _hit_value(sx: number, sy: number): any | null {
+  protected _hit_value(sx: number, sy: number): number | null {
     const [range] = this.ranges
     const {start, end, span} = range
     switch (this.dimension) {

--- a/bokehjs/src/lib/models/axes/log_axis.ts
+++ b/bokehjs/src/lib/models/axes/log_axis.ts
@@ -5,6 +5,21 @@ import type * as p from "core/properties"
 
 export class LogAxisView extends ContinuousAxisView {
   declare model: LogAxis
+  protected override _hit_value(sx: number, sy: number): any | null {
+    const [range] = this.ranges
+    const {start, end} = range
+    const {log10} = Math
+    switch (this.dimension) {
+      case 0: {
+        const {x0, width} = this.bbox
+        return log10(end/start) * (sx - x0) / width + log10(start)
+      }
+      case 1: {
+        const {y0, height} = this.bbox
+        return log10(end) - log10(end/start) * (sy - y0) / height
+      }
+    }
+  }
 }
 
 export namespace LogAxis {

--- a/bokehjs/src/lib/models/axes/log_axis.ts
+++ b/bokehjs/src/lib/models/axes/log_axis.ts
@@ -5,7 +5,8 @@ import type * as p from "core/properties"
 
 export class LogAxisView extends ContinuousAxisView {
   declare model: LogAxis
-  protected override _hit_value(sx: number, sy: number): any | null {
+
+  protected override _hit_value(sx: number, sy: number): number | null {
     const [range] = this.ranges
     const {start, end} = range
     const {log10} = Math

--- a/bokehjs/src/lib/models/axes/mercator_axis.ts
+++ b/bokehjs/src/lib/models/axes/mercator_axis.ts
@@ -1,10 +1,9 @@
-import {AxisView} from "./axis"
-import {LinearAxis} from "./linear_axis"
+import {LinearAxis, LinearAxisView} from "./linear_axis"
 import {MercatorTickFormatter} from "../formatters/mercator_tick_formatter"
 import {MercatorTicker} from "../tickers/mercator_ticker"
 import type * as p from "core/properties"
 
-export class MercatorAxisView extends AxisView {
+export class MercatorAxisView extends LinearAxisView {
   declare model: MercatorAxis
 }
 

--- a/bokehjs/test/unit/core/bokeh_events.ts
+++ b/bokehjs/test/unit/core/bokeh_events.ts
@@ -4,12 +4,13 @@ import {display} from "../_util"
 import {Serializer} from "@bokehjs/core/serialization"
 import type {BokehEvent} from "@bokehjs/core/bokeh_events"
 import {AxisClick, server_event, UserEvent} from "@bokehjs/core/bokeh_events"
-import {paint} from "@bokehjs/core/util/defer"
 import type {Model} from "@bokehjs/model"
 import {CategoricalAxis, CategoricalScale, FactorRange, Plot, Range1d, LinearAxis, LogAxis} from "@bokehjs/models"
 import type {MessageSent, Patch} from "@bokehjs/document"
 import {TextInput} from "@bokehjs/models/widgets"
 import {PlotActions, xy} from "../../interactive"
+import type {Point} from "../../interactive"
+import type {Side} from "@bokehjs/core/enums"
 
 @server_event("some_library.do_something")
 class DoSomething extends UserEvent {
@@ -66,8 +67,8 @@ describe("BokehEvent", () => {
 })
 
 describe("AxisClick event", () => {
-  for (const {side, pt} of [{side: "left", pt: xy(5, 200)}, {side: "right", pt: xy(395, 200)}, {side: "above", pt: xy(200, 5)}, {side: "below", pt: xy(200, 395)}]) {
-    it(`should support linear axes on side: ${side}`, async () => {
+  describe("should support linear axes", () => {
+    async function test(side: Side, pt: Point) {
       const plot = new Plot({
         width: 400,
         height: 400,
@@ -77,24 +78,28 @@ describe("AxisClick event", () => {
         y_range: new Range1d({start: 0, end: 10}),
       })
       const axis = new LinearAxis()
-      plot.add_layout(axis, side as any)
+      plot.add_layout(axis, side)
 
       const events: AxisClick[] = []
-      axis.on_event(AxisClick, (event: any) => events.push(event))
+      axis.on_event(AxisClick, (event) => events.push(event))
 
       const {view} = await display(plot)
 
       const actions = new PlotActions(view, {units: "screen"})
-      await paint()
       await actions.tap(pt)
 
       expect(events.length).to.be.equal(1)
       expect(events[0].value).to.be.equal(5)
-    })
-  }
+    }
 
-  for (const {side, pt} of [{side: "left", pt: xy(5, 200)}, {side: "right", pt: xy(395, 200)}, {side: "above", pt: xy(200, 5)}, {side: "below", pt: xy(200, 395)}]) {
-    it(`should support log axes on side: ${side}`, async () => {
+    it("on the left side",  async () => test("left", xy(5, 200)))
+    it("on the right side", async () => test("right", xy(395, 200)))
+    it("on the above side", async () => test("above", xy(200, 5)))
+    it("on the below side", async () => test("below", xy(200, 395)))
+  })
+
+  describe("should support log axes", () => {
+    async function test(side: Side, pt: Point) {
       const plot = new Plot({
         width: 400,
         height: 400,
@@ -104,24 +109,28 @@ describe("AxisClick event", () => {
         y_range: new Range1d({start: 1, end: 10000}),
       })
       const axis = new LogAxis()
-      plot.add_layout(axis, side as any)
+      plot.add_layout(axis, side)
 
       const events: AxisClick[] = []
-      axis.on_event(AxisClick, (event: any) => events.push(event))
+      axis.on_event(AxisClick, (event) => events.push(event))
 
       const {view} = await display(plot)
 
       const actions = new PlotActions(view, {units: "screen"})
-      await paint()
       await actions.tap(pt)
 
       expect(events.length).to.be.equal(1)
       expect(events[0].value).to.be.equal(2) // 10^2 == 100
-    })
-  }
+    }
 
-  for (const {side, pt} of [{side: "left", pt: xy(5, 200)}, {side: "right", pt: xy(395, 200)}, {side: "above", pt: xy(200, 5)}, {side: "below", pt: xy(200, 395)}]) {
-    it(`should support categorical axes on side: ${side}`, async () => {
+    it("on the left side",  async () => test("left", xy(5, 200)))
+    it("on the right side", async () => test("right", xy(395, 200)))
+    it("on the above side", async () => test("above", xy(200, 5)))
+    it("on the below side", async () => test("below", xy(200, 395)))
+  })
+
+  describe("should support categorical axes", () => {
+    async function test(side: Side, pt: Point) {
       const plot = new Plot({
         width: 400,
         height: 400,
@@ -133,19 +142,23 @@ describe("AxisClick event", () => {
         y_range: new FactorRange({factors: ["a", "b", "c", "d", "e"]}),
       })
       const axis = new CategoricalAxis()
-      plot.add_layout(axis, side as any)
+      plot.add_layout(axis, side)
 
       const events: AxisClick[] = []
-      axis.on_event(AxisClick, (event: any) => events.push(event))
+      axis.on_event(AxisClick, (event) => events.push(event))
 
       const {view} = await display(plot)
 
       const actions = new PlotActions(view, {units: "screen"})
-      await paint()
       await actions.tap(pt)
 
       expect(events.length).to.be.equal(1)
       expect(events[0].value).to.be.equal("c")
-    })
-  }
+    }
+
+    it("on the left side",  async () => test("left", xy(5, 200)))
+    it("on the right side", async () => test("right", xy(395, 200)))
+    it("on the above side", async () => test("above", xy(200, 5)))
+    it("on the below side", async () => test("below", xy(200, 395)))
+  })
 })

--- a/bokehjs/test/unit/core/bokeh_events.ts
+++ b/bokehjs/test/unit/core/bokeh_events.ts
@@ -3,10 +3,13 @@ import {display} from "../_util"
 
 import {Serializer} from "@bokehjs/core/serialization"
 import type {BokehEvent} from "@bokehjs/core/bokeh_events"
-import {server_event, UserEvent} from "@bokehjs/core/bokeh_events"
+import {AxisClick, server_event, UserEvent} from "@bokehjs/core/bokeh_events"
+import {paint} from "@bokehjs/core/util/defer"
 import type {Model} from "@bokehjs/model"
+import {CategoricalAxis, CategoricalScale, FactorRange, Plot, Range1d, LinearAxis, LogAxis} from "@bokehjs/models"
 import type {MessageSent, Patch} from "@bokehjs/document"
 import {TextInput} from "@bokehjs/models/widgets"
+import {PlotActions, xy} from "../../interactive"
 
 @server_event("some_library.do_something")
 class DoSomething extends UserEvent {
@@ -60,4 +63,89 @@ describe("BokehEvent", () => {
     expect(event.origin).to.be.null
     expect(event.values).to.be.equal({target: widget, action: "do_that"})
   })
+})
+
+describe("AxisClick event", () => {
+  for (const {side, pt} of [{side: "left", pt: xy(5, 200)}, {side: "right", pt: xy(395, 200)}, {side: "above", pt: xy(200, 5)}, {side: "below", pt: xy(200, 395)}]) {
+    it(`should support linear axes on side: ${side}`, async () => {
+      const plot = new Plot({
+        width: 400,
+        height: 400,
+        title: null,
+        toolbar_location: null,
+        x_range: new Range1d({start: 0, end: 10}),
+        y_range: new Range1d({start: 0, end: 10}),
+      })
+      const axis = new LinearAxis()
+      plot.add_layout(axis, side as any)
+
+      const events: AxisClick[] = []
+      axis.on_event(AxisClick, (event: any) => events.push(event))
+
+      const {view} = await display(plot)
+
+      const actions = new PlotActions(view, {units: "screen"})
+      await paint()
+      await actions.tap(pt)
+
+      expect(events.length).to.be.equal(1)
+      expect(events[0].value).to.be.equal(5)
+    })
+  }
+
+  for (const {side, pt} of [{side: "left", pt: xy(5, 200)}, {side: "right", pt: xy(395, 200)}, {side: "above", pt: xy(200, 5)}, {side: "below", pt: xy(200, 395)}]) {
+    it(`should support log axes on side: ${side}`, async () => {
+      const plot = new Plot({
+        width: 400,
+        height: 400,
+        title: null,
+        toolbar_location: null,
+        x_range: new Range1d({start: 1, end: 10000}),
+        y_range: new Range1d({start: 1, end: 10000}),
+      })
+      const axis = new LogAxis()
+      plot.add_layout(axis, side as any)
+
+      const events: AxisClick[] = []
+      axis.on_event(AxisClick, (event: any) => events.push(event))
+
+      const {view} = await display(plot)
+
+      const actions = new PlotActions(view, {units: "screen"})
+      await paint()
+      await actions.tap(pt)
+
+      expect(events.length).to.be.equal(1)
+      expect(events[0].value).to.be.equal(2) // 10^2 == 100
+    })
+  }
+
+  for (const {side, pt} of [{side: "left", pt: xy(5, 200)}, {side: "right", pt: xy(395, 200)}, {side: "above", pt: xy(200, 5)}, {side: "below", pt: xy(200, 395)}]) {
+    it(`should support categorical axes on side: ${side}`, async () => {
+      const plot = new Plot({
+        width: 400,
+        height: 400,
+        title: null,
+        toolbar_location: null,
+        x_scale: new CategoricalScale(),
+        y_scale: new CategoricalScale(),
+        x_range: new FactorRange({factors: ["a", "b", "c", "d", "e"]}),
+        y_range: new FactorRange({factors: ["a", "b", "c", "d", "e"]}),
+      })
+      const axis = new CategoricalAxis()
+      plot.add_layout(axis, side as any)
+
+      const events: AxisClick[] = []
+      axis.on_event(AxisClick, (event: any) => events.push(event))
+
+      const {view} = await display(plot)
+
+      const actions = new PlotActions(view, {units: "screen"})
+      await paint()
+      await actions.tap(pt)
+
+      expect(events.length).to.be.equal(1)
+      expect(events[0].value).to.be.equal("c")
+    })
+  }
 })

--- a/examples/interaction/js_callbacks/js_on_event.py
+++ b/examples/interaction/js_callbacks/js_on_event.py
@@ -60,6 +60,10 @@ button.js_on_event(events.ButtonClick, display_event(div))
 # TextInput events
 text_input.js_on_event(events.ValueSubmit, display_event(div, ["value"]))
 
+# AxisClick events
+p.xaxis[0].js_on_event(events.AxisClick, display_event(div, ["value"]))
+p.yaxis[0].js_on_event(events.AxisClick, display_event(div, ["value"]))
+
 # LOD events
 p.js_on_event(events.LODStart, display_event(div))
 p.js_on_event(events.LODEnd, display_event(div))

--- a/examples/server/app/events_app.py
+++ b/examples/server/app/events_app.py
@@ -75,12 +75,15 @@ wheel_attributes = [*point_attributes, 'delta']
 # Button event
 button.js_on_event(events.ButtonClick, display_event(div))
 
+# AxisClick events
+p.xaxis[0].js_on_event(events.AxisClick, display_event(div, ["value"]))
+p.yaxis[0].js_on_event(events.AxisClick, display_event(div, ["value"]))
+
 # LOD events
 p.js_on_event(events.LODStart, display_event(div))
 p.js_on_event(events.LODEnd,   display_event(div))
 
 # Point events
-
 p.js_on_event(events.Tap,       display_event(div, attributes=point_attributes))
 p.js_on_event(events.DoubleTap, display_event(div, attributes=point_attributes))
 p.js_on_event(events.Press,     display_event(div, attributes=point_attributes))
@@ -116,6 +119,10 @@ p.js_on_event(events.Reset, display_event(div))
 
 # Button event
 button.on_event(events.ButtonClick, print_event())
+
+# AxisClick events
+p.xaxis[0].on_event(events.AxisClick, print_event(attributes=["value"]))
+p.yaxis[0].on_event(events.AxisClick, print_event(attributes=["value"]))
 
 # LOD events
 p.on_event(events.LODStart, print_event())

--- a/src/bokeh/core/property/factors.py
+++ b/src/bokeh/core/property/factors.py
@@ -19,10 +19,9 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-import typing as tp
-from typing import TypeAlias
 
 # Bokeh imports
+from ..types import FactorSeqType, FactorType
 from .bases import Init, SingleParameterizedProperty
 from .container import Seq, Tuple
 from .either import Either
@@ -45,9 +44,6 @@ __all__ = (
 L1Factor = String
 L2Factor = Tuple(String, String)
 L3Factor = Tuple(String, String, String)
-
-FactorType: TypeAlias = str | tuple[str, str] | tuple[str, str]
-FactorSeqType: TypeAlias = tp.Sequence[str] | tp.Sequence[tuple[str, str]] | tp.Sequence[tuple[str, str]]
 
 class Factor(SingleParameterizedProperty[FactorType]):
     """ Represents a single categorical factor. """

--- a/src/bokeh/core/types.py
+++ b/src/bokeh/core/types.py
@@ -51,6 +51,10 @@ ID = NewType("ID", str)
 
 PathLike: TypeAlias = str | os.PathLike[str]
 
+FactorType: TypeAlias = str | tuple[str, str] | tuple[str, str, str]
+FactorSeqType: TypeAlias = Sequence[str] | Sequence[tuple[str, str]] | Sequence[tuple[str, str, str]]
+
+
 # TODO: move this to types/geometry.py
 class PointGeometry(TypedDict):
     type: Literal["point"]

--- a/src/bokeh/events.py
+++ b/src/bokeh/events.py
@@ -280,6 +280,13 @@ class ModelEvent(Event):
 class AxisClick(ModelEvent):
     ''' Announce a location where an axis was clicked.
 
+    For continuous numerical axes, the value will be a number. For log axes,
+    this number is the log decade.
+
+    For categorical axes, the value will be a categorical factor, i.e. a string
+    or a list of strings, representing the closest categorical factor that was
+    clicked.
+
     '''
     event_name = 'axis_click'
 

--- a/src/bokeh/events.py
+++ b/src/bokeh/events.py
@@ -79,9 +79,10 @@ from typing import (
 from .core.serialization import Deserializer, Serializable, Serializer
 
 if TYPE_CHECKING:
-    from .core.types import GeometryData
+    from .core.types import FactorType, GeometryData
     from .model import Model
     from .models.annotations import Legend, LegendItem
+    from .models.axes import Axis
     from .models.plots import Plot
     from .models.widgets.buttons import AbstractButton
     from .models.widgets.inputs import TextInput
@@ -91,6 +92,7 @@ if TYPE_CHECKING:
 #-----------------------------------------------------------------------------
 
 __all__ = (
+    'AxisClick',
     'ButtonClick',
     'ConnectionLost',
     'DocumentEvent',
@@ -274,6 +276,22 @@ class ModelEvent(Event):
 
     def event_values(self) -> dict[str, Any]:
         return dict(**super().event_values(), model=self.model)
+
+class AxisClick(ModelEvent):
+    ''' Announce a location where an axis was clicked.
+
+    '''
+    event_name = 'axis_click'
+
+    value: float | FactorType | None
+
+    def __init__(self, model: Axis | None, value: float | FactorType | None = None) -> None:
+        from .models import Axis
+        if model is not None and not isinstance(model, Axis):
+            clsname = self.__class__.__name__
+            raise ValueError(f"{clsname} event only applies to axis models")
+        super().__init__(model=model)
+        self.value = value
 
 class ButtonClick(ModelEvent):
     ''' Announce a button click event on a Bokeh button widget.

--- a/tests/unit/bokeh/test_events.py
+++ b/tests/unit/bokeh/test_events.py
@@ -26,6 +26,7 @@ from bokeh.models import (
     FileInput,
     Legend,
     LegendItem,
+    LinearAxis,
     Plot,
     TextInput,
 )
@@ -68,6 +69,8 @@ def test_common_decode_json() -> None:
 
         if issubclass(event_cls, events.ButtonClick):
             model = Button()
+        elif issubclass(event_cls, events.AxisClick):
+            model = LinearAxis()
         elif issubclass(event_cls, events.LegendItemClick):
             model = Legend(items=[legend_item])
         elif issubclass(event_cls, events.ValueSubmit):


### PR DESCRIPTION
This PR adds support for an `AxisClick` / `"axis_click"` event that reports the location that an axis was clicked. 

- [x] issues: fixes #601
- [x] tests added / passed
- [x] release document entry (if new feature or API change)

This can be tested by adding code like the following to nearly any example":
```python
from bokeh.models import CustomJS
p.xaxis[0].js_on_event("axis_click", CustomJS(code="""
    alert('It works! ' + cb_obj.value)
"""))

p.yaxis[0].js_on_event("axis_click", CustomJS(code="""
    alert('It works! ' + cb_obj.value)
"""))
```

This needs some polish:

* @mattpap as usual any suggestions for BokehJS tests welcome. I did not see much existing tests for these sorts of events that I might look to emulate
* @bokeh/dev thoughts on interesting examples? This has been long-requested but there were never concrete use-cases described that I recall. 
* @tcmetzger any thoughts on where / how much narrative docs to add are welcome