### PR TITLE
Temporarily disable bokehjs tests in CI on Windows and OSX

### DIFF
--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -66,17 +66,7 @@ jobs:
         working-directory: ./bokehjs
         shell: bash
         run: |
-          echo "node $(node --version)"
-          echo "npm $(npm --version)"
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            chromium --version
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            # TODO: this hangs; version is reported in tests
-            # c:/Program\ Files/Google/Chrome/Application/chrome.EXE --version
-            echo "Chromium ??? (see tests)"
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version
-          fi
+          node make test:info
           npm list
 
       - name: Build bokehjs

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -86,7 +86,8 @@ jobs:
           node make build
 
       - name: Run tests
-        if: success() || failure()
+        # restore Windows and OSX support when https://github.com/bokeh/bokeh/issues/14117 is fixed
+        if: runner.os == 'Linux' && (success() || failure())
         working-directory: ./bokehjs
         shell: bash
         run: |

--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -230,6 +230,12 @@ function _devtools(devtools_port: number, user_args: string[]): Promise<void> {
   })
 }
 
+task("test:info", async () => {
+  const proc = await headless(9222)
+  await devtools_info(9222)
+  proc.kill()
+})
+
 task("test:run:headless", async () => {
   const proc = await headless(9222)
   await devtools_info(9222)


### PR DESCRIPTION
Given tests are failing in CI on Windows and OSX due to changes in Chromium 130, for now it will be better to disable tests on those two platforms until the underlying problem is resolved.

addresses #14117