### PR TITLE
Add type declarations for `glyph_api.py`

### DIFF
--- a/docs/bokeh/source/docs/releases/3.7.0.rst
+++ b/docs/bokeh/source/docs/releases/3.7.0.rst
@@ -13,6 +13,7 @@ Bokeh version ``3.7.0`` (January 2025) is a minor milestone of Bokeh project.
 * Added support for stateful action tools, especially ``CustomAction`` (:bokeh-pull:`14143`)
 * Enhanced default ``DatetimeTickFormatter`` by providing additional context (:bokeh-pull:`13854`)
 * Added preliminary support for type declaration files (``*.pyi``) in ``bokeh.models`` (:bokeh-pull:`13900`)
+* Added preliminary type declarations to ``figure()`` and its glyph methods (:bokeh-pull:`14269`, :bokeh-pull:`14289`)
 * Added support for tool context menus on plots and figures (by default) (:bokeh-pull:`14228`)
 * Added support for label and on/off icons to `Switch` widget (:bokeh-pull:`14294`)
 
@@ -20,6 +21,7 @@ Deprecations
 ------------
 
 * ``ActionItem`` and ``CheckableItem`` are now combined into ``MenuItem``.
+* Use ``FloatSpec()`` instead of ``NumberSpec(accept_datetime=False, accept_timedelta=False)``.
 
 API and breaking changes
 ------------------------

--- a/examples/basic/scatters/color_scatter.py
+++ b/examples/basic/scatters/color_scatter.py
@@ -15,7 +15,7 @@ N = 4000
 x = np.random.random(size=N) * 100
 y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
-colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype="uint8")
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype=np.uint8)
 
 TOOLS="hover,crosshair,pan,wheel_zoom,zoom_in,zoom_out,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select,examine,fullscreen,help"
 

--- a/src/bokeh/_specs.pyi
+++ b/src/bokeh/_specs.pyi
@@ -1,0 +1,183 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from typing import (
+    Never,
+    NotRequired,
+    Sequence,
+    TypedDict,
+)
+
+# External imports
+import numpy as np
+import numpy.typing as npt
+
+# Bokeh imports
+from ._types import (
+    Color,
+    DashPattern,
+    Datetime,
+    FontSize,
+    FontStyle,
+    NonNegative,
+    TimeDelta,
+)
+from .core.enums import (
+    AngleUnitsType as AngleUnits,
+    CoordinateUnitsType as CoordinateUnits,
+    HatchPatternType as HatchPattern,
+    LineCapType as LineCap,
+    LineJoinType as LineJoin,
+    MarkerTypeType as MarkerType,
+    OutlineShapeNameType as OutlineShapeName,
+    SpatialUnitsType as SpatialUnits,
+    TextAlignType as TextAlign,
+    TextBaselineType as TextBaseline,
+)
+from .core.property.vectorization import Expr, Field, Value
+from .core.property_aliases import TextAnchorType as TextAnchor
+from .models.expressions import Expression
+from .models.transforms import Transform
+
+type FieldName = str
+
+class ValueDict[ValueType, UnitsType](TypedDict):
+    value: ValueType
+    transform: NotRequired[Transform]
+    units: NotRequired[UnitsType]
+
+class FieldDict[ValueType, UnitsType](TypedDict):
+    field: FieldName
+    transform: NotRequired[Transform]
+    units: NotRequired[UnitsType]
+
+class ExprDict[ValueType, UnitsType](TypedDict):
+    expr: Expression
+    transform: NotRequired[Transform]
+    units: NotRequired[UnitsType]
+
+type VectorInit[ValueType, UnitsType] = Value[ValueType] | Field | Expr
+type VectorDict[ValueType, UnitsType] = ValueDict[ValueType, UnitsType] | FieldDict[ValueType, UnitsType] | ExprDict[ValueType, UnitsType]
+type VectorLike[ValueType, UnitsType] = VectorInit[ValueType, UnitsType] | VectorDict[ValueType, UnitsType]
+
+type Vectorized[ValueType, UnitsType] = FieldName | ValueType | VectorLike[ValueType, UnitsType]
+
+type IntArray = npt.NDArray[np.integer]
+type FloatArray = npt.NDArray[np.floating]
+type NumberArray = FloatArray | npt.NDArray[np.datetime64] | npt.NDArray[np.timedelta64]
+type Number1dArray = NumberArray # TODO shape
+type Number2dArray = NumberArray # TODO shape
+type Number3dArray = NumberArray # TODO shape
+type StringArray = npt.NDArray[np.str_]
+
+type DataSpec[T] = Vectorized[T, Never]
+type UnitsSpec[T, U] = Vectorized[T, U]
+
+type IntVal = int
+type IntSpec = DataSpec[IntVal]
+type IntArg = FieldName | IntVal | IntSpec | Sequence[IntVal] | IntArray
+
+type FloatVal = float
+type FloatSpec = DataSpec[FloatVal]
+type FloatArg = FieldName | FloatVal | FloatSpec | Sequence[FloatVal] | FloatArray
+
+type NumberVal = float | Datetime | TimeDelta
+type NumberSpec = DataSpec[NumberVal]
+type NumberArg = FieldName | NumberVal | NumberSpec | Sequence[NumberVal] | NumberArray
+
+type Number1dVal = Sequence[float | Datetime | TimeDelta]
+type Number1dSpec = DataSpec[Number1dVal]
+type Number1dArg = FieldName | Number1dVal | Number1dSpec | Sequence[Number1dVal] | Number1dArray
+
+type Number2dVal = Sequence[Sequence[float | Datetime | TimeDelta]]
+type Number2dSpec = DataSpec[Number2dVal]
+type Number2dArg = FieldName | Number2dVal | Number2dSpec | Sequence[Number2dVal] | Number2dArray
+
+type Number3dVal = Sequence[Sequence[Sequence[float | Datetime | TimeDelta]]]
+type Number3dSpec = DataSpec[Number3dVal]
+type Number3dArg = FieldName | Number3dVal | Number3dSpec | Sequence[Number3dVal] | Number3dArray
+
+type SizeVal = NonNegative[float] | Datetime | TimeDelta
+type SizeSpec = DataSpec[SizeVal]
+type SizeArg = FieldName | SizeVal | Sequence[SizeVal] | SizeSpec | NumberArray
+
+type AlphaVal = FloatVal
+type AlphaSpec = FloatSpec
+type AlphaArg = FloatArg
+
+type ColorVal = Color | None
+type ColorSpec = DataSpec[Color | None]
+type ColorArg = FieldName | ColorVal | Sequence[ColorVal] | ColorSpec | npt.NDArray[np.uint8] # TODO
+
+type StringVal = str
+type StringSpec = DataSpec[StringVal]
+type StringArg = FieldName | StringVal | Sequence[StringVal] | StringSpec | StringArray
+
+type NullStringVal = StringVal | None
+type NullStringSpec = DataSpec[NullStringVal]
+type NullStringArg = FieldName | NullStringVal | Sequence[NullStringVal] | NullStringSpec | StringArray
+
+type FontSizeVal = FontSize
+type FontSizeSpec = DataSpec[FontSizeVal]
+type FontSizeArg = FieldName | FontSizeVal | Sequence[FontSizeVal] | FontSizeSpec | StringArray
+
+type FontStyleVal = FontStyle
+type FontStyleSpec = DataSpec[FontStyleVal]
+type FontStyleArg = FieldName | FontStyleVal | Sequence[FontStyleVal] | FontStyleSpec | StringArray
+
+type TextAlignVal = TextAlign
+type TextAlignSpec = DataSpec[TextAlignVal]
+type TextAlignArg = FieldName | TextAlignVal | Sequence[TextAlignVal] | TextAlignSpec | StringArray
+
+type TextBaselineVal = TextBaseline
+type TextBaselineSpec = DataSpec[TextBaselineVal]
+type TextBaselineArg = FieldName | TextBaselineVal | Sequence[TextBaselineVal] | TextBaselineSpec | StringArray
+
+type LineJoinVal = LineJoin
+type LineJoinSpec = DataSpec[LineJoinVal]
+type LineJoinArg = FieldName | LineJoinVal | Sequence[LineJoinVal] | LineJoinSpec | StringArray
+
+type LineCapVal = LineCap
+type LineCapSpec = DataSpec[LineCapVal]
+type LineCapArg = FieldName | LineCapVal | Sequence[LineCapVal] | LineCapSpec | StringArray
+
+type DashPatternVal = DashPattern
+type DashPatternSpec = DataSpec[DashPatternVal]
+type DashPatternArg = FieldName | DashPatternVal | Sequence[DashPatternVal] | DashPatternSpec | StringArray
+
+type HatchPatternVal = HatchPattern | None
+type HatchPatternSpec = DataSpec[HatchPatternVal]
+type HatchPatternArg = FieldName | HatchPatternVal | Sequence[HatchPatternVal] | HatchPatternSpec | StringArray
+
+type MarkerVal = MarkerType | str
+type MarkerSpec = DataSpec[MarkerVal]
+type MarkerArg = FieldName | MarkerVal | Sequence[MarkerVal] | MarkerSpec | StringArray
+
+type TextAnchorVal = TextAnchor
+type TextAnchorSpec = DataSpec[TextAnchorVal]
+type TextAnchorArg = FieldName | TextAnchorVal | Sequence[TextAnchorVal] | TextAnchorSpec | StringArray
+
+type OutlineShapeNameVal = OutlineShapeName
+type OutlineShapeNameSpec = DataSpec[OutlineShapeNameVal]
+type OutlineShapeNameArg = FieldName | OutlineShapeNameVal | Sequence[OutlineShapeNameVal] | OutlineShapeNameSpec | StringArray
+
+type AngleVal = float
+type AngleSpec = UnitsSpec[AngleVal, AngleUnits]
+type AngleArg = FieldName | AngleVal | Sequence[AngleVal] | AngleSpec | FloatArray
+
+type CoordinateVal = float | Datetime | TimeDelta
+type CoordinateSpec = UnitsSpec[float | Datetime | TimeDelta, CoordinateUnits]
+type CoordinateArg = FieldName | CoordinateVal | CoordinateSpec | Sequence[CoordinateVal] | NumberArray
+
+type DistanceVal = NonNegative[float] | Datetime | TimeDelta
+type DistanceSpec = UnitsSpec[DistanceVal, SpatialUnits]
+type DistanceArg = FieldName | DistanceVal | DistanceSpec | Sequence[DistanceVal] | NumberArray
+
+type NullDistanceVal = DistanceVal | None
+type NullDistanceSpec = UnitsSpec[NullDistanceVal, SpatialUnits]
+type NullDistanceArg = FieldName | NullDistanceVal | NullDistanceSpec | Sequence[NullDistanceVal] | NumberArray

