### PR TITLE
Add types to `__init__` and unify usage of `AnyRef`

### DIFF
--- a/src/bokeh/model/data_model.py
+++ b/src/bokeh/model/data_model.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from .model import Model
@@ -45,7 +48,7 @@ class DataModel(Model):
     __data_model__ = True
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/model/util.py
+++ b/src/bokeh/model/util.py
@@ -59,7 +59,7 @@ class HasDocumentRef:
     _document: Document | None
     _temp_document: Document | None
 
-    def __init__(self, *args, **kw):
+    def __init__(self, *args: Any, **kw: Any):
         super().__init__(*args, **kw)
         self._document = None
         self._temp_document = None

--- a/src/bokeh/models/annotations/annotation.py
+++ b/src/bokeh/models/annotations/annotation.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import Instance, InstanceDefault, Override
@@ -45,7 +48,7 @@ class Annotation(CompositeRenderer):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     level = Override(default="annotation")
@@ -57,7 +60,7 @@ class DataAnnotation(Annotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     source = Instance(DataSource, default=InstanceDefault(ColumnDataSource), help="""

--- a/src/bokeh/models/annotations/arrows.py
+++ b/src/bokeh/models/annotations/arrows.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.enums import CoordinateUnits
 from ...core.has_props import abstract
@@ -61,7 +64,7 @@ class ArrowHead(Marking):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     size = NumberSpec(default=25, help="""
@@ -76,7 +79,7 @@ class OpenHead(ArrowHead):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     line_props = Include(LineProps, help="""
@@ -90,7 +93,7 @@ class NormalHead(ArrowHead):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     line_props = Include(LineProps, help="""
@@ -109,7 +112,7 @@ class TeeHead(ArrowHead):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     line_props = Include(LineProps, help="""
@@ -122,7 +125,7 @@ class VeeHead(ArrowHead):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     line_props = Include(LineProps, help="""
@@ -143,7 +146,7 @@ class Arrow(DataAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     x_start = NumberSpec(default=field("x_start"), help="""

--- a/src/bokeh/models/annotations/geometry.py
+++ b/src/bokeh/models/annotations/geometry.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from math import inf
+from typing import Any
 
 # Bokeh imports
 from ...core.enums import (
@@ -83,7 +84,7 @@ class AreaVisuals(Model):
     """ Allows to style line, fill and hatch visuals. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     line_props = Include(ScalarLineProps, help="""
@@ -116,7 +117,7 @@ class BoxInteractionHandles(Model):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     all          = Required(Instance(AreaVisuals)) # move, resize
@@ -157,7 +158,7 @@ class BoxAnnotation(Annotation, AreaVisuals):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     left = Coordinate(default=lambda: Node.frame.left, help="""
@@ -345,7 +346,7 @@ class Band(DataAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     lower = UnitsSpec(default=field("lower"), units_enum=CoordinateUnits, units_default="data", help="""
@@ -391,7 +392,7 @@ class PolyAnnotation(Annotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     xs = Seq(CoordinateLike, default=[], help="""
@@ -463,7 +464,7 @@ class Slope(Annotation):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     gradient = Nullable(Float, help="""
@@ -508,7 +509,7 @@ class Span(Annotation):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     location = Nullable(CoordinateLike, help="""
@@ -551,7 +552,7 @@ class Whisker(DataAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     lower = UnitsSpec(default=field("lower"), units_enum=CoordinateUnits, units_default="data", help="""

--- a/src/bokeh/models/annotations/html/html_annotation.py
+++ b/src/bokeh/models/annotations/html/html_annotation.py
@@ -19,6 +19,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ....core.has_props import abstract
 from ..annotation import Annotation
@@ -47,7 +50,7 @@ class HTMLAnnotation(Annotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/annotations/html/labels.py
+++ b/src/bokeh/models/annotations/html/labels.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ....core.enums import (
     AngleUnits,
@@ -75,7 +78,7 @@ __all__ = (
 class HTMLTextAnnotation(HTMLAnnotation):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     padding = Padding(default=0, help="""
@@ -132,7 +135,7 @@ class HTMLLabel(HTMLTextAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     x = Required(CoordinateLike, help="""
@@ -209,7 +212,7 @@ class HTMLLabelSet(HTMLAnnotation, DataAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     x = NumberSpec(default=field("x"), help="""
@@ -276,7 +279,7 @@ class HTMLTitle(HTMLTextAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     text = String(default="", help="""

--- a/src/bokeh/models/annotations/html/toolbars.py
+++ b/src/bokeh/models/annotations/html/toolbars.py
@@ -19,6 +19,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ....core.properties import Instance
 from .html_annotation import HTMLAnnotation
@@ -38,7 +41,7 @@ __all__ = (
 class ToolbarPanel(HTMLAnnotation): # TODO: this shouldn't be an annotation
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     toolbar = Instance(".models.tools.Toolbar", help="""

--- a/src/bokeh/models/annotations/labels.py
+++ b/src/bokeh/models/annotations/labels.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.enums import (
     AngleUnits,
@@ -78,7 +81,7 @@ class TextAnnotation(Annotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     text = TextLike(default="", help="""
@@ -143,7 +146,7 @@ class Label(TextAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     anchor = TextAnchor(default="auto", help="""
@@ -234,7 +237,7 @@ class LabelSet(DataAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     x = NumberSpec(default=field("x"), help="""
@@ -301,7 +304,7 @@ class Title(TextAnnotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     vertical_align = Enum(VerticalAlign, default='bottom', help="""

--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -112,7 +112,7 @@ class BaseColorBar(Annotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     location = Either(Enum(HVAlign), Tuple(Float, Float), default="top_right", help="""
@@ -253,7 +253,7 @@ class ColorBar(BaseColorBar):
 
     '''
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     color_mapper = Instance(ColorMapper, help="""
@@ -288,7 +288,7 @@ class ContourColorBar(BaseColorBar):
 
     '''
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     fill_renderer = Instance(GlyphRenderer, help="""
@@ -365,7 +365,7 @@ class Legend(Annotation):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     location = Either(Enum(LegendLocation), Tuple(Float, Float), default="top_right", help="""

--- a/src/bokeh/models/axes.py
+++ b/src/bokeh/models/axes.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.enums import Align, LabelOrientation
 from ..core.has_props import abstract
@@ -90,7 +93,7 @@ class Axis(GuideRenderer):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     # TODO: Enum(0, 1) instead of Int
@@ -256,7 +259,7 @@ class ContinuousAxis(Axis):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class LinearAxis(ContinuousAxis):
@@ -266,7 +269,7 @@ class LinearAxis(ContinuousAxis):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     ticker = Override(default=InstanceDefault(BasicTicker))
@@ -280,7 +283,7 @@ class LogAxis(ContinuousAxis):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     ticker = Override(default=InstanceDefault(LogTicker))
@@ -297,7 +300,7 @@ class CategoricalAxis(Axis):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     ticker = Override(default=InstanceDefault(CategoricalTicker))
@@ -364,7 +367,7 @@ class DatetimeAxis(LinearAxis):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     ticker = Override(default=InstanceDefault(DatetimeTicker))

--- a/src/bokeh/models/callbacks.py
+++ b/src/bokeh/models/callbacks.py
@@ -70,7 +70,7 @@ class Callback(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class OpenURL(Callback):
@@ -79,7 +79,7 @@ class OpenURL(Callback):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     url = String("http://", help="""
@@ -98,7 +98,7 @@ class CustomCode(Callback):
     """ """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class CustomJS(CustomCode):
@@ -113,7 +113,7 @@ class CustomJS(CustomCode):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef)(default={}, help="""
@@ -209,7 +209,7 @@ class SetValue(Callback):
     """ Allows to update a property of an object. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, obj: Init[HasProps] = Intrinsic, attr: Init[str] = Intrinsic, value: Init[any] = Intrinsic, **kwargs) -> None:
+    def __init__(self, obj: Init[HasProps] = Intrinsic, attr: Init[str] = Intrinsic, value: Init[Any] = Intrinsic, **kwargs: Any) -> None:
         super().__init__(obj=obj, attr=attr, value=value, **kwargs)
 
     obj: HasProps = Required(Instance(HasProps), help="""
@@ -244,7 +244,7 @@ class ToggleVisibility(Callback):
     """ Toggle visibility of a UI element. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     target = Required(Instance(".models.ui.UIElement"), help="""
@@ -255,7 +255,7 @@ class OpenDialog(Callback):
     """ Open a dialog box. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dialog = Required(Instance(".models.ui.Dialog"), help="""
@@ -273,7 +273,7 @@ class CloseDialog(Callback):
     """ Close a dialog box. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dialog = Required(Instance(".models.ui.Dialog"), help="""

--- a/src/bokeh/models/canvas.py
+++ b/src/bokeh/models/canvas.py
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.enums import OutputBackend
 from ..core.properties import Bool, Enum
@@ -38,7 +41,7 @@ class Canvas(UIElement):
     """ """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     hidpi = Bool(default=True, help="""

--- a/src/bokeh/models/comparisons.py
+++ b/src/bokeh/models/comparisons.py
@@ -22,6 +22,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
@@ -62,7 +65,7 @@ class Comparison(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -79,7 +82,7 @@ class CustomJSCompare(Comparison):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
@@ -103,7 +106,7 @@ class NanCompare(Comparison):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     ascending_first = Bool(default=False, help="""

--- a/src/bokeh/models/coordinates.py
+++ b/src/bokeh/models/coordinates.py
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.properties import Instance, InstanceDefault
 from ..model import Model
@@ -39,7 +42,7 @@ class CoordinateMapping(Model):
     """ A mapping between two coordinate systems. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     x_source = Instance(Range, default=InstanceDefault(DataRange1d), help="""

--- a/src/bokeh/models/css.py
+++ b/src/bokeh/models/css.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import Nullable, Required, String
@@ -46,7 +49,7 @@ class StyleSheet(Model):
     """ """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class InlineStyleSheet(StyleSheet):
@@ -60,7 +63,7 @@ class InlineStyleSheet(StyleSheet):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     css = Required(String, help="""
@@ -78,7 +81,7 @@ class ImportedStyleSheet(StyleSheet):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     url = Required(String, help="""
@@ -94,7 +97,7 @@ class GlobalInlineStyleSheet(InlineStyleSheet):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class GlobalImportedStyleSheet(ImportedStyleSheet):
@@ -106,14 +109,14 @@ class GlobalImportedStyleSheet(ImportedStyleSheet):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Styles(Model):
     """ Allows to configure style attribute of DOM elements. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     align_content = Nullable(String)

--- a/src/bokeh/models/dom.py
+++ b/src/bokeh/models/dom.py
@@ -67,14 +67,14 @@ class DOMNode(Model, Qualified):
     """ Base class for DOM nodes. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Text(DOMNode):
     """ DOM text node. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     content = String("")
@@ -84,7 +84,7 @@ class DOMElement(DOMNode):
     """ Base class for DOM elements. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     style = Either(Instance(Styles), Dict(String, String), default={})
@@ -94,38 +94,38 @@ class DOMElement(DOMNode):
 class Span(DOMElement):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Div(DOMElement):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Table(DOMElement):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class TableRow(DOMElement):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
 class Action(Model, Qualified):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Template(DOMElement):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     actions = List(Instance(Action))
@@ -133,7 +133,7 @@ class Template(DOMElement):
 class ToggleGroup(Action):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     groups = List(Instance(".models.renderers.RendererGroup"))
@@ -142,7 +142,7 @@ class ToggleGroup(Action):
 class Placeholder(DOMElement):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class ValueOf(Placeholder):
@@ -169,7 +169,7 @@ class ValueOf(Placeholder):
 class Index(Placeholder):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class ValueRef(Placeholder):
@@ -177,7 +177,7 @@ class ValueRef(Placeholder):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     field = Required(String, help="""
@@ -209,7 +209,7 @@ class ValueRef(Placeholder):
 class ColorRef(ValueRef):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     hex = Bool(default=True)

--- a/src/bokeh/models/expressions.py
+++ b/src/bokeh/models/expressions.py
@@ -42,6 +42,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from math import inf
+from typing import Any
 
 # Bokeh imports
 from ..core.enums import Direction
@@ -99,7 +100,7 @@ class Expression(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -115,7 +116,7 @@ class CustomJSExpr(Expression):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
@@ -144,7 +145,7 @@ class CumSum(Expression):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     field = Required(String, help="""
@@ -180,7 +181,7 @@ class Stack(Expression):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     fields = Seq(String, default=[], help="""
@@ -201,7 +202,7 @@ class ScalarExpression(Model):
     """ Base class for scalar expressions. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -209,7 +210,7 @@ class Minimum(ScalarExpression):
     """ Computes minimum value of a data source's column. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     field = Required(String)
@@ -220,7 +221,7 @@ class Maximum(ScalarExpression):
     """ Computes maximum value of a data source's column. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     field = Required(String)
@@ -232,7 +233,7 @@ class CoordinateTransform(Expression):
     """ Base class for coordinate transforms. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @property
@@ -248,7 +249,7 @@ class PolarTransform(CoordinateTransform):
     """ Transform from polar to cartesian coordinates. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     radius = NumberSpec(default=field("radius"), help="""
@@ -272,7 +273,7 @@ class XYComponent(Expression):
     """ Base class for bi-variate expressions. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     transform = Instance(CoordinateTransform)
@@ -282,7 +283,7 @@ class XComponent(XYComponent):
     """ X-component of a coordinate system transform to cartesian coordinates. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -290,7 +291,7 @@ class YComponent(XYComponent):
     """ Y-component of a coordinate system transform to cartesian coordinates. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 

--- a/src/bokeh/models/filters.py
+++ b/src/bokeh/models/filters.py
@@ -17,10 +17,12 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
-    Any,
     AnyRef,
     Bool,
     Instance,
@@ -63,7 +65,7 @@ class Filter(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     def __invert__(self) -> Filter:
@@ -85,14 +87,14 @@ class AllIndices(Filter):
     """ Trivial filter that includes all indices in a dataset. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class InversionFilter(Filter):
     """ Inverts indices resulting from another filter. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     operand = Required(Instance(Filter), help="""
@@ -104,7 +106,7 @@ class CompositeFilter(Filter):
     """ Base class for composite filters. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     operands = Required(NonEmpty(Seq(Instance(Filter))), help="""
@@ -115,28 +117,28 @@ class IntersectionFilter(CompositeFilter):
     """ Computes intersection of indices resulting from other filters. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class UnionFilter(CompositeFilter):
     """ Computes union of indices resulting from other filters. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class DifferenceFilter(CompositeFilter):
     """ Computes difference of indices resulting from other filters. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class SymmetricDifferenceFilter(CompositeFilter):
     """ Computes symmetric difference of indices resulting from other filters. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class IndexFilter(Filter):
@@ -177,7 +179,7 @@ class GroupFilter(Filter):
     The name of the column to perform the group filtering operation on.
     """)
 
-    group = Required(Any, help="""
+    group = Required(AnyRef, help="""
     The value of the column indicating the rows of data to keep.
     """)
 
@@ -200,7 +202,7 @@ class CustomJSFilter(Filter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = RestrictedDict(String, AnyRef, disallow=("source",), help="""

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.enums import (
     ContextWhich,
@@ -89,7 +92,7 @@ class TickFormatter(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class BasicTickFormatter(TickFormatter):
@@ -99,7 +102,7 @@ class BasicTickFormatter(TickFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     precision = Either(Auto, Int, help="""
@@ -137,7 +140,7 @@ class MercatorTickFormatter(BasicTickFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dimension = Nullable(Enum(LatLon), help="""
@@ -166,7 +169,7 @@ class NumeralTickFormatter(TickFormatter):
     ''' Tick formatter based on a human-readable format string. '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     format = String("0,0", help="""
@@ -257,7 +260,7 @@ class PrintfTickFormatter(TickFormatter):
     ''' Tick formatter based on a printf-style format string. '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     format = String("%s", help="""
@@ -313,7 +316,7 @@ class LogTickFormatter(TickFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     ticker = Nullable(Instance(Ticker), help="""
@@ -334,7 +337,7 @@ class CategoricalTickFormatter(TickFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class CustomJSTickFormatter(TickFormatter):
@@ -349,7 +352,7 @@ class CustomJSTickFormatter(TickFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
@@ -589,7 +592,7 @@ class DatetimeTickFormatter(TickFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     microseconds = String(help=_DATETIME_TICK_FORMATTER_HELP("``microseconds``"),

--- a/src/bokeh/models/glyph.py
+++ b/src/bokeh/models/glyph.py
@@ -27,6 +27,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import HasProps, abstract
 from ..core.properties import Instance, List
@@ -59,7 +62,7 @@ class Glyph(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     decorations = List(Instance(Decoration), default=[], help="""
@@ -81,7 +84,7 @@ class XYGlyph(Glyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -92,7 +95,7 @@ class RadialGlyph(XYGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -103,7 +106,7 @@ class ConnectedXYGlyph(XYGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -113,7 +116,7 @@ class LineGlyph(HasProps):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -123,7 +126,7 @@ class FillGlyph(HasProps):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -133,7 +136,7 @@ class TextGlyph(HasProps):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -143,7 +146,7 @@ class HatchGlyph(HasProps):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/glyphs.py
+++ b/src/bokeh/models/glyphs.py
@@ -34,6 +34,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.enums import (
     Direction,
@@ -171,7 +174,7 @@ class Marker(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     _args = ('x', 'y', 'size', 'angle')
@@ -216,7 +219,7 @@ class LRTBGlyph(Glyph, LineGlyph, FillGlyph, HatchGlyph):
     """ Base class for axis-aligned rectangles. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     border_radius = BorderRadius(default=0, help="""
@@ -232,7 +235,7 @@ class AnnularWedge(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/AnnularWedge.py"
@@ -285,7 +288,7 @@ class Annulus(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Annulus.py"
@@ -326,7 +329,7 @@ class Arc(XYGlyph, LineGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Arc.py"
@@ -371,7 +374,7 @@ class Bezier(Glyph, LineGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Bezier.py"
@@ -420,7 +423,7 @@ class Block(LRTBGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Block.py"
@@ -459,7 +462,7 @@ class Circle(RadialGlyph, LineGlyph, FillGlyph, HatchGlyph):
     ''' Render circle markers. '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Circle.py"
@@ -521,7 +524,7 @@ class Ellipse(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Ellipse.py"
@@ -567,7 +570,7 @@ class HArea(Glyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/HArea.py"
@@ -601,7 +604,7 @@ class HAreaStep(Glyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/HAreaStep.py"
@@ -644,7 +647,7 @@ class HBar(LRTBGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/HBar.py"
@@ -685,7 +688,7 @@ class HexTile(Glyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/HexTile.py"
@@ -748,7 +751,7 @@ class HexTile(Glyph, LineGlyph, FillGlyph, HatchGlyph):
 class ImageBase(XYGlyph):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     x = NumberSpec(default=field("x"), help="""
@@ -852,7 +855,7 @@ class ImageRGBA(ImageBase):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
@@ -872,7 +875,7 @@ class ImageStack(ImageBase):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
@@ -895,7 +898,7 @@ class ImageURL(XYGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/ImageURL.py"
@@ -978,7 +981,7 @@ class Line(ConnectedXYGlyph, LineGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     _args = ('x', 'y')
@@ -1006,7 +1009,7 @@ class MultiLine(Glyph, LineGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/MultiLine.py"
@@ -1038,7 +1041,7 @@ class MultiPolygons(Glyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/MultiPolygons.py"
@@ -1081,7 +1084,7 @@ class Ngon(RadialGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Ngon.py"
@@ -1143,7 +1146,7 @@ class Patch(ConnectedXYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Patch.py"
@@ -1192,7 +1195,7 @@ class Patches(Glyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Patches.py"
@@ -1235,7 +1238,7 @@ class Quad(LRTBGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Quad.py"
@@ -1276,7 +1279,7 @@ class Quadratic(Glyph, LineGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Quadratic.py"
@@ -1317,7 +1320,7 @@ class Ray(XYGlyph, LineGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Ray.py"
@@ -1357,7 +1360,7 @@ class Rect(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Rect.py"
@@ -1469,7 +1472,7 @@ class Scatter(Marker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Scatter.py"
@@ -1527,7 +1530,7 @@ class Segment(Glyph, LineGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Segment.py"
@@ -1566,7 +1569,7 @@ class Step(XYGlyph, LineGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Step.py"
@@ -1600,7 +1603,7 @@ class Text(XYGlyph, TextGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Text.py"
@@ -1713,7 +1716,7 @@ class MathTextGlyph(Text):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class MathMLGlyph(MathTextGlyph):
@@ -1725,7 +1728,7 @@ class MathMLGlyph(MathTextGlyph):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class TeXGlyph(MathTextGlyph):
@@ -1746,7 +1749,7 @@ class TeXGlyph(MathTextGlyph):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     macros = Dict(String, Either(String, Tuple(String, Int)), help="""
@@ -1787,7 +1790,7 @@ class VArea(Glyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/VArea.py"
@@ -1821,7 +1824,7 @@ class VAreaStep(Glyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/VAreaStep.py"
@@ -1863,7 +1866,7 @@ class VBar(LRTBGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/VBar.py"
@@ -1904,7 +1907,7 @@ class Wedge(XYGlyph, LineGlyph, FillGlyph, HatchGlyph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/Wedge.py"
@@ -1951,7 +1954,7 @@ class HSpan(Glyph, LineGlyph):
     """ Horizontal lines of infinite width. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/HSpan.py"
@@ -1970,7 +1973,7 @@ class VSpan(Glyph, LineGlyph):
     """ Vertical lines of infinite height. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/VSpan.py"
@@ -1989,7 +1992,7 @@ class HStrip(Glyph, LineGlyph, FillGlyph, HatchGlyph):
     """ Horizontal strips of infinite width. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/HStrip.py"
@@ -2020,7 +2023,7 @@ class VStrip(Glyph, LineGlyph, FillGlyph, HatchGlyph):
     """ Vertical strips of infinite height. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/reference/models/VStrip.py"

--- a/src/bokeh/models/graphics.py
+++ b/src/bokeh/models/graphics.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import Enum, Instance, Required
@@ -43,7 +46,7 @@ class Marking(Model):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Decoration(Model):
@@ -52,7 +55,7 @@ class Decoration(Model):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     marking = Instance(Marking, help="""

--- a/src/bokeh/models/graphs.py
+++ b/src/bokeh/models/graphs.py
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
@@ -65,7 +68,7 @@ class LayoutProvider(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @property
@@ -82,7 +85,7 @@ class StaticLayoutProvider(LayoutProvider):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     graph_layout = Dict(Either(Int, String), Len(Seq(Float), 2), default={}, help="""
@@ -108,7 +111,7 @@ class GraphCoordinates(CoordinateTransform):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     layout = Instance(LayoutProvider)
@@ -120,7 +123,7 @@ class NodeCoordinates(GraphCoordinates):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -131,7 +134,7 @@ class EdgeCoordinates(GraphCoordinates):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -142,7 +145,7 @@ class GraphHitTestPolicy(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -154,7 +157,7 @@ class EdgesOnly(GraphHitTestPolicy):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -166,7 +169,7 @@ class NodesOnly(GraphHitTestPolicy):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -180,7 +183,7 @@ class NodesAndLinkedEdges(GraphHitTestPolicy):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -194,7 +197,7 @@ class EdgesAndLinkedNodes(GraphHitTestPolicy):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -209,7 +212,7 @@ class NodesAndAdjacentNodes(GraphHitTestPolicy):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 

--- a/src/bokeh/models/grids.py
+++ b/src/bokeh/models/grids.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.properties import (
     Auto,
@@ -57,7 +60,7 @@ class Grid(GuideRenderer):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dimension = Int(0, help="""

--- a/src/bokeh/models/labeling.py
+++ b/src/bokeh/models/labeling.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
@@ -48,7 +51,7 @@ class LabelingPolicy(Model):
     """ Base class for labeling policies. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -56,7 +59,7 @@ class AllLabels(LabelingPolicy):
     """ Select all labels even if they overlap. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -64,7 +67,7 @@ class NoOverlap(LabelingPolicy):
     """ Basic labeling policy avoiding label overlap. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     min_distance = Int(default=5, help="""
@@ -84,7 +87,7 @@ class CustomLabelingPolicy(LabelingPolicy):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""

--- a/src/bokeh/models/layouts.py
+++ b/src/bokeh/models/layouts.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..colors import RGB, Color, ColorLike
 from ..core.enums import (
@@ -98,7 +101,7 @@ class LayoutDOM(Pane):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     disabled = Bool(False, help="""
@@ -337,7 +340,7 @@ class Spacer(LayoutDOM):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -394,7 +397,7 @@ class GridBox(LayoutDOM, GridCommon):
     """ A CSS grid-based grid container. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     children = List(Either(
@@ -413,7 +416,7 @@ class HBox(LayoutDOM):
     """ A CSS grid-based horizontal box. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     children = List(Struct(child=Instance(UIElement), col=Optional(Int), span=Optional(Int)), default=[], help="""
@@ -438,7 +441,7 @@ class VBox(LayoutDOM):
     """ A CSS grid-based vertical box. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     children = List(Struct(child=Instance(UIElement), row=Optional(Int), span=Optional(Int)), default=[], help="""
@@ -513,7 +516,7 @@ class Row(FlexBox):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     def _sphinx_height_hint(self) -> int|None:
@@ -529,7 +532,7 @@ class Column(FlexBox):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     def _sphinx_height_hint(self) -> int|None:
@@ -543,7 +546,7 @@ class TabPanel(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     title = String(default="", help="""
@@ -575,7 +578,7 @@ class Tabs(LayoutDOM):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/interaction/widgets/tab_panes.py"
@@ -599,7 +602,7 @@ class GroupBox(LayoutDOM):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     title = Nullable(String, help="""
@@ -623,7 +626,7 @@ class ScrollBox(LayoutDOM):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     child = Instance(UIElement, help="""

--- a/src/bokeh/models/map_plots.py
+++ b/src/bokeh/models/map_plots.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.enums import MapType
 from ..core.has_props import abstract
@@ -70,7 +73,7 @@ class MapOptions(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     lat = Required(Float, help="""
@@ -112,7 +115,7 @@ class GMapOptions(MapOptions):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     map_type = Enum(MapType, default="roadmap", help="""
@@ -170,7 +173,7 @@ class GMapPlot(MapPlot):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     # TODO (bev) map plot might not have these

--- a/src/bokeh/models/mappers.py
+++ b/src/bokeh/models/mappers.py
@@ -22,6 +22,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from .. import palettes
 from ..core.enums import Palette
@@ -78,7 +81,7 @@ class Mapper(Transform):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -112,7 +115,7 @@ class CategoricalMapper(Mapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     factors = FactorSeq(help="""
@@ -157,7 +160,7 @@ class CategoricalColorMapper(CategoricalMapper, ColorMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @warning(PALETTE_LENGTH_FACTORS_MISMATCH)
@@ -181,7 +184,7 @@ class CategoricalMarkerMapper(CategoricalMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     markers = Seq(MarkerType, help="""
@@ -204,7 +207,7 @@ class CategoricalPatternMapper(CategoricalMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     patterns = Seq(HatchPatternType, help="""
@@ -223,7 +226,7 @@ class ContinuousColorMapper(ColorMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     domain = List(Tuple(Instance("bokeh.models.renderers.GlyphRenderer"), Either(String, List(String))), default=[], help="""
@@ -267,7 +270,7 @@ class LinearColorMapper(ContinuousColorMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class LogColorMapper(ContinuousColorMapper):
@@ -290,14 +293,14 @@ class LogColorMapper(ContinuousColorMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
 class ScanningColorMapper(ContinuousColorMapper):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -307,7 +310,7 @@ class EqHistColorMapper(ScanningColorMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     bins = Int(default=256*256, help="Number of histogram bins")
@@ -330,7 +333,7 @@ class StackColorMapper(ColorMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class WeightedStackColorMapper(StackColorMapper):
@@ -348,7 +351,7 @@ class WeightedStackColorMapper(StackColorMapper):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     alpha_mapper = Instance(ContinuousColorMapper, help="""

--- a/src/bokeh/models/misc/group_by.py
+++ b/src/bokeh/models/misc/group_by.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import Instance, List, Required
@@ -41,14 +44,14 @@ class GroupBy(Model):
     """ Base class for grouping behaviors. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class GroupByModels(GroupBy):
     """ Group models by manually predefined groups. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     groups = Required(List(List(Instance(Model))), help="""
@@ -59,7 +62,7 @@ class GroupByName(GroupBy):
     """ Group models by their names (``Model.name`` property). """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 # TODO GroupByCustomJS(GroupBy)

--- a/src/bokeh/models/plots.py
+++ b/src/bokeh/models/plots.py
@@ -119,7 +119,7 @@ class Plot(LayoutDOM):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     def select(self, *args, **kwargs):
@@ -865,7 +865,7 @@ class GridPlot(LayoutDOM, GridCommon):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     toolbar = Instance(Toolbar, default=InstanceDefault(Toolbar), help="""

--- a/src/bokeh/models/ranges.py
+++ b/src/bokeh/models/ranges.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from collections import Counter
 from math import nan
+from typing import Any
 
 # Bokeh imports
 from ..core.enums import PaddingUnits, StartEnd
@@ -74,7 +75,7 @@ class Range(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -84,7 +85,7 @@ class NumericalRange(Range):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     start = Required(Either(Float, Datetime, TimeDelta), help="""
@@ -172,7 +173,7 @@ class DataRange(NumericalRange):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = Either(List(Instance(Model)), Auto, help="""

--- a/src/bokeh/models/renderers/contour_renderer.py
+++ b/src/bokeh/models/renderers/contour_renderer.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from ...core.properties import Float, Instance, Seq
@@ -51,7 +51,7 @@ class ContourRenderer(DataRenderer):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     line_renderer = Instance(GlyphRenderer, help="""

--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -71,7 +71,7 @@ class GlyphRenderer(DataRenderer):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @error(CDSVIEW_FILTERS_WITH_CONNECTED)

--- a/src/bokeh/models/renderers/graph_renderer.py
+++ b/src/bokeh/models/renderers/graph_renderer.py
@@ -19,6 +19,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.properties import Instance, InstanceDefault
 from ...core.validation import error
@@ -58,7 +61,7 @@ class GraphRenderer(DataRenderer):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @error(MALFORMED_GRAPH_SOURCE)

--- a/src/bokeh/models/renderers/renderer.py
+++ b/src/bokeh/models/renderers/renderer.py
@@ -61,7 +61,7 @@ class RendererGroup(Model):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     visible = Bool(default=True, help="""
@@ -79,7 +79,7 @@ class Renderer(StyledElement):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     level = Enum(RenderLevel, help="""
@@ -160,7 +160,7 @@ class DataRenderer(Renderer):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     level = Override(default="glyph")
@@ -173,7 +173,7 @@ class GuideRenderer(Renderer):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     level = Override(default="guide")

--- a/src/bokeh/models/renderers/tile_renderer.py
+++ b/src/bokeh/models/renderers/tile_renderer.py
@@ -19,6 +19,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.properties import (
     Bool,
@@ -48,7 +51,7 @@ class TileRenderer(Renderer):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     tile_source = Instance(TileSource, default=InstanceDefault(WMTSTileSource), help="""

--- a/src/bokeh/models/scales.py
+++ b/src/bokeh/models/scales.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import Instance, Required
@@ -69,7 +72,7 @@ class Scale(Transform):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -79,7 +82,7 @@ class ContinuousScale(Scale):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -89,7 +92,7 @@ class LinearScale(ContinuousScale):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class LogScale(ContinuousScale):
@@ -98,7 +101,7 @@ class LogScale(ContinuousScale):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class CategoricalScale(Scale):
@@ -108,7 +111,7 @@ class CategoricalScale(Scale):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class CompositeScale(Scale):
@@ -118,7 +121,7 @@ class CompositeScale(Scale):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     source_scale = Required(Instance(Scale), help="""

--- a/src/bokeh/models/selections.py
+++ b/src/bokeh/models/selections.py
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
@@ -56,7 +59,7 @@ class Selection(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     indices = Seq(Int, default=[], help="""
@@ -99,7 +102,7 @@ class SelectionPolicy(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -112,7 +115,7 @@ class IntersectRenderers(SelectionPolicy):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -125,7 +128,7 @@ class UnionRenderers(SelectionPolicy):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 

--- a/src/bokeh/models/selectors.py
+++ b/src/bokeh/models/selectors.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import Required, String
@@ -47,14 +50,14 @@ class Selector(Model):
     """ Base class for selector queries. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class ByID(Selector):
     """ Represents a CSS ID selector query. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, query: Init[str] = Intrinsic, **kwargs) -> None:
+    def __init__(self, query: Init[str] = Intrinsic, **kwargs: Any) -> None:
         super().__init__(query=query, **kwargs)
 
     query = Required(String, help="""
@@ -65,7 +68,7 @@ class ByClass(Selector):
     """ Represents a CSS class selector query. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, query: Init[str] = Intrinsic, **kwargs) -> None:
+    def __init__(self, query: Init[str] = Intrinsic, **kwargs: Any) -> None:
         super().__init__(query=query, **kwargs)
 
     query = Required(String, help="""
@@ -76,7 +79,7 @@ class ByCSS(Selector):
     """ Represents a CSS selector query. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, query: Init[str] = Intrinsic, **kwargs) -> None:
+    def __init__(self, query: Init[str] = Intrinsic, **kwargs: Any) -> None:
         super().__init__(query=query, **kwargs)
 
     query = Required(String, help="""
@@ -87,7 +90,7 @@ class ByXPath(Selector):
     """ Represents an XPath selector query. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, query: Init[str] = Intrinsic, **kwargs) -> None:
+    def __init__(self, query: Init[str] = Intrinsic, **kwargs: Any) -> None:
         super().__init__(query=query, **kwargs)
 
     query = Required(String, help="""

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from typing import (
     TYPE_CHECKING,
-    Any as TAny,
+    Any,
     Sequence,
     TypeAlias,
     overload,
@@ -33,7 +33,8 @@ import numpy as np
 from ..core.has_props import abstract
 from ..core.properties import (
     JSON,
-    Any,
+    Any as AnyVal,
+    AnyRef,
     Bool,
     ColumnData,
     Dict,
@@ -82,7 +83,7 @@ __all__ = (
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    DataDict: TypeAlias = dict[str, Sequence[TAny] | npt.NDArray[TAny] | pd.Series | pd.Index]
+    DataDict: TypeAlias = dict[str, Sequence[Any] | npt.NDArray[Any] | pd.Series | pd.Index]
 
     Index: TypeAlias = int | slice | tuple[int | slice, ...]
 
@@ -95,7 +96,7 @@ class DataSource(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     selected = Readonly(Instance(Selection), default=InstanceDefault(Selection), help="""
@@ -112,10 +113,10 @@ class ColumnarDataSource(DataSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    default_values = Dict(String, Any, default={}, help="""
+    default_values = Dict(String, AnyRef, default={}, help="""
     Defines the default value for each column.
 
     This is used when inserting rows into a data source, e.g. by edit tools,
@@ -199,7 +200,7 @@ class ColumnDataSource(ColumnarDataSource):
 
     '''
 
-    data = ColumnData(String, Seq(Any), help="""
+    data = ColumnData(String, Seq(AnyVal), help="""
     Mapping of column names to sequences of data. The columns can be, e.g,
     Python lists or tuples, NumPy arrays, etc.
 
@@ -216,11 +217,11 @@ class ColumnDataSource(ColumnarDataSource):
                     f"Current lengths: {', '.join(sorted(str((k, len(v))) for k, v in data.items()))}", BokehUserWarning))
 
     @overload
-    def __init__(self, data: DataDict | pd.DataFrame | pd.core.groupby.GroupBy, **kwargs: TAny) -> None: ...
+    def __init__(self, data: DataDict | pd.DataFrame | pd.core.groupby.GroupBy, **kwargs: Any) -> None: ...
     @overload
-    def __init__(self, **kwargs: TAny) -> None: ...
+    def __init__(self, **kwargs: Any) -> None: ...
 
-    def __init__(self, *args: TAny, **kwargs: TAny) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         ''' If called with a single argument that is a dict or
         ``pandas.DataFrame``, treat that implicitly as the "data" attribute.
 
@@ -747,7 +748,7 @@ class CDSView(Model):
 
     '''
 
-    def __init__(self, *args: TAny, **kwargs: TAny) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     filter = Instance(Filter, default=InstanceDefault(AllIndices), help="""
@@ -771,7 +772,7 @@ class GeoJSONDataSource(ColumnarDataSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     geojson = Required(JSON, help="""
@@ -791,7 +792,7 @@ class WebDataSource(ColumnDataSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     adapter = Nullable(Instance(CustomJS), help="""
@@ -827,7 +828,7 @@ class ServerSentDataSource(WebDataSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class AjaxDataSource(WebDataSource):
@@ -862,7 +863,7 @@ class AjaxDataSource(WebDataSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     polling_interval = Nullable(Int, help="""

--- a/src/bokeh/models/text.py
+++ b/src/bokeh/models/text.py
@@ -19,6 +19,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.has_props import abstract
 from ..core.properties import (
@@ -71,7 +74,7 @@ class MathText(BaseText):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Ascii(MathText):
@@ -81,7 +84,7 @@ class Ascii(MathText):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class MathML(MathText):
@@ -93,7 +96,7 @@ class MathML(MathText):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class TeX(MathText):
@@ -113,7 +116,7 @@ class TeX(MathText):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     macros = Dict(String, Either(String, Tuple(String, Int)), help="""
@@ -141,7 +144,7 @@ class PlainText(BaseText):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/textures.py
+++ b/src/bokeh/models/textures.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.enums import TextureRepetition
 from ..core.has_props import abstract
@@ -47,7 +50,7 @@ class Texture(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     repetition = Enum(TextureRepetition, default="repeat", help="""
@@ -60,7 +63,7 @@ class CanvasTexture(Texture):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     code = Required(String, help="""
@@ -74,7 +77,7 @@ class ImageURLTexture(Texture):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     url = Required(String, help="""

--- a/src/bokeh/models/tickers.py
+++ b/src/bokeh/models/tickers.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.enums import LatLon
 from ..core.has_props import abstract
@@ -79,7 +82,7 @@ class Ticker(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class CustomJSTicker(Ticker):
@@ -98,7 +101,7 @@ class CustomJSTicker(Ticker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
@@ -161,7 +164,7 @@ class ContinuousTicker(Ticker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     num_minor_ticks = Int(5, help="""
@@ -188,7 +191,7 @@ class FixedTicker(ContinuousTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     ticks = Seq(Float, default=[], help="""
@@ -211,7 +214,7 @@ class AdaptiveTicker(ContinuousTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     base = Float(10.0, help="""
@@ -243,7 +246,7 @@ class CompositeTicker(ContinuousTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     tickers = NonEmpty(Seq(Instance(Ticker)), help="""
@@ -261,7 +264,7 @@ class BaseSingleIntervalTicker(ContinuousTicker):
     ''' Base class for single interval tickers. '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class SingleIntervalTicker(BaseSingleIntervalTicker):
@@ -271,7 +274,7 @@ class SingleIntervalTicker(BaseSingleIntervalTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     interval = Required(Float, help="""
@@ -284,7 +287,7 @@ class DaysTicker(BaseSingleIntervalTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     days = Seq(Int, default=[], help="""
@@ -299,7 +302,7 @@ class MonthsTicker(BaseSingleIntervalTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     months = Seq(Int, default=[], help="""
@@ -312,7 +315,7 @@ class YearsTicker(BaseSingleIntervalTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class BasicTicker(AdaptiveTicker):
@@ -324,7 +327,7 @@ class BasicTicker(AdaptiveTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class LogTicker(AdaptiveTicker):
@@ -333,7 +336,7 @@ class LogTicker(AdaptiveTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     mantissas = Override(default=[1, 5])
@@ -345,7 +348,7 @@ class MercatorTicker(BasicTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dimension = Nullable(Enum(LatLon), help="""
@@ -376,7 +379,7 @@ class CategoricalTicker(Ticker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 ONE_MILLI = 1.0
@@ -393,7 +396,7 @@ class DatetimeTicker(CompositeTicker):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     num_minor_ticks = Override(default=0)
@@ -440,7 +443,7 @@ class BinnedTicker(Ticker):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     mapper = Instance(ScanningColorMapper, help="""

--- a/src/bokeh/models/tiles.py
+++ b/src/bokeh/models/tiles.py
@@ -20,9 +20,12 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.properties import (
-    Any,
+    AnyRef,
     Bool,
     Dict,
     Float,
@@ -59,7 +62,7 @@ class TileSource(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     _args = ('url', 'tile_size', 'min_zoom', 'max_zoom', 'extra_url_vars')
@@ -80,7 +83,7 @@ class TileSource(Model):
     A maximum zoom level for the tile layer. This is the most zoomed-in level.
     """)
 
-    extra_url_vars = Dict(String, Any, help="""
+    extra_url_vars = Dict(String, AnyRef, help="""
     A dictionary that maps url variable template keys to values.
 
     These variables are useful for parts of tile urls which do not change from
@@ -110,7 +113,7 @@ class MercatorTileSource(TileSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     _args = ('url', 'tile_size', 'min_zoom', 'max_zoom', 'x_origin_offset', 'y_origin_offset', 'extra_url_vars', 'initial_resolution')
@@ -145,7 +148,7 @@ class TMSTileSource(MercatorTileSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class WMTSTileSource(MercatorTileSource):
@@ -159,7 +162,7 @@ class WMTSTileSource(MercatorTileSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class QUADKEYTileSource(MercatorTileSource):
@@ -170,7 +173,7 @@ class QUADKEYTileSource(MercatorTileSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class BBoxTileSource(MercatorTileSource):
@@ -181,7 +184,7 @@ class BBoxTileSource(MercatorTileSource):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     use_latlon = Bool(default=False, help="""

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import difflib
 from math import nan
-from typing import Callable, ClassVar
+from typing import Any, Callable, ClassVar
 
 # Bokeh imports
 from ..core.enums import (
@@ -59,7 +59,6 @@ from ..core.enums import (
 from ..core.has_props import abstract
 from ..core.properties import (
     Alpha,
-    Any,
     AnyRef,
     Auto,
     Bool,
@@ -195,7 +194,7 @@ class Tool(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     icon = Nullable(IconLike, help="""
@@ -239,7 +238,7 @@ class Tool(Model):
 class ToolProxy(Model):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     tools = List(Instance(Tool))
@@ -253,7 +252,7 @@ class ActionTool(Tool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -263,7 +262,7 @@ class PlotActionTool(ActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -273,7 +272,7 @@ class GestureTool(Tool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -283,7 +282,7 @@ class Drag(GestureTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -293,7 +292,7 @@ class Scroll(GestureTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -303,7 +302,7 @@ class Tap(GestureTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -313,7 +312,7 @@ class SelectTool(GestureTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = Either(Auto, List(Instance(DataRenderer)), default="auto", help="""
@@ -328,7 +327,7 @@ class RegionSelectTool(SelectTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     mode = Enum(RegionSelectionMode, default="replace", help="""
@@ -369,7 +368,7 @@ class InspectTool(GestureTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     toggleable = DeprecatedAlias("visible", since=(3, 4, 0))
@@ -380,7 +379,7 @@ class Toolbar(UIElement):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     logo = Nullable(Enum("normal", "grey"), default="normal", help="""
@@ -429,7 +428,7 @@ class ToolMenu(Menu):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     toolbar = Required(Instance(Toolbar), help="""
@@ -453,7 +452,7 @@ class PanTool(Drag):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dimensions = Enum(Dimensions, default="both", help="""
@@ -469,7 +468,7 @@ class ClickPanTool(PlotActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     direction = Required(Enum(PanDirection), help="""
@@ -526,7 +525,7 @@ class RangeTool(Tool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     x_range = Nullable(Instance(Range), help="""
@@ -600,7 +599,7 @@ class WheelPanTool(Scroll):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dimension = Enum(Dimension, default="width", help="""
@@ -655,7 +654,7 @@ class WheelZoomTool(Scroll):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     # ZoomBaseTool common {
@@ -792,7 +791,7 @@ class CustomAction(ActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     active = Bool(default=False, help="""
@@ -845,7 +844,7 @@ class SaveTool(ActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     filename = Nullable(String, help="""
@@ -868,7 +867,7 @@ class CopyTool(ActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class ResetTool(PlotActionTool):
@@ -885,7 +884,7 @@ class ResetTool(PlotActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class TapTool(Tap, SelectTool):
@@ -910,7 +909,7 @@ class TapTool(Tap, SelectTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     mode = Enum(SelectionMode, default="toggle", help="""
@@ -1007,7 +1006,7 @@ class CrosshairTool(InspectTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     overlay = Either(
@@ -1112,7 +1111,7 @@ class BoxZoomTool(Drag):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dimensions = Either(Enum(Dimensions), Auto, default="auto", help="""
@@ -1148,7 +1147,7 @@ class ZoomBaseTool(PlotActionTool):
     """ Abstract base class for zoom action tools. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = Either(Auto, List(Instance(DataRenderer)), default="auto", help="""
@@ -1187,7 +1186,7 @@ class ZoomInTool(ZoomBaseTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class ZoomOutTool(ZoomBaseTool):
@@ -1203,7 +1202,7 @@ class ZoomOutTool(ZoomBaseTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     maintain_focus = Bool(default=True, help="""
@@ -1231,7 +1230,7 @@ class BoxSelectTool(Drag, RegionSelectTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     dimensions = Enum(Dimensions, default="both", help="""
@@ -1291,7 +1290,7 @@ class LassoSelectTool(Drag, RegionSelectTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     overlay = Instance(PolyAnnotation, default=DEFAULT_POLY_OVERLAY, help="""
@@ -1325,7 +1324,7 @@ class PolySelectTool(Tap, RegionSelectTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     overlay = Instance(PolyAnnotation, default=DEFAULT_POLY_OVERLAY, help="""
@@ -1385,7 +1384,7 @@ class CustomJSHover(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
@@ -1492,7 +1491,7 @@ class HoverTool(InspectTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = Either(Auto, List(Instance(DataRenderer)), default="auto", help="""
@@ -1674,7 +1673,7 @@ class HelpTool(ActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     description = Override(default=DEFAULT_HELP_TIP)
@@ -1687,14 +1686,14 @@ class ExamineTool(ActionTool):
     ''' A tool that allows to inspect and configure a model. '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class FullscreenTool(ActionTool):
     ''' A tool that allows to enlarge a UI element to fullscreen. '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class UndoTool(PlotActionTool):
@@ -1709,7 +1708,7 @@ class UndoTool(PlotActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class RedoTool(PlotActionTool):
@@ -1724,7 +1723,7 @@ class RedoTool(PlotActionTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -1734,10 +1733,10 @@ class EditTool(GestureTool):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    default_overrides = Dict(String, Any, default={}, help="""
+    default_overrides = Dict(String, AnyRef, default={}, help="""
     Padding values overriding ``ColumnarDataSource.default_values``.
 
     Defines values to insert into non-coordinate columns when a new glyph is
@@ -1767,7 +1766,7 @@ class PolyTool(EditTool):
     ''' A base class for polygon draw/edit tools. '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     vertex_renderer = Nullable(GlyphRendererOf(XYGlyph), help="""
@@ -1815,7 +1814,7 @@ class BoxEditTool(EditTool, Drag, Tap):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = List(GlyphRendererOf(LRTBGlyph, Rect, HStrip, VStrip), help="""
@@ -1875,7 +1874,7 @@ class PointDrawTool(EditTool, Drag, Tap):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = List(GlyphRendererOf(XYGlyph), help="""
@@ -1933,7 +1932,7 @@ class PolyDrawTool(PolyTool, Drag, Tap):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = List(GlyphRendererOf(MultiLine, Patches), help="""
@@ -1976,7 +1975,7 @@ class FreehandDrawTool(EditTool, Drag, Tap):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = List(GlyphRendererOf(MultiLine, Patches), help="""
@@ -2024,7 +2023,7 @@ class PolyEditTool(PolyTool, Drag, Tap):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = List(GlyphRendererOf(MultiLine, Patches), help="""
@@ -2058,7 +2057,7 @@ class LineEditTool(EditTool, Drag, Tap):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     renderers = List(GlyphRendererOf(Line), help="""

--- a/src/bokeh/models/transforms.py
+++ b/src/bokeh/models/transforms.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ..core.enums import JitterRandomDistribution, StepMode
 from ..core.has_props import abstract
@@ -77,7 +80,7 @@ class Transform(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -93,7 +96,7 @@ class CustomJSTransform(Transform):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     args = Dict(String, AnyRef, help="""
@@ -147,7 +150,7 @@ class Dodge(Transform):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Float(default=0, help="""
@@ -166,7 +169,7 @@ class Jitter(Transform):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     mean = Float(default=0, help="""
@@ -220,7 +223,7 @@ class Interpolator(Transform):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     x = Required(Either(String, Seq(Float)), help="""
@@ -248,7 +251,7 @@ class LinearInterpolator(Interpolator):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -259,7 +262,7 @@ class StepInterpolator(Interpolator):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     mode = Enum(StepMode, default="after", help="""

--- a/src/bokeh/models/ui/dialogs.py
+++ b/src/bokeh/models/ui/dialogs.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.enums import Movable, Resizable
 from ...core.properties import (
@@ -53,7 +56,7 @@ class Dialog(UIElement):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     title = Nullable(Either(String, Instance(DOMNode), Instance(UIElement)), help="""

--- a/src/bokeh/models/ui/examiner.py
+++ b/src/bokeh/models/ui/examiner.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.has_props import HasProps
 from ...core.properties import Instance, Nullable
@@ -45,7 +48,7 @@ class Examiner(UIElement):
     """ A diagnostic tool for examining documents, models, properties, etc. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     target = Nullable(Instance(HasProps), help="""

--- a/src/bokeh/models/ui/floating.py
+++ b/src/bokeh/models/ui/floating.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.enums import Location
 from ...core.properties import (
@@ -47,7 +50,7 @@ class Drawer(Pane):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     location = Required(Enum(Location))(help="""

--- a/src/bokeh/models/ui/icons.py
+++ b/src/bokeh/models/ui/icons.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.enums import ToolIcon
 from ...core.has_props import abstract
@@ -63,7 +66,7 @@ class Icon(UIElement):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     size = Either(Int, FontSize, default="1em", help="""
@@ -75,7 +78,7 @@ class BuiltinIcon(Icon):
     """ Built-in icons included with BokehJS. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, icon_name: Init[str] = Intrinsic, **kwargs) -> None:
+    def __init__(self, icon_name: Init[str] = Intrinsic, **kwargs: Any) -> None:
         super().__init__(icon_name=icon_name, **kwargs)
 
     icon_name = Required(Either(Enum(ToolIcon), String), help="""
@@ -107,7 +110,7 @@ class SVGIcon(Icon):
     """ SVG icons with inline definitions. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, svg: Init[str] = Intrinsic, **kwargs) -> None:
+    def __init__(self, svg: Init[str] = Intrinsic, **kwargs: Any) -> None:
         super().__init__(svg=svg, **kwargs)
 
     svg = Required(String, help="""
@@ -131,7 +134,7 @@ class TablerIcon(Icon):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, icon_name: Init[str] = Intrinsic, **kwargs) -> None:
+    def __init__(self, icon_name: Init[str] = Intrinsic, **kwargs: Any) -> None:
         super().__init__(icon_name=icon_name, **kwargs)
 
     icon_name = Required(String, help="""

--- a/src/bokeh/models/ui/menus.py
+++ b/src/bokeh/models/ui/menus.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.properties import (
     Bool,
@@ -58,7 +61,7 @@ class MenuItem(Model):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     checked = Nullable(Bool, default=None, help="""
@@ -106,7 +109,7 @@ class MenuItem(Model):
 class ActionItem(MenuItem):
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         deprecated((3, 7, 0), "ActionItem", "MenuItem")
         super().__init__(*args, **kwargs)
 
@@ -114,7 +117,7 @@ class CheckableItem(MenuItem):
     """ A two state checkable menu item. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         deprecated((3, 7, 0), "CheckableItem", "ActionItem.checked")
         super().__init__(*args, **kwargs)
 
@@ -122,7 +125,7 @@ class DividerItem(Model):
     """ A dividing line between two groups of menu items. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Menu(UIElement):
@@ -132,7 +135,7 @@ class Menu(UIElement):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     items = List(Either(Instance(MenuItem), Instance(DividerItem), Null), default=[], help="""

--- a/src/bokeh/models/ui/panels.py
+++ b/src/bokeh/models/ui/panels.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.properties import (
     Auto,
@@ -46,7 +49,7 @@ class Panel(Pane):
     """ A DOM-based UI element that allows for controlling its bounding box. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     position = Required(Instance(Coordinate), help="""

--- a/src/bokeh/models/ui/panes.py
+++ b/src/bokeh/models/ui/panes.py
@@ -18,6 +18,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.properties import Either, Instance, List
 from ..dom import DOMNode
@@ -46,7 +49,7 @@ class Pane(UIElement):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     elements = List(Either(Instance(UIElement), Instance(DOMNode)), default=[], help="""

--- a/src/bokeh/models/ui/tooltips.py
+++ b/src/bokeh/models/ui/tooltips.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.enums import Anchor, TooltipAttachment
 from ...core.properties import (
@@ -58,7 +61,7 @@ class Tooltip(UIElement):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     visible = Override(default=False)

--- a/src/bokeh/models/ui/ui_element.py
+++ b/src/bokeh/models/ui/ui_element.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import (
@@ -60,7 +63,7 @@ class StyledElement(Model):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     css_classes = List(String, default=[], help="""
@@ -104,7 +107,7 @@ class UIElement(StyledElement):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     visible = Bool(default=True, help="""

--- a/src/bokeh/models/widgets/buttons.py
+++ b/src/bokeh/models/widgets/buttons.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 # Bokeh imports
 from ...core.enums import ButtonType
@@ -72,7 +72,7 @@ class ButtonLike(HasProps):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     button_type = Enum(ButtonType, help="""
@@ -99,7 +99,7 @@ class AbstractButton(Widget, ButtonLike):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     label = Either(Instance(DOMNode), String, default="Button", help="""
@@ -122,7 +122,7 @@ class Button(AbstractButton):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     label = Override(default="Button")
@@ -149,7 +149,7 @@ class Toggle(AbstractButton):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     label = Override(default="Toggle")
@@ -179,7 +179,7 @@ class Dropdown(AbstractButton):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     label = Override(default="Dropdown")
@@ -216,7 +216,7 @@ class HelpButton(AbstractButton):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     tooltip = Required(Instance(Tooltip), help="""

--- a/src/bokeh/models/widgets/groups.py
+++ b/src/bokeh/models/widgets/groups.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import (
@@ -58,7 +61,7 @@ class AbstractGroup(Widget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     labels = List(String, help="""
@@ -72,7 +75,7 @@ class ToggleButtonGroup(AbstractGroup, ButtonLike):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     orientation = Enum("horizontal", "vertical", help="""
@@ -87,7 +90,7 @@ class ToggleInputGroup(AbstractGroup):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     inline = Bool(False, help="""
@@ -105,7 +108,7 @@ class CheckboxGroup(ToggleInputGroup):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     active = List(Int, help="""
@@ -118,7 +121,7 @@ class RadioGroup(ToggleInputGroup):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     active = Nullable(Int, help="""
@@ -131,7 +134,7 @@ class CheckboxButtonGroup(ToggleButtonGroup):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     active = List(Int, help="""
@@ -144,7 +147,7 @@ class RadioButtonGroup(ToggleButtonGroup):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     active = Nullable(Int, help="""

--- a/src/bokeh/models/widgets/inputs.py
+++ b/src/bokeh/models/widgets/inputs.py
@@ -22,12 +22,12 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from math import inf
-from typing import Any as TAny
+from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import (
-    Any,
+    AnyRef,
     Auto,
     Bool,
     Color,
@@ -93,7 +93,7 @@ class InputWidget(Widget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     title = Either(String, Instance(HTML), default="", help="""
@@ -130,7 +130,7 @@ class FileInput(InputWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Readonly(Either(String, List(String)), help='''
@@ -239,7 +239,7 @@ class NumericInput(InputWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Either(Null, Float, Int, help="""
@@ -278,7 +278,7 @@ class Spinner(NumericInput):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value_throttled = Readonly(Either(Null, Float, Int), help="""
@@ -306,7 +306,7 @@ class ToggleInput(Widget):
     """ Base class for toggleable (boolean) input widgets. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     active = Bool(default=False, help="""
@@ -321,14 +321,14 @@ class Checkbox(ToggleInput):
     """ A checkbox widget. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class Switch(ToggleInput):
     """ A checkbox-like widget. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     on_icon = Nullable(IconLike, default=None, help="""
@@ -343,7 +343,7 @@ class TextLikeInput(InputWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = String(default="", help="""
@@ -373,7 +373,7 @@ class TextInput(TextLikeInput):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     prefix = Nullable(String, help="""
@@ -392,7 +392,7 @@ class TextAreaInput(TextLikeInput):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     cols = Int(default=20, help="""
@@ -418,7 +418,7 @@ class PasswordInput(TextInput):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -428,7 +428,7 @@ class AutocompleteInput(TextInput):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     completions = List(String, help="""
@@ -459,7 +459,7 @@ class AutocompleteInput(TextInput):
     match any substring of a completion string.
     """)
 
-Options = List(Either(String, Tuple(Any, String)))
+Options = List(Either(String, Tuple(AnyRef, String)))
 OptionsGroups = Dict(String, Options)
 
 NotSelected = "" # TODO symbol
@@ -470,7 +470,7 @@ class Select(InputWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     options = Either(Options, OptionsGroups, help="""
@@ -486,7 +486,7 @@ class Select(InputWidget):
     values are in the aforementioned list format.
     """).accepts(List(Either(Null, String)), lambda v: [ NotSelected if item is None else item for item in v ])
 
-    value = Any(default=NotSelected, help="""
+    value = AnyRef(default=NotSelected, help="""
     Initial or selected value.
     """).accepts(Null, lambda _: NotSelected)
 
@@ -496,7 +496,7 @@ class MultiSelect(InputWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     options = List(Either(String, Tuple(String, String)), help="""
@@ -523,7 +523,7 @@ class MultiChoice(InputWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     options = List(Either(String, Tuple(String, String)), help="""
@@ -567,7 +567,7 @@ class ColorPicker(InputWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     color = ColorHex(default='#000000', help="""
@@ -580,7 +580,7 @@ class PaletteSelect(InputWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Required(String, help="""
@@ -604,7 +604,7 @@ class PaletteSelect(InputWidget):
     The number of columns to split the display of the palettes into.
     """)
 
-def ColorMap(*args: TAny, **kwargs: TAny) -> PaletteSelect:
+def ColorMap(*args: Any, **kwargs: Any) -> PaletteSelect:
     ''' Color palette select widget.
 
     .. deprecated:: 3.4.0

--- a/src/bokeh/models/widgets/markups.py
+++ b/src/bokeh/models/widgets/markups.py
@@ -26,6 +26,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import Bool, String
@@ -59,7 +62,7 @@ class Markup(Widget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     text = String(default="", help="""
@@ -91,7 +94,7 @@ class Paragraph(Markup):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/interaction/widgets/paragraph.py"
@@ -103,7 +106,7 @@ class Div(Markup):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/interaction/widgets/div.py"
@@ -121,7 +124,7 @@ class PreText(Paragraph):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     __example__ = "examples/interaction/widgets/pretext.py"

--- a/src/bokeh/models/widgets/pickers.py
+++ b/src/bokeh/models/widgets/pickers.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.enums import CalendarPosition
 from ...core.has_props import HasProps, abstract
@@ -63,7 +66,7 @@ class PickerBase(InputWidget):
     """ Base class for various kinds of picker widgets. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     position = Enum(CalendarPosition, default="auto", help="""
@@ -79,7 +82,7 @@ class TimeCommon(HasProps):
     """ Common properties for time-like picker widgets. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     hour_increment = Positive(Int)(default=1, help="""
@@ -107,7 +110,7 @@ class TimePicker(PickerBase, TimeCommon):
     """ Widget for picking time. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Nullable(Time, default=None, help="""
@@ -143,7 +146,7 @@ class DateCommon(HasProps):
     """ Common properties for date-like picker widgets. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     disabled_dates = Nullable(List(Either(Date, Tuple(Date, Date))), default=None, help="""
@@ -193,7 +196,7 @@ class BaseDatePicker(PickerBase, DateCommon):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     min_date = Nullable(Date, default=None, help="""
@@ -210,7 +213,7 @@ class DatePicker(BaseDatePicker):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Nullable(Date, default=None, help="""
@@ -221,7 +224,7 @@ class DateRangePicker(BaseDatePicker):
     """ Calendar-based picker of date ranges. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Nullable(Tuple(Date, Date), default=None, help="""
@@ -232,7 +235,7 @@ class MultipleDatePicker(BaseDatePicker):
     """ Calendar-based picker of dates. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = List(Date, default=[], help="""
@@ -250,7 +253,7 @@ class BaseDatetimePicker(PickerBase, DateCommon, TimeCommon):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     min_date = Nullable(Either(Datetime, Date), default=None, help="""
@@ -269,7 +272,7 @@ class DatetimePicker(BaseDatetimePicker):
     """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Nullable(Datetime, default=None, help="""
@@ -280,7 +283,7 @@ class DatetimeRangePicker(BaseDatetimePicker):
     """ Calendar-based picker of date and time ranges. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Nullable(Tuple(Datetime, Datetime), default=None, help="""
@@ -291,7 +294,7 @@ class MultipleDatetimePicker(BaseDatetimePicker):
     """ Calendar-based picker of dates and times. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = List(Datetime, default=[], help="""

--- a/src/bokeh/models/widgets/sliders.py
+++ b/src/bokeh/models/widgets/sliders.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import numbers
 from datetime import date, datetime, timezone
+from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
@@ -130,7 +131,7 @@ class NumericalSlider(AbstractSlider):
     """ Base class for numerical sliders. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     format = Either(String, Instance(TickFormatter), help="""
@@ -144,7 +145,7 @@ class CategoricalSlider(AbstractSlider):
     """ Discrete slider allowing selection from a collection of values. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     categories = Required(Seq(String), help="""
@@ -163,7 +164,7 @@ class Slider(NumericalSlider):
     """ Slider-based number selection widget. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     start = Required(Float, help="""
@@ -192,7 +193,7 @@ class RangeSlider(NumericalSlider):
     """ Range-slider based number range selection widget. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     value = Required(Tuple(Float, Float), help="""
@@ -221,7 +222,7 @@ class DateSlider(NumericalSlider):
     """ Slider-based date selection widget. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @property
@@ -279,7 +280,7 @@ class DateRangeSlider(NumericalSlider):
     """ Slider-based date range selection widget. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @property
@@ -350,7 +351,7 @@ class DatetimeRangeSlider(NumericalSlider):
     """ Slider-based datetime range selection widget. """
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     @property

--- a/src/bokeh/models/widgets/tables.py
+++ b/src/bokeh/models/widgets/tables.py
@@ -20,6 +20,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.enums import (
     AutosizeMode,
@@ -95,7 +98,7 @@ class CellFormatter(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -105,7 +108,7 @@ class CellEditor(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 @abstract
@@ -115,7 +118,7 @@ class RowAggregator(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     field_ = String('', help="""
@@ -132,7 +135,7 @@ class StringFormatter(CellFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     font_style = FontStyleSpec(default="normal", help="""
@@ -167,7 +170,7 @@ class ScientificFormatter(StringFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     precision = Int(10, help="""
@@ -194,7 +197,7 @@ class NumberFormatter(StringFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     format = String("0,0", help="""
@@ -291,7 +294,7 @@ class BooleanFormatter(CellFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     icon = Enum('check', 'check-circle', 'check-circle-o', 'check-square', 'check-square-o', help="""
@@ -304,7 +307,7 @@ class DateFormatter(StringFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     format = Either(Enum(DateFormat), String, default='ISO-8601', help="""
@@ -547,7 +550,7 @@ class HTMLTemplateFormatter(CellFormatter):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     template = String('<%= value %>', help="""
@@ -560,7 +563,7 @@ class StringEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     completions = List(String, help="""
@@ -573,7 +576,7 @@ class TextEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class SelectEditor(CellEditor):
@@ -582,7 +585,7 @@ class SelectEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     options = List(String, help="""
@@ -595,7 +598,7 @@ class PercentEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class CheckboxEditor(CellEditor):
@@ -604,7 +607,7 @@ class CheckboxEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class IntEditor(CellEditor):
@@ -613,7 +616,7 @@ class IntEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     step = Int(1, help="""
@@ -626,7 +629,7 @@ class NumberEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     step = Float(0.01, help="""
@@ -639,7 +642,7 @@ class TimeEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class DateEditor(CellEditor):
@@ -648,7 +651,7 @@ class DateEditor(CellEditor):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class AvgAggregator(RowAggregator):
@@ -657,7 +660,7 @@ class AvgAggregator(RowAggregator):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class MinAggregator(RowAggregator):
@@ -666,7 +669,7 @@ class MinAggregator(RowAggregator):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class MaxAggregator(RowAggregator):
@@ -675,7 +678,7 @@ class MaxAggregator(RowAggregator):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class SumAggregator(RowAggregator):
@@ -684,7 +687,7 @@ class SumAggregator(RowAggregator):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 class TableColumn(Model):
@@ -693,7 +696,7 @@ class TableColumn(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     field = Required(String, help="""
@@ -743,7 +746,7 @@ class TableWidget(Widget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     source = Instance(DataSource, default=InstanceDefault(ColumnDataSource), help="""
@@ -763,7 +766,7 @@ class DataTable(TableWidget):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     autosize_mode = Enum(AutosizeMode, default="force_fit", help="""
@@ -937,7 +940,7 @@ class GroupingInfo(Model):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     getter = String('', help="""
@@ -958,7 +961,7 @@ class DataCube(DataTable):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     grouping = List(Instance(GroupingInfo), help="""

--- a/src/bokeh/models/widgets/widget.py
+++ b/src/bokeh/models/widgets/widget.py
@@ -25,6 +25,9 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import Any
+
 # Bokeh imports
 from ...core.has_props import abstract
 from ...core.properties import Override
@@ -53,7 +56,7 @@ class Widget(LayoutDOM):
     '''
 
     # explicit __init__ to support Init signatures
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
     margin = Override(default=5)


### PR DESCRIPTION
The primary goal of this PR is to add `Any` type to `args` and `kwargs` of all `__init__` methods used for signature generation, to reduce unnecessary type checking noise. This change badly interacts with our `Any` property which is sparingly, but noticeably used in the codebase. This isn't new and we have many ways of resolving this naming conflict in various modules.

Most usage of `Any` property is in my opinion wrong, because it unnecessarily limits values to non-references. Thus I changed all `Any` to `AnyRef` occurrences except one, which is `data` in `ColumnarDataSource`. I think the distinction between `Any` and `AnyRef` was introduced solely as a performance optimization when dealing which large data, thus it shouldn't be necessary in any other context. If we want to limit the type of a property to a primitive type, then we should introduce an appropriate property type or an alias.

fixes #14316