### PR TITLE
Add support for `legend_name` argument to glyph API

### DIFF
--- a/examples/basic/annotations/legend_name.py
+++ b/examples/basic/annotations/legend_name.py
@@ -1,0 +1,15 @@
+from bokeh.models import Legend, LinearAxis, Range1d
+from bokeh.plotting import figure, save
+
+p = figure(y_range=Range1d(0.9, 3.1), toolbar_location="above")
+
+p.add_layout(Legend(click_policy="hide", location="left"), "below")
+p.add_layout(Legend(click_policy="hide", location="right", name="right"), "below")
+
+p.extra_y_ranges = {"foo": Range1d(-3.1, 0.1)}
+p.add_layout(LinearAxis(y_range_name="foo"), 'right')
+
+p.line([1, 2, 3], [1, 2, 3], color='blue', legend_label="blue line")
+p.line([1, 2, 3], [0, -2, -3], color='red', legend_label="red line", legend_name="right", y_range_name="foo")
+
+save(p)

--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -39,7 +39,7 @@ from ...core.properties import (
 from ...core.validation import error
 from ...core.validation.errors import BAD_COLUMN_NAME, CDSVIEW_FILTERS_WITH_CONNECTED
 from ..filters import AllIndices
-from ..glyphs import ConnectedXYGlyph, Glyph
+from ..glyph import ConnectedXYGlyph, Glyph
 from ..graphics import Decoration, Marking
 from ..sources import (
     CDSView,

--- a/src/bokeh/plotting/_legends.py
+++ b/src/bokeh/plotting/_legends.py
@@ -52,14 +52,15 @@ LEGEND_ARGS = ['legend', 'legend_label', 'legend_field', 'legend_group']
 # Dev API
 #-----------------------------------------------------------------------------
 
-def pop_legend_kwarg(kwargs: dict[str, Any]):
+def pop_legend_kwarg(kwargs: dict[str, Any]) -> tuple[Any, str]:
     result = {attr: kwargs.pop(attr) for attr in LEGEND_ARGS if attr in kwargs}
     if len(result) > 1:
         raise ValueError(f"Only one of {nice_join(LEGEND_ARGS)} may be provided, got: {nice_join(result.keys())}")
-    return result
+    legend_name = kwargs.pop("legend_name", None)
+    return result, legend_name
 
-def update_legend(plot: Plot, legend_kwarg: dict[str, Any], glyph_renderer: GlyphRenderer[Glyph]):
-    legend = _get_or_create_legend(plot)
+def update_legend(plot: Plot, legend_kwarg: dict[str, Any], legend_name: str | None, glyph_renderer: GlyphRenderer[Glyph]):
+    legend = _get_or_create_legend(plot, legend_name)
     kwarg, value = next(iter(legend_kwarg.items()))
 
     _LEGEND_KWARG_HANDLERS[kwarg](value, legend, glyph_renderer)
@@ -74,7 +75,7 @@ def _find_legend_item(label: DataSpec[str | None], legend: Legend) -> LegendItem
             return item
     return None
 
-def _get_or_create_legend(plot: Plot) -> Legend:
+def _get_or_create_legend(plot: Plot, legend_name: str | None) -> Legend:
     # Using the simpler plot.select(type=Legend) to find the existing legend
     # here is very inefficient on already populated plots, therefore we do it
     # like this. TODO: This will need to be reworked when introducing nested
@@ -82,13 +83,23 @@ def _get_or_create_legend(plot: Plot) -> Legend:
     panels = plot.above + plot.below + plot.left + plot.right + plot.center
     legends = [obj for obj in panels if isinstance(obj, Legend)]
 
-    if not legends:
-        legend = Legend()
-        plot.add_layout(legend)
-        return legend
-    if len(legends) == 1:
-        return legends[0]
-    raise RuntimeError(f"Plot {plot} configured with more than one legend renderer, cannot use legend_* convenience arguments")
+    if legend_name is not None:
+        legends = [legend for legend in legends if legend.name == legend_name]
+        if len(legends) == 1:
+            return legends[0]
+        elif not legends:
+            raise RuntimeError(f"can't find Legend instance with '{legend_name}' name")
+        else:
+            raise RuntimeError(f"found multiple Legend instances with '{legend_name}' name")
+    else:
+        legends = [legend for legend in legends if legend.name is None]
+        if not legends:
+            legend = Legend()
+            plot.add_layout(legend)
+            return legend
+        if len(legends) == 1:
+            return legends[0]
+        raise RuntimeError(f"Plot {plot} configured with more than one legend renderer, cannot use legend_* convenience arguments")
 
 def _handle_legend_field(label: str, legend: Legend, glyph_renderer: GlyphRenderer[Glyph]):
     if not isinstance(label, str):

--- a/src/bokeh/plotting/_legends.py
+++ b/src/bokeh/plotting/_legends.py
@@ -99,7 +99,10 @@ def _get_or_create_legend(plot: Plot, legend_name: str | None) -> Legend:
             return legend
         if len(legends) == 1:
             return legends[0]
-        raise RuntimeError(f"Plot {plot} configured with more than one legend renderer, cannot use legend_* convenience arguments")
+        raise RuntimeError(
+            f"Plot {plot} configured with more than one legend renderer, cannot use legend_* convenience arguments."
+            "Make legends unique by applying a name and assign renderers with 'legend_name' argument to a legend.",
+        )
 
 def _handle_legend_field(label: str, legend: Legend, glyph_renderer: GlyphRenderer[Glyph]):
     if not isinstance(label, str):

--- a/src/bokeh/plotting/_renderer.py
+++ b/src/bokeh/plotting/_renderer.py
@@ -133,9 +133,8 @@ def create_renderer(glyphclass: type[Glyph], plot: Plot, **kwargs: Any) -> Glyph
     plot.renderers.append(glyph_renderer)
 
     if legend_kwarg:
-        # It must be after the renderer is added because
-        # if it creates a new `LegendItem`, the referenced
-        # renderer must already be present.
+        # It must be after the renderer is added because if it creates a new `LegendItem`,
+        # the referenced renderer must already be present.
         update_legend(plot, legend_kwarg, legend_name, glyph_renderer)
 
     return glyph_renderer

--- a/src/bokeh/plotting/_renderer.py
+++ b/src/bokeh/plotting/_renderer.py
@@ -84,7 +84,7 @@ def create_renderer(glyphclass: type[Glyph], plot: Plot, **kwargs: Any) -> Glyph
     is_user_source = _convert_data_source(kwargs)
 
     # save off legend kwargs before we get going
-    legend_kwarg = pop_legend_kwarg(kwargs)
+    legend_kwarg, legend_name = pop_legend_kwarg(kwargs)
 
     # need to check if user source is present before pop_renderer_args
     renderer_kws = _pop_renderer_args(kwargs)
@@ -136,7 +136,7 @@ def create_renderer(glyphclass: type[Glyph], plot: Plot, **kwargs: Any) -> Glyph
         # It must be after the renderer is added because
         # if it creates a new `LegendItem`, the referenced
         # renderer must already be present.
-        update_legend(plot, legend_kwarg, glyph_renderer)
+        update_legend(plot, legend_kwarg, legend_name, glyph_renderer)
 
     return glyph_renderer
 

--- a/src/bokeh/plotting/glyph_api.pyi
+++ b/src/bokeh/plotting/glyph_api.pyi
@@ -185,6 +185,7 @@ class AuxGlyphArgs(TypedDict, total=False):
     muted: bool
 
     legend: Legend
+    legend_name: str
     legend_label: str
     legend_field: str
     legend_group: str

--- a/tests/unit/bokeh/plotting/test__legends.py
+++ b/tests/unit/bokeh/plotting/test__legends.py
@@ -5,6 +5,8 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+# pyright: reportPrivateUsage=false
+
 #-----------------------------------------------------------------------------
 # Boilerplate
 #-----------------------------------------------------------------------------
@@ -18,8 +20,10 @@ import pytest ; pytest
 
 # Standard library imports
 import itertools
+from typing import Any
 
 # Bokeh imports
+from bokeh.core.enums import PlaceType as Place
 from bokeh.core.properties import field, value
 from bokeh.models import (
     ColumnDataSource,
@@ -36,10 +40,10 @@ import bokeh.plotting._legends as bpl # isort:skip
 # Setup
 #-----------------------------------------------------------------------------
 
-def all_combinations(lst):
+def all_combinations(lst: list[str]):
     return itertools.chain.from_iterable(
-        itertools.combinations(lst, i + 1)
-        for i in range(2, len(lst)))
+        itertools.combinations(lst, i + 1) for i in range(2, len(lst))
+    )
 
 LEGEND_KWS = ['legend', 'legend_label', 'legend_field', 'legend_group']
 
@@ -52,12 +56,12 @@ LEGEND_KWS = ['legend', 'legend_label', 'legend_field', 'legend_group']
 #-----------------------------------------------------------------------------
 
 @pytest.mark.parametrize('key', LEGEND_KWS)
-def test_pop_legend_kwarg(key) -> None:
+def test_pop_legend_kwarg(key: str) -> None:
     kws = {'foo': 10, key: 'bar'}
-    assert bpl.pop_legend_kwarg(kws) == {key: "bar"}
+    assert bpl.pop_legend_kwarg(kws) == ({key: "bar"}, None)
 
 @pytest.mark.parametrize('keys', all_combinations(LEGEND_KWS))
-def test_pop_legend_kwarg_error(keys) -> None:
+def test_pop_legend_kwarg_error(keys: list[str]) -> None:
     kws = dict(zip(keys, range(len(keys))))
     with pytest.raises(ValueError):
         bpl.pop_legend_kwarg(kws)
@@ -74,9 +78,9 @@ def test__find_legend_item() -> None:
 
 class Test__handle_legend_field:
     @pytest.mark.parametrize('arg', [1, 2.7, None, False, [], {}])
-    def test_bad_arg(self, arg) -> None:
+    def test_bad_arg(self, arg: Any) -> None:
         with pytest.raises(ValueError):
-            bpl._handle_legend_field(arg, "legend", "renderer")
+            bpl._handle_legend_field(arg, Legend(), GlyphRenderer())
 
     def test_label_already_exists(self) -> None:
         legend = Legend(items=[LegendItem(label=field("foo"))])
@@ -99,15 +103,15 @@ class Test__handle_legend_field:
 
 class Test__handle_legend_group:
     @pytest.mark.parametrize('arg', [1, 2.7, None, False, [], {}])
-    def test_bad_arg(self, arg) -> None:
+    def test_bad_arg(self, arg: Any) -> None:
         with pytest.raises(ValueError):
-            bpl._handle_legend_group(arg, "legend", "renderer")
+            bpl._handle_legend_group(arg, Legend(), GlyphRenderer())
 
     def test_bad_source(self) -> None:
         with pytest.raises(ValueError):
-            bpl._handle_legend_group("foo", "legend", GlyphRenderer())
+            bpl._handle_legend_group("foo", Legend(), GlyphRenderer())
         with pytest.raises(ValueError):
-            bpl._handle_legend_group("foo", "legend", GlyphRenderer(data_source=ColumnDataSource(data=dict(bar=[]))))
+            bpl._handle_legend_group("foo", Legend(), GlyphRenderer(data_source=ColumnDataSource(data=dict(bar=[]))))
 
     def test_items(self) -> None:
         source = ColumnDataSource(data=dict(foo=[10,10,20,30,20,30,40]))
@@ -134,9 +138,9 @@ class Test__handle_legend_group:
 
 class Test__handle_legend_label:
     @pytest.mark.parametrize('arg', [1, 2.7, None, False, [], {}])
-    def test_bad_arg(self, arg) -> None:
+    def test_bad_arg(self, arg: Any) -> None:
         with pytest.raises(ValueError):
-            bpl._handle_legend_label(arg, "legend", "renderer")
+            bpl._handle_legend_label(arg, Legend(), GlyphRenderer())
 
     def test_label_already_exists(self) -> None:
         legend = Legend(items=[LegendItem(label=value("foo"))])
@@ -161,16 +165,16 @@ class Test__get_or_create_legend:
     def test_legend_not_already_exists(self) -> None:
         plot = figure()
         assert plot.legend == []
-        legend = bpl._get_or_create_legend(plot)
+        legend = bpl._get_or_create_legend(plot, None)
         assert plot.legend == [legend]
 
     @pytest.mark.parametrize('place', ['above', 'below', 'left', 'right', 'center'])
-    def test_legend_already_exists(self, place) -> None:
+    def test_legend_already_exists(self, place: Place) -> None:
         plot = figure()
         legend = Legend()
         plot.add_layout(legend, place)
 
-        got_legend = bpl._get_or_create_legend(plot)
+        got_legend = bpl._get_or_create_legend(plot, None)
         assert got_legend == legend
 
     def test_multiple_legends(self) -> None:
@@ -179,5 +183,5 @@ class Test__get_or_create_legend:
         plot.add_layout(Legend())
 
         with pytest.raises(RuntimeError) as e:
-            bpl._get_or_create_legend(plot)
+            bpl._get_or_create_legend(plot, None)
             assert str(e).endswith('configured with more than one legend renderer, cannot use legend_* convenience arguments')

--- a/tests/unit/bokeh/plotting/test__legends.py
+++ b/tests/unit/bokeh/plotting/test__legends.py
@@ -185,3 +185,29 @@ class Test__get_or_create_legend:
         with pytest.raises(RuntimeError) as e:
             bpl._get_or_create_legend(plot, None)
             assert str(e).endswith('configured with more than one legend renderer, cannot use legend_* convenience arguments')
+
+    def test_legend_name(self) -> None:
+        p = figure()
+        legend = Legend(name="foo")
+        p.add_layout(legend, "below")
+        cr = p.circle([1, 2, 3], [1, 2, 3], legend_label="bar", legend_name="foo")
+
+        assert len(legend.items) == 1
+        assert legend.items[0].label == value("bar")
+        assert legend.items[0].renderers == [cr]
+
+    def test_legend_name_missing(self) -> None:
+        p = figure()
+
+        with pytest.raises(RuntimeError):
+            p.circle([1, 2, 3], [1, 2, 3], legend_label="bar", legend_name="foo")
+
+    def test_legend_name_multiple(self) -> None:
+        p = figure()
+        legend0 = Legend(name="foo")
+        legend1 = Legend(name="foo")
+        p.add_layout(legend0, "below")
+        p.add_layout(legend1, "above")
+
+        with pytest.raises(RuntimeError):
+            p.circle([1, 2, 3], [1, 2, 3], legend_label="bar", legend_name="foo")


### PR DESCRIPTION
This PR adds support for `legend_name` to glyph API. For now I reuse `Model.name` to give a name to `Legend`, but new `Legend.legend_name` could be introduced if the current setup is too confusing.

Updated example from the issue:
```py
from bokeh.plotting import save, figure
from bokeh.models import Legend, LinearAxis, Range1d

p = figure(y_range=Range1d(0.9, 3.1))

p.add_layout(Legend(click_policy="hide", location="left"), "below")
p.add_layout(Legend(click_policy="hide", location="right", name="right"), "below")

p.extra_y_ranges = {"foo": Range1d(-3.1,0.1)}
p.add_layout(LinearAxis(y_range_name="foo"), 'right')

p.line([1,2,3], [1,2,3], color='blue', legend_label="blue line" )
p.line([1,2,3], [0,-2,-3], color='red', legend_label="red line", legend_name="right", y_range_name="foo")

save(p)
```

Additionally I fixed a few problems with type declarations that arose when inspecting the provided example and added preliminary types to the modified module.

fixes #14324