--- a/src/bokeh/_types.pyi
+++ b/src/bokeh/_types.pyi
@@ -8,13 +8,7 @@
 # Standard library imports
 import datetime
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Never,
-    NotRequired,
-    Sequence,
-    TypedDict,
-)
+from typing import TYPE_CHECKING, Sequence
 
 # External imports
 import numpy as np
@@ -24,24 +18,10 @@ if TYPE_CHECKING:
     import PIL.Image
 
 # Bokeh imports
-from .core.enums import (
-    AngleUnitsType as AngleUnits,
-    CoordinateUnitsType as CoordinateUnits,
-    DashPatternType,
-    HatchPatternType as HatchPattern,
-    LineCapType as LineCap,
-    LineJoinType as LineJoin,
-    MarkerTypeType as MarkerType,
-    SpatialUnitsType as SpatialUnits,
-    TextAlignType as TextAlign,
-    TextBaselineType as TextBaseline,
-)
-from .core.property.vectorization import Expr, Field, Value
-from .models.expressions import Expression
+from .core.enums import DashPatternType
 from .models.nodes import Node
 from .models.ranges import Factor
 from .models.text import BaseText
-from .models.transforms import Transform
 
 type NonNegative[T] = T
 type Positive[T] = T
@@ -67,63 +47,9 @@ type FontStyle = str
 
 type Regex = str
 
-type DashPattern = DashPatternType | Regex | Sequence[int] # Regex(r"^(\d+(\s+\d+)*)?$")
+type DashPattern = DashPatternType | str | Sequence[int]
 
 type Image = str | Path | PIL.Image.Image | npt.NDArray[np.uint8]
-
-type FieldName = str
-
-class ValueDict[ValueType, UnitsType](TypedDict):
-    value: ValueType
-    transform: NotRequired[Transform]
-    units: NotRequired[UnitsType]
-
-class FieldDict[ValueType, UnitsType](TypedDict):
-    field: FieldName
-    transform: NotRequired[Transform]
-    units: NotRequired[UnitsType]
-
-class ExprDict[ValueType, UnitsType](TypedDict):
-    expr: Expression
-    transform: NotRequired[Transform]
-    units: NotRequired[UnitsType]
-
-type VectorInit[ValueType, UnitsType] = Value[ValueType] | Field | Expr
-type VectorDict[ValueType, UnitsType] = ValueDict[ValueType, UnitsType] | FieldDict[ValueType, UnitsType] | ExprDict[ValueType, UnitsType]
-type VectorLike[ValueType, UnitsType] = VectorInit[ValueType, UnitsType] | VectorDict[ValueType, UnitsType]
-
-type Vectorized[ValueType, UnitsType] = FieldName | ValueType | VectorLike[ValueType, UnitsType]
-
-type DataSpec[T] = Vectorized[T, Never]
-type UnitsSpec[T, U] = Vectorized[T, U]
-
-type IntSpec = DataSpec[int]
-type FloatSpec = DataSpec[float]
-
-type NumberSpec = DataSpec[float | Datetime | TimeDelta]
-type SizeSpec = DataSpec[NonNegative[float] | Datetime | TimeDelta]
-type AlphaSpec = FloatSpec
-
-type ColorSpec = DataSpec[Color | None]
-
-type StringSpec = DataSpec[str]
-type NullStringSpec = DataSpec[str | None]
-
-type FontSizeSpec = DataSpec[FontSize]
-type FontStyleSpec = DataSpec[FontStyle]
-type TextAlignSpec = DataSpec[TextAlign]
-type TextBaselineSpec = DataSpec[TextBaseline]
-type LineJoinSpec = DataSpec[LineJoin]
-type LineCapSpec = DataSpec[LineCap]
-type DashPatternSpec = DataSpec[DashPattern]
-type HatchPatternSpec = DataSpec[HatchPattern | None]
-type MarkerSpec = DataSpec[MarkerType | Regex] # Regex("^@.*$")
-
-type CoordinateSpec = UnitsSpec[float | Datetime | TimeDelta, CoordinateUnits]
-type AngleSpec = UnitsSpec[float, AngleUnits]
-
-type DistanceSpec = UnitsSpec[NonNegative[float] | Datetime | TimeDelta, SpatialUnits]
-type NullDistanceSpec = UnitsSpec[NonNegative[float] | Datetime | TimeDelta | None, SpatialUnits]
 
 type Bytes = bytes
 type JSON = str

