### PR TITLE
Update NodeJS types

### DIFF
--- a/bokehjs/make/package.json
+++ b/bokehjs/make/package.json
@@ -13,7 +13,7 @@
   ],
   "devDependencies": {
     "@types/eslint": "^8.56.7",
-    "@types/node": "^22.5.5",
+    "@types/node": "^22.7.4",
     "@types/which": "^3.0.3",
     "@types/yargs": "^17.0.32",
     "acorn": "^8.12.1",
@@ -24,8 +24,8 @@
     "semver": "^7.6.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript-eslint": "^7.16.0",
     "typescript": "~5.6.2",
+    "typescript-eslint": "^7.16.0",
     "which": "^3.0.1",
     "yargs": "^17.7.2"
   }

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -48,7 +48,7 @@
       ],
       "devDependencies": {
         "@types/eslint": "^8.56.7",
-        "@types/node": "^22.5.5",
+        "@types/node": "^22.7.4",
         "@types/which": "^3.0.3",
         "@types/yargs": "^17.0.32",
         "acorn": "^8.12.1",
@@ -629,9 +629,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4227,7 +4227,7 @@
         "@types/convert-source-map": "^2.0.3",
         "@types/css": "^0.0.37",
         "@types/less": "^3.0.6",
-        "@types/node": "^22.5.5",
+        "@types/node": "^22.7.4",
         "@types/yargs": "^17.0.32",
         "chalk": "^4.1.2",
         "combine-source-map": "^0.8.0",
@@ -4249,7 +4249,7 @@
       "version": "3.7.0-dev.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
-        "@types/node": "^22.5.5",
+        "@types/node": "^22.7.4",
         "@types/ws": "^8.5.10",
         "@types/yargs": "^17.0.32",
         "chalk": "^4.1.2",
@@ -4270,7 +4270,7 @@
         "@types/cli-progress": "^3.11.5",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
-        "@types/node": "^22.5.5",
+        "@types/node": "^22.7.4",
         "@types/nunjucks": "^3.2.6",
         "@types/pngjs": "^6.0.4",
         "@types/sinon": "^17.0.2",

--- a/bokehjs/src/compiler/package.json
+++ b/bokehjs/src/compiler/package.json
@@ -13,7 +13,7 @@
     "@types/convert-source-map": "^2.0.3",
     "@types/css": "^0.0.37",
     "@types/less": "^3.0.6",
-    "@types/node": "^22.5.5",
+    "@types/node": "^22.7.4",
     "@types/yargs": "^17.0.32",
     "chalk": "^4.1.2",
     "combine-source-map": "^0.8.0",

--- a/bokehjs/src/server/package.json
+++ b/bokehjs/src/server/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/bokeh/bokeh.git"
   },
   "devDependencies": {
-    "@types/node": "^22.5.5",
+    "@types/node": "^22.7.4",
     "@types/ws": "^8.5.10",
     "@types/yargs": "^17.0.32",
     "chalk": "^4.1.2",

--- a/bokehjs/test/package.json
+++ b/bokehjs/test/package.json
@@ -15,7 +15,7 @@
     "@types/cli-progress": "^3.11.5",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
-    "@types/node": "^22.5.5",
+    "@types/node": "^22.7.4",
     "@types/nunjucks": "^3.2.6",
     "@types/pngjs": "^6.0.4",
     "@types/sinon": "^17.0.2",


### PR DESCRIPTION
This updates the minimum version of `@types/node` used by `bokehjs` in advance of a breaking change coming in TypeScript 5.7 that affects the NodeJS `Buffer` type.

---

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #14083
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
