### PR TITLE
Generate correct `*.d.ts` files for CSS modules

### DIFF
--- a/bokehjs/src/compiler/styles.ts
+++ b/bokehjs/src/compiler/styles.ts
@@ -84,8 +84,10 @@ export function wrap_css_modules(css_dir: string, js_dir: string, dts_dir: strin
 
     const css_out = CSS.stringify(ast, {compress: true})
     js.push(`export default \`${css_out}\``)
-    dts.push("export default \"\"")
-    dts_internal.push("  export default \"\"")
+    dts.push("const __css__: string")
+    dts.push("export default __css__")
+    dts_internal.push("  const __css__: string")
+    dts_internal.push("  export default __css__")
     dts_internal.push("}")
 
     const js_file = `${join(js_dir, "styles", sub_path)}.js`


### PR DESCRIPTION
Looks like TypeScript was able to figure out things regardless of the bug. No error reporting for this was probably due to `skipLibCheck: true` in our `tsconfig.json` files.

Extracted from PR #14028.