### PR TITLE
Repaint when viewport scale/pixel ratio changes

### DIFF
--- a/bokehjs/src/lib/core/util/canvas.ts
+++ b/bokehjs/src/lib/core/util/canvas.ts
@@ -28,7 +28,10 @@ export class CanvasLayer {
     return this._el
   }
 
-  readonly pixel_ratio: number = 1
+  private _pixel_ratio: number = 1
+  get pixel_ratio(): number {
+    return this._pixel_ratio
+  }
 
   bbox: BBox = new BBox()
 
@@ -43,7 +46,7 @@ export class CanvasLayer {
         }
         this._ctx = ctx
         if (hidpi) {
-          this.pixel_ratio = devicePixelRatio
+          this._pixel_ratio = devicePixelRatio
         }
         break
       }
@@ -67,9 +70,24 @@ export class CanvasLayer {
     })
   }
 
+  get pixel_ratio_changed(): boolean {
+    if (this.hidpi && (this.backend == "canvas" || this.backend == "webgl")) {
+      return this.pixel_ratio != devicePixelRatio
+    } else {
+      return false
+    }
+  }
+
   resize(width: number, height: number): void {
-    if (this.bbox.width == width && this.bbox.height == height) {
+    const size_changed = this.bbox.width != width || this.bbox.height != height
+    const {pixel_ratio_changed} = this
+
+    if (!size_changed && !pixel_ratio_changed) {
       return
+    }
+
+    if (pixel_ratio_changed) {
+      this._pixel_ratio = devicePixelRatio
     }
 
     this.bbox = new BBox({left: 0, top: 0, width, height})

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -146,11 +146,15 @@ export class CanvasView extends UIElementView {
   }
 
   get pixel_ratio(): number {
-    return this.primary.pixel_ratio // XXX: primary
+    return this.primary.pixel_ratio
+  }
+
+  get pixel_ratio_changed(): boolean {
+    return this.primary.pixel_ratio_changed
   }
 
   override _update_bbox(): boolean {
-    const changed = super._update_bbox()
+    const changed = super._update_bbox() || this.pixel_ratio_changed
 
     if (changed) {
       const {width, height} = this.bbox
@@ -185,9 +189,10 @@ export class CanvasView extends UIElementView {
     this.overlays.resize(width, height)
   }
 
-  resize(): void {
-    this._update_bbox()
+  resize(): boolean {
+    const changed = this._update_bbox()
     this._after_resize()
+    return changed
   }
 
   prepare_webgl(frame_box: BBox): void {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -939,6 +939,14 @@ export class PlotView extends LayoutDOMView implements Paintable {
     })
 
     this.model.toolbar.active_changed.connect(() => this._update_touch_action())
+
+    if (visualViewport != null) {
+      visualViewport.addEventListener("resize", () => {
+        if (this.canvas.resize()) {
+          this.request_repaint()
+        }
+      })
+    }
   }
 
   protected _update_touch_action(): void {


### PR DESCRIPTION
Previously zooming in/out would result in blurry plots when using canvas or webgl backends, and would require page reload to fix that (or other way of forcing canvas resize):

[Screencast from 2024-10-31 11-03-06.webm](https://github.com/user-attachments/assets/2d598af1-2a92-410f-adc3-24e26941f8d5)

Now plots get repainted each time that scale (or in general pixel density) changes:

[Screencast from 2024-10-31 11-03-44.webm](https://github.com/user-attachments/assets/b50ba8d0-4bf5-4097-960f-1cfc1d47c30b)

Currently we don't have any way to test this. We can vary scale/pixel density before a test, but not during.