### PR TITLE
Add Google Chrome for Testing to list of Chrome executable names

### DIFF
--- a/bokehjs/make/tasks/test.ts
+++ b/bokehjs/make/tasks/test.ts
@@ -86,7 +86,7 @@ function chrome(): string {
       throw new BuildError("headless", `can't find BOKEH_CHROME=${bokeh_chrome}`)
     }
   }
-  const names = [`chromium_${supported_chromium_revision}`, "chromium", "chromium-browser", "chrome", "google-chrome", "Google Chrome"]
+  const names = [`chromium_${supported_chromium_revision}`, "chromium", "chromium-browser", "chrome", "google-chrome", "Google Chrome for Testing", "Google Chrome"]
   const path = sys_path()
 
   for (const name of names) {


### PR DESCRIPTION
This change will make it easier to work with a version of Chrome installed at the project level to meet the version that Bokeh's test suite expects. For more context, see #14117.