### PR TITLE
Test Bokeh with Python 3.13 rc

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -188,7 +188,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -1,0 +1,90 @@
+name: bk-test
+channels:
+  - conda-forge/label/python_rc
+  - conda-forge
+dependencies:
+  - python=3.13
+
+  # runtime
+  - contourpy >=1.2
+  - jinja2 >=2.7
+  - numpy >=1.20.0
+  - packaging >=16.8
+  - pandas >=1.2
+  - pillow >=4.0
+  - python-dateutil >=2.1
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices>=2021.09.1
+
+  # tests
+  - beautifulsoup4
+  # - channels  # Not yet available for Python 3.13
+  - click
+  - colorama
+  - colorcet
+  - coverage
+  - firefox >=96
+  - geckodriver
+  - ipython
+  - isort 5.8
+  - json5
+  # - nbconvert >=5.4 # Not yet available for Python 3.13
+  - networkx
+  - nodejs 20.*
+  - pre-commit
+  - psutil
+  - pygments
+  - pygraphviz
+  - pytest >=7.0
+  - pytest-asyncio ==0.21.1 # https://github.com/bokeh/bokeh/issues/13578
+  - pytest-cov >=1.8.1
+  - pytest-html
+  - pytest-xdist
+  - pytest-timeout
+  - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
+  - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
+  - scipy
+  - pooch # required in scipy.datasets
+  - selenium 4.2
+  - toml
+  - typing_extensions >=4.0.0
+
+  # examples
+  - flask >=1.0
+  # - h5py # Not yet available for Python 3.13
+  - icalendar
+  # - notebook # Not yet available for Python 3.13
+  - pandas-datareader
+  - pyshp
+  - scikit-learn
+  #- squarify
+  - sympy
+
+  # pip dependencies
+  - pip
+  - pip:
+    - mypy >=1.11
+    # docs
+    - bokeh_sampledata
+    - pydata_sphinx_theme
+    - requests-unixsocket >= 0.3.0
+    - sphinx >= 7.1.0
+    - sphinx-copybutton
+    - sphinx-design
+    - sphinx-favicon
+    - sphinxext-opengraph
+    # tests
+    - pandas-stubs >=2.2
+    - ruff ==0.4.2
+    - types-boto
+    - types-colorama
+    - types-mock
+    - types-pillow
+    - types-pyyaml
+    - types-requests
+    - types-toml
+    - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13407
+    - vermin
+    # move the following back to conda sections above when python 3.12 conda-forge packages available
+    - squarify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: JavaScript",
     "Topic :: Office/Business",
     "Topic :: Office/Business :: Financial",

--- a/tests/unit/bokeh/application/handlers/test_directory.py
+++ b/tests/unit/bokeh/application/handlers/test_directory.py
@@ -139,7 +139,7 @@ class Test_DirectoryHandler:
         assert len(doc.roots) == 2
 
     def test_directory_empty_mainipynb(self) -> None:
-        import nbformat
+        nbformat = pytest.importorskip("nbformat")  # Python 3.13
 
         doc = Document()
         source = nbformat.v4.new_notebook()
@@ -159,7 +159,7 @@ class Test_DirectoryHandler:
         assert not doc.roots
 
     def test_directory_mainipynb_adds_roots(self) -> None:
-        import nbformat
+        nbformat = pytest.importorskip("nbformat")  # Python 3.13
 
         doc = Document()
         source = nbformat.v4.new_notebook()
@@ -189,7 +189,7 @@ class Test_DirectoryHandler:
             if handler.failed:
                 raise RuntimeError(handler.error)
 
-        import nbformat
+        nbformat = pytest.importorskip("nbformat")  # Python 3.13
         source = nbformat.v4.new_notebook()
 
         with_directory_contents({

--- a/tests/unit/bokeh/application/handlers/test_notebook__handlers.py
+++ b/tests/unit/bokeh/application/handlers/test_notebook__handlers.py
@@ -15,6 +15,8 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+# TODO: Python 3.13 compatibility, remove nbconvert can be ran on Python 3.13
+pytest.importorskip("nbconvert")
 
 # External imports
 import nbconvert


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

With the release of Pandas 2.2.3 last week, installing Bokeh in a Python 3.13 environment is now possible. And with the upcoming release of Bokeh 3.6, it could be nice to check that there aren't any major problems with it.

The jupyter ecosystem is waiting on pywin32 release. Migration can be found here: https://conda-forge.org/status/migration/?name=python313 