### PR TITLE
use np.asarray instead of copy=False

### DIFF
--- a/src/bokeh/core/property/wrappers.py
+++ b/src/bokeh/core/property/wrappers.py
@@ -547,7 +547,7 @@ class PropertyValueColumnData(PropertyValueDict[Sequence[Any]]):
                     self[name][ind] = value
                 else:
                     shape = self[name][ind[0]][tuple(ind[1:])].shape
-                    self[name][ind[0]][tuple(ind[1:])] = np.array(value, copy=False).reshape(shape)
+                    self[name][ind[0]][tuple(ind[1:])] = np.asarray(value).reshape(shape)
 
         from ...document.events import ColumnsPatchedEvent
         self._notify_owners(old, hint=ColumnsPatchedEvent(doc, source, "data", patches, setter))


### PR DESCRIPTION
This PR makes the necessary NumPy 2.x update for migrating `np.array(..., copy=False)`.

The bug seems like it only occurred in the case when patching was applied to a CDS column with "multi" data, e.g. for `multi_line`. The test is fairly ugly but all these tests are ugly. I did confirm it fails appropriately with the old version of code. 

I did a quick code grep and did not find any other occurrences that needed similar updating. 

- [x] issues: fixes #14296
- [x] tests added / passed
