### PR TITLE
Show grab/grabbing cursor when moving box selection

### DIFF
--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -365,6 +365,7 @@ export class UIEventBus {
           this._current_pan_view.on_pan(event)
         } else if (event_type == "pan:end") {
           this._current_pan_view.on_pan_end(event)
+          this.set_cursor(this._current_pan_view.cursor(event.sx, event.sy));
           this._current_pan_view = null
         }
         srcEvent.preventDefault()

--- a/bokehjs/src/lib/core/ui_events.ts
+++ b/bokehjs/src/lib/core/ui_events.ts
@@ -365,7 +365,7 @@ export class UIEventBus {
           this._current_pan_view.on_pan(event)
         } else if (event_type == "pan:end") {
           this._current_pan_view.on_pan_end(event)
-          this.set_cursor(this._current_pan_view.cursor(event.sx, event.sy));
+          this.set_cursor(this._current_pan_view.cursor(event.sx, event.sy))
           this._current_pan_view = null
         }
         srcEvent.preventDefault()

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -131,6 +131,7 @@ export class BoxAnnotationView extends AnnotationView implements Pannable, Pinch
         top_units: "canvas",
         bottom_units: "canvas",
         level: this.model.level,
+        is_handle: true,
       }
 
       function attrs_of(source: AreaVisuals) {
@@ -469,7 +470,8 @@ export class BoxAnnotationView extends AnnotationView implements Pannable, Pinch
   }
 
   get movable(): boolean {
-    return this.model.movable != "none"
+    const movable = this.model.movable != "none"
+    return this.model.is_handle ? movable : this.model.editable && movable
   }
 
   private _hittable(): {[key in Box.HitTarget]: boolean} {
@@ -829,6 +831,7 @@ export namespace BoxAnnotation {
 
     use_handles: p.Property<boolean>
     handles: p.Property<BoxInteractionHandles>
+    is_handle: p.Property<boolean>
 
     inverted: p.Property<boolean>
 
@@ -911,6 +914,7 @@ export class BoxAnnotation extends Annotation {
 
       use_handles:  [ Bool, false ],
       handles:      [ Ref(BoxInteractionHandles), DEFAULT_HANDLES ],
+      is_handle:    [ Bool, false ],
 
       inverted:     [ Bool, false ],
     }))

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -773,29 +773,23 @@ export class BoxAnnotationView extends AnnotationView implements Pannable, Pinch
     } = this.model
 
     switch (target) {
-      case "top_left":     return this._handles.top_left == null     ? tl_cursor : null
-      case "top_right":    return this._handles.top_right == null    ? tr_cursor : null
-      case "bottom_left":  return this._handles.bottom_left == null  ? bl_cursor : null
-      case "bottom_right": return this._handles.bottom_right == null ? br_cursor : null
-      case "left":         return this._handles.left == null         ? ew_cursor : null
-      case "right":        return this._handles.right == null        ? ew_cursor : null
-      case "top":          return this._handles.top == null          ? ns_cursor : null
-      case "bottom":       return this._handles.bottom == null       ? ns_cursor : null
+      case "top_left":     return this._handles.top_left == null     ? tl_cursor : this._handles.top_left.tl_cursor
+      case "top_right":    return this._handles.top_right == null    ? tr_cursor : this._handles.top_right.tr_cursor
+      case "bottom_left":  return this._handles.bottom_left == null  ? bl_cursor : this._handles.bottom_left.bl_cursor
+      case "bottom_right": return this._handles.bottom_right == null ? br_cursor : this._handles.bottom_right.br_cursor
+      case "left":         return this._handles.left == null         ? ew_cursor : this._handles.left.ew_cursor
+      case "right":        return this._handles.right == null        ? ew_cursor : this._handles.right.ew_cursor
+      case "top":          return this._handles.top == null          ? ns_cursor : this._handles.top.ns_cursor
+      case "bottom":       return this._handles.bottom == null       ? ns_cursor : this._handles.bottom.ns_cursor
       case "area": {
         if (this._handles.area == null) {
-          if (this._pan_state && in_cursor === "grab") {
-            return "grabbing";
+          if (this._pan_state != null && in_cursor === "grab") {
+            return "grabbing"
           } else {
-            return in_cursor;
-          }
-          switch (this.model.movable) {
-            case "both": return in_cursor
-            case "x":    return ew_cursor
-            case "y":    return ns_cursor
-            case "none": return null
+            return in_cursor
           }
         } else {
-          return null
+          return this._handles.area.in_cursor
         }
       }
     }

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -163,7 +163,7 @@ export class BoxAnnotationView extends AnnotationView implements Pannable, Pinch
       } = this.model
 
       this._handles = {
-        area:         movable                ? new BoxAnnotation({...common, ...attrs.area,         movable: this.model.movable}) : null,
+        area:         movable                ? new BoxAnnotation({...common, ...attrs.area,         in_cursor: "move", movable: this.model.movable}) : null,
         left:         resizable.left         ? new BoxAnnotation({...common, ...attrs.left,         in_cursor: ew_cursor}) : null,
         right:        resizable.right        ? new BoxAnnotation({...common, ...attrs.right,        in_cursor: ew_cursor}) : null,
         top:          resizable.top          ? new BoxAnnotation({...common, ...attrs.top,          in_cursor: ns_cursor}) : null,
@@ -783,6 +783,11 @@ export class BoxAnnotationView extends AnnotationView implements Pannable, Pinch
       case "bottom":       return this._handles.bottom == null       ? ns_cursor : null
       case "area": {
         if (this._handles.area == null) {
+          if (this._pan_state && in_cursor === "grab") {
+            return "grabbing";
+          } else {
+            return in_cursor;
+          }
           switch (this.model.movable) {
             case "both": return in_cursor
             case "x":    return ew_cursor
@@ -923,7 +928,7 @@ export class BoxAnnotation extends Annotation {
       br_cursor: [ Str, "nwse-resize" ],
       ew_cursor: [ Str, "ew-resize" ],
       ns_cursor: [ Str, "ns-resize" ],
-      in_cursor: [ Str, "move" ],
+      in_cursor: [ Str, "grab" ],
     }))
 
     this.override<BoxAnnotation.Props>({

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -916,12 +916,11 @@ export class BoxAnnotation extends Annotation {
 
       use_handles:  [ Bool, false ],
       handles:      [ Ref(BoxInteractionHandles), DEFAULT_HANDLES ],
-      is_handle:    [ Bool, false ],
 
       inverted:     [ Bool, false ],
     }))
 
-    this.internal<BoxAnnotation.Props>(({Str}) => ({
+    this.internal<BoxAnnotation.Props>(({Str, Bool}) => ({
       tl_cursor: [ Str, "nwse-resize" ],
       tr_cursor: [ Str, "nesw-resize" ],
       bl_cursor: [ Str, "nesw-resize" ],
@@ -929,6 +928,9 @@ export class BoxAnnotation extends Annotation {
       ew_cursor: [ Str, "ew-resize" ],
       ns_cursor: [ Str, "ns-resize" ],
       in_cursor: [ Str, "grab" ],
+
+      // Is this BoxAnnotation functioning as a handle for another BoxAnnotation?
+      is_handle: [ Bool, false ],
     }))
 
     this.override<BoxAnnotation.Props>({

--- a/bokehjs/src/lib/models/annotations/box_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/box_annotation.ts
@@ -784,7 +784,9 @@ export class BoxAnnotationView extends AnnotationView implements Pannable, Pinch
       case "top":          return this._handles.top == null          ? ns_cursor : this._handles.top.ns_cursor
       case "bottom":       return this._handles.bottom == null       ? ns_cursor : this._handles.bottom.ns_cursor
       case "area": {
-        if (this._handles.area == null) {
+        if (!this.movable) {
+          return null
+        } else if (this._handles.area == null) {
           if (this._pan_state != null && in_cursor === "grab") {
             return "grabbing"
           } else {

--- a/bokehjs/test/interactive.ts
+++ b/bokehjs/test/interactive.ts
@@ -303,7 +303,7 @@ export class PlotActions {
     }
   }
 
-  protected *_hover(path: Path, keys: EventKeys = {}): Iterable<PointerEvent> {
+  *_hover(path: Path, keys: EventKeys = {}): Iterable<PointerEvent> {
     yield* this._move(path, MOVE_PRESSURE, MouseButton.None, keys)
   }
 

--- a/bokehjs/test/unit/models/annotations/box_annotation.ts
+++ b/bokehjs/test/unit/models/annotations/box_annotation.ts
@@ -1,0 +1,121 @@
+import {expect} from "assertions"
+import type {PlotActions} from "../../../interactive"
+import {actions, xy} from "../../../interactive"
+import {display} from "../../_util"
+
+import type {PlotView} from "@bokehjs/models/plots/plot"
+import {Plot, Range1d, LinearAxis, BoxAnnotation} from "@bokehjs/models"
+import {no_repeated} from "@bokehjs/core/util/iterator"
+
+describe("BoxAnnotation", () => {
+
+  async function mkplot(box: BoxAnnotation): Promise<PlotView> {
+    const plot = new Plot({
+      width: 400,
+      height: 400,
+      min_border: 0,
+      x_range: new Range1d({start: 0, end: 1}),
+      y_range: new Range1d({start: 0, end: 1}),
+    })
+    plot.add_layout(box)
+    plot.add_layout(new LinearAxis(), "above")
+    plot.add_layout(new LinearAxis(), "left")
+    const {view} = await display(plot)
+    return view
+  }
+
+  function get_cursor(plot_view: PlotView): string {
+    return getComputedStyle(plot_view.canvas_view.events_el).cursor
+  }
+
+  async function get_cursors(ac: PlotActions, events: Iterable<UIEvent>): Promise<string[]> {
+    const cursors = []
+    for await (const _ of ac._emit(events)) {
+      cursors.push(get_cursor(ac.target))
+    }
+    return cursors
+  }
+
+  describe("when movable without handles", () => {
+    function mkbox() {
+      return new BoxAnnotation({
+        left: 0,
+        top: 0,
+        right: 0.5,
+        bottom: 0.5,
+        editable: true,
+        movable: "both",
+      })
+    }
+
+    it("should set cursor to \"grab\" inside box", async () => {
+      const plot_view = await mkplot(mkbox())
+      const ac = actions(plot_view, {units: "data"})
+
+      // inside box
+      await ac.hover(xy(0.25, 0.25))
+      expect(get_cursor(plot_view)).to.be.equal("grab")
+
+      // outside box
+      await ac.hover(xy(0.75, 0.75))
+      expect(get_cursor(plot_view)).to.be.equal("default")
+    })
+
+    it("should set cursor to \"grabbing\" when panning", async () => {
+      const plot_view = await mkplot(mkbox())
+      const ac = actions(plot_view, {units: "data"})
+
+      // First, hover to put the cursor in the correct initial state ("grab")
+      await ac.hover(xy(0.25, 0.25))
+
+      // Next, pan
+      const events = ac._pan({type: "line", xy0: xy(0.25, 0.25), xy1: xy(0.75, 0.75), n: 5})
+      const cursors = await get_cursors(ac, events)
+
+      expect([...no_repeated(cursors)]).to.be
+        .equal([...no_repeated(["grab", "grabbing", "grab"])])
+    })
+  })
+
+  describe("when movable with handles", () => {
+    function mkbox() {
+      return new BoxAnnotation({
+        left: 0,
+        top: 0,
+        right: 0.5,
+        bottom: 0.5,
+        editable: true,
+        movable: "both",
+        use_handles: true,
+      })
+    }
+
+    it("should set cursor to \"move\" in the middle", async () => {
+      const plot_view = await mkplot(mkbox())
+      const ac = actions(plot_view, {units: "data"})
+
+      // inside box
+      await ac.hover(xy(0.25, 0.25))
+      expect(get_cursor(plot_view)).to.be.equal("move")
+
+      // outside box
+      await ac.hover(xy(0.75, 0.75))
+      expect(get_cursor(plot_view)).to.be.equal("default")
+    })
+
+    it("should set cursor to \"move\" when panning", async () => {
+      const plot_view = await mkplot(mkbox())
+      const ac = actions(plot_view, {units: "data"})
+
+      // First, hover to put the cursor in the correct initial state ("move")
+      await ac.hover(xy(0.25, 0.25))
+
+      // Next, pan
+      const events = ac._pan({type: "line", xy0: xy(0.25, 0.25), xy1: xy(0.75, 0.75), n: 5})
+      const cursors = await get_cursors(ac, events)
+
+      expect(cursors).to.be
+        .equal(["move", "move", "default", "move", "move", "move", "move"])
+    })
+  })
+})

--- a/docs/bokeh/source/docs/releases/3.7.0.rst
+++ b/docs/bokeh/source/docs/releases/3.7.0.rst
@@ -22,6 +22,7 @@ Bokeh version ``3.7.0`` (January 2025) is a minor milestone of Bokeh project.
 * Added support for ``html_id`` and ``html_attributes`` properties to UI components (:bokeh-pull:`14357`)
 * Added support for value formatting to ``ValueOf(obj, attr)`` (:bokeh-pull:`14358`)
 * Added support for determinate and indeterminate ``Progress`` widgets (:bokeh-pull:`13546`)
+* Improved cursor handling in editable/movable ``BoxAnnotation`` (:bokeh-pull:`14151`)
 
 Deprecations
 ------------


### PR DESCRIPTION
- [x] issues: fixes #13027
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

### Changes, screenshots

Default cursor for moving the box selection is now the hand "grab" cursor instead of the "move" cursor.

![](https://github.com/user-attachments/assets/3f7d874a-65c5-487b-8298-043285498a8c)

When dragging the box selection, the cursor changes from "grab" to "grabbing".

![](https://github.com/user-attachments/assets/6f40ae4b-4e2b-478e-8bbf-68b18a920254)

Box handle cursors are unchanged.

![](https://github.com/user-attachments/assets/2885294b-bfe9-4d66-8dd4-a66af43f9e9c)

However, box handle cursors now persist while the handle is being dragged.

![](https://github.com/user-attachments/assets/e52c1d7f-98a2-4b26-83eb-ced805c18e83)

### Some example plots to manually test 

Here are some example plots to examine against this PR. 

In examples/interactions/tools:

- [range_tool.py](https://docs.bokeh.org/en/latest/docs/examples/interaction/tools/range_tool.html)
- [persistent_selections.py](https://docs.bokeh.org/en/latest/docs/examples/interaction/tools/persistent_selections.html)
- [box_select_handles.py](https://docs.bokeh.org/en/latest/docs/examples/interaction/tools/box_select_handles.html) (used in the screenshots above)

In examples/basic/annotations:

- [box_annotation.py](https://docs.bokeh.org/en/latest/docs/examples/basic/annotations/box_annotation.html)
