### PR TITLE
Address `CanvasRenderingContext2D.fill(rule)` regression in Chromium 130

### DIFF
--- a/bokehjs/src/lib/core/visuals/fill.ts
+++ b/bokehjs/src/lib/core/visuals/fill.ts
@@ -15,7 +15,7 @@ export class Fill extends VisualProperties {
     return !(color == null || alpha == 0)
   }
 
-  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, rule: CanvasFillRule = "nonzero"): boolean {
     const {doit} = this
     if (doit) {
       this.set_value(ctx)
@@ -70,7 +70,7 @@ export class FillScalar extends VisualUniforms {
     return !(color == 0 || alpha == 0)
   }
 
-  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, rule: CanvasFillRule = "nonzero"): boolean {
     const {doit} = this
     if (doit) {
       this.set_value(ctx)
@@ -121,7 +121,7 @@ export class FillVector extends VisualUniforms {
     return true
   }
 
-  apply(ctx: Context2d, i: number, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, i: number, rule: CanvasFillRule = "nonzero"): boolean {
     const doit = this.v_doit(i)
     if (doit) {
       this.set_vectorize(ctx, i)

--- a/bokehjs/src/lib/core/visuals/hatch.ts
+++ b/bokehjs/src/lib/core/visuals/hatch.ts
@@ -61,7 +61,7 @@ export class Hatch extends VisualProperties {
     return !(color == null || alpha == 0 || pattern == " " || pattern == "blank" || pattern == null)
   }
 
-  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, rule: CanvasFillRule = "nonzero"): boolean {
     const {doit} = this
     if (doit) {
       this.set_value(ctx)
@@ -230,7 +230,7 @@ export class HatchScalar extends VisualUniforms {
     return this._static_doit
   }
 
-  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, rule: CanvasFillRule = "nonzero"): boolean {
     const {doit} = this
     if (doit) {
       this.set_value(ctx)
@@ -395,7 +395,7 @@ export class HatchVector extends VisualUniforms {
     return true
   }
 
-  apply(ctx: Context2d, i: number, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, i: number, rule: CanvasFillRule = "nonzero"): boolean {
     const doit = this.v_doit(i)
     if (doit) {
       this.set_vectorize(ctx, i)


### PR DESCRIPTION
fixes #14090 
