### PR TITLE
Bring 3.5.x point release notes to 3.6.0

### DIFF
--- a/docs/bokeh/source/docs/releases/3.5.1.rst
+++ b/docs/bokeh/source/docs/releases/3.5.1.rst
@@ -1,0 +1,17 @@
+.. _release-3-5-1:
+
+3.5.1
+=====
+
+Bokeh version ``3.5.1`` (July 2024) is a patch release that fixes a number of
+minor bugs/regressions and docs issues.
+
+Changes
+-------
+
+* Fixed handling of certain classes of objects in ``HasProps`` internals (:bokeh-pull:`13970`)
+* Restored support for ``BOKEH_MINIFIED=no`` in resources (:bokeh-pull:`13974`)
+* Updated the location of ``*.d.ts`` files in ``package.json`` (:bokeh-pull:`13975`)
+* Fixed merging of plots in grid plots when only one plot is involved (:bokeh-pull:`13978`)
+* Restored a bit of legacy font measurement logic for Firefox ESR (:bokeh-pull:`13979`)
+* Fixed indexing of categories in ``CategoricalSlider`` widget (:bokeh-pull:`13966`)

--- a/docs/bokeh/source/docs/releases/3.5.2.rst
+++ b/docs/bokeh/source/docs/releases/3.5.2.rst
@@ -1,0 +1,17 @@
+.. _release-3-5-2:
+
+3.5.2
+=====
+
+Bokeh version ``3.5.2`` (August 2024) is a patch release that fixes a number of
+minor bugs/regressions and docs issues.
+
+Changes
+-------
+
+* Fixed a bug in masking indices with secondary ranges in ``Patches`` and ``MultiPolygons`` glyphs (:bokeh-pull:`14016`)
+* Restored support for browsers that don't implement ``OffscreenCanvas`` (:bokeh-pull:`14008`)
+* Improved determination of WebSocket protocol in ``<iframe>`` embedding (:bokeh-pull:`14003`)
+* Fixed a bug in handling of CORS requests (:bokeh-pull:`13999`)
+* Fixed an issue with numpy 2.0 and streaming ndarrays (:bokeh-pull:`14007`)
+* Fixed bad string formatting in various error messages (:bokeh-pull:`14020`, :bokeh-pull:`14022`)


### PR DESCRIPTION
This PR collects the release notes  of the release `3.5.1` and `3.5.2` and bring them to the `3.6` branch, so that they aren't missing in an upcoming release.
