### PR TITLE
exclude tornado on emscripten

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - python >=3.10
 
     {% for dep in data['project']['dependencies'] %}
-    - {{ dep.lower() }}
+    - {{ dep.lower().split(";")[0] }}
     {% endfor %}
 
 about:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pandas >=1.2",
     "pillow >=7.1.0",
     "PyYAML >=3.10",
-    "tornado >=6.2",
+    "tornado >=6.2; sys_platform != 'emscripten'",
     "xyzservices >=2021.09.1",
 ]
 authors = [


### PR DESCRIPTION
- [x] issues: fixes #13817

If this works it might be nice to add some platform checks with nicer error messages to the top of `bokeh.server` and `bokeh.client`, etc. but let's get this merged and into a dev build that can actually be tested with first. 

I did try testing locally with `s/emscripten/darwin/` and `pip install` on the resulting wheel did behave as hoped. Should we also exclude `wasi`?