### PR TITLE
Add `process-only` to avoid failing `lock-threads` workflow

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v5
         with:
+          process-only: 'issues, prs'
           issue-inactive-days: "100"
           pr-inactive-days: "100"
           issue-comment: >


### PR DESCRIPTION
The workflow failed, because lack of permission to write to discussions. I'm not sure if we really want to close discussions automatically, so for now I reconfigured the workflow to only close issues and PRs.

addresses #14114