### PR TITLE
Fix image hover values in custom hover templates

### DIFF
--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -202,7 +202,7 @@ const regex = /((?:[$@][\p{Letter}\p{Number}_]+)|(?:[$@]\{(?:[^{}]+)\}))(?:\{([^
 type PlaceholderReplacer = (type: PlaceholderType, name: string, format: string | undefined, i: number, spec: string) => string | null | undefined
 
 export function process_placeholders(text: string, fn: PlaceholderReplacer): string {
-  let i = 0
+  let i = 0 // this var is used for testing purposes
   return text.replace(regex, (_match, spec: string, format: string | undefined) => {
     const type = spec[0] as "@" | "$"
     const name = spec.substring(1).replace(/^{/, "").replace(/}$/, "").trim()

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.ts
@@ -546,7 +546,7 @@ export class HoverToolView extends InspectToolView {
     return rows
   }
 
-  _render_template(template: HTMLElement, tooltips: [string, string][], ds: ColumnarDataSource, i: Index | null, vars: TooltipVars): HTMLElement {
+  _render_template(template: HTMLElement, tooltips: [string, string][], ds: ColumnarDataSource, index: Index | null, vars: TooltipVars): HTMLElement {
     const el = template.cloneNode(true) as HTMLElement
 
     const value_els = el.querySelectorAll<HTMLElement>("[data-value]")
@@ -557,7 +557,7 @@ export class HoverToolView extends InspectToolView {
       const color_match = value.match(COLOR_RE)
 
       if (swatch_match == null && color_match == null) {
-        const content = replace_placeholders(value.replace("$~", "$data_"), ds, i, this.model.formatters, vars)
+        const content = replace_placeholders(value.replace("$~", "$data_"), ds, index, this.model.formatters, vars)
         if (isString(content)) {
           value_els[j].textContent = content
         } else {
@@ -575,7 +575,7 @@ export class HoverToolView extends InspectToolView {
         if (column == null) {
           value_els[j].textContent = `${colname} unknown`
         } else {
-          const color = isNumber(i) ? column[i] : null
+          const color = isNumber(index) ? column[index] : null
 
           if (color != null) {
             swatch_els[j].style.backgroundColor = color2css(color)
@@ -593,7 +593,7 @@ export class HoverToolView extends InspectToolView {
         }
         const hex = opts.indexOf("hex") >= 0
         const swatch = opts.indexOf("swatch") >= 0
-        const color: Color | null = isNumber(i) ? column[i] : null
+        const color: Color | null = isNumber(index) ? column[index] : null
         if (color == null) {
           value_els[j].textContent = "(null)"
           continue


### PR DESCRIPTION
fixes #14054 
 
I'm not going to have time to finish the swatch deprecation before the release, and it probably needs some discussion in any case. But I did want to include this small fix for image index handling in hover templates. 

With the OP code:

```python
import numpy as np
from bokeh.plotting import figure, show
from bokeh.models import ColumnDataSource,HoverTool

x = np.linspace(0, 10, 300)
y = np.linspace(0, 10, 300)
xx, yy = np.meshgrid(x, y)
d = np.sin(xx) * np.cos(yy)

s1 = ColumnDataSource(data=dict(x=[xx], y=[yy], image=[d]))
p = figure(width=400, height=400)
p.x_range.range_padding = p.y_range.range_padding = 0
p.image(image='image',source=s1, x=0, y=0, dw=10, dh=10, palette="Sunset11", level="image")
p.add_tools(HoverTool(tooltips="""<div style="background-color: #f0f0f0; padding: 5px; border-radius: 5px; box-shadow: 0px 0px 5px rgba(0,0,0,0.3);">        <font size="5" style="background-color: #f0f0f0; padding: 5px; border-radius: 5px;">
            <i>x:</i> <b>$x</b> <br>
            <i>y:</i> <b>$y</b> <br>
            <i>image:</i> <b>@image</b> <br>
        </font> </div> <style> :host { --tooltip-border: transparent;  /* Same border color used everywhere */ --tooltip-color: transparent; --tooltip-text: #2f2f2f;} </style> """,
    ))
show(p)
```

The hover now renders only a single value

<img width="402" alt="Screenshot 2024-09-23 at 20 36 09" src="https://github.com/user-attachments/assets/f519a16e-aac9-41b3-ad4c-04e3d5fdb182">
