### PR TITLE
Use pseudo type members to avoid casting

### DIFF
--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -57,6 +57,8 @@ export abstract class AxisView extends GuideRendererView {
   declare model: Axis
   declare visuals: Axis.Visuals
 
+  declare readonly RangeType: Range
+
   layout?: Layoutable
 
   private _panel: SidePanel
@@ -555,7 +557,7 @@ export abstract class AxisView extends GuideRendererView {
     }
   }
 
-  get ranges(): [Range, Range] {
+  get ranges(): [typeof this["RangeType"], typeof this["RangeType"]] {
     const i = this.dimension
     const j = 1 - i
     const {ranges} = this.coordinates

--- a/bokehjs/src/lib/models/axes/categorical_axis.ts
+++ b/bokehjs/src/lib/models/axes/categorical_axis.ts
@@ -24,6 +24,8 @@ export class CategoricalAxisView extends AxisView {
   declare model: CategoricalAxis
   declare visuals: CategoricalAxis.Visuals
 
+  declare readonly RangeType: FactorRange
+
   protected override _paint(): void {
     const {tick_coords, extents} = this
     const ctx = this.layer.ctx
@@ -33,7 +35,7 @@ export class CategoricalAxisView extends AxisView {
   }
 
   protected _draw_group_separators(ctx: Context2d, _extents: Extents, _tick_coords: TickCoords): void {
-    const [range] = this.ranges as [FactorRange, FactorRange]
+    const [range] = this.ranges
     const [start, end] = this.computed_bounds
 
     const {factors} = range
@@ -94,7 +96,7 @@ export class CategoricalAxisView extends AxisView {
   }
 
   protected _get_factor_info(): [GraphicsBoxes, Coords, Orient | number, visuals.Text][] {
-    const [range] = this.ranges as [FactorRange, FactorRange]
+    const [range] = this.ranges
     const [start, end] = this.computed_bounds
     const loc = this.loc
 
@@ -142,7 +144,7 @@ export class CategoricalAxisView extends AxisView {
   override get tick_coords(): CategoricalTickCoords {
     const i = this.dimension
     const j = 1 - i
-    const [range] = this.ranges as [FactorRange, FactorRange]
+    const [range] = this.ranges
     const [start, end] = this.computed_bounds
 
     const ticks = this.model.ticker.get_ticks(start, end, range, this.loc)


### PR DESCRIPTION
Allows to remove `as [FactorRange, FactorRange]` from `CategoricalAxis` implementation.