### PR TITLE
Update links to sponsor page

### DIFF
--- a/docs/bokeh/source/_templates/sections/footer.html
+++ b/docs/bokeh/source/_templates/sections/footer.html
@@ -56,7 +56,7 @@
             <a class="nav-link" href="https://docs.bokeh.org/en/latest/docs/dev_guide.html">Contributor Guide</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://bokeh.org/sponsor/">Sponsor</a>
+            <a class="nav-link" href="https://github.com/bokeh/bokeh#support">Sponsor</a>
           </li>
         </ul>
       </div>

--- a/src/bokeh/server/views/app_index.html
+++ b/src/bokeh/server/views/app_index.html
@@ -152,7 +152,7 @@
               <a class="nav-link" href="https://docs.bokeh.org/en/latest/docs/dev_guide.html">Contributor Guide</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="https://bokeh.org/sponsor/">Sponsor</a>
+              <a class="nav-link" href="https://github.com/bokeh/bokeh#support">Sponsor</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Link directly to Support section in Bokeh README instead of deprecated Sponsors page. See https://github.com/bokeh/bokeh.org/pull/25.

I believe that this pull request is straightforward enough that it does not need an associated issue. If this is not the case, please let me know.
