### PR TITLE
Fix bokehjs/examples/hover

### DIFF
--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -53,7 +53,8 @@ export namespace HoverfulScatter {
     div.style.width = "200px"
     div.style.height = "75px"
     if (info.index != null) {
-      div.style.backgroundColor = ds.get("colors")[info.index] as string
+      const [r, g, b] = ds.get("colors")[info.index] as [number, number, number]
+      div.style.backgroundColor = `rgb(${r}, ${g}, ${b})`
     }
     return div
   }

--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -47,14 +47,14 @@ export namespace HoverfulScatter {
   })
 
   const hover = p.toolbar.get_one(Bokeh.HoverTool)
-  hover.tooltips = (source, info) => {
-    const ds = source as Bokeh.ColumnDataSource
+  hover.tooltips = (data_source: typeof source, info) => {
     const div = document.createElement("div")
     div.style.width = "200px"
     div.style.height = "75px"
     if (info.index != null) {
-      const [r, g, b] = ds.get("colors")[info.index] as [number, number, number]
-      div.style.backgroundColor = `rgb(${r}, ${g}, ${b})`
+      div.style.backgroundColor = Bokeh.Plotting.color(
+        (data_source.get("colors") as typeof colors)[info.index],
+      )
     }
     return div
   }

--- a/bokehjs/examples/hover/hover.ts
+++ b/bokehjs/examples/hover/hover.ts
@@ -52,9 +52,9 @@ export namespace HoverfulScatter {
     div.style.width = "200px"
     div.style.height = "75px"
     if (info.index != null) {
-      div.style.backgroundColor = Bokeh.Plotting.color(
-        (data_source.get("colors") as typeof colors)[info.index],
-      )
+      const color_source = data_source.get("colors") as typeof colors
+      const css_color = Bokeh.Plotting.color(color_source[info.index])
+      div.style.backgroundColor = css_color
     }
     return div
   }


### PR DESCRIPTION
Fixes https://github.com/bokeh/bokeh/issues/14328.

### How to test

```
cd bokehjs
node test/devtools server
```

Go to http://127.0.0.1:5777/examples/hover, and hover over the dots. The tooltip should be box with no text whose background color matches the color of the hovered dot.