--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -153,6 +153,7 @@ __all__ = (
     'SpatialUnits',
     'StartEnd',
     'StepMode',
+    'TeXDisplay',
     'TextAlign',
     'TextBaseline',
     'TextureRepetition',
@@ -574,6 +575,10 @@ StartEnd = enumeration(StartEndType)
 #: Specify a mode for stepwise interpolation
 StepModeType = Literal["before", "after", "center"]
 StepMode = enumeration(StepModeType)
+
+#: Display mode in TeX
+TeXDisplayType = Literal["inline", "block", "auto"]
+TeXDisplay = enumeration(TeXDisplayType)
 
 #: Specify the horizontal alignment for rendering text
 TextAlignType = Literal["left", "right", "center"]

--- a/src/bokeh/core/properties.py
+++ b/src/bokeh/core/properties.py
@@ -130,6 +130,7 @@ DataSpec Properties
 .. autoclass:: ColorSpec
 .. autoclass:: DataSpec
 .. autoclass:: DistanceSpec
+.. autoclass:: FloatSpec
 .. autoclass:: FontSizeSpec
 .. autoclass:: MarkerSpec
 .. autoclass:: NumberSpec
@@ -233,6 +234,7 @@ __all__ = (
     'Factor',
     'FactorSeq',
     'Float',
+    'FloatSpec',
     'FontSize',
     'FontSizeSpec',
     'FontStyleSpec',
@@ -336,6 +338,7 @@ from .property.dataspec import ColorSpec
 from .property.dataspec import DashPatternSpec
 from .property.dataspec import DataSpec
 from .property.dataspec import DistanceSpec
+from .property.dataspec import FloatSpec
 from .property.dataspec import FontSizeSpec
 from .property.dataspec import FontStyleSpec
 from .property.dataspec import HatchPatternSpec

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from ...util.dataclasses import Unspecified
+from ...util.deprecation import deprecated
 from ...util.serialization import convert_datetime_type, convert_timedelta_type
 from ...util.strings import nice_join
 from .. import enums
@@ -74,6 +75,7 @@ __all__ = (
     'DashPatternSpec',
     'DataSpec',
     'DistanceSpec',
+    'FloatSpec',
     'FontSizeSpec',
     'FontStyleSpec',
     'HatchPatternSpec',
@@ -247,6 +249,10 @@ class IntSpec(DataSpec):
     def __init__(self, default, *, help: str | None = None) -> None:
         super().__init__(Int, default=default, help=help)
 
+class FloatSpec(DataSpec):
+    def __init__(self, default, *, help: str | None = None) -> None:
+        super().__init__(Float, default=default, help=help)
+
 class NumberSpec(DataSpec):
     """ A |DataSpec| property that accepts numeric and datetime fixed values.
 
@@ -268,18 +274,24 @@ class NumberSpec(DataSpec):
 
     """
 
-    def __init__(self, default=Undefined, *, help: str | None = None, accept_datetime=True, accept_timedelta=True) -> None:
+    def __init__(self, default=Undefined, *, help: str | None = None, accept_datetime: bool = True, accept_timedelta: bool = True) -> None:
         super().__init__(Float, default=default, help=help)
+
         if accept_timedelta:
             self.accepts(TimeDelta, convert_timedelta_type)
+        else:
+            deprecated((3, 7, 0), "NumberSpec(..., accept_datetime=False)", "FloatSpec()")
+
         if accept_datetime:
             self.accepts(Datetime, convert_datetime_type)
+        else:
+            deprecated((3, 7, 0), "NumberSpec(..., accept_timedelta=False)", "FloatSpec()")
 
-class AlphaSpec(NumberSpec):
+class AlphaSpec(FloatSpec):
 
     def __init__(self, default=1.0, *, help: str | None = None) -> None:
         help = f"{help or ''}\n{ALPHA_DEFAULT_HELP}"
-        super().__init__(default=default, help=help, accept_datetime=False, accept_timedelta=False)
+        super().__init__(default=default, help=help)
 
 class NullStringSpec(DataSpec):
     def __init__(self, default=None, *, help: str | None = None) -> None:

--- a/src/bokeh/core/property_aliases.pyi
+++ b/src/bokeh/core/property_aliases.pyi
@@ -12,7 +12,7 @@ from typing import Literal, NotRequired, TypedDict
 from .._types import Image, NonNegative
 from ..core.enums import (
     AlignType as Align,
-    AnchorType,
+    AnchorType as Anchor_,
     AutoType as Auto,
     HAlignType as HAlign,
     ToolIconType as ToolIcon,
@@ -52,31 +52,45 @@ class Corners[T](TypedDict):
     bottom_right: NotRequired[T]
     bottom_left: NotRequired[T]
 
-type Pixels = NonNegative[int]
+type PixelsType = NonNegative[int]
+Pixels = Property[PixelsType]
 
-type HAnchor = Align | HAlign | float
-type VAnchor = Align | VAlign | float
+type HAnchorType = Align | HAlign | float
+HAnchor = Property[HAnchorType]
 
-type Anchor = AnchorType | tuple[HAnchor, VAnchor]
+type VAnchorType = Align | VAlign | float
+VAnchor = Property[VAnchorType]
 
-type AutoAnchor = Auto | Anchor | tuple[Auto | HAnchor, Auto | VAnchor]
+type AnchorType = Anchor_ | tuple[HAnchor, VAnchor]
+Anchor = Property[AnchorType]
 
-type TextAnchor = Anchor | Auto
+type AutoAnchorType = Auto | Anchor | tuple[Auto | HAnchor, Auto | VAnchor]
+AutoAnchor = Property[AutoAnchorType]
 
-type BorderRadius = Pixels | tuple[Pixels, Pixels, Pixels, Pixels] | Corners[Pixels]
+type TextAnchorType = Anchor | Auto
+TextAnchor = Property[TextAnchorType]
 
-type Padding = Pixels | tuple[Pixels, Pixels] | XY[Pixels] | tuple[Pixels, Pixels, Pixels, Pixels] | Corners[Pixels]
+type BorderRadiusType = Pixels | tuple[Pixels, Pixels, Pixels, Pixels] | Corners[Pixels]
+BorderRadius = Property[BorderRadiusType]
 
-type GridSpacing = Pixels | tuple[Pixels, Pixels]
+type PaddingType = Pixels | tuple[Pixels, Pixels] | XY[Pixels] | tuple[Pixels, Pixels, Pixels, Pixels] | Corners[Pixels]
+Padding = Property[PaddingType]
 
-type TrackAlign = Literal["start", "center", "end", "auto"]
+type GridSpacingType = Pixels | tuple[Pixels, Pixels]
+GridSpacing = Property[GridSpacingType]
 
-type TrackSize = str
+type TrackAlignType = Literal["start", "center", "end", "auto"]
+TrackAlign = Property[TrackAlignType]
+
+type TrackSizeType = str
+TrackSize = Property[TrackSizeType]
 
 class FullTrackSize(TypedDict):
     size: NotRequired[TrackSize]
     align: NotRequired[TrackAlign]
 
-type TrackSizing = TrackSize | FullTrackSize
+type TrackSizingType = TrackSize | FullTrackSize
+TrackSizing = Property[TrackSizingType]
 
-type TracksSizing = TrackSizing | list[TrackSizing] | dict[int, TrackSizing]
+type TracksSizingType = TrackSizing | list[TrackSizing] | dict[int, TrackSizing]
+TracksSizing = Property[TracksSizingType]

--- a/src/bokeh/core/property_mixins.py
+++ b/src/bokeh/core/property_mixins.py
@@ -100,6 +100,7 @@ from .properties import (
     Dict,
     Enum,
     Float,
+    FloatSpec,
     FontSize,
     FontSizeSpec,
     FontStyleSpec,
@@ -275,9 +276,9 @@ class HatchProps(HasProps):
 
     hatch_color = ColorSpec(default="black", help=_color_help % "hatching")
     hatch_alpha = AlphaSpec(help=_alpha_help % "hatching")
-    hatch_scale = NumberSpec(default=12.0, accept_datetime=False, accept_timedelta=False, help=_hatch_scale_help)
+    hatch_scale = FloatSpec(default=12.0, help=_hatch_scale_help)
     hatch_pattern = HatchPatternSpec(default=None, help=_hatch_pattern_help)
-    hatch_weight = NumberSpec(default=1.0, accept_datetime=False, accept_timedelta=False, help=_hatch_weight_help)
+    hatch_weight = FloatSpec(default=1.0, help=_hatch_weight_help)
     hatch_extra = Dict(String, Instance("bokeh.models.textures.Texture"))
 
 class ScalarHatchProps(HasProps):
@@ -322,7 +323,7 @@ class LineProps(HasProps):
 
     line_color = ColorSpec(default="black", help=_color_help % "stroke paths")
     line_alpha = AlphaSpec(help=_alpha_help % "stroke paths")
-    line_width = NumberSpec(default=1, accept_datetime=False, accept_timedelta=False, help=_line_width_help)
+    line_width = FloatSpec(default=1, help=_line_width_help)
     line_join = LineJoinSpec(default="bevel", help=_line_join_help)
     line_cap = LineCapSpec(default="butt", help=_line_cap_help)
     line_dash = DashPatternSpec(default=[], help="""How should the line be dashed.""")

--- a/src/bokeh/core/property_mixins.pyi
+++ b/src/bokeh/core/property_mixins.pyi
@@ -9,15 +9,11 @@
 from dataclasses import dataclass
 
 # Bokeh imports
-from .._types import (
-    Alpha,
+from .._specs import (
     AlphaSpec,
-    Color,
     ColorSpec,
-    DashPattern,
     DashPatternSpec,
     FloatSpec,
-    FontSize,
     FontSizeSpec,
     FontStyleSpec,
     HatchPatternSpec,
@@ -25,10 +21,16 @@ from .._types import (
     LineCapSpec,
     LineJoinSpec,
     NumberSpec,
-    Size,
     StringSpec,
     TextAlignSpec,
     TextBaselineSpec,
+)
+from .._types import (
+    Alpha,
+    Color,
+    DashPattern,
+    FontSize,
+    Size,
 )
 from ..models.textures import Texture
 from .enums import (

--- a/src/bokeh/models/glyphs.py
+++ b/src/bokeh/models/glyphs.py
@@ -54,6 +54,7 @@ from ..core.properties import (
     Either,
     Enum,
     Float,
+    FloatSpec,
     Include,
     Instance,
     InstanceDefault,
@@ -1622,14 +1623,14 @@ class Text(XYGlyph, TextGlyph):
     The angles to rotate the text, as measured from the horizontal.
     """)
 
-    x_offset = NumberSpec(default=0, help="""
+    x_offset = FloatSpec(default=0, help="""
     Offset values in pixels to apply to the x-coordinates.
 
     This is useful, for instance, if it is desired to "float" text a fixed
     distance in |screen units| from a given data position.
     """)
 
-    y_offset = NumberSpec(default=0, help="""
+    y_offset = FloatSpec(default=0, help="""
     Offset values in pixels to apply to the y-coordinates.
 
     This is useful, for instance, if it is desired to "float" text a fixed

--- a/src/bokeh/models/glyphs.pyi
+++ b/src/bokeh/models/glyphs.pyi
@@ -7,10 +7,9 @@
 
 # Standard library imports
 from dataclasses import dataclass
-from typing import Literal
 
 # Bokeh imports
-from .._types import (
+from .._specs import (
     AngleSpec,
     DataSpec,
     DistanceSpec,
@@ -29,6 +28,7 @@ from ..core.enums import (
     PaletteType as Palette,
     RadiusDimensionType as RadiusDimension,
     StepModeType as StepMode,
+    TeXDisplayType as TeXDisplay,
 )
 from ..core.has_props import abstract
 from ..core.property_aliases import (
@@ -208,6 +208,18 @@ class HBar(LRTBGlyph):
     left: NumberSpec = ...
 
     right: NumberSpec = ...
+
+@dataclass
+class HSpan(Glyph, LineProps):
+
+    y: NumberSpec = ...
+
+@dataclass
+class HStrip(Glyph, LineProps, FillProps, HatchProps):
+
+    y0: NumberSpec = ...
+
+    y1: NumberSpec = ...
 
 @dataclass
 class HexTile(Glyph, LineProps, FillProps, HatchProps):
@@ -454,7 +466,7 @@ class TeXGlyph(MathTextGlyph):
 
     macros: dict[str, str | tuple[str, int]] = ...
 
-    display: Literal["inline", "block", "auto"] = ...
+    display: TeXDisplay = ...
 
 @dataclass
 class VArea(Glyph, ScalarFillProps, HatchProps):
@@ -488,6 +500,18 @@ class VBar(LRTBGlyph):
     top: NumberSpec = ...
 
 @dataclass
+class VSpan(Glyph, LineProps):
+
+    x: NumberSpec = ...
+
+@dataclass
+class VStrip(Glyph, LineProps, FillProps, HatchProps):
+
+    x0: NumberSpec = ...
+
+    x1: NumberSpec = ...
+
+@dataclass
 class Wedge(XYGlyph, LineProps, FillProps, HatchProps):
 
     x: NumberSpec = ...
@@ -501,27 +525,3 @@ class Wedge(XYGlyph, LineProps, FillProps, HatchProps):
     end_angle: AngleSpec = ...
 
     direction: Direction = ...
-
-@dataclass
-class HSpan(Glyph, LineProps):
-
-    y: NumberSpec = ...
-
-@dataclass
-class VSpan(Glyph, LineProps):
-
-    x: NumberSpec = ...
-
-@dataclass
-class HStrip(Glyph, LineProps, FillProps, HatchProps):
-
-    y0: NumberSpec = ...
-
-    y1: NumberSpec = ...
-
-@dataclass
-class VStrip(Glyph, LineProps, FillProps, HatchProps):
-
-    x0: NumberSpec = ...
-
-    x1: NumberSpec = ...

--- a/src/bokeh/models/glyphs.pyi
+++ b/src/bokeh/models/glyphs.pyi
@@ -13,6 +13,7 @@ from .._specs import (
     AngleSpec,
     DataSpec,
     DistanceSpec,
+    FloatSpec,
     MarkerSpec,
     NonNegative,
     NullDistanceSpec,
@@ -440,9 +441,9 @@ class Text(XYGlyph, TextProps, BackgroundFillProps, BackgroundHatchProps, Border
 
     angle: AngleSpec = ...
 
-    x_offset: NumberSpec = ...
+    x_offset: FloatSpec = ...
 
-    y_offset: NumberSpec = ...
+    y_offset: FloatSpec = ...
 
     anchor: DataSpec[TextAnchor] = ...
 

--- a/src/bokeh/plotting/_renderer.py
+++ b/src/bokeh/plotting/_renderer.py
@@ -32,7 +32,8 @@ from ..util.strings import nice_join
 from ._legends import pop_legend_kwarg, update_legend
 
 if TYPE_CHECKING:
-    from ..models import Glyph, Plot
+    from ..models.glyph import Glyph
+    from ..models.plots import Plot
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -78,7 +79,7 @@ def get_default_color(plot: Plot | None = None) -> str:
 # Dev API
 #-----------------------------------------------------------------------------
 
-def create_renderer(glyphclass: type[Glyph], plot: Plot, **kwargs: Any) -> GlyphRenderer:
+def create_renderer(glyphclass: type[Glyph], plot: Plot, **kwargs: Any) -> GlyphRenderer[Glyph]:
     # convert data source, if necessary
     is_user_source = _convert_data_source(kwargs)
 

--- a/src/bokeh/plotting/glyph_api.pyi
+++ b/src/bokeh/plotting/glyph_api.pyi
@@ -1,0 +1,1018 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from typing import TypedDict, Unpack
+
+# Bokeh imports
+from .._specs import (
+    AlphaArg,
+    AngleArg,
+    ColorArg,
+    DashPatternArg,
+    DistanceArg,
+    FloatArg,
+    FontSizeArg,
+    FontStyleArg,
+    HatchPatternArg,
+    IntArg,
+    LineCapArg,
+    LineJoinArg,
+    MarkerArg,
+    NonNegative,
+    NullDistanceArg,
+    Number1dArg,
+    Number2dArg,
+    Number3dArg,
+    NumberArg,
+    OutlineShapeNameArg,
+    SizeArg,
+    StringArg,
+    TextAlignArg,
+    TextAnchorArg,
+    TextBaselineArg,
+)
+from ..core.enums import (
+    AnchorType as Anchor,
+    AngleUnitsType as AngleUnits,
+    DirectionType as Direction,
+    RadiusDimensionType as RadiusDimension,
+    SpatialUnitsType as SpatialUnits,
+    StepModeType as StepMode,
+    TeXDisplayType as TeXDisplay,
+)
+from ..core.property_aliases import (
+    BorderRadiusType as BorderRadius,
+    PaddingType as Padding,
+)
+from ..models import glyphs
+from ..models.callbacks import CustomJS
+from ..models.coordinates import CoordinateMapping
+from ..models.plots import Plot
+from ..models.renderers import GlyphRenderer
+from ..models.sources import ColumnarDataSource, DataDictLike
+from ..models.textures import Texture
+
+class AuxVisuals(TypedDict, total=False):
+    color: ColorArg
+    alpha: AlphaArg
+
+    selection_color: ColorArg
+    selection_alpha: AlphaArg
+
+    nonselection_color: ColorArg
+    nonselection_alpha: AlphaArg
+
+    hover_color: ColorArg
+    hover_alpha: AlphaArg
+
+    muted_color: ColorArg
+    muted_alpha: AlphaArg
+
+class AuxHatchVisuals(TypedDict, total=False):
+    selection_hatch_color: ColorArg
+    selection_hatch_alpha: AlphaArg
+
+    nonselection_hatch_color: ColorArg
+    nonselection_hatch_alpha: AlphaArg
+
+    hover_hatch_color: ColorArg
+    hover_hatch_alpha: AlphaArg
+
+    muted_hatch_color: ColorArg
+    muted_hatch_alpha: AlphaArg
+
+class AuxFillVisuals(TypedDict, total=False):
+    selection_fill_color: ColorArg
+    selection_fill_alpha: AlphaArg
+
+    nonselection_fill_color: ColorArg
+    nonselection_fill_alpha: AlphaArg
+
+    hover_fill_color: ColorArg
+    hover_fill_alpha: AlphaArg
+
+    muted_fill_color: ColorArg
+    muted_fill_alpha: AlphaArg
+
+class AuxImageVisuals(TypedDict, total=False):
+    pass
+
+class AuxLineVisuals(TypedDict, total=False):
+    selection_line_color: ColorArg
+    selection_line_alpha: AlphaArg
+
+    nonselection_line_color: ColorArg
+    nonselection_line_alpha: AlphaArg
+
+    hover_line_color: ColorArg
+    hover_line_alpha: AlphaArg
+
+    muted_line_color: ColorArg
+    muted_line_alpha: AlphaArg
+
+class AuxTextVisuals(TypedDict, total=False):
+    selection_text_color: ColorArg
+    selection_text_alpha: AlphaArg
+
+    nonselection_text_color: ColorArg
+    nonselection_text_alpha: AlphaArg
+
+    hover_text_color: ColorArg
+    hover_text_alpha: AlphaArg
+
+    muted_text_color: ColorArg
+    muted_text_alpha: AlphaArg
+
+class FillVisuals(AuxFillVisuals, total=False):
+    fill_color: ColorArg
+    fill_alpha: AlphaArg
+
+class HatchVisuals(AuxHatchVisuals, total=False):
+    hatch_color: ColorArg
+    hatch_alpha: AlphaArg
+    hatch_scale: FloatArg
+    hatch_pattern: HatchPatternArg
+    hatch_weight: FloatArg
+    hatch_extra: dict[str, Texture]
+
+class ImageVisuals(AuxImageVisuals, total=False):
+    global_alpha: AlphaArg
+
+class LineVisuals(AuxLineVisuals, total=False):
+    line_color: ColorArg
+    line_alpha: AlphaArg
+    line_width: FloatArg
+    line_join: LineJoinArg
+    line_cap: LineCapArg
+    line_dash: DashPatternArg
+    line_dash_offset: IntArg
+
+class TextVisuals(AuxTextVisuals, total=False):
+    text_color: ColorArg
+    text_outline_color: ColorArg
+    text_alpha: AlphaArg
+    text_font: StringArg
+    text_font_size: FontSizeArg
+    text_font_style: FontStyleArg
+    text_align: TextAlignArg
+    text_baseline: TextBaselineArg
+    text_line_height: NumberArg
+
+
+class AuxGlyphArgs(TypedDict, total=False):
+    source: ColumnarDataSource | DataDictLike
+
+    legend_label: str
+    legend_field: str
+    legend_group: str
+
+class GlyphArgs(AuxGlyphArgs, AuxVisuals, total=False):
+    pass
+
+class AnnularWedgeArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # inner_radius: DistanceArg
+    inner_radius_units: SpatialUnits
+    # outer_radius: DistanceArg
+    outer_radius_units: SpatialUnits
+    # start_angle: AngleArg
+    start_angle_units: AngleUnits
+    # end_angle: AngleArg
+    end_angle_units: AngleUnits
+    # direction: Direction
+
+class AnnulusArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # inner_radius: DistanceArg
+    inner_radius_units: SpatialUnits
+    # outer_radius: DistanceArg
+    outer_radius_units: SpatialUnits
+
+class ArcArgs(GlyphArgs, LineVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # radius: DistanceArg
+    radius_units: SpatialUnits
+    # start_angle: AngleArg
+    start_angle_units: AngleUnits
+    # end_angle: AngleArg
+    end_angle_units: AngleUnits
+    # direction: Direction
+
+class BezierArgs(GlyphArgs, LineVisuals, total=False):
+    # x0: NumberArg
+    # y0: NumberArg
+    # x1: NumberArg
+    # y1: NumberArg
+    # cx0: NumberArg
+    # cy0: NumberArg
+    # cx1: NumberArg
+    # cy1: NumberArg
+    pass
+
+class BlockArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # width: DistanceArg
+    width_units: SpatialUnits
+    # height: DistanceArg
+    height_units: SpatialUnits
+
+class CircleArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # radius: DistanceArg
+    radius_units: SpatialUnits
+    radius_dimension: RadiusDimension
+    hit_dilation: NonNegative[float]
+
+class EllipseArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # width: DistanceArg
+    width_units: SpatialUnits
+    # height: DistanceArg
+    height_units: SpatialUnits
+    # angle: AngleArg
+    angel_units: AngleUnits
+
+class HAreaArgs(GlyphArgs, FillVisuals, HatchVisuals, total=False):
+    # x1: NumberArg
+    # x2: NumberArg
+    # y: NumberArg
+    pass
+
+class HAreaStepArgs(GlyphArgs, FillVisuals, HatchVisuals, total=False):
+    # x1: NumberArg
+    # x2: NumberArg
+    # y: NumberArg
+    step_mode: StepMode
+
+class HBarArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # y: NumberArg
+    # height: DistanceArg
+    height_units: SpatialUnits
+    # left: NumberArg
+    # right: NumberArg
+
+class HSpanArgs(GlyphArgs, LineVisuals, total=False):
+    # y: NumberArg
+    pass
+
+class HStripArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # y0: NumberArg
+    # y1: NumberArg
+    pass
+
+class HexTileArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # r: NumberArg
+    # q: NumberArg
+    size: float
+    aspect_scale: float
+    scale: NumberArg
+    orientation: str
+
+class ImageArgs(GlyphArgs, total=False):
+    # image: Number2dArg
+    # x: NumberArg
+    # y: NumberArg
+    # dw: DistanceArg
+    # dh: DistanceArg
+    # dilate: bool
+    pass
+
+class ImageRGBAArgs(GlyphArgs, total=False):
+    # image: Number2dArg
+    # x: NumberArg
+    # y: NumberArg
+    # dw: DistanceArg
+    # dh: DistanceArg
+    # dilate: bool
+    pass
+
+class ImageStackArgs(GlyphArgs, total=False):
+    # image: Number3dArg
+    # x: NumberArg
+    # y: NumberArg
+    # dw: DistanceArg
+    # dh: DistanceArg
+    # dilate: bool
+    pass
+
+class ImageURLArgs(GlyphArgs, total=False):
+    # url: StringArg
+    # x: NumberArg
+    # y: NumberArg
+    # w: NullDistanceArg
+    w_units: SpatialUnits
+    # h: NullDistanceArg
+    h_units: SpatialUnits
+    # angle: AngleArg
+    angle_units: AngleUnits
+    global_alpha: NumberArg
+    # dilate: bool
+    anchor: Anchor
+    retry_attempts: int
+    retry_timeout: int
+
+class LineArgs(GlyphArgs, LineVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    pass
+
+class MarkerArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # size: SizeArg
+    # angle: AngleArg
+    hit_dilation: NonNegative[float]
+
+class MathMLArgs(GlyphArgs, TextVisuals, total=False):
+    pass
+
+class MultiLineArgs(GlyphArgs, LineVisuals, total=False):
+    # xs: Number1dArg
+    # ys: Number1dArg
+    pass
+
+class MultiPolygonsArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # xs: Number3dArg
+    # ys: Number3dArg
+    pass
+
+class NgonArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # radius: DistanceArg
+    radius_units: SpatialUnits
+    # angle: AngleArg
+    angle_units: AngleUnits
+    n: NumberArg
+    radius_dimension: RadiusDimension
+
+class PatchArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    pass
+
+class PatchesArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # xs: Number1dArg
+    # ys: Number1dArg
+    pass
+
+class QuadArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # left: NumberArg
+    # right: NumberArg
+    # bottom: NumberArg
+    # top: NumberArg
+    pass
+
+class QuadraticArgs(GlyphArgs, LineVisuals, total=False):
+    # x0: NumberArg
+    # y0: NumberArg
+    # x1: NumberArg
+    # y1: NumberArg
+    # cx: NumberArg
+    # cy: NumberArg
+    pass
+
+class RayArgs(GlyphArgs, LineVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # length: DistanceArg
+    length_units: SpatialUnits
+    # angle: AngleArg
+    angle_units: AngleUnits
+
+class RectArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # width: DistanceArg
+    width_units: SpatialUnits
+    # height: DistanceArg
+    height_units: SpatialUnits
+    # angle: AngleArg
+    angle_units: AngleUnits
+    # dilate: bool
+    border_radius: BorderRadius
+
+class ScatterArgs(MarkerArgs, total=False):
+    # marker: MarkerArg
+    defs: dict[str, CustomJS]
+
+class SegmentArgs(GlyphArgs, LineVisuals, total=False):
+    # x0: NumberArg
+    # y0: NumberArg
+    # x1: NumberArg
+    # y1: NumberArg
+    pass
+
+class StepArgs(GlyphArgs, LineVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    mode: StepMode
+
+class TeXArgs(GlyphArgs, TextVisuals, total=False):
+    macros: dict[str, str | tuple[str, int]]
+    display: TeXDisplay
+
+class TextArgs(GlyphArgs, TextVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # text: StringArg
+    # angle: AngleArg
+    angle_units: AngleUnits
+    # x_offset: FloatArg
+    # y_offset: FloatArg
+    anchor: TextAnchorArg
+    padding: Padding
+    border_radius: BorderRadius
+    outline_shape: OutlineShapeNameArg
+
+class VAreaArgs(GlyphArgs, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y1: NumberArg
+    # y2: NumberArg
+    pass
+
+class VAreaStepArgs(GlyphArgs, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y1: NumberArg
+    # y2: NumberArg
+    step_mode: StepMode
+
+class VBarArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # width: DistanceArg
+    width_units: SpatialUnits
+    # bottom: NumberArg
+    # top: NumberArg
+
+class VSpanArgs(GlyphArgs, LineVisuals, total=False):
+    # x: NumberArg
+    pass
+
+class VStripArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x0: NumberArg
+    # x1: NumberArg
+    pass
+
+class WedgeArgs(GlyphArgs, LineVisuals, FillVisuals, HatchVisuals, total=False):
+    # x: NumberArg
+    # y: NumberArg
+    # radius: DistanceArg
+    radius_units: SpatialUnits
+    # start_angle: AngleArg
+    start_angle_units: AngleUnits
+    # end_angle: AngleArg
+    end_angle_units: AngleUnits
+    # direction: Direction
+
+class GlyphAPI:
+
+    @property
+    def plot(self) -> Plot | None: ...
+
+    @property
+    def coordinates(self) -> CoordinateMapping | None: ...
+
+    def __init__(self, parent: Plot | None = None, coordinates: CoordinateMapping | None = None) -> None: ...
+
+    def annular_wedge(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        inner_radius: DistanceArg = ...,
+        outer_radius: DistanceArg = ...,
+        start_angle: AngleArg = ...,
+        end_angle: AngleArg = ...,
+        direction: Direction = ...,
+        **kwargs: Unpack[AnnularWedgeArgs],
+    ) -> GlyphRenderer[glyphs.AnnularWedge]: ...
+
+    def annulus(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        inner_radius: DistanceArg = ...,
+        outer_radius: DistanceArg = ...,
+        **kwargs: Unpack[AnnulusArgs],
+    ) -> GlyphRenderer[glyphs.Annulus]: ...
+
+    def arc(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        radius: DistanceArg = ...,
+        start_angle: AngleArg = ...,
+        end_angle: AngleArg = ...,
+        direction: Direction = ...,
+        **kwargs: Unpack[ArcArgs],
+    ) -> GlyphRenderer[glyphs.Arc]: ...
+
+    def bezier(self,
+        x0: NumberArg = ...,
+        y0: NumberArg = ...,
+        x1: NumberArg = ...,
+        y1: NumberArg = ...,
+        cx0: NumberArg = ...,
+        cy0: NumberArg = ...,
+        cx1: NumberArg = ...,
+        cy1: NumberArg = ...,
+        **kwargs: Unpack[BezierArgs],
+    ) -> GlyphRenderer[glyphs.Bezier]: ...
+
+    def circle(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        radius: DistanceArg = ...,
+        **kwargs: Unpack[CircleArgs],
+    ) -> GlyphRenderer[glyphs.Circle]: ...
+
+    def block(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        width: DistanceArg = ...,
+        height: DistanceArg = ...,
+        **kwargs: Unpack[BlockArgs],
+    ) -> GlyphRenderer[glyphs.Block]: ...
+
+    def harea(self,
+        x1: NumberArg = ...,
+        x2: NumberArg = ...,
+        y: NumberArg = ...,
+        **kwargs: Unpack[HAreaArgs],
+    ) -> GlyphRenderer[glyphs.HArea]: ...
+
+    def harea_step(self,
+        x1: NumberArg = ...,
+        x2: NumberArg = ...,
+        y: NumberArg = ...,
+        **kwargs: Unpack[HAreaStepArgs],
+    ) -> GlyphRenderer[glyphs.HAreaStep]: ...
+
+    def hbar(self,
+        y: NumberArg = ...,
+        height: DistanceArg = ...,
+        right: NumberArg = ...,
+        left: NumberArg = ...,
+        **kwargs: Unpack[HBarArgs],
+    ) -> GlyphRenderer[glyphs.HBar]: ...
+
+    def hspan(self,
+        y: NumberArg = ...,
+        **kwargs: Unpack[HSpanArgs],
+    ) -> GlyphRenderer[glyphs.HSpan]: ...
+
+    def hstrip(self,
+        y0: NumberArg = ...,
+        y1: NumberArg = ...,
+        **kwargs: Unpack[HStripArgs],
+    ) -> GlyphRenderer[glyphs.HStrip]: ...
+
+    def ellipse(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        width: DistanceArg = ...,
+        height: DistanceArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[EllipseArgs],
+    ) -> GlyphRenderer[glyphs.Ellipse]: ...
+
+    def hex_tile(self,
+        q: NumberArg = ...,
+        r: NumberArg = ...,
+        **kwargs: Unpack[HexTileArgs],
+    ) -> GlyphRenderer[glyphs.HexTile]: ...
+
+    def image(self,
+        image: Number2dArg = ...,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        dw: DistanceArg = ...,
+        dh: DistanceArg = ...,
+        dilate: bool = ...,
+        **kwargs: Unpack[ImageArgs],
+    ) -> GlyphRenderer[glyphs.Image]: ...
+
+    def image_rgba(self,
+        image: Number2dArg = ...,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        dw: DistanceArg = ...,
+        dh: DistanceArg = ...,
+        dilate: bool = ...,
+        **kwargs: Unpack[ImageRGBAArgs],
+    ) -> GlyphRenderer[glyphs.ImageRGBA]: ...
+
+    def image_stack(self,
+        image: Number3dArg = ...,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        dw: DistanceArg = ...,
+        dh: DistanceArg = ...,
+        dilate: bool = ...,
+        **kwargs: Unpack[ImageStackArgs],
+    ) -> GlyphRenderer[glyphs.ImageStack]: ...
+
+    def image_url(self,
+        url: StringArg = ...,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        w: NullDistanceArg = ...,
+        h: NullDistanceArg = ...,
+        angle: AngleArg = ...,
+        dilate: bool = ...,
+        **kwargs: Unpack[ImageURLArgs],
+    ) -> GlyphRenderer[glyphs.ImageURL]: ...
+
+    def line(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        **kwargs: Unpack[LineArgs],
+    ) -> GlyphRenderer[glyphs.Line]: ...
+
+    def mathml(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        text: StringArg = ...,
+        angle: AngleArg = ...,
+        x_offset: FloatArg = ...,
+        y_offset: FloatArg = ...,
+        **kwargs: Unpack[MathMLArgs],
+    ) -> GlyphRenderer[glyphs.MathMLGlyph]: ...
+
+    def multi_line(self,
+        xs: Number1dArg = ...,
+        ys: Number1dArg = ...,
+        **kwargs: Unpack[MultiLineArgs],
+    ) -> GlyphRenderer[glyphs.MultiLine]: ...
+
+    def multi_polygons(self,
+        xs: Number3dArg = ...,
+        ys: Number3dArg = ...,
+        **kwargs: Unpack[MultiPolygonsArgs],
+    ) -> GlyphRenderer[glyphs.MultiPolygons]: ...
+
+    def ngon(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        radius: DistanceArg = ...,
+        **kwargs: Unpack[NgonArgs],
+    ) -> GlyphRenderer[glyphs.Ngon]: ...
+
+    def patch(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        **kwargs: Unpack[PatchArgs],
+    ) -> GlyphRenderer[glyphs.Patch]: ...
+
+    def patches(self,
+        xs: Number1dArg = ...,
+        ys: Number1dArg = ...,
+        **kwargs: Unpack[PatchesArgs],
+    ) -> GlyphRenderer[glyphs.Patches]: ...
+
+    def quad(self,
+        left: NumberArg = ...,
+        right: NumberArg = ...,
+        top: NumberArg = ...,
+        bottom: NumberArg = ...,
+        **kwargs: Unpack[QuadArgs],
+    ) -> GlyphRenderer[glyphs.Quad]: ...
+
+    def quadratic(self,
+        x0: NumberArg = ...,
+        y0: NumberArg = ...,
+        x1: NumberArg = ...,
+        y1: NumberArg = ...,
+        cx: NumberArg = ...,
+        cy: NumberArg = ...,
+        **kwargs: Unpack[QuadraticArgs],
+    ) -> GlyphRenderer[glyphs.Quadratic]: ...
+
+    def ray(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        length: DistanceArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[RayArgs],
+    ) -> GlyphRenderer[glyphs.Ray]: ...
+
+    def rect(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        width: DistanceArg = ...,
+        height: DistanceArg = ...,
+        angle: AngleArg = ...,
+        dilate: bool = ...,
+        **kwargs: Unpack[RectArgs],
+    ) -> GlyphRenderer[glyphs.Rect]: ...
+
+    def step(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        **kwargs: Unpack[StepArgs],
+    ) -> GlyphRenderer[glyphs.Step]: ...
+
+    def segment(self,
+        x0: NumberArg = ...,
+        y0: NumberArg = ...,
+        x1: NumberArg = ...,
+        y1: NumberArg = ...,
+        **kwargs: Unpack[SegmentArgs],
+    ) -> GlyphRenderer[glyphs.Segment]: ...
+
+    def tex(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        text: StringArg = ...,
+        angle: AngleArg = ...,
+        x_offset: FloatArg = ...,
+        y_offset: FloatArg = ...,
+        **kwargs: Unpack[TeXArgs],
+    ) -> GlyphRenderer[glyphs.TeXGlyph]: ...
+
+    def text(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        text: StringArg = ...,
+        angle: AngleArg = ...,
+        x_offset: FloatArg = ...,
+        y_offset: FloatArg = ...,
+        **kwargs: Unpack[TextArgs],
+    ) -> GlyphRenderer[glyphs.Text]: ...
+
+    def varea(self,
+        x: NumberArg = ...,
+        y1: NumberArg = ...,
+        y2: NumberArg = ...,
+        **kwargs: Unpack[VAreaArgs],
+    ) -> GlyphRenderer[glyphs.VArea]: ...
+
+    def varea_step(self,
+        x: NumberArg = ...,
+        y1: NumberArg = ...,
+        y2: NumberArg = ...,
+        **kwargs: Unpack[VAreaStepArgs],
+    ) -> GlyphRenderer[glyphs.VAreaStep]: ...
+
+    def vbar(self,
+        x: NumberArg = ...,
+        width: DistanceArg = ...,
+        top: NumberArg = ...,
+        bottom: NumberArg = ...,
+        **kwargs: Unpack[VBarArgs],
+    ) -> GlyphRenderer[glyphs.VBar]: ...
+
+    def vspan(self,
+        x: NumberArg = ...,
+        **kwargs: Unpack[VSpanArgs],
+    ) -> GlyphRenderer[glyphs.VSpan]: ...
+
+    def vstrip(self,
+        x0: NumberArg = ...,
+        x1: NumberArg = ...,
+        **kwargs: Unpack[VStripArgs],
+    ) -> GlyphRenderer[glyphs.VStrip]: ...
+
+    def wedge(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        radius: DistanceArg = ...,
+        start_angle: AngleArg = ...,
+        end_angle: AngleArg = ...,
+        direction: Direction = ...,
+        **kwargs: Unpack[WedgeArgs],
+    ) -> GlyphRenderer[glyphs.Wedge]: ...
+
+    def scatter(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        marker: MarkerArg = ...,
+        **kwargs: Unpack[ScatterArgs],
+    ) -> GlyphRenderer[glyphs.Scatter]: ...
+
+    # Markers
+
+    def asterisk(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def circle_cross(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def circle_dot(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def circle_x(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def circle_y(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def cross(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def dash(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def diamond(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def diamond_cross(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def diamond_dot(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def dot(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def hex(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def hex_dot(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def inverted_triangle(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def plus(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def square(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def square_cross(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def square_dot(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def square_pin(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def square_x(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def star(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def star_dot(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def triangle(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def triangle_dot(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def triangle_pin(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def x(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...
+
+    def y(self,
+        x: NumberArg = ...,
+        y: NumberArg = ...,
+        size: SizeArg = ...,
+        angle: AngleArg = ...,
+        **kwargs: Unpack[MarkerArgs],
+    ) -> GlyphRenderer[glyphs.Marker]: ...

--- a/tests/unit/bokeh/core/property/test_dataspec.py
+++ b/tests/unit/bokeh/core/property/test_dataspec.py
@@ -33,6 +33,7 @@ from bokeh.core.property.vectorization import (
     field,
     value,
 )
+from bokeh.util.deprecation import BokehDeprecationWarning
 from tests.support.util.api import verify_all
 
 # Module under test
@@ -49,6 +50,7 @@ ALL = (
     'DashPatternSpec',
     'DataSpec',
     'DistanceSpec',
+    'FloatSpec',
     'FontSizeSpec',
     'FontStyleSpec',
     'HatchPatternSpec',
@@ -415,70 +417,79 @@ class Test_NumberSpec:
         assert Foo.__dict__["x"].get_value(f) == Value(32)
 
     def tests_accepts_timedelta(self):
-        class Foo(HasProps):
-            dt = bcpd.NumberSpec("dt", accept_datetime=True)
-            ndt = bcpd.NumberSpec("ndt", accept_datetime=False)
-
-        f = Foo()
-
-        # FYI Numpy erroneously raises an annoying warning about elementwise
-        # comparison below because a timedelta is compared to a float.
-        # https://github.com/numpy/numpy/issues/10095
         with warnings.catch_warnings():
-            warnings.simplefilter(action='ignore', category=DeprecationWarning)
+            warnings.simplefilter(action="ignore", category=BokehDeprecationWarning)
 
-            f.dt = datetime.timedelta(3, 54)
-            assert f.dt == 259254000.0
+            class Foo(HasProps):
+                dt = bcpd.NumberSpec("dt", accept_datetime=True)
+                ndt = bcpd.NumberSpec("ndt", accept_datetime=False)
 
-            # counts as number.Real out of the box
-            f.dt = np.timedelta64(3000, "ms")
-            assert f.dt == np.timedelta64(3000, "ms")
+            f = Foo()
 
-            f.ndt = datetime.timedelta(3, 54)
-            assert f.ndt == 259254000.0
+            # FYI Numpy erroneously raises an annoying warning about elementwise
+            # comparison below because a timedelta is compared to a float.
+            # https://github.com/numpy/numpy/issues/10095
+            with warnings.catch_warnings():
+                warnings.simplefilter(action='ignore', category=DeprecationWarning)
 
-            # counts as number.Real out of the box
-            f.ndt = np.timedelta64(3000, "ms")
-            assert f.ndt == np.timedelta64(3000, "ms")
+                f.dt = datetime.timedelta(3, 54)
+                assert f.dt == 259254000.0
+
+                # counts as number.Real out of the box
+                f.dt = np.timedelta64(3000, "ms")
+                assert f.dt == np.timedelta64(3000, "ms")
+
+                f.ndt = datetime.timedelta(3, 54)
+                assert f.ndt == 259254000.0
+
+                # counts as number.Real out of the box
+                f.ndt = np.timedelta64(3000, "ms")
+                assert f.ndt == np.timedelta64(3000, "ms")
 
     def tests_accepts_timedelta_with_pandas(self):
-        class Foo(HasProps):
-            dt = bcpd.NumberSpec("dt", accept_datetime=True)
-            ndt = bcpd.NumberSpec("ndt", accept_datetime=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=BokehDeprecationWarning)
 
-        f = Foo()
+            class Foo(HasProps):
+                dt = bcpd.NumberSpec("dt", accept_datetime=True)
+                ndt = bcpd.NumberSpec("ndt", accept_datetime=False)
 
-        # counts as number.Real out of the box
-        f.dt = pd.Timedelta("3000ms")
-        assert f.dt == 3000.0
+            f = Foo()
 
-        f.ndt = pd.Timedelta("3000ms")
-        assert f.ndt == 3000.0
+            # counts as number.Real out of the box
+            f.dt = pd.Timedelta("3000ms")
+            assert f.dt == 3000.0
+
+            f.ndt = pd.Timedelta("3000ms")
+            assert f.ndt == 3000.0
 
     def test_accepts_datetime(self) -> None:
-        class Foo(HasProps):
-            dt = bcpd.NumberSpec("dt", accept_datetime=True)
-            ndt = bcpd.NumberSpec("ndt", accept_datetime=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=BokehDeprecationWarning)
 
-        f = Foo()
+            class Foo(HasProps):
+                dt = bcpd.NumberSpec("dt", accept_datetime=True)
+                ndt = bcpd.NumberSpec("ndt", accept_datetime=False)
 
-        f.dt = datetime.datetime(2016, 5, 11)
-        assert f.dt == 1462924800000.0
+            f = Foo()
 
-        f.dt = np.datetime64("2016-05-11")
-        assert f.dt == 1462924800000.0
+            f.dt = datetime.datetime(2016, 5, 11)
+            assert f.dt == 1462924800000.0
 
-        f.dt = datetime.date(2016, 5, 11)
-        assert f.dt == 1462924800000.0
+            f.dt = np.datetime64("2016-05-11")
+            assert f.dt == 1462924800000.0
 
-        with pytest.raises(ValueError):
-            f.ndt = datetime.datetime(2016, 5, 11)
+            f.dt = datetime.date(2016, 5, 11)
+            assert f.dt == 1462924800000.0
 
-        with pytest.raises(ValueError):
-            f.ndt = datetime.date(2016, 5, 11)
+            with pytest.raises(ValueError):
+                f.ndt = datetime.datetime(2016, 5, 11)
 
-        with pytest.raises(ValueError):
-            f.ndt = np.datetime64("2016-05-11")
+            with pytest.raises(ValueError):
+                f.ndt = datetime.date(2016, 5, 11)
+
+            with pytest.raises(ValueError):
+                f.ndt = np.datetime64("2016-05-11")
 
     def test_default(self) -> None:
         class Foo(HasProps):

--- a/tests/unit/bokeh/core/test_enums.py
+++ b/tests/unit/bokeh/core/test_enums.py
@@ -93,6 +93,7 @@ ALL = (
     'SpatialUnits',
     'StartEnd',
     'StepMode',
+    'TeXDisplay',
     'TextAlign',
     'TextBaseline',
     'TextureRepetition',
@@ -346,6 +347,9 @@ class Test_bce:
 
     def test_StepMode(self) -> None:
         assert tuple(bce.StepMode) == ("before", "after", "center")
+
+    def test_TeXDisplay(self) -> None:
+        assert tuple(bce.TeXDisplay) == ("inline", "block", "auto")
 
     def test_TextAlign(self) -> None:
         assert tuple(bce.TextAlign) == ("left", "right", "center")

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -82,6 +82,7 @@ ALL = (
     'Factor',
     'FactorSeq',
     'Float',
+    'FloatSpec',
     'FontSize',
     'FontSizeSpec',
     'FontStyleSpec',


### PR DESCRIPTION
Given limitations of Python's typing (e.g. no conditional and mapped types, no type extractors), then there will be a lot of duplication necessary to finalize this. A redesign of model type declarations may also be necessary, because typing of `**kwargs` has to be done using `Unpack[]` which only supports `TypedDict`.

fixes #14254