### PR TITLE
Add a title attribute to the logo link to display the Bokeh version

### DIFF
--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -22,6 +22,7 @@ import {HelpTool} from "./actions/help_tool"
 import type {At} from "core/util/menus"
 import {ContextMenu} from "core/util/menus"
 import {Signal0} from "core/signaling"
+import {version} from "version"
 
 import toolbars_css, * as toolbars from "styles/toolbar.css"
 import logos_css, * as logos from "styles/logo.css"
@@ -193,7 +194,7 @@ export class ToolbarView extends UIElementView {
 
     if (this.model.logo != null) {
       const gray = this.model.logo === "grey" ? logos.grey : null
-      const logo_el = a({href: "https://bokeh.org/", target: "_blank", class: [logos.logo, logos.logo_small, gray]})
+      const logo_el = a({href: "https://bokeh.org/", target: "_blank", class: [logos.logo, logos.logo_small, gray], title: `Bokeh ${version}`})
       this._items.push(logo_el)
       this.shadow_el.appendChild(logo_el)
     }


### PR DESCRIPTION
I opened this PR quickly after opening the issue https://github.com/bokeh/bokeh/issues/14184 as it proved very easy to implement. I'm not sure there will be interest in this (and would be fine if not). If so, let me know if there's more to do in this PR.

- [x] issues: fixes https://github.com/bokeh/bokeh/issues/14184
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

<img width="712" alt="image" src="https://github.com/user-attachments/assets/a4ae5de5-3330-4405-a608-92de8bc2a5c1">
