### PR TITLE
Forward ports docs 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 ---
-default_stages: [push]
+default_stages: [pre-push]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.2
     hooks:
       - id: ruff
-        stages: [commit]
+        stages: [pre-commit]
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.10.1

--- a/docs/bokeh/source/docs/releases/3.6.1.rst
+++ b/docs/bokeh/source/docs/releases/3.6.1.rst
@@ -1,0 +1,9 @@
+.. _release-3-6-1:
+
+3.6.1
+=====
+
+Bokeh version ``3.6.1`` (November 2024) is a hotfix release of Bokeh project.
+
+* Add workaround for Chrome 130 regression (:bokeh-pull:`14093`)
+* Improved handling of ``touch-action`` based on active tools and their supported events (:bokeh-pull:`14109`)

--- a/docs/bokeh/source/docs/releases/3.6.2.rst
+++ b/docs/bokeh/source/docs/releases/3.6.2.rst
@@ -1,0 +1,16 @@
+.. _release-3-6-2:
+
+3.6.2
+=====
+
+Bokeh version ``3.6.2`` (December 2024) is a patch release that fixes a number of
+minor bugs/regressions and documentation issues.
+
+Changes
+-------
+
+* Fixed a regression in `ScaleBar` positioning (:bokeh-pull:`14154`)
+* Restored the ability to add more than one tile renderer (:bokeh-pull:`14170`)
+* Fixed search box in the documentation (:bokeh-pull:`14161`)
+* Fixed regressions after splitting up `Circle` and `Scatter` glyphs (:bokeh-pull:`14085`, :bokeh-pull:`14089`)
+* Updated links to sponsor page (:bokeh-pull:`14086`)

--- a/docs/bokeh/source/docs/releases/3.6.3.rst
+++ b/docs/bokeh/source/docs/releases/3.6.3.rst
@@ -1,0 +1,15 @@
+.. _release-3-6-3:
+
+3.6.3
+=====
+
+Bokeh version ``3.6.3`` (January 2025) is a patch release that fixes a
+long-standing performance issue for data tables, and number of other
+minor bugs/regressions and documentation issues.
+
+Changes
+-------
+
+* Fixed serious data table sort performance bug (:bokeh-pull:`14262`)
+* Fixed visual bug with math text used in titles (:bokeh-pull:`14202`)
+* Fixed issues with CSS color formats in SVG exports causing problems for other applications (:bokeh-pull:`14264`)


### PR DESCRIPTION
This PR brings the `branch-3.6` release notes into `branch-3.7`.  Additionally a deprecation warning about `pre-commit` is fixed. 
