### PR TITLE
Fix logic error in UI event emit code

### DIFF
--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -634,7 +634,9 @@ export class UIEventBus {
     } else {
       let result = false
       for (const tool of this._tools.keys()) {
-        result ||= emit(tool)
+        // don't conflate these lines because of short circuiting nature of ||= operator
+        const emitted = emit(tool)
+        result ||= emitted
       }
       return result
     }


### PR DESCRIPTION
Operator in `result ||= emit(tool)` is short circuiting, thus if the first emit returned `true`, which is always for key event handlers, then no other would emit.

fixes #14058