### PR TITLE
Add a workflow to test Chromium versions on demand

### DIFF
--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build a release for (e.g. 3.0.0, 2.4.0.dev8)"
+        description: "Version to build a release for (e.g. 3.7.0, 3.6.0.dev3)"
         required: true
 
 defaults:

--- a/.github/workflows/bokehjs-test-chromium.yml
+++ b/.github/workflows/bokehjs-test-chromium.yml
@@ -1,0 +1,116 @@
+name: BokehJS - Test Chromium
+run-name: BokehJS - Test Chromium ${{ github.event.inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Chromium version to test"
+        required: true
+        type: choice
+        options:
+          - "stable"
+          - "beta"
+          - "candidate"
+          - "edge"
+        default: "beta"
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-24.04]
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Install node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Upgrade npm
+        shell: bash
+        run: |
+          npm install --location=global npm
+
+      - name: Install chromium
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          CHANNEL="latest/${{ github.event.inputs.version }}"
+          sudo snap install --channel=CHANNEL chromium
+
+      - name: Install dependencies
+        working-directory: ./bokehjs
+        shell: bash
+        run: |
+          npm ci --no-progress
+
+      - name: List installed software
+        working-directory: ./bokehjs
+        shell: bash
+        run: |
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
+          chromium --version
+
+      - name: Build bokehjs
+        working-directory: ./bokehjs
+        shell: bash
+        run: |
+          node make build
+
+      - name: Run tests
+        if: success() || failure()
+        working-directory: ./bokehjs
+        shell: bash
+        run: |
+          node make test --screenshot=save # screenshots will almost always fail
+
+      - name: Lint codebase
+        if: success() || failure()
+        working-directory: ./bokehjs
+        shell: bash
+        run: |
+          node make lint
+
+      - name: Check repository status
+        if: success() || failure()
+        shell: bash
+        run: |
+          OUTPUT=$(git status --short bokehjs -- ':!bokehjs/test/baselines')
+          if [[ ! -z "$OUTPUT" ]]; then echo $OUTPUT; exit 1; fi
+
+      - name: Collect results
+        if: runner.os == 'Linux' && (success() || failure())
+        shell: bash
+        run: |
+          SRC="bokehjs/test/baselines/linux"
+          DST="bokehjs-report/${SRC}"
+          mkdir -p ${DST}
+          if [[ -e ${SRC}/report.json ]];
+          then
+            CHANGED=$(git status --short ${SRC}/\*.blf ${SRC}/\*.png | cut -c4-)
+            cp ${SRC}/report.{json,out} ${CHANGED} ${DST}
+          fi
+
+      - name: Upload package
+        if: runner.os == 'Linux' && (success() || failure())
+        uses: actions/upload-artifact@v4
+        with:
+          name: bokehjs-package
+          path: bokehjs/build/dist/bokeh-bokehjs-*.tgz
+
+      - name: Upload report
+        if: runner.os == 'Linux' && (success() || failure())
+        uses: actions/upload-artifact@v4
+        with:
+          name: bokehjs-report
+          path: bokehjs-report

--- a/.github/workflows/bokehjs-test-chromium.yml
+++ b/.github/workflows/bokehjs-test-chromium.yml
@@ -14,6 +14,8 @@ on:
           - "candidate"
           - "edge"
         default: "beta"
+  schedule:
+    cron: '0 15 * * WED' # two hours before weekly meeting
 
 jobs:
   test:
@@ -44,7 +46,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          CHANNEL="latest/${{ github.event.inputs.version }}"
+          CHANNEL="latest/${{ github.event.inputs.version || "beta" }}"
           sudo snap install --channel=CHANNEL chromium
 
       - name: Install dependencies


### PR DESCRIPTION
This adds a separate on demand bokehjs workflow for testing new versions of Chromium (issue #14090). This workflow is essentially equivalent to bokehjs' default workflow, but instead of running image baseline tests, this workflow only generates images, but doesn't compare them, because they would fail most of the time anyway. Note that this workflow may fail regardless, so inspection of the output is needed every time.

There is one optional argument to the workflow, which allows to specify the snap channel to install Chromium from. The default is `beta`. To determine what version is associated with each channel, use:
```sh
$ snap info chromium
(...)
channels:
  latest/stable:    129.0.6668.100 2024-10-11 (2972) 181MB -
  latest/candidate: 130.0.6723.44  2024-10-17 (2977) 180MB -
  latest/beta:      130.0.6723.44  2024-10-14 (2973) 181MB -
  latest/edge:      131.0.6753.0   2024-10-08 (2970) 184MB -
```