### PR TITLE
Fix data_table sort performance

### DIFF
--- a/bokehjs/src/lib/core/util/array.ts
+++ b/bokehjs/src/lib/core/util/array.ts
@@ -150,6 +150,12 @@ export function argmax(array: number[]): number {
   return max_by(range(array.length), (i) => array[i])
 }
 
+export function argsort(array: number[]): number[] {
+  const indices = Array.from(array.keys())
+  indices.sort((a, b) => array[a] - array[b])
+  return indices
+}
+
 export function uniq<T>(array: Arrayable<T>): T[] {
   const result = new Set<T>()
   for (const value of array) {

--- a/bokehjs/src/lib/core/util/array.ts
+++ b/bokehjs/src/lib/core/util/array.ts
@@ -150,6 +150,9 @@ export function argmax(array: number[]): number {
   return max_by(range(array.length), (i) => array[i])
 }
 
+/**
+ * Return the permutation indices for sorting an array.
+ */
 export function argsort(array: number[]): number[] {
   const indices = Array.from(array.keys())
   indices.sort((a, b) => array[a] - array[b])

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -118,7 +118,7 @@ export class TableDataProvider implements DataProvider<Item> {
 
     const records = this.getRecords()
 
-    const lookup: { [key: number]: number} = {}
+    const lookup: {[key: number]: number} = {}
     this.index.forEach((v, i) => lookup[v] = i)
 
     this.index.sort((i0, i1) => {

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -11,7 +11,7 @@ import type {Arrayable} from "core/types"
 import {dict} from "core/util/object"
 import {unique_id} from "core/util/string"
 import {isString, isNumber} from "core/util/types"
-import {argsort, some, range, sort_by, map} from "core/util/array"
+import {some, range, sort_by, map} from "core/util/array"
 import {filter} from "core/util/arrayable"
 import {is_NDArray} from "core/util/ndarray"
 import {logger} from "core/logging"
@@ -118,13 +118,14 @@ export class TableDataProvider implements DataProvider<Item> {
 
     const records = this.getRecords()
 
-    const sorted_indices = argsort(this.index)
+    const lookup: { [key: number]: number} = {}
+    this.index.forEach((v, i) => lookup[v] = i)
 
     this.index.sort((i0, i1) => {
       for (const [col, sign] of cols) {
         const field = col.field!
-        const v0 = records[sorted_indices[i0]][field]
-        const v1 = records[sorted_indices[i1]][field]
+        const v0 = records[lookup[i0]][field]
+        const v1 = records[lookup[i1]][field]
         if (col.sorter != null) {
           return sign * col.sorter.compute(v0, v1)
         }

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -11,7 +11,7 @@ import type {Arrayable} from "core/types"
 import {dict} from "core/util/object"
 import {unique_id} from "core/util/string"
 import {isString, isNumber} from "core/util/types"
-import {some, range, sort_by, map} from "core/util/array"
+import {argsort, some, range, sort_by, map} from "core/util/array"
 import {filter} from "core/util/arrayable"
 import {is_NDArray} from "core/util/ndarray"
 import {logger} from "core/logging"
@@ -117,12 +117,14 @@ export class TableDataProvider implements DataProvider<Item> {
     }
 
     const records = this.getRecords()
-    const old_index = this.index.slice()
+
+    const sorted_indices = argsort(this.index)
 
     this.index.sort((i0, i1) => {
       for (const [col, sign] of cols) {
-        const v0 = records[old_index.indexOf(i0)][col.field!]
-        const v1 = records[old_index.indexOf(i1)][col.field!]
+        const field = col.field!
+        const v0 = records[sorted_indices[i0]][field]
+        const v1 = records[sorted_indices[i1]][field]
         if (col.sorter != null) {
           return sign * col.sorter.compute(v0, v1)
         }

--- a/bokehjs/test/unit/core/util/array.ts
+++ b/bokehjs/test/unit/core/util/array.ts
@@ -173,6 +173,14 @@ describe("core/util/array module", () => {
     expect(array.argmax([4, 3, 2, 1])).to.be.equal(0)
   })
 
+  it("argsort should return the permutation indices for sorting an array", () => {
+    expect(array.argsort([])).to.be.equal([])
+    expect(array.argsort([2])).to.be.equal([0])
+    expect(array.argsort([1, 2, 3, 4])).to.be.equal([0, 1, 2, 3])
+    expect(array.argsort([4, 3, 2, 1])).to.be.equal([3, 2, 1, 0])
+    expect(array.argsort([2, 4, 1, 3])).to.be.equal([2, 0, 3, 1])
+  })
+
   it("should support resize() function", () => {
     expect(array.resize([1, 2, 3], 0, 0)).to.be.equal([])
     expect(array.resize([1, 2, 3], 1, 0)).to.be.equal([1])


### PR DESCRIPTION
This PR removes unnecessary array scans in a tight inner loop that introduced quadratic runtime behavior for table sorts. 

- [x] issues: fixes #14261 
- [x] tests added / passed

Here is a chrome profile showing that a sort on the OP code with N=500000 now takes ~1s.

<img width="1553" alt="Screenshot 2025-01-28 at 21 11 18" src="https://github.com/user-attachments/assets/88a5b867-d2a9-4d95-945d-96e7e43f5b72" />

I do actually wonder if `getRecords` could be improved, and also wonder why `sort` is called so many times for a single click. But I don't think it is worth investing much more effort until/unless we do an actual top-to-bottom evaluation of our slickgrid usage wrt to current best practices.

### Update

OK `argsort` is not quite the right solution here in general since in the presence of CDS views the indices may not be contiguous. I am beginning to see why I did things the way I did in 2017, even though I was surely aware of `argsort` at the time. However, I think constructing a manual reverse lookup will do just as well. @mattpap if there's any better typescript way to write this please let me know. I have gone ahead and left the `argsort` util since it is tiny and has tests and may be useful somewhere. 