### PR TITLE
Align canvas panel items to start, remove max-content legend height

### DIFF
--- a/bokehjs/src/less/canvas_panel.less
+++ b/bokehjs/src/less/canvas_panel.less
@@ -1,6 +1,8 @@
 :host {
   position: relative;
   pointer-events: none;
+  align-items: start;
+  justify-items: start;
 }
 
 :host(.bk-above), :host(.bk-below) {

--- a/bokehjs/src/less/canvas_panel.less
+++ b/bokehjs/src/less/canvas_panel.less
@@ -1,6 +1,16 @@
 :host {
   position: relative;
   pointer-events: none;
+}
+
+/* The default for CSS grids is to stretch items to completely fill a grid cell
+  if their width or height is `auto`. So we would have to explicitly set the
+  width and height on components to something other than `auto`, such as
+  `max-content` to prevent it from being stretched. This change allows us to
+  leave the width and height properties to their default value, which is `auto`.
+  See discussion on GitHub:
+  https://github.com/bokeh/bokeh/pull/14191#discussion_r1880500434 */
+:host {
   align-items: start;
   justify-items: start;
 }

--- a/bokehjs/src/less/legend.less
+++ b/bokehjs/src/less/legend.less
@@ -1,6 +1,5 @@
 :host {
   position: relative;
-  width: max-content;
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: auto;

--- a/bokehjs/src/less/legend.less
+++ b/bokehjs/src/less/legend.less
@@ -1,7 +1,6 @@
 :host {
   position: relative;
   width: max-content;
-  height: max-content;
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: auto;


### PR DESCRIPTION
Fixes legend height in Safari (when rendering to DOM rather than painting to canvas)

- [x] issues: fixes #14134
- [ ] tests added / passed 
    :x: Adding a new separate regression test just for WebKit not feasible at this time. See discussion on this pull request.
- [ ] release document entry (if new feature or API change)
   :x: Not applicable.

There is at least one test that will fail if you only remove the `max-content` rule from the legend but do not change the align- and justify-items rules for the canvas panel grid:

```
node make test:integration -k \
  "Legend annotation should support various combinations of locations and orientations"
```

@mattpap pasted a [passing screenshot](https://github.com/bokeh/bokeh/pull/14191#issuecomment-2537439834) in the comments below.

The same applies to the [legend_location_outside example](https://docs.bokeh.org/en/latest/docs/examples/styling/plots/legend_location_outside.html).