### PR TITLE
fix: highlight with python-console when needed

### DIFF
--- a/docs/bokeh/source/docs/user_guide/styling/plots.rst
+++ b/docs/bokeh/source/docs/user_guide/styling/plots.rst
@@ -21,14 +21,14 @@ examples.
 To query for any Bokeh plot object, use the |select| method on |Plot|. For
 example, to find all `PanTool` objects in a plot:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> p.select(type=PanTool)
     [<bokeh.models.tools.PanTool at 0x106608b90>]
 
 You can also use the |select| method to query on other attributes as well:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> p.circle(0, 0, radius=1, name="mycircle")
     <bokeh.plotting.figure at 0x106608810>
@@ -163,7 +163,7 @@ To style the fill, line, or text properties of a glyph, you first need to
 identify which ``GlyphRenderer`` you want to customize. If you are using the
 |bokeh.plotting| interface, the glyph functions return the renderer:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> r = p.circle([1,2,3,4,5], [2,5,8,2,7], radius=1)
     >>> r
@@ -172,7 +172,7 @@ identify which ``GlyphRenderer`` you want to customize. If you are using the
 Next, obtain the glyph itself from the ``.glyph`` attribute of a
 ``GlyphRenderer``:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> r.glyph
     <bokeh.models.glyphs.Circle at 0x10799ba10>
@@ -276,7 +276,7 @@ This section focuses on changing various visual properties of Bokeh plot axes.
 To set style attributes on Axis objects, use the |xaxis|, |yaxis|, and
 |axis| methods on |Plot| to first obtain a plot's Axis objects. For example:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> p.xaxis
     [<bokeh.models.axes.LinearAxis at 0x106fa2390>]
