### PR TITLE
Address DeprecationWarning from beautifulsoup4

### DIFF
--- a/tests/unit/bokeh/embed/test_server__embed.py
+++ b/tests/unit/bokeh/embed/test_server__embed.py
@@ -66,7 +66,7 @@ class TestServerDocument:
         assert 'bokeh-app-path=/foo/bar/sliders' in r
         assert 'bokeh-absolute-url=http://localhost:8081/foo/bar/sliders' in r
         html = bs4.BeautifulSoup(r, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         assert len(scripts) == 1
         script = scripts[0]
         attrs = script.attrs
@@ -80,7 +80,7 @@ class TestServerDocument:
         r = bes.server_document(arguments=dict(foo=10))
         assert 'foo=10' in r
         html = bs4.BeautifulSoup(r, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         assert len(scripts) == 1
         script = scripts[0]
         attrs = script.attrs
@@ -95,7 +95,7 @@ class TestServerDocument:
         assert 'bokeh-app-path=/foo/bar/sliders' in r
         assert 'bokeh-absolute-url=http://localhost:8081/foo/bar/sliders' in r
         html = bs4.BeautifulSoup(r, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         assert len(scripts) == 1
         script = scripts[0]
         attrs = script.attrs
@@ -109,7 +109,7 @@ class TestServerDocument:
         r = bes.server_document(url=url, relative_urls=True)
         assert 'bokeh-app-path=/foo/bar/sliders' in r
         html = bs4.BeautifulSoup(r, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         assert len(scripts) == 1
         script = scripts[0]
         attrs = script.attrs
@@ -137,7 +137,7 @@ class TestServerSession:
         url = "http://localhost:5006"
         r = bes.server_session(test_plot, session_id='fakesession')
         html = bs4.BeautifulSoup(r, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         assert len(scripts) == 1
         script = scripts[0]
         attrs = script.attrs
@@ -165,7 +165,7 @@ class TestServerSession:
         url = "http://localhost:5006"
         r = bes.server_session(None, session_id='fakesession')
         html = bs4.BeautifulSoup(r, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         assert len(scripts) == 1
         script = scripts[0]
         attrs = script.attrs
@@ -179,7 +179,7 @@ class TestServerSession:
         url = "http://localhost:5006"
         r = bes.server_session(test_plot, session_id='fakesession')
         html = bs4.BeautifulSoup(r, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         assert len(scripts) == 1
         script = scripts[0]
         attrs = script.attrs

--- a/tests/unit/bokeh/test_resources.py
+++ b/tests/unit/bokeh/test_resources.py
@@ -356,7 +356,7 @@ class TestResources:
         r.components.remove("bokeh-mathjax")
         out = r.render_js()
         html = bs4.BeautifulSoup(out, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         for script in scripts:
             if "src" not in script.attrs:
                 continue
@@ -369,7 +369,7 @@ class TestResources:
         monkeypatch.setattr(resources, "__version__", v)
         out = resources.CDN.render_js()
         html = bs4.BeautifulSoup(out, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         for script in scripts:
             assert "crossorigin" not in script.attrs
             assert "integrity" not in script.attrs
@@ -382,7 +382,7 @@ class TestResources:
         r.components.remove("bokeh-mathjax")
         out = r.render_js()
         html = bs4.BeautifulSoup(out, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         for script in scripts:
             if "src" not in script.attrs:
                 continue
@@ -395,7 +395,7 @@ class TestResources:
         monkeypatch.setattr(resources, "__version__", v)
         out = resources.INLINE.render_js()
         html = bs4.BeautifulSoup(out, "html.parser")
-        scripts = html.findAll(name='script')
+        scripts = html.find_all(name='script')
         for script in scripts:
             assert "crossorigin" not in script.attrs
             assert "integrity" not in script.attrs


### PR DESCRIPTION
From the [beautifulsoup4 4.13 changelog](https://git.launchpad.net/beautifulsoup/tree/CHANGELOG):

> These things now give DeprecationWarnings when you try to use them,
> and are scheduled to be removed in Beautiful Soup 4.15.0.
> 
> * Every deprecated method, attribute and class from the 3.0 and 2.0
>   major versions of Beautiful Soup. These have been deprecated for a
>   very long time, but they didn't issue DeprecationWarning when you
>   tried to use them. Now they do, and they're all going away soon.
> 
>   This mainly refers to methods and attributes with camelCase names,
>   for example: renderContents, replaceWith, replaceWithChildren,
>   findAll, findAllNext, findAllPrevious, findNext, findNextSibling,
>   findNextSiblings, findParent, findParents, findPrevious,
>   findPreviousSibling, findPreviousSiblings, getText, nextSibling,
>   previousSibling, isSelfClosing, fetchNextSiblings,
>   fetchPreviousSiblings, fetchPrevious, fetchPreviousSiblings,
>   fetchParents, findChild, findChildren, childGenerator,
>   nextGenerator, nextSiblingGenerator, previousGenerator,
>   previousSiblingGenerator, recursiveChildGenerator, and
>   parentGenerator.

---

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes https://github.com/bokeh/bokeh/issues/14274
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
