### PR TITLE
fix table selection performance with with a lookup

### DIFF
--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -265,7 +265,9 @@ export class DataTableView extends WidgetView {
     }
 
     const {indices} = this.model.source.selected
-    const permuted_indices = sort_by(map(indices, (x) => this.data.index.indexOf(x)), (x) => x)
+    const lookup: {[key: number]: number} = {}
+    this.data.index.forEach((v, i) => lookup[v] = i)
+    const permuted_indices = sort_by(map(indices, (x) => lookup[x]), (x) => x)
 
     this._in_selection_update = true
     try {


### PR DESCRIPTION
Fixes #11434 

Similar to #14262 this PR fixes a quadratic runtime bug due to a nested `indexOf` call by replacing the search with a lookup from a pre-computed reverse lookup table. 

If we have a 3.6.4 this should go in it but it seems unlikely that we will. 