### PR TITLE
Lock closed issues/prs

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,31 @@
+name: "Lock Threads"
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+      # - cron: "0 0 * * 2"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          issue-inactive-days: "100"
+          pr-inactive-days: "100"
+          issue-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-comment: >
+            This pull request has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.


### PR DESCRIPTION
Resolves https://github.com/bokeh/bokeh/discussions/14114

Same as the one used on HoloViews [holoviz/holoviews@main/.github/workflows/lock.yaml](https://github.com/holoviz/holoviews/blob/main/.github/workflows/lock.yaml)

It is set to lock 100 issues/PRs every hour, every day. When the backlog is completed, it can be changed to run each Tuesday night (the commented-out cron job).

Example:
![image](https://github.com/user-attachments/assets/b7856fb3-be79-4bfb-a058-9f2fb55d0b3d)