### PR TITLE
Add support for dataspec data validation

### DIFF
--- a/bokehjs/src/lib/models/glyphs/image_base.ts
+++ b/bokehjs/src/lib/models/glyphs/image_base.ts
@@ -12,6 +12,7 @@ import {Selection} from "../selections/selection"
 import type {PointGeometry} from "core/geometry"
 import type {SpatialIndex} from "core/util/spatial"
 import type {NDArrayType} from "core/util/ndarray"
+import {is_NDArray} from "core/util/ndarray"
 import {assert} from "core/util/assert"
 import type {XY} from "core/util/bbox"
 import {Anchor} from "../common/kinds"
@@ -127,7 +128,14 @@ export abstract class ImageBaseView extends XYGlyphView {
         }
 
         const img = this.image.get(i)
-        assert(img.dimension == image_dimension, `expected a ${image_dimension}D array, not ${img.dimension}D`)
+
+        if (!is_NDArray(img)) {
+          console.error(`expected a ${image_dimension}D array`)
+          continue
+        } else if (img.dimension != image_dimension) {
+          console.error(`expected a ${image_dimension}D array, not ${img.dimension}D`)
+          continue
+        }
 
         const [height, width] = img.shape
         this.image_width[i] = width

--- a/src/bokeh/_specs.pyi
+++ b/src/bokeh/_specs.pyi
@@ -107,10 +107,6 @@ Number2dVal: TypeAlias = Sequence[Sequence[float | Datetime | TimeDelta]]
 Number2dSpec: TypeAlias = DataSpec[Number2dVal]
 Number2dArg: TypeAlias = FieldName | Number2dVal | Number2dSpec | Sequence[Number2dVal] | Number2dArray
 
-Number3dVal: TypeAlias = Sequence[Sequence[Sequence[float | Datetime | TimeDelta]]]
-Number3dSpec: TypeAlias = DataSpec[Number3dVal]
-Number3dArg: TypeAlias = FieldName | Number3dVal | Number3dSpec | Sequence[Number3dVal] | Number3dArray
-
 Image2dVal: TypeAlias = Number2dArray
 Image2dSpec: TypeAlias = DataSpec[Image2dVal]
 Image2dArg: TypeAlias = FieldName | Image2dSpec | Sequence[Image2dVal]

--- a/src/bokeh/core/properties.py
+++ b/src/bokeh/core/properties.py
@@ -131,6 +131,7 @@ DataSpec Properties
 .. autoclass:: FloatSpec
 .. autoclass:: FontSizeSpec
 .. autoclass:: MarkerSpec
+.. autoclass:: NDArraySpec
 .. autoclass:: NumberSpec
 .. autoclass:: SizeSpec
 .. autoclass:: StringSpec
