### PR TITLE
Backports for 3.6.1

### DIFF
--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -66,17 +66,7 @@ jobs:
         working-directory: ./bokehjs
         shell: bash
         run: |
-          echo "node $(node --version)"
-          echo "npm $(npm --version)"
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            chromium --version
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            # TODO: this hangs; version is reported in tests
-            # c:/Program\ Files/Google/Chrome/Application/chrome.EXE --version
-            echo "Chromium ??? (see tests)"
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version
-          fi
+          node make test:info
           npm list
 
       - name: Build bokehjs
@@ -86,7 +76,8 @@ jobs:
           node make build
 
       - name: Run tests
-        if: success() || failure()
+        # restore Windows and OSX support when https://github.com/bokeh/bokeh/issues/14117 is fixed
+        if: runner.os == 'Linux' && (success() || failure())
         working-directory: ./bokehjs
         shell: bash
         run: |

--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -230,6 +230,12 @@ function _devtools(devtools_port: number, user_args: string[]): Promise<void> {
   })
 }
 
+task("test:info", async () => {
+  const proc = await headless(9222)
+  await devtools_info(9222)
+  proc.kill()
+})
+
 task("test:run:headless", async () => {
   const proc = await headless(9222)
   await devtools_info(9222)

--- a/bokehjs/src/lib/core/visuals/fill.ts
+++ b/bokehjs/src/lib/core/visuals/fill.ts
@@ -15,7 +15,7 @@ export class Fill extends VisualProperties {
     return !(color == null || alpha == 0)
   }
 
-  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, rule: CanvasFillRule = "nonzero"): boolean {
     const {doit} = this
     if (doit) {
       this.set_value(ctx)
@@ -70,7 +70,7 @@ export class FillScalar extends VisualUniforms {
     return !(color == 0 || alpha == 0)
   }
 
-  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, rule: CanvasFillRule = "nonzero"): boolean {
     const {doit} = this
     if (doit) {
       this.set_value(ctx)
@@ -121,7 +121,7 @@ export class FillVector extends VisualUniforms {
     return true
   }
 
-  apply(ctx: Context2d, i: number, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, i: number, rule: CanvasFillRule = "nonzero"): boolean {
     const doit = this.v_doit(i)
     if (doit) {
       this.set_vectorize(ctx, i)

--- a/bokehjs/src/lib/core/visuals/hatch.ts
+++ b/bokehjs/src/lib/core/visuals/hatch.ts
@@ -61,7 +61,7 @@ export class Hatch extends VisualProperties {
     return !(color == null || alpha == 0 || pattern == " " || pattern == "blank" || pattern == null)
   }
 
-  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, rule: CanvasFillRule = "nonzero"): boolean {
     const {doit} = this
     if (doit) {
       this.set_value(ctx)
@@ -230,7 +230,7 @@ export class HatchScalar extends VisualUniforms {
     return this._static_doit
   }
 
-  apply(ctx: Context2d, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, rule: CanvasFillRule = "nonzero"): boolean {
     const {doit} = this
     if (doit) {
       this.set_value(ctx)
@@ -395,7 +395,7 @@ export class HatchVector extends VisualUniforms {
     return true
   }
 
-  apply(ctx: Context2d, i: number, rule?: CanvasFillRule): boolean {
+  apply(ctx: Context2d, i: number, rule: CanvasFillRule = "nonzero"): boolean {
     const doit = this.v_doit(i)
     if (doit) {
       this.set_vectorize(ctx, i)

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -86,7 +86,9 @@ export class CanvasView extends UIElementView {
 
   ui_event_bus: UIEventBus
 
-  protected _size = new InlineStyleSheet()
+  protected readonly _size = new InlineStyleSheet()
+
+  readonly touch_action = new InlineStyleSheet()
 
   override initialize(): void {
     super.initialize()
@@ -127,7 +129,7 @@ export class CanvasView extends UIElementView {
   }
 
   override stylesheets(): StyleSheetLike[] {
-    return [...super.stylesheets(), canvas_css.default, icons_css, this._size]
+    return [...super.stylesheets(), canvas_css.default, icons_css, this._size, this.touch_action]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -21,6 +21,7 @@ import {ActionTool} from "./actions/action_tool"
 import {HelpTool} from "./actions/help_tool"
 import type {At} from "core/util/menus"
 import {ContextMenu} from "core/util/menus"
+import {Signal0} from "core/signaling"
 
 import toolbars_css, * as toolbars from "styles/toolbar.css"
 import logos_css, * as logos from "styles/logo.css"
@@ -369,6 +370,8 @@ export class Toolbar extends UIElement {
     })
   }
 
+  active_changed: Signal0<this>
+
   get horizontal(): boolean {
     return this.location == "above" || this.location == "below"
   }
@@ -389,6 +392,7 @@ export class Toolbar extends UIElement {
 
   override initialize(): void {
     super.initialize()
+    this.active_changed  = new Signal0(this, "active_changed")
     this._init_tools()
     this._activate_tools()
   }
@@ -477,7 +481,10 @@ export class Toolbar extends UIElement {
     for (const gesture of values(this.gestures)) {
       for (const tool of gesture.tools) {
         // XXX: connect once
-        this.connect(tool.properties.active.change, () => this._active_change(tool))
+        this.connect(tool.properties.active.change, () => {
+          this._active_change(tool)
+          this.active_changed.emit()
+        })
       }
     }
 
@@ -526,6 +533,8 @@ export class Toolbar extends UIElement {
         }
       }
     }
+
+    this.active_changed.emit()
   }
 
   _active_change(tool: ToolLike<GestureTool>): void {

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -28,6 +28,7 @@ import {
   Line,
   LinearColorMapper,
   Node,
+  PanTool,
   Pane,
   Plot,
   Range1d,
@@ -41,6 +42,7 @@ import {
   Title,
   Toolbar,
   WMTSTileSource,
+  WheelZoomTool,
 } from "@bokehjs/models"
 
 import {
@@ -1712,6 +1714,34 @@ describe("Bug", () => {
       await scroll_down(view.input_el)
       await view.ready
       expect(spinner.value).to.be.equal(1)
+    })
+  })
+
+  describe("in issue #14107", () => {
+    it("doesn't allow for default browser touch actions when no tools are enabled", async () => {
+      const p0 = fig([200, 200], {tools: [], toolbar_location: "right"})
+      p0.scatter([1, 2, 3], [1, 2, 3], {size: 20})
+      const {view: pv0} = await display(p0)
+      expect(getComputedStyle(pv0.canvas.events_el).touchAction).to.be.equal("auto")
+
+      const pan1 = new PanTool()
+      const p1 = fig([200, 200], {tools: [pan1], active_drag: pan1, toolbar_location: "right"})
+      p1.scatter([1, 2, 3], [1, 2, 3], {size: 20})
+      const {view: pv1} = await display(p1)
+      expect(getComputedStyle(pv1.canvas.events_el).touchAction).to.be.equal("pinch-zoom")
+
+      const zoom2 = new WheelZoomTool()
+      const p2 = fig([200, 200], {tools: [zoom2], active_scroll: zoom2, toolbar_location: "right"})
+      p2.scatter([1, 2, 3], [1, 2, 3], {size: 20})
+      const {view: pv2} = await display(p2)
+      expect(getComputedStyle(pv2.canvas.events_el).touchAction).to.be.equal("pan-x pan-y")
+
+      const pan3 = new PanTool()
+      const zoom3 = new WheelZoomTool()
+      const p3 = fig([200, 200], {tools: [pan3, zoom3], active_drag: pan3, active_scroll: zoom3, toolbar_location: "right"})
+      p3.scatter([1, 2, 3], [1, 2, 3], {size: 20})
+      const {view: pv3} = await display(p3)
+      expect(getComputedStyle(pv3.canvas.events_el).touchAction).to.be.equal("none")
     })
   })
 })

--- a/docs/bokeh/source/docs/releases/3.6.1.rst
+++ b/docs/bokeh/source/docs/releases/3.6.1.rst
@@ -3,7 +3,7 @@
 3.6.1
 =====
 
-Bokeh version ``3.6.1`` (October 2024) is a hotfix release of Bokeh project.
+Bokeh version ``3.6.1`` (November 2024) is a hotfix release of Bokeh project.
 
 * Add workaround for Chrome 130 regression (:bokeh-pull:`14093`)
 * Improved handling of ``touch-action`` based on active tools and their supported events (:bokeh-pull:`14109`)

--- a/docs/bokeh/source/docs/releases/3.6.1.rst
+++ b/docs/bokeh/source/docs/releases/3.6.1.rst
@@ -6,3 +6,4 @@
 Bokeh version ``3.6.1`` (October 2024) is a hotfix release of Bokeh project.
 
 * Add workaround for Chrome 130 regression (:bokeh-pull:`14093`)
+* Improved handling of ``touch-action`` based on active tools and their supported events (:bokeh-pull:`14109`)

--- a/docs/bokeh/source/docs/releases/3.6.1.rst
+++ b/docs/bokeh/source/docs/releases/3.6.1.rst
@@ -1,0 +1,8 @@
+.. _release-3-6-1:
+
+3.6.1
+=====
+
+Bokeh version ``3.6.1`` (October 2024) is a hotfix release of Bokeh project.
+
+* Add workaround for Chrome 130 regression (:bokeh-pull:`14093`)

--- a/docs/bokeh/switcher.json
+++ b/docs/bokeh/switcher.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "3.6.0 (latest)",
-    "version": "3.6.0",
+    "name": "3.6.1 (latest)",
+    "version": "3.6.1",
     "url": "https://docs.bokeh.org/en/latest/",
     "preferred": true
   },


### PR DESCRIPTION
This PR collects bug-fixes and tasks for a 3.6.1 release:

- [x] #14093 
- [x] #14109
- [x] #14125
- [x] 3.6.1 release notes
- [x] updated switcher.json

Release checklist:

- [x] do **not** squash merge
- [x] update milestone to `3.6.1` of relevant issues and PRs
- [x] remove `NEEDS BACKPORT` label