### PR TITLE
Run lock threads workflow once a week

### DIFF
--- a/.github/workflows/bokehjs-test-chromium.yml
+++ b/.github/workflows/bokehjs-test-chromium.yml
@@ -1,5 +1,5 @@
 name: BokehJS - Test Chromium
-run-name: BokehJS - Test Chromium ${{ github.event.inputs.version }}
+run-name: BokehJS - Test Chromium ${{ github.event.inputs.version || 'beta' }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -2,8 +2,7 @@ name: "Lock Threads"
 
 on:
   schedule:
-    - cron: "0 * * * *"
-      # - cron: "0 0 * * 2"
+    - cron: '0 15 * * WED' # two hours before weekly meeting
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Given that the workflow did its job so far, there's no need to run it all the time anymore. With our issue/PR throughput, once a week should more than enough to cover newly closed threads. Unrelated, but I also unified the name of bokehjs' test chromium workflow across manual and automated runs.