### PR TITLE
Add return annotation to wrapped glyph/marker renderer methods

### DIFF
--- a/src/bokeh/plotting/_decorators.py
+++ b/src/bokeh/plotting/_decorators.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from functools import wraps
-from inspect import Parameter, Signature
+from inspect import Parameter, Signature, signature
 
 # Bokeh imports
 from ..util.deprecation import deprecated
@@ -63,7 +63,7 @@ def marker_method():
             kwargs["marker"] = marker_type
             return create_renderer(Scatter, self, **kwargs)
 
-        wrapped.__signature__ = Signature(parameters=sigparams)
+        wrapped.__signature__ = Signature(parameters=sigparams, return_annotation=signature(func).return_annotation)
         wrapped.__name__ = func.__name__
 
         wrapped.__doc__ = generate_docstring(glyphclass, parameters, func.__doc__)
@@ -88,7 +88,7 @@ def glyph_method(glyphclass):
                 kwargs.setdefault("coordinates", self.coordinates)
             return create_renderer(glyphclass, self.plot, **kwargs)
 
-        wrapped.__signature__ = Signature(parameters=sigparams)
+        wrapped.__signature__ = Signature(parameters=sigparams, return_annotation=signature(func).return_annotation)
         wrapped.__name__ = func.__name__
 
         wrapped.__doc__ = generate_docstring(glyphclass, parameters, func.__doc__)

--- a/src/bokeh/plotting/_decorators.py
+++ b/src/bokeh/plotting/_decorators.py
@@ -64,7 +64,6 @@ def marker_method():
             return create_renderer(Scatter, self, **kwargs)
 
         wrapped.__signature__ = Signature(parameters=sigparams, return_annotation=signature(func).return_annotation)
-        wrapped.__name__ = func.__name__
 
         wrapped.__doc__ = generate_docstring(glyphclass, parameters, func.__doc__)
 
@@ -89,7 +88,6 @@ def glyph_method(glyphclass):
             return create_renderer(glyphclass, self.plot, **kwargs)
 
         wrapped.__signature__ = Signature(parameters=sigparams, return_annotation=signature(func).return_annotation)
-        wrapped.__name__ = func.__name__
 
         wrapped.__doc__ = generate_docstring(glyphclass, parameters, func.__doc__)
 

--- a/tests/unit/bokeh/plotting/test__decorators.py
+++ b/tests/unit/bokeh/plotting/test__decorators.py
@@ -17,11 +17,13 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from inspect import signature
 from unittest import mock
 
 # Bokeh imports
 from bokeh.models import CDSView, Marker
 from bokeh.plotting import figure
+from bokeh.plotting._docstring import generate_docstring
 from bokeh.plotting._renderer import RENDERER_ARGS
 
 # Module under test
@@ -62,6 +64,26 @@ def test__glyph_receives_renderer_arg(arg, values) -> None:
             fn(figure(), x=0, y=0, **{arg: value})
             _, kwargs = gr_mock.call_args
             assert arg in kwargs and kwargs[arg] == value
+
+
+def test__glyph_method_keeps_metadata() -> None:
+    def foo(**kw) -> GlyphRenderer: pass
+    glyphclass = Marker
+    fn = bpd.glyph_method(glyphclass)(foo)
+    expected_doc = generate_docstring(glyphclass, glyphclass.parameters(), foo.__doc__)
+    assert fn.__name__ == foo.__name__
+    assert fn.__doc__ == expected_doc
+    assert signature(fn).return_annotation == signature(foo).return_annotation
+
+
+def test__marker_method_keeps_metadata() -> None:
+    def foo(**kw) -> GlyphRenderer: pass
+    fn = bpd.marker_method()(foo)
+    expected_doc = generate_docstring(Marker, Marker.parameters(), foo.__doc__)
+    assert fn.__name__ == foo.__name__
+    assert fn.__doc__ == expected_doc
+    assert signature(fn).return_annotation == signature(foo).return_annotation
+
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/plotting/test__decorators.py
+++ b/tests/unit/bokeh/plotting/test__decorators.py
@@ -24,7 +24,7 @@ from unittest import mock
 from bokeh.models import CDSView, Marker
 from bokeh.plotting import figure
 from bokeh.plotting._docstring import generate_docstring
-from bokeh.plotting._renderer import RENDERER_ARGS
+from bokeh.plotting._renderer import RENDERER_ARGS, GlyphRenderer
 
 # Module under test
 import bokeh.plotting._decorators as bpd # isort:skip


### PR DESCRIPTION
fixes #14247 

`glyph_method` and `marker_method` inspect the function they wrap and create a new signature with the appropriate parameters. This change adds the wrapped functions return annotation to the signature.
