### PR TITLE
Rename `scripts:watch` task to `watch`

### DIFF
--- a/bokehjs/make/tasks/watch.ts
+++ b/bokehjs/make/tasks/watch.ts
@@ -10,7 +10,7 @@ import {argv} from "../main"
 import chokidar from "chokidar"
 import chalk from "chalk"
 
-task("scripts:watch", [], async () => {
+task("watch", [], async () => {
   const watched_paths = new Map([
     [paths.src_dir.less, build_scripts], // build_styles
     [paths.src_dir.lib, build_scripts],


### PR DESCRIPTION
Forgot to rename the task in PR #14081.