@@ -538,7 +538,7 @@ lines and grid bands on Bokeh plots.
 To obtain a plot's Grid objects, use the |xgrid|, |ygrid|, and |grid| methods on
 |Plot|. This works similar to the convenience methods for axes:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> p.grid
     [<bokeh.models.grids.Grid at 0x106fa2278>,
@@ -637,7 +637,7 @@ obtain a plot's |Legend| objects:
 
 bokeh.models.plots.Plot.legend
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> p.legend
     [<bokeh.models.annotations.Legend at 0x106fa2278>]

--- a/docs/bokeh/source/docs/user_guide/styling/visuals.rst
+++ b/docs/bokeh/source/docs/user_guide/styling/visuals.rst
@@ -138,7 +138,7 @@ module.
 When you import ``"Spectral6"``, for example, Bokeh gives you access to a list that
 contains six RGB(A) hex strings from the Brewer ``"Spectral"`` color map:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> from bokeh.palettes import Spectral6
     >>> Spectral6

--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -31,7 +31,7 @@ Typically, enumerations are used to define |Enum| properties:
 
 Enumerations have a defined order and support iteration:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> for loc in MyEnum:
     ...     print(loc)
@@ -41,7 +41,7 @@ Enumerations have a defined order and support iteration:
 
 as well as containment tests:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> "port" in MyEnum
     True

--- a/src/bokeh/core/json_encoder.py
+++ b/src/bokeh/core/json_encoder.py
@@ -102,7 +102,7 @@ def serialize_json(obj: Any | Serialized[Any], *, pretty: bool | None = None, in
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> import numpy as np
 
@@ -140,7 +140,7 @@ def serialize_json(obj: Any | Serialized[Any], *, pretty: bool | None = None, in
         this function and ``dumps()`` is handling of memory buffers. Use the
         following setup:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> s = Serializer(deferred=False)
 

--- a/src/bokeh/core/properties.py
+++ b/src/bokeh/core/properties.py
@@ -53,7 +53,7 @@ But also by setting the attributes on an instance:
 Attempts to set a property to a value of the wrong type will
 result in a ``ValueError`` exception:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> m.foo = 2.3
     Traceback (most recent call last):

--- a/src/bokeh/core/property/any.py
+++ b/src/bokeh/core/property/any.py
@@ -59,7 +59,7 @@ class Any(Property[typing.Any]):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class AnyModel(HasProps):
             ...     prop = Any()

--- a/src/bokeh/core/property/auto.py
+++ b/src/bokeh/core/property/auto.py
@@ -45,7 +45,7 @@ class Auto(Enum):
         This property is often most useful in conjunction with the
         :class:`~bokeh.core.properties.Either` property.
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class AutoModel(HasProps):
             ...     prop = Either(Float, Auto)

--- a/src/bokeh/core/property/color.py
+++ b/src/bokeh/core/property/color.py
@@ -99,7 +99,7 @@ class Color(Either):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class ColorModel(HasProps):
             ...     prop = Color()

--- a/src/bokeh/core/property/descriptor_factory.py
+++ b/src/bokeh/core/property/descriptor_factory.py
@@ -100,7 +100,7 @@ class PropertyDescriptorFactory(Generic[T]):
 
     Then we can observe the following:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> m = SomeModel()
 

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -261,7 +261,7 @@ class PropertyDescriptor(Generic[T]):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: python-console
 
                 >>> from bokeh.models import Range1d
 

--- a/src/bokeh/core/property/either.py
+++ b/src/bokeh/core/property/either.py
@@ -56,7 +56,7 @@ class Either(ParameterizedProperty[Any]):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class EitherModel(HasProps):
             ...     prop = Either(Bool, Int, Auto)

--- a/src/bokeh/core/property/numeric.py
+++ b/src/bokeh/core/property/numeric.py
@@ -94,7 +94,7 @@ class Interval(SingleParameterizedProperty[T]):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class RangeModel(HasProps):
             ...     prop = Range(Float, 10, 20)
@@ -139,7 +139,7 @@ class Byte(Interval[int]):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class ByteModel(HasProps):
             ...     prop = Byte(default=0)
@@ -172,7 +172,7 @@ class Size(Float):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class SizeModel(HasProps):
             ...     prop = Size()
@@ -213,7 +213,7 @@ class Percent(Float):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class PercentModel(HasProps):
             ...     prop = Percent()

--- a/src/bokeh/core/property/override.py
+++ b/src/bokeh/core/property/override.py
@@ -80,7 +80,7 @@ class Override(Generic[T]):
         to specify that the default value for the ``foo`` property should be
         20 on instances of the child class:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> p = Parent()
             >>> p.foo

--- a/src/bokeh/core/property/primitive.py
+++ b/src/bokeh/core/property/primitive.py
@@ -76,7 +76,7 @@ class Bool(PrimitiveProperty[bool]):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class BoolModel(HasProps):
             ...     prop = Bool(default=False)
@@ -130,7 +130,7 @@ class Int(PrimitiveProperty[int]):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class IntModel(HasProps):
             ...     prop = Int()
@@ -165,7 +165,7 @@ class Float(PrimitiveProperty[float]):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class FloatModel(HasProps):
             ...     prop = Float()
@@ -211,7 +211,7 @@ class String(PrimitiveProperty[str]):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class StringModel(HasProps):
             ...     prop = String()

--- a/src/bokeh/core/property/string.py
+++ b/src/bokeh/core/property/string.py
@@ -58,7 +58,7 @@ class Regex(String):
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> class RegexModel(HasProps):
             ...     prop = Regex("foo[0-9]+bar")

--- a/src/bokeh/core/property/wrappers.py
+++ b/src/bokeh/core/property/wrappers.py
@@ -184,7 +184,7 @@ class PropertyValueList(PropertyValueContainer, list[T]):
     Instances of ``PropertyValueList`` can be explicitly created by passing
     any object that the standard list initializer accepts, for example:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> PropertyValueList([10, 20])
         [10, 20]
@@ -322,7 +322,7 @@ class PropertyValueDict(PropertyValueContainer, dict[str, T_Val]):
     Instances of ``PropertyValueDict`` can be eplicitly created by passing
     any object that the standard dict initializer accepts, for example:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> PropertyValueDict(dict(a=10, b=20))
         {'a': 10, 'b': 20}

--- a/src/bokeh/core/query.py
+++ b/src/bokeh/core/query.py
@@ -125,7 +125,7 @@ def match(obj: Model, selector: SelectorType) -> bool:
 
     For example:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> from bokeh.plotting import figure
         >>> p = figure(width=400)
@@ -139,7 +139,7 @@ def match(obj: Model, selector: SelectorType) -> bool:
     There are two selector keys that are handled especially. The first
     is 'type', which will do an isinstance check:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> from bokeh.plotting import figure
         >>> from bokeh.models import Axis
@@ -156,7 +156,7 @@ def match(obj: Model, selector: SelectorType) -> bool:
     used to query against this list of tags. An object matches if any of the
     tags in the selector match any of the tags on the object:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> from bokeh.plotting import figure
         >>> p = figure(tags = ["my plot", 10])

--- a/src/bokeh/core/validation/__init__.py
+++ b/src/bokeh/core/validation/__init__.py
@@ -28,7 +28,7 @@ is the case for EMPTY_LAYOUT for instance. Since warnings don't necessarily
 indicate misuse, they are configurable. To silence a warning, use the silence
 function provided.
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> from bokeh.core.validation import silence
     >>> from bokeh.core.validation.warnings import EMPTY_LAYOUT

--- a/src/bokeh/core/validation/check.py
+++ b/src/bokeh/core/validation/check.py
@@ -83,7 +83,7 @@ def silence(warning: Warning, silence: bool = True) -> set[Warning]:
     is referred to when running ``check_integrity``. If a warning
     is added to the silencers - then it will never be raised.
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> from bokeh.core.validation.warnings import EMPTY_LAYOUT
         >>> bokeh.core.validation.silence(EMPTY_LAYOUT, True)
@@ -92,7 +92,7 @@ def silence(warning: Warning, silence: bool = True) -> set[Warning]:
     To turn a warning back on use the same method but with the silence
     argument set to false
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> bokeh.core.validation.silence(EMPTY_LAYOUT, False)
         set()
@@ -139,7 +139,7 @@ def check_integrity(models: Iterable[Model]) -> ValidationIssues:
     warning conditions that are detected. For example, layouts without
     any children will add a warning to the collection:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> empty_row = Row()
 
@@ -187,7 +187,7 @@ def process_validation_issues(issues: ValidationIssues) -> None:
     warning conditions in the dictionary. For example, a dictionary
     containing a warning for empty layout will trigger a warning:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> process_validation_issues(validations)
         W-1002 (EMPTY_LAYOUT): Layout has no children: Row(id='2404a029-c69b-4e30-9b7d-4b7b6cdaad5b', ...)

--- a/src/bokeh/model/util.py
+++ b/src/bokeh/model/util.py
@@ -153,7 +153,7 @@ def get_class(view_model_name: str) -> type[Model]:
 
     Example:
 
-        .. code-block:: python
+        .. code-block:: python-console
 
             >>> from bokeh.model import get_class
             >>> get_class("Range1d")

--- a/src/bokeh/palettes.py
+++ b/src/bokeh/palettes.py
@@ -264,7 +264,7 @@ following notable attributes in the ``bokeh.palettes`` module:
 
     For example, the first eight palette names are:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> bp.__palettes__[:8]
         ('Accent3', 'Accent4', 'Accent5', 'Accent6', 'Accent7', 'Accent8', 'Blues3', 'Blues4')
@@ -1694,7 +1694,7 @@ def magma(n: int) -> Palette:
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> magma(6)
         ('#000003', '#3B0F6F', '#8C2980', '#DD4968', '#FD9F6C', '#FBFCBF')
@@ -1723,7 +1723,7 @@ def inferno(n: int) -> Palette:
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> inferno(6)
         ('#000003', '#410967', '#932567', '#DC5039', '#FBA40A', '#FCFEA4')
@@ -1752,7 +1752,7 @@ def plasma(n: int) -> Palette:
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> plasma(6)
         ('#0C0786', '#6A00A7', '#B02A8F', '#E06461', '#FCA635', '#EFF821')
@@ -1781,7 +1781,7 @@ def viridis(n: int) -> Palette:
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> viridis(6)
         ('#440154', '#404387', '#29788E', '#22A784', '#79D151', '#FDE724')
@@ -1810,7 +1810,7 @@ def cividis(n: int) -> Palette:
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> cividis(6)
         ('#00204C', '#31446B', '#666870', '#958F78', '#CAB969', '#FFE945')
@@ -1843,7 +1843,7 @@ def turbo(n: int) -> Palette:
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> turbo(6)
         ('#00204C', '#31446B', '#666870', '#958F78', '#CAB969', '#FFE945')
@@ -1872,7 +1872,7 @@ def grey(n: int) -> Palette:
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> grey(6)
         ('#000000', '#333333', '#666666', '#999999', '#cccccc', '#ffffff')
@@ -1904,7 +1904,7 @@ def gray(n: int) -> Palette:
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: python-console
 
         >>> gray(6)
         ('#000000', '#333333', '#666666', '#999999', '#cccccc', '#ffffff')


### PR DESCRIPTION
The [`python-console`](https://pygments.org/docs/lexers/#pygments.lexers.python.PythonConsoleLexer) lexer (or `pycon`) should be used when displaying interpreter output instead of [`python`](https://pygments.org/docs/lexers/#pygments.lexers.python.PythonLexer) lexer. `python` is for source code.

By fixing it, the highlighting in the documentation would be better.

The PR is the same change every lines. There are still python highlighting in the documentation because they are really source code examples.

- [ ] issues: fixes #14137
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