@@ -255,6 +256,7 @@ __all__ = (
     'MarkerType',
     'MathString',
     'MinMaxBounds',
+    'NDArraySpec',
     'NonEmpty',
     'NonNegative',
     'NotSerialized',
@@ -346,6 +348,7 @@ from .property.dataspec import IntSpec
 from .property.dataspec import LineCapSpec
 from .property.dataspec import LineJoinSpec
 from .property.dataspec import MarkerSpec
+from .property.dataspec import NDArraySpec
 from .property.dataspec import NullDistanceSpec
 from .property.dataspec import NullStringSpec
 from .property.dataspec import NumberSpec

--- a/src/bokeh/core/property/bases.py
+++ b/src/bokeh/core/property/bases.py
@@ -42,6 +42,7 @@ from ...util.dependencies import uses_pandas
 from ._sphinx import property_link, register_type_link, type_link
 from .descriptor_factory import PropertyDescriptorFactory
 from .descriptors import PropertyDescriptor
+from .exceptions import ValueValidationError
 from .singletons import (
     Intrinsic,
     IntrinsicType,
@@ -304,7 +305,7 @@ class Property(PropertyDescriptorFactory[T]):
             None
 
         Raises:
-            ValueError if the value is not valid for this property type
+            ValueValidationError if the value is not valid for this property type
 
         """
         pass
@@ -322,7 +323,7 @@ class Property(PropertyDescriptorFactory[T]):
         try:
             if validation_on():
                 self.validate(value, False)
-        except ValueError:
+        except ValueValidationError:
             return False
         else:
             return True
@@ -347,7 +348,7 @@ class Property(PropertyDescriptorFactory[T]):
             if validation_on():
                 hinted_value = self._hinted_value(value, hint)
                 self.validate(hinted_value)
-        except ValueError as e:
+        except ValueValidationError as e:
             for tp, converter in self.alternatives:
                 if tp.is_valid(value):
                     value = converter(value)
@@ -361,7 +362,7 @@ class Property(PropertyDescriptorFactory[T]):
             value = self.transform(value)
         else:
             obj_repr = owner if isinstance(owner, HasProps) else owner.__name__
-            raise ValueError(f"failed to validate {obj_repr}.{name}: {error}")
+            raise ValueValidationError(f"failed to validate {obj_repr}.{name}: {error}")
 
         if isinstance(owner, HasProps):
             obj = owner
@@ -376,7 +377,7 @@ class Property(PropertyDescriptorFactory[T]):
 
                 if not result:
                     if isinstance(msg_or_fn, str):
-                        raise ValueError(msg_or_fn)
+                        raise ValueValidationError(msg_or_fn)
                     else:
                         msg_or_fn(obj, name, value)
 
@@ -552,13 +553,13 @@ class PrimitiveProperty(Property[T]):
             return
 
         if not detail:
-            raise ValueError("")
+            raise ValueValidationError("")
 
         from ...util.strings import nice_join
 
         expected_type = nice_join([ cls.__name__ for cls in self._underlying_type ])
         msg = f"expected a value of type {expected_type}, got {value} of type {type(value).__name__}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 class ContainerProperty(ParameterizedProperty[T]):
     """ A base class for Container-like type properties.

--- a/src/bokeh/core/property/color.py
+++ b/src/bokeh/core/property/color.py
@@ -31,6 +31,7 @@ from .bases import Init, Property
 from .container import Tuple
 from .either import Either
 from .enum import Enum
+from .exceptions import ValueValidationError
 from .numeric import Byte, Percent
 from .primitive import Int
 from .singletons import Undefined
@@ -82,7 +83,7 @@ class RGB(Property[colors.RGB]):
             return
 
         msg = "" if not detail else f"expected RGB value, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 
 class Color(Either):
@@ -116,9 +117,9 @@ class Color(Either):
 
             >>> m.prop = (100, 100, 255, 0.5)
 
-            >>> m.prop = "junk"              # ValueError !!
+            >>> m.prop = "junk"              # ValueValidationError !!
 
-            >>> m.prop = (100.2, 57.3, 10.2) # ValueError !!
+            >>> m.prop = (100.2, 57.3, 10.2) # ValueValidationError !!
 
     """
 

--- a/src/bokeh/core/property/constraints.py
+++ b/src/bokeh/core/property/constraints.py
@@ -31,6 +31,7 @@ from .bases import (
     SingleParameterizedProperty,
     TypeOrInst,
 )
+from .exceptions import ValueValidationError
 from .singletons import Intrinsic
 
 #-----------------------------------------------------------------------------
@@ -88,12 +89,12 @@ class TypeOfAttr(SingleParameterizedProperty[T]):
         try:
             attr = getattr(value, name)
         except AttributeError:
-            raise ValueError(f"expected {value!r} to have an attribute '{name}'" if detail else "")
+            raise ValueValidationError(f"expected {value!r} to have an attribute '{name}'" if detail else "")
 
         if type.is_valid(attr):
             return
 
-        raise ValueError(f"expected {value!r} to have an attribute {name!r} of type {type}" if detail else "")
+        raise ValueValidationError(f"expected {value!r} to have an attribute {name!r} of type {type}" if detail else "")
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/core/property/container.py
+++ b/src/bokeh/core/property/container.py
@@ -42,6 +42,7 @@ from .bases import (
 )
 from .descriptors import ColumnDataPropertyDescriptor
 from .enum import Enum
+from .exceptions import ValueValidationError
 from .numeric import Int
 from .singletons import Intrinsic, Undefined
 from .wrappers import (
@@ -106,10 +107,10 @@ class Seq(ContainerProperty[T]):
                 if not self.item_type.is_valid(item):
                     invalid.append(item)
             msg = "" if not detail else f"expected an element of {self}, got seq with invalid items {invalid!r}"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
         msg = "" if not detail else f"expected an element of {self}, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     def _should_skip_item_validation(self):
         return isinstance(self.item_type, AnyVal)
@@ -214,7 +215,7 @@ class Dict(ContainerProperty[Any]):
         expected = f"expected a dict of type {self}"
 
         if not isinstance(value, dict):
-            raise ValueError(f"{expected}, got a value of type {type(value)}" if detail else "")
+            raise ValueValidationError(f"{expected}, got a value of type {type(value)}" if detail else "")
 
         bad_keys = [str(k) for k in value if not key_is_valid(k)]
         bad_value_keys = [str(k) for (k, v) in value.items() if not value_is_valid(v)]
@@ -223,13 +224,13 @@ class Dict(ContainerProperty[Any]):
         bad_value_keys_str = f"invalid values for keys: {', '.join(bad_value_keys)}"
         err = None
         if (has_bad_keys := any(bad_keys)) & (has_bad_key_values := any(bad_value_keys)):
-            err = ValueError(f"{exception_header} {bad_keys_str} and {bad_value_keys_str}")
+            err = ValueValidationError(f"{exception_header} {bad_keys_str} and {bad_value_keys_str}")
         elif has_bad_keys:
-            err = ValueError(f"{exception_header} {bad_keys_str}")
+            err = ValueValidationError(f"{exception_header} {bad_keys_str}")
         elif has_bad_key_values:
-            err = ValueError(f"{exception_header} {bad_value_keys_str}")
+            err = ValueValidationError(f"{exception_header} {bad_value_keys_str}")
         if err:
-            raise err if detail else ValueError("")
+            raise err if detail else ValueValidationError("")
 
     def wrap(self, value):
         """ Some property types need to wrap their values in special containers, etc.
@@ -304,7 +305,7 @@ class Tuple(ContainerProperty):
                 return
 
         msg = "" if not detail else f"expected an element of {self}, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     def transform(self, value):
         """ Change the value into a JSON serializable format.
@@ -341,7 +342,7 @@ class RestrictedDict(Dict):
 
         if error_keys:
             msg = "" if not detail else f"Disallowed keys: {error_keys!r}"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
 TSeq = TypeVar("TSeq", bound=Seq[Any])
 
@@ -357,7 +358,7 @@ class NonEmpty(SingleParameterizedProperty[TSeq]):
 
         if not value:
             msg = "" if not detail else "Expected a non-empty container"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
 class Len(SingleParameterizedProperty[TSeq]):
     """ Allows only containers of the given length. """
@@ -372,7 +373,7 @@ class Len(SingleParameterizedProperty[TSeq]):
 
         if len(value) != self.length:
             msg = "" if not detail else f"Expected a container of length #{self.length}, got #{len(value)}"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/core/property/data_frame.py
+++ b/src/bokeh/core/property/data_frame.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from .bases import Property
+from .exceptions import ValueValidationError
 
 if TYPE_CHECKING:
     from narwhals.stable.v1.typing import IntoDataFrame, IntoSeries  # noqa: F401
@@ -63,7 +64,7 @@ class EagerDataFrame(Property["IntoDataFrame"]):
             return
 
         msg = "" if not detail else f"expected object convertible to Narwhals DataFrame, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 class EagerSeries(Property["IntoSeries"]):
     """ Accept eager series supported by Narwhals.
@@ -81,7 +82,7 @@ class EagerSeries(Property["IntoSeries"]):
             return
 
         msg = "" if not detail else f"expected object convertible to Narwhals Series, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 class PandasDataFrame(Property["DataFrame"]):
     """ Accept Pandas DataFrame values.
@@ -104,7 +105,7 @@ class PandasDataFrame(Property["DataFrame"]):
             return
 
         msg = "" if not detail else f"expected Pandas DataFrame, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 class PandasGroupBy(Property["GroupBy[Any]"]):
     """ Accept Pandas DataFrame values.
@@ -123,7 +124,7 @@ class PandasGroupBy(Property["GroupBy[Any]"]):
             return
 
         msg = "" if not detail else f"expected Pandas GroupBy, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -21,8 +21,13 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any, Literal, override
 from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Sequence,
+)
 
 # External imports
 import numpy as np
@@ -110,6 +115,13 @@ class ValidationEntry:
 class ValidationContext:
 
     entries: list[ValidationEntry]
+
+    @property
+    def has_failure(self) -> bool:
+        return self.entries != []
+
+    def __init__(self) -> None:
+        self.entries = []
 
     def warn(self, text: str, exception: ValueValidationError | None = None) -> None:
         self.entries.append(ValidationEntry("warning", text, exception))
@@ -268,13 +280,8 @@ class DataSpec(Either):
 
         return val
 
-    def validate_column_type(self, column: Any, context: ValidationContext) -> bool:
-        """ Validate the type of the column, but not its data, i.e. fast validation. """
-        return True
-
-    def validate_column_data(self, column: Any, context: ValidationContext) -> bool:
-        """ Validate the data in the column, i.e. slow validation. """
-        return True
+    def validate_column(self, column: Any, context: ValidationContext) -> None:
+        """ Validate the data in a column of a ``ColumnarDataSource``. """
 
 class BoolSpec(DataSpec):
     def __init__(self, default, *, help: str | None = None) -> None:
@@ -665,17 +672,25 @@ class NDArraySpec(DataSpec):
         super().__init__(Float, default=default, help=help)
         self.ndims = ndims
 
-    @override
-    def validate_column_type(self, column: Any, context: ValidationContext) -> bool:
-        if isinstance(column, np.ndarray):
-            if not (column.ndim == self.ndims and column.dtype == np.floating):
-                context.error(f"expected ndarray[{self.ndims}d, floating], got ndarray[{column.ndim}d, {column.dtype}]")
-                return False
-        else:
-            context.error(f"expected an ndarray, got a value of type {type(column)})")
-            return False
+    # TODO @override
+    # Can't use it currently, because it must be imported from typing_extensions because of Python 3.10 and
+    # 3.11. However, that module is banned on the top-level and this is a decorator, so we can't hide it
+    # behind TYPE_CHECKING.
+    def validate_column(self, column: Any, context: ValidationContext) -> None:
+        super().validate_column(column, context)
 
-        return True
+        if not isinstance(column, Sequence):
+            context.error(f"expected a sequence of ndarrays, got a value of type {type(column)}")
+        else:
+            for i, value in enumerate(column):
+                if not isinstance(value, np.ndarray):
+                    context.error(f"expected {self._nd_type} at index {i}, got a value of type {type(value)}")
+                elif not (value.ndim == self.ndims and (value.dtype == np.floating or value.dtype == np.integer)):
+                    context.error(f"expected {self._nd_type} at index {i}, got ndarray[{value.ndim}d, {value.dtype}]")
+
+    @property
+    def _nd_type(self) -> str:
+        return f"ndarray[{self.ndims}d, floating | integer]"
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -21,7 +21,11 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, override
+from dataclasses import dataclass
+
+# External imports
+import numpy as np
 
 # Bokeh imports
 from ...util.dataclasses import Unspecified
@@ -84,6 +88,7 @@ __all__ = (
     'LineCapSpec',
     'LineJoinSpec',
     'MarkerSpec',
+    'NDArraySpec',
     'NumberSpec',
     'SizeSpec',
     'StringSpec',
@@ -94,6 +99,23 @@ __all__ = (
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+@dataclass
+class ValidationEntry:
+
+    type: Literal["warning", "error"]
+    text: str
+    exception: ValueValidationError | None = None
+
+class ValidationContext:
+
+    entries: list[ValidationEntry]
+
+    def warn(self, text: str, exception: ValueValidationError | None = None) -> None:
+        self.entries.append(ValidationEntry("warning", text, exception))
+
+    def error(self, text: str, exception: ValueValidationError | None = None) -> None:
+        self.entries.append(ValidationEntry("error", text, exception))
 
 class DataSpec(Either):
     """ Base class for properties that accept either a fixed value, or a
@@ -246,6 +268,14 @@ class DataSpec(Either):
 
         return val
 
+    def validate_column_type(self, column: Any, context: ValidationContext) -> bool:
+        """ Validate the type of the column, but not its data, i.e. fast validation. """
+        return True
+
+    def validate_column_data(self, column: Any, context: ValidationContext) -> bool:
+        """ Validate the data in the column, i.e. slow validation. """
+        return True
+
 class BoolSpec(DataSpec):
     def __init__(self, default, *, help: str | None = None) -> None:
         super().__init__(Bool, default=default, help=help)
@@ -255,6 +285,7 @@ class IntSpec(DataSpec):
         super().__init__(Int, default=default, help=help)
 
 class FloatSpec(DataSpec):
+
     def __init__(self, default, *, help: str | None = None) -> None:
         super().__init__(Float, default=default, help=help)
 
@@ -622,6 +653,29 @@ class ColorSpec(DataSpec):
         if self.is_color_tuple_shape(value):
             value = tuple(int(v) if i < 3 else v for i, v in enumerate(value))
         return super().prepare_value(cls, name, value)
+
+class NDArraySpec(DataSpec):
+    """ A |DataSpec| property that accepts N-dimensional arrays of numbers.
+
+    """
+
+    ndims: int
+
+    def __init__(self, ndims: int, default, *, help: str | None = None) -> None:
+        super().__init__(Float, default=default, help=help)
+        self.ndims = ndims
+
+    @override
+    def validate_column_type(self, column: Any, context: ValidationContext) -> bool:
+        if isinstance(column, np.ndarray):
+            if not (column.ndim == self.ndims and column.dtype == np.floating):
+                context.error(f"expected ndarray[{self.ndims}d, floating], got ndarray[{column.ndim}d, {column.dtype}]")
+                return False
+        else:
+            context.error(f"expected an ndarray, got a value of type {type(column)})")
+            return False
+
+        return True
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -32,6 +32,7 @@ from .datetime import Datetime, TimeDelta
 from .descriptors import DataSpecPropertyDescriptor, UnitsSpecPropertyDescriptor
 from .either import Either
 from .enum import Enum
+from .exceptions import ValueValidationError
 from .instance import Instance
 from .nothing import Nothing
 from .nullable import Nullable
@@ -236,7 +237,7 @@ class DataSpec(Either):
         try:
             self.value_type.replace(String, Nothing()).validate(val, False)
             return Value(val)
-        except ValueError:
+        except ValueValidationError:
             pass
 
         # Check for data source field name
@@ -355,7 +356,7 @@ class FontSizeSpec(DataSpec):
         if isinstance(value, str):
             if len(value) == 0 or (value[0].isdigit() and not CSS_LENGTH_RE.match(value)):
                 msg = "" if not detail else f"{value!r} is not a valid font size value"
-                raise ValueError(msg)
+                raise ValueValidationError(msg)
 
 class FontStyleSpec(DataSpec):
     def __init__(self, default, *, help: str | None = None) -> None:

--- a/src/bokeh/core/property/datetime.py
+++ b/src/bokeh/core/property/datetime.py
@@ -31,6 +31,7 @@ from ...util.serialization import (
     is_timedelta_type,
 )
 from .bases import Init, Property
+from .exceptions import ValueValidationError
 from .primitive import bokeh_integer_types
 from .singletons import Undefined
 
@@ -67,7 +68,7 @@ class Date(Property[str | datetime.date]):
         # datetime.datetime is datetime.date, exclude manually up front
         if isinstance(value, datetime.datetime):
             msg = "" if not detail else "Expected a date value, got a datetime.datetime"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
         if isinstance(value, datetime.date):
             return
@@ -76,7 +77,7 @@ class Date(Property[str | datetime.date]):
             datetime.datetime.fromisoformat(value)
         except Exception:
             msg = "" if not detail else f"Expected an ISO date string, got {value!r}"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
 class Datetime(Property[str | datetime.date | datetime.datetime]):
     """ Accept ISO format Datetime values.
@@ -118,7 +119,7 @@ class Datetime(Property[str | datetime.date | datetime.datetime]):
                 pass
 
         msg = "" if not detail else f"Expected a date, datetime object, or timestamp, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     @staticmethod
     def is_timestamp(value: Any) -> bool:
@@ -146,7 +147,7 @@ class Time(Property[str | datetime.time]):
                 pass
 
         msg = "" if not detail else f"Expected a time object, or ISO formatted time string, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     def transform(self, value: Any) -> Any:
         value = super().transform(value)
@@ -176,7 +177,7 @@ class TimeDelta(Property[datetime.timedelta]):
             return
 
         msg = "" if not detail else f"Expected a timedelta instance, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -44,7 +44,7 @@ set operations to the ``Float`` property.
 
     # But can raise a validation exception if an attempt to set to a list
     # is made
-    rng.end = [1,2,3]   # ValueError !
+    rng.end = [1,2,3]   # ValueValidationError !
 
 More sophisticated properties such as ``DataSpec`` and its subclasses can
 exert control over how values are serialized. Consider this example with
@@ -101,6 +101,7 @@ from typing import (
 )
 
 # Bokeh imports
+from .exceptions import ValueValidationError
 from .singletons import Undefined
 from .wrappers import PropertyValueColumnData, PropertyValueContainer
 
@@ -808,7 +809,7 @@ class DataSpecPropertyDescriptor(PropertyDescriptor):
                     self.property.value_type.validate(old, False)
                     if 'value' in value:
                         value = value['value']
-                except ValueError:
+                except ValueValidationError:
                     if isinstance(old, str) and 'field' in value:
                         value = value['field']
                 # leave it as a dict if 'old' was a dict

--- a/src/bokeh/core/property/either.py
+++ b/src/bokeh/core/property/either.py
@@ -34,6 +34,7 @@ from .bases import (
     Property,
     TypeOrInst,
 )
+from .exceptions import ValueValidationError
 from .singletons import Intrinsic
 
 #-----------------------------------------------------------------------------
@@ -69,9 +70,9 @@ class Either(ParameterizedProperty[Any]):
 
             >>> m.prop = "auto"
 
-            >>> m.prop = 10.3   # ValueError !!
+            >>> m.prop = 10.3   # ValueValidationError !!
 
-            >>> m.prop = "foo"  # ValueError !!
+            >>> m.prop = "foo"  # ValueValidationError !!
 
     """
 
@@ -99,7 +100,7 @@ class Either(ParameterizedProperty[Any]):
         from ...util.strings import nice_join
 
         msg = "" if not detail else f"expected an element of either {nice_join([ str(param) for param in self.type_params ])}, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     def wrap(self, value):
         for tp in self.type_params:

--- a/src/bokeh/core/property/enum.py
+++ b/src/bokeh/core/property/enum.py
@@ -28,6 +28,7 @@ from .. import enums
 from ._sphinx import model_link, property_link, register_type_link
 from .bases import Init, Property
 from .either import Either
+from .exceptions import ValueValidationError
 from .primitive import Int, String
 from .singletons import Intrinsic
 
@@ -102,7 +103,7 @@ class Enum(Either):
         from ...util.strings import nice_join
 
         msg = "" if not detail else f"invalid value: {value!r}; allowed values are {nice_join(self.allowed_values)}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     # override replace so that .replace() doesn't descend this type
     def replace(self, old: type[Property[Any]], new: Property[Any]) -> Property[Any]:

--- a/src/bokeh/core/property/exceptions.py
+++ b/src/bokeh/core/property/exceptions.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-""" Provide the JSON property.
+"""
 
 """
 
@@ -20,55 +20,24 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
-# Standard library imports
-from typing import Any
-
-# Bokeh imports
-from .exceptions import ValueValidationError
-from .primitive import String
-
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
 
 __all__ = (
-    'JSON',
+    "ValueValidationError",
 )
 
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
 
-class JSON(String):
-    """ Accept JSON string values.
-
-    The value is transmitted and received by BokehJS as a *string*
-    containing JSON content. i.e., you must use ``JSON.parse`` to unpack
-    the value into a JavaScript hash.
-
-    Args:
-        default (string, optional) :
-            A default value for attributes created from this property to
-            have.
-
-        help (str or None, optional) :
-            A documentation string for this property. (default: None)
-
-    """
-
-    def validate(self, value: Any, detail: bool = True) -> None:
-        super().validate(value, detail)
-
-        try:
-            import json
-            json.loads(value)
-        except ValueError:
-            msg = "" if not detail else f"expected JSON text, got {value!r}"
-            raise ValueValidationError(msg)
-
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
+
+class ValueValidationError(ValueError):
+    pass
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/src/bokeh/core/property/instance.py
+++ b/src/bokeh/core/property/instance.py
@@ -38,6 +38,7 @@ from ..has_props import HasProps
 from ..serialization import Serializable
 from ._sphinx import model_link, property_link, register_type_link
 from .bases import Init, Property
+from .exceptions import ValueValidationError
 from .singletons import Undefined
 
 #-----------------------------------------------------------------------------
@@ -118,7 +119,7 @@ class Object(Property[T]):
         instance_type = self.instance_type.__name__
         value_type = type(value).__name__
         msg = "" if not detail else f"expected an instance of type {instance_type}, got {value} of type {value_type}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     def _may_have_unstable_default(self):
         # because the instance value is mutable

--- a/src/bokeh/core/property/nothing.py
+++ b/src/bokeh/core/property/nothing.py
@@ -23,6 +23,7 @@ from typing import Any, NoReturn
 
 # Bokeh imports
 from .bases import Property, Undefined
+from .exceptions import ValueValidationError
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -43,7 +44,7 @@ class Nothing(Property[NoReturn]):
         super().__init__(default=Undefined, help=help)
 
     def validate(self, value: Any, detail: bool = True) -> None:
-        raise ValueError("no value is allowed")
+        raise ValueValidationError("no value is allowed")
 
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/core/property/nullable.py
+++ b/src/bokeh/core/property/nullable.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 # Bokeh imports
 from ._sphinx import property_link, register_type_link, type_link
 from .bases import SingleParameterizedProperty
+from .exceptions import ValueValidationError
 
 if TYPE_CHECKING:
     from .bases import Init, Property, TypeOrInst
@@ -60,13 +61,13 @@ class Nullable(SingleParameterizedProperty[T | None]):
 
         try:
             super().validate(value, detail=False)
-        except ValueError:
+        except ValueValidationError:
             pass
         else:
             return
 
         msg = "" if not detail else f"expected either None or a value of type {self.type_param}, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/core/property/numeric.py
+++ b/src/bokeh/core/property/numeric.py
@@ -30,6 +30,7 @@ from .bases import (
     SingleParameterizedProperty,
     TypeOrInst,
 )
+from .exceptions import ValueValidationError
 from .primitive import Float, Int
 from .singletons import Intrinsic, Undefined
 
@@ -63,7 +64,7 @@ class NonNegative(SingleParameterizedProperty[T]):
         super().validate(value, detail)
 
         if not (0 <= value):
-            raise ValueError(f"expected a non-negative number, got {value!r}")
+            raise ValueValidationError(f"expected a non-negative number, got {value!r}")
 
 class Positive(SingleParameterizedProperty[T]):
     """ A property accepting a value of some other type while having undefined default. """
@@ -75,7 +76,7 @@ class Positive(SingleParameterizedProperty[T]):
         super().validate(value, detail)
 
         if not (0 < value):
-            raise ValueError(f"expected a positive number, got {value!r}")
+            raise ValueValidationError(f"expected a positive number, got {value!r}")
 
 class Interval(SingleParameterizedProperty[T]):
     """ Accept numeric values that are contained within a given interval.
@@ -108,11 +109,11 @@ class Interval(SingleParameterizedProperty[T]):
 
             >>> m.prop = 15
 
-            >>> m.prop = 2     # ValueError !!
+            >>> m.prop = 2     # ValueValidationError !!
 
-            >>> m.prop = 22    # ValueError !!
+            >>> m.prop = 22    # ValueValidationError !!
 
-            >>> m.prop = "foo" # ValueError !!
+            >>> m.prop = "foo" # ValueValidationError !!
 
     """
     def __init__(self, type_param: TypeOrInst[Property[T]], start: T, end: T, *,
@@ -132,7 +133,7 @@ class Interval(SingleParameterizedProperty[T]):
 
         if not (self.type_param.is_valid(value) and value >= self.start and value <= self.end):
             msg = "" if not detail else f"expected a value of type {self.type_param} in range [{self.start}, {self.end}], got {value!r}"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
 class Byte(Interval[int]):
     """ Accept integral byte values (0-255).
@@ -149,9 +150,9 @@ class Byte(Interval[int]):
 
             >>> m.prop = 255
 
-            >>> m.prop = 256  # ValueError !!
+            >>> m.prop = 256  # ValueValidationError !!
 
-            >>> m.prop = 10.3 # ValueError !!
+            >>> m.prop = 10.3 # ValueValidationError !!
 
     """
 
@@ -182,9 +183,9 @@ class Size(Float):
 
             >>> m.prop = 10e6
 
-            >>> m.prop = -10   # ValueError !!
+            >>> m.prop = -10   # ValueValidationError !!
 
-            >>> m.prop = "foo" # ValueError !!
+            >>> m.prop = "foo" # ValueValidationError !!
 
     """
     def validate(self, value: Any, detail: bool = True) -> None:
@@ -192,7 +193,7 @@ class Size(Float):
 
         if value < 0:
             msg = "" if not detail else f"expected a non-negative number, got {value!r}"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
 class Percent(Float):
     """ Accept floating point percentage values.
@@ -223,9 +224,9 @@ class Percent(Float):
 
             >>> m.prop = 1.0
 
-            >>> m.prop = -2  # ValueError !!
+            >>> m.prop = -2  # ValueValidationError !!
 
-            >>> m.prop = 5   # ValueError !!
+            >>> m.prop = 5   # ValueValidationError !!
 
     """
 
@@ -236,7 +237,7 @@ class Percent(Float):
             return
 
         msg = "" if not detail else f"expected a value in range [0, 1], got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 class Angle(Float):
     """ Accept floating point angle values.

--- a/src/bokeh/core/property/string.py
+++ b/src/bokeh/core/property/string.py
@@ -28,6 +28,7 @@ from typing import Any
 
 # Bokeh imports
 from .bases import Init
+from .exceptions import ValueValidationError
 from .primitive import String
 from .singletons import Undefined
 
@@ -66,9 +67,9 @@ class Regex(String):
 
             >>> m.prop = "foo123bar"
 
-            >>> m.prop = "foo"      # ValueError !!
+            >>> m.prop = "foo"      # ValueValidationError !!
 
-            >>> m.prop = [1, 2, 3]  # ValueError !!
+            >>> m.prop = [1, 2, 3]  # ValueValidationError !!
 
     """
 
@@ -87,7 +88,7 @@ class Regex(String):
             return
 
         msg = "" if not detail else f"expected a string matching {self.regex.pattern!r} pattern, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 class MathString(String):
     """ A string with math TeX/LaTeX delimiters.

--- a/src/bokeh/core/property/struct.py
+++ b/src/bokeh/core/property/struct.py
@@ -27,6 +27,7 @@ from typing import Any, Generic, TypeVar
 
 # Bokeh imports
 from .bases import ParameterizedProperty, Property
+from .exceptions import ValueValidationError
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -105,7 +106,7 @@ class Struct(ParameterizedProperty[T]):
                     return
 
         msg = "" if not detail else f"expected an element of {self}, got {value!r}"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     def __str__(self) -> str:
         class_name = self.__class__.__name__

--- a/src/bokeh/core/property/visual.py
+++ b/src/bokeh/core/property/visual.py
@@ -39,6 +39,7 @@ from .container import Seq, Tuple
 from .datetime import Datetime, TimeDelta
 from .either import Either
 from .enum import Enum
+from .exceptions import ValueValidationError
 from .nullable import Nullable
 from .numeric import Float, Int
 from .primitive import String
@@ -115,7 +116,7 @@ class CSSLength(String):
 
         if not (isinstance(value, str) and CSS_LENGTH_RE.match(value)):
             msg = "" if not detail else f"{value!r} is not a valid CSS length"
-            raise ValueError(msg)
+            raise ValueValidationError(msg)
 
 class FontSize(String):
 
@@ -125,10 +126,10 @@ class FontSize(String):
         if isinstance(value, str):
             if len(value) == 0:
                 msg = "" if not detail else "empty string is not a valid font size value"
-                raise ValueError(msg)
+                raise ValueValidationError(msg)
             elif not CSS_LENGTH_RE.match(value):
                 msg = "" if not detail else f"{value!r} is not a valid font size value"
-                raise ValueError(msg)
+                raise ValueValidationError(msg)
 
 class HatchPatternType(Either):
     """ Accept built-in fill hatching specifications.
@@ -172,7 +173,7 @@ class Image(Property[str]):
                 return
 
         msg = "" if not detail else f"invalid value: {value!r}; allowed values are string filenames, PIL.Image.Image instances, or RGB(A) NumPy arrays"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
     def transform(self, value: Any) -> str:
         import numpy as np
@@ -215,7 +216,7 @@ class MinMaxBounds(Either):
 
     Bounds are provided as a tuple of ``(min, max)`` so regardless of whether your range is
     increasing or decreasing, the first item should be the minimum value of the range and the
-    second item should be the maximum. Setting min > max will result in a ``ValueError``.
+    second item should be the maximum. Setting min > max will result in a ``ValueValidationError``.
 
     Setting bounds to None will allow your plot to pan/zoom as far as you want. If you only
     want to constrain one end of the plot, you can set min or max to
@@ -261,7 +262,7 @@ class MinMaxBounds(Either):
             return
 
         msg = "" if not detail else "Invalid bounds: maximum smaller than minimum. Correct usage: bounds=(min, max)"
-        raise ValueError(msg)
+        raise ValueValidationError(msg)
 
 class MarkerType(Enum):
     """

--- a/src/bokeh/core/validation/errors.py
+++ b/src/bokeh/core/validation/errors.py
@@ -238,6 +238,10 @@ NON_MATCHING_SCALE_BAR_UNIT = Error(
     1031,
     "NON_MATCHING_SCALE_BAR_UNIT",
     "ScaleBar.unit must be an element of ScaleBar's units of measurement basis")
+BAD_COLUMN_DATA = Error(
+    1032,
+    "BAD_COLUMN_DATA",
+    "ColumnDataSource contains invalid data for Glyph")
 EXT = Error(
     9999,
     "EXT",

--- a/src/bokeh/models/glyphs.py
+++ b/src/bokeh/models/glyphs.py
@@ -55,6 +55,7 @@ from ..core.property.dataspec import (
     DistanceSpec,
     FloatSpec,
     MarkerSpec,
+    NDArraySpec,
     NullDistanceSpec,
     NumberSpec,
     SizeSpec,
@@ -835,8 +836,8 @@ class Image(ImageBase):
         ),
     }
 
-    image = NumberSpec(default=field("image"), help="""
-    The arrays of scalar data for the images to be colormapped.
+    image = NDArraySpec(2, default=field("image"), help="""
+    The 2D arrays of scalar data for the images to be colormapped.
     """)
 
     color_mapper = Instance(ColorMapper, default=InstanceDefault(LinearColorMapper, palette="Greys9"), help="""
@@ -861,8 +862,8 @@ class ImageRGBA(ImageBase):
 
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 
-    image = NumberSpec(default=field("image"), help="""
-    The arrays of RGBA data for the images.
+    image = NDArraySpec(2, default=field("image"), help="""
+    The 2D arrays of RGBA data for the images.
     """)
 
 class ImageStack(ImageBase):
@@ -881,7 +882,7 @@ class ImageStack(ImageBase):
 
     _args = ('image', 'x', 'y', 'dw', 'dh', 'dilate')
 
-    image = NumberSpec(default=field("image"), help="""
+    image = NDArraySpec(3, default=field("image"), help="""
     The 3D arrays of data for the images.
     """)
 
@@ -910,8 +911,7 @@ class ImageURL(XYGlyph):
     The URLs to retrieve images from.
 
     .. note::
-        The actual retrieving and loading of the images happens on
-        the client.
+        The actual retrieving and loading of the images happens on the client.
     """)
 
     x = NumberSpec(default=field("x"), help="""

--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -21,20 +21,31 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from difflib import get_close_matches
-from typing import TYPE_CHECKING, Any, Literal
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    cast,
+)
 
 # Bokeh imports
-from bokeh.core.property.vectorization import Field
+from bokeh.core.property.vectorization import Field, Value
 
 # Bokeh imports
 from ...core.property.auto import Auto
+from ...core.property.dataspec import ValidationContext
 from ...core.property.either import Either
 from ...core.property.instance import Instance, InstanceDefault
 from ...core.property.nullable import Nullable
 from ...core.property.primitive import Bool
 from ...core.property.required import Required
 from ...core.validation import error
-from ...core.validation.errors import BAD_COLUMN_NAME, CDSVIEW_FILTERS_WITH_CONNECTED
+from ...core.validation.errors import (
+    BAD_COLUMN_DATA,
+    BAD_COLUMN_NAME,
+    CDSVIEW_FILTERS_WITH_CONNECTED,
+)
+from ...settings import settings
 from ..filters import AllIndices
 from ..glyph import ConnectedXYGlyph, Glyph
 from ..graphics import Decoration, Marking
@@ -99,6 +110,38 @@ class GlyphRenderer(DataRenderer):
 
         if missing:
             return f"{', '.join(missing)} {{renderer: {self}}}"
+
+    @error(BAD_COLUMN_DATA)
+    def _check_bad_column_type(self):
+        if not settings.validate_data():
+            return
+
+        source = self.data_source
+        glyph = cast(Glyph, self.glyph) # XXX bad types
+
+        if not isinstance(source, ColumnDataSource) or isinstance(source, WebDataSource):
+            return
+
+        props = glyph.properties_with_values(include_defaults=False)
+        specs = glyph.dataspecs()
+
+        for name, spec in specs.items():
+            if name not in props:
+                continue
+
+            obj = props[name]
+            if isinstance(obj, Field):
+                field = obj.field
+                if field in source.data:
+                    column = source.data[field]
+                    ctx = ValidationContext()
+                    spec.validate_column(column, ctx)
+                    if ctx.has_failure:
+                        return "\n" + "\n".join(map(lambda entry: entry.text, ctx.entries))
+            elif isinstance(obj, Value):
+                # TODO validate scalar value
+                # value = obj.value
+                pass
 
     data_source = Required(Instance(DataSource), help="""
     Local data source to use when rendering glyphs on the plot.

--- a/src/bokeh/plotting/_plot.py
+++ b/src/bokeh/plotting/_plot.py
@@ -31,6 +31,7 @@ import numpy as np
 
 # Bokeh imports
 from ..core.property.datetime import Datetime
+from ..core.property.exceptions import ValueValidationError
 from ..core.property.singletons import Intrinsic
 from ..models import (
     Axis,
@@ -96,7 +97,7 @@ def get_range(range_input: Range | tuple[float, float] | npt.NDArray[Any] | Sequ
                 if end is None:
                     end = Intrinsic
                 return Range1d(start=start, end=end)
-            except ValueError:  # @mattpap suggests ValidationError instead
+            except ValueValidationError:
                 pass
     elif uses_pandas(range_input):
         from pandas import Series

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -828,6 +828,12 @@ class Settings:
     A password to decrypt the SSL keyfile, if necessary.
     """)
 
+    validate_data: PrioritizedSetting[bool] = PrioritizedSetting("validate_data", "BOKEH_VALIDATE_DATA", default=False, help="""
+    Whether the contents of ``ColumnDataSource`` will be validated or not.
+
+    This is an experimental feature and may result in significant performance reduction.
+    """)
+
     validation_level: PrioritizedSetting[ValidationLevel] = PrioritizedSetting("validation_level", "BOKEH_VALIDATION_LEVEL",
         default="none", convert=convert_validation, help="""
     Whether validation checks should log or raise exceptions on errors and warnings.

--- a/tests/unit/bokeh/core/property/test_validation__property.py
+++ b/tests/unit/bokeh/core/property/test_validation__property.py
@@ -57,6 +57,7 @@ from bokeh.core.properties import (
 )
 from bokeh.core.property.any import Any
 from bokeh.core.property.bases import validation_on
+from bokeh.core.property.exceptions import ValueValidationError
 from tests.support.util.api import verify_all
 
 # Module under test
@@ -125,54 +126,54 @@ class TestValidateDetailDefault:
 
     def test_Angle(self) -> None:
         p = Angle()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Real, got junk of type str")
     def test_Bool(self) -> None:
         p = Bool()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type bool or bool_?, got junk of type str")
     def test_Complex(self) -> None:
         p = Complex()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Complex, got junk of type str")
     def test_Float(self) -> None:
         p = Float()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Real, got junk of type str")
     def test_Int(self) -> None:
         p = Int()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Integral, got junk of type str")
     def test_Interval(self) -> None:
         p = Interval(Float, 0.0, 1.0)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(2)
         assert matches(str(e.value), r"expected a value of type Float in range \[0.0, 1.0\], got 2")
     def test_Percent(self) -> None:
         p = Percent()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(10)
         assert matches(str(e.value), r"expected a value in range \[0, 1\], got 10")
     def test_Size(self) -> None:
         p = Size()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a value of type Real, got junk of type str")
 
 
     def test_List(self) -> None:
         p = List(Float)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected sequence List\(Float\), got 'junk' of type <class 'str'>")
     def test_Seq(self) -> None:
         p = Seq(Float)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected sequence Seq\(Float\), got 'junk' of type <class 'str'>")
     def test_Seq_Any(self) -> None:
@@ -182,19 +183,19 @@ class TestValidateDetailDefault:
         assert matches(str(e.value), r"expected sequence Seq\(Any\), got 'junk' of type <class 'str'>")
     def test_Dict(self) -> None:
         p = Dict(String, Float)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a dict of type Dict\(String, Float\), got a value of type <class 'str'>")
 
     def test_Dict_Invalid_Key(self) -> None:
         d = Dict(String, String)
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueValidationError) as err:
             d.validate({"Foo": "Bar", 1: "Baz"})
         assert "invalid keys: 1" in str(err.value)
 
     def test_Dict_Invalid_Value(self) -> None:
         d = Dict(String, String)
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueValidationError) as err:
             d.validate({"Foo": "Bar", "Baz": 1})
         assert "invalid values for keys: Baz" in str(err.value)
 
@@ -204,97 +205,97 @@ class TestValidateDetailDefault:
         d = Dict(key_type, val_type)
         try:
             d.validate({key: val})
-        except ValueError:
-            pytest.fail("ValueError should not be raised on validating a correct dictionary")
+        except ValueValidationError:
+            pytest.fail("ValueValidationError should not be raised on validating a correct dictionary")
 
     def test_Dict_Multiple_Invalid_Keys(self) -> None:
         d = Dict(String, String)
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueValidationError) as err:
             d.validate({"Foo": "Bar", 1: "Baz", None: "Bosh", 4.5: "Bump"})
         assert "invalid keys: 1, None, 4.5" in str(err.value)
 
     def test_Dict_Multiple_Invalid_Values(self) -> None:
         d = Dict(String, String)
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueValidationError) as err:
             d.validate({"Foo": "Bar", "Baz": 1, "Bosh": 3.2, "Bump": None})
         assert "invalid values for keys: Baz, Bosh, Bump" in str(err.value)
 
     def test_Dict_Multiple_Invalid_Keys_And_Values(self) -> None:
         d = Dict(String, String)
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueValidationError) as err:
             d.validate({"Foo": 2, 1: "Baz", None: None, 4.5: "Bump", "Fow": 3.2})
         assert "invalid keys: 1, None, 4.5 and invalid values for keys: Foo, None, Fow" in str(err.value)
 
     def test_Tuple(self) -> None:
         p = Tuple(Int, Int)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of Tuple\(Int, Int\), got 'junk'")
 
 
     def test_Color(self) -> None:
         p = Color()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of either Enum\(.*\), .* or RGB, got 'junk'")
     def test_ColumnData(self) -> None:
         p = ColumnData(String, Seq(Float))
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a dict of type ColumnData\(String, Seq\(Float\)\), got a value of type <class 'str'>")
     def test_Datetime(self) -> None:
         p = Datetime()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(object())
         assert matches(str(e.value), r"Expected a date, datetime object, or timestamp, got <object object at 0x.*>")
     def test_Date(self) -> None:
         p = Date()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(object())
         assert matches(str(e.value), r"Expected an ISO date string, got <object object at 0x.*>")
     def test_DashPattern(self) -> None:
         p = DashPattern()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of either Enum\(.*\), Regex\(.*\) or Seq\(Int\), got 'junk'")
     def test_Either(self) -> None:
         p = Either(Int, Float)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an element of either Int or Float, got 'junk'")
     def test_Enum(self) -> None:
         p = Enum("red", "green")
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"invalid value: 'junk'; allowed values are red or green")
     def test_FontSize(self) -> None:
         p = FontSize()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"'junk' is not a valid font size value")
     def test_Instance(self) -> None:
         p = Instance(HasProps)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected an instance of type HasProps, got junk of type str")
     def test_MinMaxBounds(self) -> None:
         p = MinMaxBounds()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(10)
         assert matches(str(e.value), r"expected an element of either .*, got 10")
     def test_Regex(self) -> None:
         p = Regex("green")
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk")
         assert matches(str(e.value), r"expected a string matching 'green' pattern, got 'junk'")
     def test_String(self) -> None:
         p = String()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(10)
         assert matches(str(e.value), r"expected a value of type str, got 10 of type int")
     def test_MarkerType(self) -> None:
         p = MarkerType()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("foo")
         assert matches(str(e.value), r"invalid value: 'foo'; allowed values are asterisk, .* or y")
 
@@ -302,7 +303,7 @@ class TestValidateDetailDefault:
     @pytest.mark.parametrize('spec', SPECS)
     def test_Spec(self, spec) -> None:
         p = spec(default=None)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(dict(bad="junk"))
         assert matches(str(e.value), r"expected an element of either String, .*, got {'bad': 'junk'}")
 
@@ -314,54 +315,54 @@ class TestValidateDetailExplicit:
 
     def test_Angle(self, detail) -> None:
         p = Angle()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Bool(self, detail) -> None:
         p = Bool()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Complex(self, detail) -> None:
         p = Complex()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Float(self, detail) -> None:
         p = Float()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Int(self, detail) -> None:
         p = Int()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Interval(self, detail) -> None:
         p = Interval(Float, 0.0, 1.0)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(2, detail)
         assert (str(e.value) == "") == (not detail)
     def test_Percent(self, detail) -> None:
         p = Percent()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(10, detail)
         assert (str(e.value) == "") == (not detail)
     def test_Size(self, detail) -> None:
         p = Size()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
 
 
     def test_List(self, detail) -> None:
         p = List(Float)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Seq(self, detail) -> None:
         p = Seq(Float)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Seq_Any(self, detail) -> None:
@@ -371,74 +372,74 @@ class TestValidateDetailExplicit:
         assert (str(e.value) == "") == (not detail)
     def test_Dict(self, detail) -> None:
         p = Dict(String, Float)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Tuple(self, detail) -> None:
         p = Tuple(Int, Int)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
 
 
     def test_Color(self, detail) -> None:
         p = Color()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_ColumnData(self, detail) -> None:
         p = ColumnData(String, Seq(Float))
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Date(self, detail) -> None:
         p = Date()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(p, detail)
         assert (str(e.value) == "") == (not detail)
     def test_DashPattern(self, detail) -> None:
         p = DashPattern()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Either(self, detail) -> None:
         p = Either(Int, Float)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Enum(self, detail) -> None:
         p = Enum("red", "green")
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_FontSize(self, detail) -> None:
         p = FontSize()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_Instance(self, detail) -> None:
         p = Instance(HasProps)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_MinMaxBounds(self, detail) -> None:
         p = MinMaxBounds()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(10, detail)
         assert (str(e.value) == "") == (not detail)
     def test_Regex(self, detail) -> None:
         p = Regex("green")
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("junk", detail)
         assert (str(e.value) == "") == (not detail)
     def test_String(self, detail) -> None:
         p = String()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(10, detail)
         assert (str(e.value) == "") == (not detail)
     def test_MarkerType(self, detail) -> None:
         p = MarkerType()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate("foo", detail)
         assert (str(e.value) == "") == (not detail)
 
@@ -446,7 +447,7 @@ class TestValidateDetailExplicit:
     @pytest.mark.parametrize('spec', SPECS)
     def test_Spec(self, detail, spec) -> None:
         p = spec(default=None)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueValidationError) as e:
             p.validate(dict(bad="junk"), detail)
         assert (str(e.value) == "") == (not detail)
 


### PR DESCRIPTION
This is very early work in progress. Currently we support validation of property values and checking integrity of models. The goal of this PR is to add support for validation of data provided in data sources with respect to glyphs' and other renderers' dataspecs.

fixes #12615