### PR TITLE
Configure `touch-action` based on active tools and their events

### DIFF
--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -86,7 +86,9 @@ export class CanvasView extends UIElementView {
 
   ui_event_bus: UIEventBus
 
-  protected _size = new InlineStyleSheet()
+  protected readonly _size = new InlineStyleSheet()
+
+  readonly touch_action = new InlineStyleSheet()
 
   override initialize(): void {
     super.initialize()
@@ -127,7 +129,7 @@ export class CanvasView extends UIElementView {
   }
 
   override stylesheets(): StyleSheetLike[] {
-    return [...super.stylesheets(), canvas_css.default, icons_css, this._size]
+    return [...super.stylesheets(), canvas_css.default, icons_css, this._size, this.touch_action]
   }
 
   override render(): void {

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -21,6 +21,7 @@ import {ActionTool} from "./actions/action_tool"
 import {HelpTool} from "./actions/help_tool"
 import type {At} from "core/util/menus"
 import {ContextMenu} from "core/util/menus"
+import {Signal0} from "core/signaling"
 
 import toolbars_css, * as toolbars from "styles/toolbar.css"
 import logos_css, * as logos from "styles/logo.css"
@@ -369,6 +370,8 @@ export class Toolbar extends UIElement {
     })
   }
 
+  active_changed: Signal0<this>
+
   get horizontal(): boolean {
     return this.location == "above" || this.location == "below"
   }
@@ -389,6 +392,7 @@ export class Toolbar extends UIElement {
 
   override initialize(): void {
     super.initialize()
+    this.active_changed  = new Signal0(this, "active_changed")
     this._init_tools()
     this._activate_tools()
   }
@@ -477,7 +481,10 @@ export class Toolbar extends UIElement {
     for (const gesture of values(this.gestures)) {
       for (const tool of gesture.tools) {
         // XXX: connect once
-        this.connect(tool.properties.active.change, () => this._active_change(tool))
+        this.connect(tool.properties.active.change, () => {
+          this._active_change(tool)
+          this.active_changed.emit()
+        })
       }
     }
 
@@ -526,6 +533,8 @@ export class Toolbar extends UIElement {
         }
       }
     }
+
+    this.active_changed.emit()
   }
 
   _active_change(tool: ToolLike<GestureTool>): void {

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -28,6 +28,7 @@ import {
   Line,
   LinearColorMapper,
   Node,
+  PanTool,
   Pane,
   Plot,
   Range1d,
@@ -41,6 +42,7 @@ import {
   Title,
   Toolbar,
   WMTSTileSource,
+  WheelZoomTool,
 } from "@bokehjs/models"
 
 import {
@@ -1712,6 +1714,34 @@ describe("Bug", () => {
       await scroll_down(view.input_el)
       await view.ready
       expect(spinner.value).to.be.equal(1)
+    })
+  })
+
+  describe("in issue #14107", () => {
+    it("doesn't allow for default browser touch actions when no tools are enabled", async () => {
+      const p0 = fig([200, 200], {tools: [], toolbar_location: "right"})
+      p0.scatter([1, 2, 3], [1, 2, 3], {size: 20})
+      const {view: pv0} = await display(p0)
+      expect(getComputedStyle(pv0.canvas.events_el).touchAction).to.be.equal("auto")
+
+      const pan1 = new PanTool()
+      const p1 = fig([200, 200], {tools: [pan1], active_drag: pan1, toolbar_location: "right"})
+      p1.scatter([1, 2, 3], [1, 2, 3], {size: 20})
+      const {view: pv1} = await display(p1)
+      expect(getComputedStyle(pv1.canvas.events_el).touchAction).to.be.equal("pinch-zoom")
+
+      const zoom2 = new WheelZoomTool()
+      const p2 = fig([200, 200], {tools: [zoom2], active_scroll: zoom2, toolbar_location: "right"})
+      p2.scatter([1, 2, 3], [1, 2, 3], {size: 20})
+      const {view: pv2} = await display(p2)
+      expect(getComputedStyle(pv2.canvas.events_el).touchAction).to.be.equal("pan-x pan-y")
+
+      const pan3 = new PanTool()
+      const zoom3 = new WheelZoomTool()
+      const p3 = fig([200, 200], {tools: [pan3, zoom3], active_drag: pan3, active_scroll: zoom3, toolbar_location: "right"})
+      p3.scatter([1, 2, 3], [1, 2, 3], {size: 20})
+      const {view: pv3} = await display(p3)
+      expect(getComputedStyle(pv3.canvas.events_el).touchAction).to.be.equal("none")
     })
   })
 })

--- a/docs/bokeh/source/docs/releases/3.7.0.rst
+++ b/docs/bokeh/source/docs/releases/3.7.0.rst
@@ -6,3 +6,4 @@
 Bokeh version ``3.7.0`` (January 2025) is a minor milestone of Bokeh project.
 
 * Improved ``PanTool``'s cursor and state management handling (:bokeh-pull:`14106`)
+* Improved handling of ``touch-action`` based on active tools and their supported events (:bokeh-pull:`14109`)


### PR DESCRIPTION
Restores support for default browser touch actions on touch devices when no tools using relevant touch events are active.

fixes #14107