### PR TITLE
Add options to colorbar's title to set location, orientation and alignment

### DIFF
--- a/bokehjs/src/lib/models/annotations/base_color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/base_color_bar.ts
@@ -15,7 +15,7 @@ import {LinearScale} from "../scales"
 import type {Range} from "../ranges"
 import {Range1d} from "../ranges"
 import {BaseText} from "../text/base_text"
-import {Anchor, Location, Orientation, Side} from "core/enums"
+import {Anchor, Location, Orientation, Side, TextAlign, VerticalAlign} from "core/enums"
 import type * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import type * as p from "core/properties"
@@ -177,6 +177,8 @@ export abstract class BaseColorBarView extends AnnotationView {
     const attrs: Partial<Title.Attrs> = {
       text: this.model.title ?? "",
       standoff: this.model.title_standoff,
+      align: this.model.title_text_halign,
+      vertical_align: this.model.title_text_valign,
       // TODO: this needs strict typing
       ...mixins.attrs_of(this.model, "title_", mixins.Text, false),
     }
@@ -575,6 +577,8 @@ export namespace BaseColorBar {
     title_standoff: p.Property<number>
     title_location: p.Property<Location | "auto">
     title_orientation: p.Property<string>
+    title_text_halign: p.Property<TextAlign>
+    title_text_valign: p.Property<VerticalAlign>
     width: p.Property<number | "auto">
     height: p.Property<number | "auto">
     scale_alpha: p.Property<number>
@@ -639,6 +643,8 @@ export class BaseColorBar extends Annotation {
       title_standoff:        [ Float, 2 ],
       title_location:        [ Or(Location, Auto), "auto" ],
       title_orientation:     [ Str, "auto" ],
+      title_text_halign:     [ TextAlign, "left" ],
+      title_text_valign:     [ VerticalAlign, "bottom" ],
       width:                 [ Or(Float, Auto), "auto" ],
       height:                [ Or(Float, Auto), "auto" ],
       scale_alpha:           [ Alpha, 1.0 ],

--- a/bokehjs/src/lib/models/annotations/base_color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/base_color_bar.ts
@@ -28,7 +28,7 @@ import {SidePanel} from "core/layout/side_panel"
 import type {IterViews} from "core/build_views"
 import {build_view} from "core/build_views"
 import {BBox} from "core/util/bbox"
-import {isString} from "core/util/types"
+import {isNumber, isString} from "core/util/types"
 
 const MINOR_DIM = 25
 const MAJOR_DIM_MIN_SCALAR = 0.3
@@ -307,7 +307,14 @@ export abstract class BaseColorBarView extends AnnotationView {
     layout.left_panel   = left_panel
     layout.right_panel  = right_panel
 
-    const padding_box = {left: padding, right: padding, top: padding, bottom: padding}
+    const padding_box = (() => {
+      if (isNumber(padding)) {
+        return {top: padding, right: padding, bottom: padding, left: padding}
+      } else {
+        return {top: padding[0], right: padding[1], bottom: padding[2], left: padding[3]}
+      }
+    })()
+
     const margin_box = (() => {
       if (this.panel == null) {
         if (isString(location)) {
@@ -588,7 +595,7 @@ export namespace BaseColorBar {
     major_label_policy: p.Property<LabelingPolicy>
     label_standoff: p.Property<number>
     margin: p.Property<number>
-    padding: p.Property<number>
+    padding: p.Property<number | [number, number, number, number]>
     major_tick_in: p.Property<number>
     major_tick_out: p.Property<number>
     minor_tick_in: p.Property<number>
@@ -654,7 +661,7 @@ export class BaseColorBar extends Annotation {
       major_label_policy:    [ Ref(LabelingPolicy), () => new NoOverlap() ],
       label_standoff:        [ Float, 5 ],
       margin:                [ Float, 30 ],
-      padding:               [ Float, 10 ],
+      padding:               [ Or(Float, Tuple(Float, Float, Float, Float)), 10 ],
       major_tick_in:         [ Float, 5 ],
       major_tick_out:        [ Float, 0 ],
       minor_tick_in:         [ Float, 0 ],

--- a/bokehjs/src/lib/models/annotations/base_color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/base_color_bar.ts
@@ -15,7 +15,8 @@ import {LinearScale} from "../scales"
 import type {Range} from "../ranges"
 import {Range1d} from "../ranges"
 import {BaseText} from "../text/base_text"
-import {Anchor, Location, Orientation, Side, TextAlign, VerticalAlign} from "core/enums"
+import {Anchor, Location, Orientation, TextAlign, VerticalAlign} from "core/enums"
+import type {Side} from "core/enums"
 import type * as visuals from "core/visuals"
 import * as mixins from "core/property_mixins"
 import type * as p from "core/properties"
@@ -483,7 +484,7 @@ export abstract class BaseColorBarView extends AnnotationView {
     const {_title_view} = this
     _title_view.panel = new SidePanel(title_direction)
     _title_view.update_layout()
-    
+
     if (title_location == "above") {
       top_panel.children.push(_title_view.layout)
     } else if (title_location == "below") {

--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -146,6 +146,15 @@ class BaseColorBar(Annotation):
     The title text to render.
     """)
 
+    title_orientation = String("auto", help="""
+    Wheter the color bar's title should be oriented upward,
+    downward or horizontal.
+    """)
+
+    title_location = Either(Enum(Location), Auto, default="auto", help="""
+    Specifies on which side of the color bar the title will be located.
+    """)
+
     title_props = Include(ScalarTextProps, prefix="title", help="""
     The {prop} values for the title text.
     """)

--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -34,6 +34,7 @@ from ...core.enums import (
     Location,
     Orientation,
     VAlign,
+    VerticalAlign,
 )
 from ...core.has_props import abstract
 from ...core.properties import (
@@ -162,6 +163,14 @@ class BaseColorBar(Annotation):
     title_text_font_size = Override(default="13px")
 
     title_text_font_style = Override(default="italic")
+
+    title_text_halign = Enum(HAlign, default="left", help="""
+    Specifies where to align color bar's title horizontally.
+    """)
+
+    title_text_valign = Enum(VerticalAlign, default="bottom", help="""
+    Specifies where to align color bar's title vertically.
+    """)
 
     title_standoff = Int(2, help="""
     The distance (in pixels) to separate the title from the color bar.

--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -197,9 +197,10 @@ class BaseColorBar(Annotation):
     Amount of margin (in pixels) around the outside of the color bar.
     """)
 
-    padding = Int(10, help="""
+    padding = Either(Int, Tuple(Int, Int, Int, Int), default=10, help="""
     Amount of padding (in pixels) between the color scale and color bar border.
-    """)
+    This can also be specified as a tuple in the form (padding_top, padding_right,
+    padding_bottom, padding_left) to set individual padding values for each side.
 
     major_label_props = Include(ScalarTextProps, prefix="major_label", help="""
     The {prop} of the major tick labels.

--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -201,6 +201,7 @@ class BaseColorBar(Annotation):
     Amount of padding (in pixels) between the color scale and color bar border.
     This can also be specified as a tuple in the form (padding_top, padding_right,
     padding_bottom, padding_left) to set individual padding values for each side.
+    """)
 
     major_label_props = Include(ScalarTextProps, prefix="major_label", help="""
     The {prop} of the major tick labels.


### PR DESCRIPTION
- [x] issues: fixes #14149
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

As I exposed in #14149 , this PR add some optional arguments to the colorbar's title to define its location, orientation and alignment. I also modified the padding input so it can be a tuple with four values (top, right, bottom and left sides).

I'm using the [colorbar_log example](https://docs.bokeh.org/en/latest/docs/examples/basic/annotations/colorbar_log.html) as a test.

## Example 1
```python
color_bar = r.construct_color_bar(padding=(0, 0, 0, 10), title='Title', title_location='above')
plot.add_layout(color_bar, "right")
```
![imagen](https://github.com/user-attachments/assets/4f4a531f-e067-4265-8466-d8e1ac002620)

## Example 2

```python
color_bar = r.construct_color_bar(padding=(10, 0, 0, 0), title='Title', title_location='below', title_text_halign='center')
plot.add_layout(color_bar, "below")
```

![imagen](https://github.com/user-attachments/assets/3fa38634-aa25-4c34-82b7-1d1027138533)

## Example 3

```python
color_bar = r.construct_color_bar(padding=(0, 0, 0, 10), title='Title', title_location='right', title_orientation='horizontal', title_text_valign='middle')
plot.add_layout(color_bar, "right")
```

![imagen](https://github.com/user-attachments/assets/5c3e3c56-5931-4615-a0e8-d3a68db38bd8)

I'm still dealing with some combinations and the idea is to preserve the old behavior if the new arguments are omitted, so it's work in progress.

I'd like to read your opinions on this.