### PR TITLE
Improve `PanTool`'s cursor and state handling

### DIFF
--- a/bokehjs/src/less/canvas.less
+++ b/bokehjs/src/less/canvas.less
@@ -12,4 +12,5 @@
 .bk-events {
   touch-action: none;
   overflow: visible;
+  cursor: default;
 }

--- a/bokehjs/src/lib/core/util/iterator.ts
+++ b/bokehjs/src/lib/core/util/iterator.ts
@@ -127,6 +127,18 @@ export function* filter<T>(iterable: Iterable<T>, fn: (item: T, i: number) => bo
   }
 }
 
+const nothing = Symbol("nothing")
+
+export function* no_repeated<T>(iterable: Iterable<T>): Iterable<T> {
+  let last: T | typeof nothing = nothing
+  for (const item of iterable) {
+    if (item !== last) {
+      yield item
+    }
+    last = item
+  }
+}
+
 export function every<T>(iterable: Iterable<T>, predicate: (item: T) => boolean): boolean {
   for (const item of iterable) {
     if (!predicate(item)) {

--- a/bokehjs/test/interactive.ts
+++ b/bokehjs/test/interactive.ts
@@ -7,6 +7,7 @@ import type {KeyModifiers} from "@bokehjs/core/ui_events"
 import {UIGestures} from "@bokehjs/core/ui_gestures"
 
 export type Point = {x: number, y: number}
+export type XY = Point
 
 export function xy(x: number, y: number): Point {
   return {x, y}
@@ -192,10 +193,18 @@ export class PlotActions {
     }
   }
 
-  protected async emit(events: Iterable<UIEvent> | AsyncIterable<UIEvent>): Promise<void> {
+  async emit(events: Iterable<UIEvent> | AsyncIterable<UIEvent>): Promise<void> {
     for await (const ev of events) {
       this.el.dispatchEvent(ev)
       await delay(this.options.pause)
+    }
+  }
+
+  async *_emit(events: Iterable<UIEvent> | AsyncIterable<UIEvent>): AsyncGenerator<void> {
+    for await (const ev of events) {
+      this.el.dispatchEvent(ev)
+      await delay(this.options.pause)
+      yield
     }
   }
 
@@ -281,7 +290,7 @@ export class PlotActions {
     yield* this._move(path, MOVE_PRESSURE, MouseButton.None, keys)
   }
 
-  protected *_pan(path: Path, keys: EventKeys = {}): Iterable<PointerEvent> {
+  *_pan(path: Path, keys: EventKeys = {}): Iterable<PointerEvent> {
     const [xy0, xy1] = this._bounds(path)
     yield new PointerEvent("pointerdown", {..._pointer_common, ...this.screen(xy0), pressure: HOLD_PRESSURE, ...keys, buttons: MouseButton.Left})
     yield* this._move(path, HOLD_PRESSURE, MouseButton.Left, keys)

--- a/bokehjs/test/unit/core/util/iterator.ts
+++ b/bokehjs/test/unit/core/util/iterator.ts
@@ -2,7 +2,7 @@ import {expect} from "assertions"
 
 import {
   range, reverse, enumerate, take, skip, tail, join, zip,
-  interleave, map, flat_map, every, some, combinations, subsets,
+  interleave, map, flat_map, no_repeated, every, some, combinations, subsets,
 } from "@bokehjs/core/util/iterator"
 
 import {AssertionError} from "@bokehjs/core/util/assert"
@@ -108,6 +108,11 @@ describe("core/util/iterator module", () => {
       yield* Array(k).fill(k)
     })
     expect([...r1]).to.be.equal([1, 2, 2, 3, 3, 3])
+  })
+
+  it("implements no_repeated() function", () => {
+    expect([...no_repeated([])]).to.be.equal([])
+    expect([...no_repeated([1, 1, 2, 2, 2, 1, 3, 3, 1, 1, 1, 3, 3, 4])]).to.be.equal([1, 2, 1, 3, 1, 3, 4])
   })
 
   it("implements some() function", () => {

--- a/bokehjs/test/unit/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/pan_tool.ts
@@ -1,0 +1,70 @@
+import {expect} from "assertions"
+import type {XY} from "../../../../interactive"
+import {actions, xy} from "../../../../interactive"
+import {display} from "../../../_util"
+
+import type {Tool} from "@bokehjs/models/tools/tool"
+import {PanTool} from "@bokehjs/models/tools/gestures/pan_tool"
+import type {PlotView} from "@bokehjs/models/plots/plot"
+import {Plot, Range1d, LinearAxis} from "@bokehjs/models"
+import {no_repeated} from "@bokehjs/core/util/iterator"
+
+describe("PanTool", () => {
+
+  async function mkplot(tool: Tool): Promise<PlotView> {
+    const plot = new Plot({
+      width: 400,
+      height: 400,
+      min_border: 0,
+      x_range: new Range1d({start: 0, end: 1}),
+      y_range: new Range1d({start: 0, end: 1}),
+    })
+    plot.add_tools(tool)
+    plot.add_layout(new LinearAxis(), "above")
+    plot.add_layout(new LinearAxis(), "left")
+    const {view} = await display(plot)
+    return view
+  }
+
+  function get_cursor(plot_view: PlotView): string {
+    return getComputedStyle(plot_view.canvas_view.events_el).cursor
+  }
+
+  async function expect_cursor(plot_view: PlotView, xy0: XY, xy1: XY, cursor: string): Promise<void> {
+    const ac = actions(plot_view, {units: "screen"})
+    const cursors: string[] = []
+    for await (const _ of ac._emit(ac._pan({type: "line", xy0, xy1, n: 5}))) {
+      cursors.push(get_cursor(plot_view))
+    }
+    expect([...no_repeated(cursors)]).to.be.equal([...no_repeated(["default", cursor, "default"])])
+  }
+
+  describe("should support cursor", () => {
+    it("width dimensions='both'", async () => {
+      const tool = new PanTool({dimensions: "both"})
+      const plot_view = await mkplot(tool)
+
+      await expect_cursor(plot_view, xy(200, 200), xy(220, 220), "move")
+      await expect_cursor(plot_view, xy(200, 10), xy(220, 10), "ew-resize")
+      await expect_cursor(plot_view, xy(0, 200), xy(0, 220), "ns-resize")
+    })
+
+    it("width dimensions='width'", async () => {
+      const tool = new PanTool({dimensions: "width"})
+      const plot_view = await mkplot(tool)
+
+      await expect_cursor(plot_view, xy(200, 200), xy(220, 220), "ew-resize")
+      await expect_cursor(plot_view, xy(200, 10), xy(220, 10), "ew-resize")
+      await expect_cursor(plot_view, xy(0, 200), xy(0, 220), "default")
+    })
+
+    it("width dimensions='height'", async () => {
+      const tool = new PanTool({dimensions: "height"})
+      const plot_view = await mkplot(tool)
+
+      await expect_cursor(plot_view, xy(200, 200), xy(220, 220), "ns-resize")
+      await expect_cursor(plot_view, xy(200, 10), xy(220, 10), "default")
+      await expect_cursor(plot_view, xy(0, 200), xy(0, 220), "ns-resize")
+    })
+  })
+})

--- a/docs/bokeh/source/docs/releases/3.7.0.rst
+++ b/docs/bokeh/source/docs/releases/3.7.0.rst
@@ -1,0 +1,8 @@
+.. _release-3-7-0:
+
+3.7.0
+=====
+
+Bokeh version ``3.7.0`` (January 2025) is a minor milestone of Bokeh project.
+
+* Improved ``PanTool``'s cursor and state management handling (:bokeh-pull:`14106`)


### PR DESCRIPTION
This PR improves cursor handling for `PanTool` specifically, but also in general for tools implementing `pan` gesture. It also robustifies state handling in the tool and detection of on-axis panning (uses actual axes).

With `dimensions="both"`:

[Screencast from 2024-10-18 12-56-05.webm](https://github.com/user-attachments/assets/637bb34b-b367-46d5-bd85-7d3870a362c7)

With `dimensions="width"`:

[Screencast from 2024-10-18 12-56-45.webm](https://github.com/user-attachments/assets/32df8d1a-16f7-4abd-9620-94e08f49f6f6)

addresses #11032