### PR TITLE
Allow to configure the zoom out gesture of `BoxZoomTool`

### DIFF
--- a/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_zoom_tool.ts
@@ -8,6 +8,10 @@ import type {PanEvent, KeyEvent, TapEvent} from "core/ui_events"
 import {Dimensions, BoxOrigin} from "core/enums"
 import type {MenuItem} from "core/util/menus"
 import * as icons from "styles/icons.css"
+import {Enum} from "core/kinds"
+
+const ZoomOutGesture = Enum("double_tap")
+type ZoomOutGesture = typeof ZoomOutGesture["__type__"]
 
 type Point = [number, number]
 
@@ -170,6 +174,13 @@ export class BoxZoomToolView extends GestureToolView {
   }
 
   override _doubletap(_ev: TapEvent): void {
+    if (!this.model.active) {
+      return
+    }
+    if (this.model.zoom_out_gesture != "double_tap") {
+      return
+    }
+
     const {state} = this.plot_view
     if (state.peek()?.type == "box_zoom") {
       state.undo()
@@ -237,6 +248,7 @@ export namespace BoxZoomTool {
     overlay: p.Property<BoxAnnotation>
     match_aspect: p.Property<boolean>
     origin: p.Property<BoxOrigin>
+    zoom_out_gesture: p.Property<ZoomOutGesture | null>
   }
 }
 
@@ -253,11 +265,12 @@ export class BoxZoomTool extends GestureTool {
   static {
     this.prototype.default_view = BoxZoomToolView
 
-    this.define<BoxZoomTool.Props>(({Bool, Ref, Or, Auto}) => ({
-      dimensions:   [ Or(Dimensions, Auto), "auto" ],
-      overlay:      [ Ref(BoxAnnotation), DEFAULT_BOX_OVERLAY ],
-      match_aspect: [ Bool, false ],
-      origin:       [ BoxOrigin, "corner" ],
+    this.define<BoxZoomTool.Props>(({Bool, Ref, Or, Auto, Nullable}) => ({
+      dimensions:       [ Or(Dimensions, Auto), "auto" ],
+      overlay:          [ Ref(BoxAnnotation), DEFAULT_BOX_OVERLAY ],
+      match_aspect:     [ Bool, false ],
+      origin:           [ BoxOrigin, "corner" ],
+      zoom_out_gesture: [ Nullable(ZoomOutGesture), "double_tap"],
     }))
 
     this.register_alias("box_zoom", () => new BoxZoomTool({dimensions: "both"}))

--- a/docs/bokeh/source/docs/releases/3.7.0.rst
+++ b/docs/bokeh/source/docs/releases/3.7.0.rst
@@ -11,3 +11,4 @@ Bokeh version ``3.7.0`` (January 2025) is a minor milestone of Bokeh project.
 * Added support for dual canvas and DOM rendering to ``Legend`` annotation (:bokeh-pull:`14028`)
 * Added support for custom marker definitions to ``Scatter`` glyph (:bokeh-pull:`14165`)
 * Added support for stateful action tools, especially ``CustomAction`` (:bokeh-pull:`14143`)
+* Allowed to configure zoom out behavior in ``BoxZoomTool`` (:bokeh-pull:`14190`)

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -1135,6 +1135,10 @@ class BoxZoomTool(Drag):
     (top-left or bottom-right depending on direction) or the center of the box.
     """)
 
+    zoom_out_gesture = Nullable(Enum("double_tap"), default="double_tap", help="""
+    Allows to configure what gesture, if any, is used to zoom out the plot.
+    """)
+
 @abstract
 class ZoomBaseTool(PlotActionTool):
     """ Abstract base class for zoom action tools. """

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -6248,6 +6248,7 @@
     },
     match_aspect: false,
     origin: "corner",
+    zoom_out_gesture: "double_tap",
   },
   ClickPanTool: {
     __extends__: "PlotActionTool",


### PR DESCRIPTION
Resolves https://discourse.bokeh.org/t/box-zoom-double-tap/12137. Treating this as a new feature, but it may also be considered as a regression fix, especially if we revert to `null` as the default. @bokeh/dev, any thoughts about this?