### PR TITLE
Add `BOKEH_CHROME` environment variable for BokehJS test

### DIFF
--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -78,6 +78,14 @@ function sys_path(): string {
 const supported_chromium_revision = "r2670" // 118.0.5993.88
 
 function chrome(): string {
+  const bokeh_chrome = process.env.BOKEH_CHROME
+  if (bokeh_chrome !== undefined) {
+    if (fs.existsSync(bokeh_chrome)) {
+      return bokeh_chrome
+    } else {
+      throw new BuildError("headless", `can't find BOKEH_CHROME=${bokeh_chrome}`)
+    }
+  }
   const names = [`chromium_${supported_chromium_revision}`, "chromium", "chromium-browser", "chrome", "google-chrome", "Google Chrome"]
   const path = sys_path()
 

--- a/docs/bokeh/source/docs/dev_guide/testing.rst
+++ b/docs/bokeh/source/docs/dev_guide/testing.rst
@@ -254,7 +254,9 @@ Run JavaScript tests
 Most of the JavaScript-based tests for :term:`BokehJS` use a custom-made testing
 framework. This framework **requires Google Chrome or Chromium**. You need a
 recent version of one of these browsers available on your system to run those
-tests locally.
+tests locally. Bokeh will try to find Google Chrome or Chromium in your
+``PATH``, but you can set the environment variable ``BOKEH_CHROME`` to point to
+the executable if desired.
 
 .. _contributor_guide_testing_local_javascript_all:
 


### PR DESCRIPTION
This is an escape hatch for a custom chrome path without updating the `PATH`. I want to set this environment variable when I activate my conda environment. This should also make it easier to switch between different Chrome versions. 



![image](https://github.com/user-attachments/assets/a777423a-e34b-4d92-9ebb-4422067db4b1)
