### PR TITLE
make radial glyph radius value required

### DIFF
--- a/bokehjs/src/lib/models/glyphs/radial_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/radial_glyph.ts
@@ -123,7 +123,7 @@ export class RadialGlyph extends XYGlyph {
     this.mixins<RadialGlyph.Mixins>([LineVector, FillVector, HatchVector])
 
     this.define<RadialGlyph.Props>(() => ({
-      radius:           [ p.DistanceSpec, {field: "radius"} ],
+      radius:           [ p.DistanceSpec ],
       radius_dimension: [ RadiusDimension, "x" ],
     }))
   }

--- a/bokehjs/test/integration/glyphs/glyphs.ts
+++ b/bokehjs/test/integration/glyphs/glyphs.ts
@@ -1006,7 +1006,7 @@ describe("Glyph models", () => {
         },
       })
       data_source.selected.indices = range(N).filter((i) => i % 2 == 0)
-      const glyph = new Circle({fill_color: {field: "color"}})
+      const glyph = new Circle({radius: {field: "radius"}, fill_color: {field: "color"}})
       const selection_glyph = new Circle({radius: {field: "selection_radius"}, fill_color: {field: "color"}})
       const glyph_renderer = new GlyphRenderer({data_source, glyph, selection_glyph})
       p.renderers.push(glyph_renderer)
@@ -1053,7 +1053,7 @@ describe("Glyph models", () => {
         },
       })
       data_source.selected.indices = range(N).filter((i) => i % 2 == 0)
-      const glyph = new Circle({fill_color: {field: "color"}})
+      const glyph = new Circle({radius: {field: "radius"}, fill_color: {field: "color"}})
       const selection_glyph = new Rect({fill_color: {field: "color"}})
       const glyph_renderer = new GlyphRenderer({data_source, glyph, selection_glyph})
       p.renderers.push(glyph_renderer)

--- a/bokehjs/test/unit/api/plotting.ts
+++ b/bokehjs/test/unit/api/plotting.ts
@@ -12,14 +12,14 @@ describe("in api/plotting module", () => {
         const gr0 = figure().circle()
         expect(gr0.glyph.x).to.be.equal({field: "x"})
         expect(gr0.glyph.y).to.be.equal({field: "y"})
-        expect(gr0.glyph.radius).to.be.equal({field: "radius"})
+        expect(gr0.glyph.properties.radius.is_unset).to.be.true
         expect(gr0.data_source).to.not.be.equal(source)
 
         const gr1 = figure().circle({source})
         expect(gr1.glyph.x).to.be.equal({field: "x"})
         expect(gr1.glyph.y).to.be.equal({field: "y"})
-        expect(gr1.glyph.radius).to.be.equal({field: "radius"})
-        expect(gr1.data_source).to.be.equal(source)
+        expect(gr1.glyph.properties.radius.is_unset).to.be.true
+        expect(gr1.data_source).to.be.identical(source)
 
         const gr2 = figure().circle(5, 10, 0.5)
         expect(gr2.glyph.x).to.be.equal({value: 5})

--- a/bokehjs/test/unit/core/visuals.ts
+++ b/bokehjs/test/unit/core/visuals.ts
@@ -5,8 +5,8 @@ import type {Context2d} from "@bokehjs/core/util/canvas"
 import {CanvasLayer} from "@bokehjs/core/util/canvas"
 import {CDSView} from "@bokehjs/models/sources/cds_view"
 import {IndexFilter} from "@bokehjs/models/filters/index_filter"
-import type {CircleView} from "@bokehjs/models/glyphs/circle"
-import {Circle} from "@bokehjs/models/glyphs/circle"
+import type {ScatterView} from "@bokehjs/models/glyphs/scatter"
+import {Scatter} from "@bokehjs/models/glyphs/scatter"
 
 import {Model} from "@bokehjs/model"
 import {DOMComponentView} from "@bokehjs/core/dom_view"
@@ -231,9 +231,9 @@ describe("core/visuals", () => {
     describe("interacting with GlyphViews", () => {
 
       it("should get initialized with appropriate indices", async () => {
-        const circle = new Circle({fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}})
+        const scatter = new Scatter({fill_color: {field: "fill_color"}, fill_alpha: {field: "fill_alpha"}})
         const data = {fill_color: ["red", "green", "blue"], fill_alpha: [0, 0.6, 0.8]}
-        const renderer_view = await create_glyph_renderer_view(circle, data)
+        const renderer_view = await create_glyph_renderer_view(scatter, data)
 
         const filter = new IndexFilter({indices: [1, 2]})
         renderer_view.model.view = new CDSView({filter})
@@ -243,7 +243,7 @@ describe("core/visuals", () => {
         const canvas = document.createElement("canvas")
         const ctx = canvas.getContext("2d")! as Context2d
 
-        const glyph_view = renderer_view.glyph as CircleView
+        const glyph_view = renderer_view.glyph as ScatterView
         glyph_view.visuals.fill.set_vectorize(ctx, 1)
 
         expect(ctx.fillStyle).to.be.equal("rgba(0, 0, 255, 0.8)")

--- a/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
+++ b/bokehjs/test/unit/models/graphs/graph_hit_test_policy.ts
@@ -7,7 +7,7 @@ import {Selection} from "@bokehjs/models/selections/selection"
 import {Plot} from "@bokehjs/models/plots/plot"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 
-import {Circle} from "@bokehjs/models/glyphs/circle"
+import {Scatter} from "@bokehjs/models/glyphs/scatter"
 import {MultiLine} from "@bokehjs/models/glyphs/multi_line"
 import {EdgesOnly, NodesOnly, NodesAndLinkedEdges, EdgesAndLinkedNodes, NodesAndAdjacentNodes} from "@bokehjs/models/graphs/graph_hit_test_policy"
 import {LayoutProvider} from "@bokehjs/models/graphs/layout_provider"
@@ -61,7 +61,7 @@ describe("GraphHitTestPolicy", () => {
         ys: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
       },
     })
-    const node_renderer = new GlyphRenderer({data_source: node_source, glyph: new Circle()})
+    const node_renderer = new GlyphRenderer({data_source: node_source, glyph: new Scatter()})
     const edge_renderer = new GlyphRenderer({data_source: edge_source, glyph: new MultiLine()})
 
     gr = new GraphRenderer({

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -13,7 +13,7 @@ import {Place} from "@bokehjs/core/enums"
 import {GraphRenderer, GraphRendererView} from "@bokehjs/models/renderers/graph_renderer"
 import {GlyphRenderer, GlyphRendererView} from "@bokehjs/models/renderers/glyph_renderer"
 import {ResetTool, PanTool, Toolbar} from "@bokehjs/models"
-import {Rect, Circle, MultiLine} from "@bokehjs/models/glyphs"
+import {Rect, Scatter, MultiLine} from "@bokehjs/models/glyphs"
 import {ColumnDataSource} from "@bokehjs/models/sources"
 import {StaticLayoutProvider} from "@bokehjs/models/graphs"
 
@@ -80,7 +80,7 @@ describe("Plot module", () => {
         layout_provider: new StaticLayoutProvider(),
         node_renderer: new GlyphRenderer({
           data_source: new ColumnDataSource({data: {start: [], end: []}}),
-          glyph: new Circle(),
+          glyph: new Scatter(),
         }),
         edge_renderer: new GlyphRenderer({
           data_source: new ColumnDataSource({data: {index: []}}),

--- a/bokehjs/test/unit/models/ranges/data_range1d.ts
+++ b/bokehjs/test/unit/models/ranges/data_range1d.ts
@@ -4,7 +4,7 @@ import {Plot} from "@bokehjs/models/plots/plot"
 import {DataRange1d} from "@bokehjs/models/ranges/data_range1d"
 import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
-import {Circle} from "@bokehjs/models/glyphs/circle"
+import {Scatter} from "@bokehjs/models/glyphs/scatter"
 import type {PaddingUnits} from "@bokehjs/core/enums"
 import {build_view} from "@bokehjs/core/build_views"
 
@@ -141,13 +141,13 @@ describe("DataRange1d", () => {
 
     it("should add renderers from one plot", async () => {
       const r1 = new DataRange1d()
-      const g1 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Circle()})
+      const g1 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Scatter()})
       const p1 = new Plot({renderers: [g1], x_range: r1})
       await build_view(p1)
       expect(r1.computed_renderers()).to.be.equal([g1])
 
       const r2 = new DataRange1d()
-      const g2 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Circle()})
+      const g2 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Scatter()})
       const p2 = new Plot({renderers: [g1, g2], x_range: r2})
       await build_view(p2)
       expect(r2.computed_renderers()).to.be.equal([g1, g2])
@@ -156,11 +156,11 @@ describe("DataRange1d", () => {
     it("should add renderers from multiple plot", async () => {
       const r = new DataRange1d()
 
-      const g1 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Circle()})
+      const g1 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Scatter()})
       const p1 = new Plot({renderers: [g1], x_range: r})
       await build_view(p1)
 
-      const g2 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Circle()})
+      const g2 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Scatter()})
       const p2 = new Plot({renderers: [g2], x_range: r})
       await build_view(p2)
 
@@ -168,8 +168,8 @@ describe("DataRange1d", () => {
     })
 
     it("should respect user-set renderers", async () => {
-      const g1 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Circle()})
-      const g2 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Circle()})
+      const g1 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Scatter()})
+      const g2 = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Scatter()})
 
       const r = new DataRange1d({renderers: [g2]})
 
@@ -380,7 +380,7 @@ describe("DataRange1d", () => {
 
     it("should update its start and end values", async () => {
       const r = new DataRange1d()
-      const g = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Circle()})
+      const g = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Scatter()})
       const p = new Plot({renderers: [g], x_range: r})
       const pv = await build_view(p)
 
@@ -394,7 +394,7 @@ describe("DataRange1d", () => {
 
     it("should not update its start or end values to NaN when log", async () => {
       const r = new DataRange1d({scale_hint: "log"})
-      const g = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Circle()})
+      const g = new GlyphRenderer({data_source: new ColumnDataSource(), glyph: new Scatter()})
       const p = new Plot({renderers: [g], x_range: r})
       const pv = await build_view(p)
 

--- a/bokehjs/test/unit/models/renderers/glyph_renderer.ts
+++ b/bokehjs/test/unit/models/renderers/glyph_renderer.ts
@@ -6,13 +6,13 @@ import {PlotActions, xy} from "../../../interactive"
 
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import {GlyphRenderer, GlyphRendererView} from "@bokehjs/models/renderers/glyph_renderer"
-import {Circle} from "@bokehjs/models/glyphs"
+import {Circle, Scatter} from "@bokehjs/models/glyphs"
 import {build_view} from "@bokehjs/core/build_views"
 import {Plot} from "@bokehjs/models/plots"
 import {FactorRange} from "@bokehjs/models/ranges"
 import {CategoricalScale} from "@bokehjs/models/scales"
 
-function mkrenderer(glyph: Circle): GlyphRenderer {
+function mkrenderer(glyph: Scatter): GlyphRenderer {
   const data_source = new ColumnDataSource({
     data: {
       x: [10, 20, 30, 40],
@@ -27,7 +27,7 @@ function mkrenderer(glyph: Circle): GlyphRenderer {
 describe("GlyphRendererView", () => {
   // Basic case with no all glyphs going to their defaults
   async function make_grv() {
-    const basic_circle = new Circle({fill_color: "red"})
+    const basic_circle = new Scatter({fill_color: "red"})
     const glyph_renderer = mkrenderer(basic_circle)
     const grv = await build_view(
       glyph_renderer,
@@ -69,7 +69,7 @@ describe("GlyphRendererView", () => {
 
   it("should have default nonselection_glyph with 0.2 alpha", async () => {
     const {nonselection_glyph} = await make_grv()
-    expect((nonselection_glyph.model as Circle).fill_alpha).to.be.equal({value: 0.2})
+    expect((nonselection_glyph.model as Scatter).fill_alpha).to.be.equal({value: 0.2})
   })
 
   it("should have undefined hover_glyph if renderer hover_glyph is null", async () => {
@@ -80,13 +80,13 @@ describe("GlyphRendererView", () => {
 
   it("should have default muted_glyph with 0.2 alpha", async () => {
     const {muted_glyph} = await make_grv()
-    expect((muted_glyph.model as Circle).fill_alpha).to.be.equal({value: 0.2})
+    expect((muted_glyph.model as Scatter).fill_alpha).to.be.equal({value: 0.2})
   })
 
   it("should have default decimated_glyph with 0.3 line alpha and color grey", async () => {
     const {decimated_glyph} = await make_grv()
-    expect((decimated_glyph.model as Circle).line_alpha).to.be.equal({value: 0.3})
-    expect((decimated_glyph.model as Circle).line_color).to.be.equal({value: "grey"})
+    expect((decimated_glyph.model as Scatter).line_alpha).to.be.equal({value: 0.3})
+    expect((decimated_glyph.model as Scatter).line_color).to.be.equal({value: "grey"})
   })
 
   it("should call set_data() once when working with FactorRange", async () => {

--- a/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
+++ b/bokehjs/test/unit/models/tools/edit/poly_edit_tool.ts
@@ -5,8 +5,8 @@ import {display} from "../../../_util"
 
 import {build_view} from "@bokehjs/core/build_views"
 
-import type {CircleView} from "@bokehjs/models/glyphs/circle"
-import {Circle} from "@bokehjs/models/glyphs/circle"
+import type {ScatterView} from "@bokehjs/models/glyphs/scatter"
+import {Scatter} from "@bokehjs/models/glyphs/scatter"
 import type {PatchesView} from "@bokehjs/models/glyphs/patches"
 import {Patches} from "@bokehjs/models/glyphs/patches"
 import {Plot} from "@bokehjs/models/plots/plot"
@@ -25,7 +25,7 @@ export interface PolyEditTestCase {
   draw_tool_view: PolyEditToolView
   glyph_view: PatchesView
   glyph_renderer: GlyphRenderer<Patches>
-  vertex_glyph_view: CircleView
+  vertex_glyph_view: ScatterView
   vertex_source: ColumnDataSource
   vertex_renderer: GlyphRenderer
 }
@@ -51,7 +51,7 @@ async function make_testcase(): Promise<PolyEditTestCase> {
     xs: {field: "xs"},
     ys: {field: "ys"},
   })
-  const vertex_glyph = new Circle({
+  const vertex_glyph = new Scatter({
     x: {field: "x"},
     y: {field: "y"},
   })
@@ -82,7 +82,7 @@ async function make_testcase(): Promise<PolyEditTestCase> {
     draw_tool_view,
     glyph_view: glyph_renderer_view.glyph as PatchesView,
     glyph_renderer,
-    vertex_glyph_view: vertex_renderer_view.glyph as CircleView,
+    vertex_glyph_view: vertex_renderer_view.glyph as ScatterView,
     vertex_source,
     vertex_renderer,
   }

--- a/bokehjs/test/unit/models/tools/inspectors/hover_tool.ts
+++ b/bokehjs/test/unit/models/tools/inspectors/hover_tool.ts
@@ -1,8 +1,8 @@
 import {expect, expect_not_null} from "assertions"
 import {display, fig} from "../../../_util"
 
-import type {CircleView} from "@bokehjs/models/glyphs/circle"
-import {Circle} from "@bokehjs/models/glyphs/circle"
+import type {ScatterView} from "@bokehjs/models/glyphs/scatter"
+import {Scatter} from "@bokehjs/models/glyphs/scatter"
 import {Plot} from "@bokehjs/models/plots/plot"
 import {Range1d} from "@bokehjs/models/ranges/range1d"
 import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
@@ -10,11 +10,11 @@ import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 import type {HoverToolView, TooltipVars} from "@bokehjs/models/tools/inspectors/hover_tool"
 import {HoverTool} from "@bokehjs/models/tools/inspectors/hover_tool"
 
-async function make_testcase(): Promise<{hover_view: HoverToolView, data_source: ColumnDataSource, glyph_view: CircleView}> {
+async function make_testcase(): Promise<{hover_view: HoverToolView, data_source: ColumnDataSource, glyph_view: ScatterView}> {
   const data = {x: [0, 0.5, 1], y: [0, 0.5, 1]}
   const data_source = new ColumnDataSource({data})
 
-  const glyph = new Circle({x: {field: "x"}, y: {field: "y"}})
+  const glyph = new Scatter({x: {field: "x"}, y: {field: "y"}})
   const glyph_renderer = new GlyphRenderer({glyph, data_source})
 
   const plot = new Plot({

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -13,7 +13,6 @@ import {
   CDSView,
   Canvas,
   CategoricalColorMapper,
-  Circle,
   Column,
   ColumnDataSource,
   CopyTool,
@@ -205,7 +204,7 @@ describe("Bug", () => {
     it("prevents initializing GlyphRenderer with an empty data source", async () => {
       const plot = fig([200, 200])
       const data_source = new ColumnDataSource({data: {}})
-      const glyph = new Circle({x: {field: "x_field"}, y: {field: "y_field"}})
+      const glyph = new Scatter({x: {field: "x_field"}, y: {field: "y_field"}})
       const renderer = new GlyphRenderer({data_source, glyph})
       plot.add_renderers(renderer)
       const {view} = await display(plot)

--- a/src/bokeh/models/glyphs.py
+++ b/src/bokeh/models/glyphs.py
@@ -477,7 +477,7 @@ class Circle(RadialGlyph, LineGlyph, FillGlyph, HatchGlyph):
     The y-coordinates of the center of the circles.
     """)
 
-    radius = DistanceSpec(default=field("radius"), help="""
+    radius = DistanceSpec(help="""
     The radius values for circles (in |data units|, by default).
 
     .. warning::
@@ -1099,7 +1099,7 @@ class Ngon(RadialGlyph):
     The y-coordinates of the center of the n-gons.
     """)
 
-    radius = DistanceSpec(default=field("radius"), help="""
+    radius = DistanceSpec(help="""
     The radius values for n-gons (in |data units|, by default). The radius is
     measured from the center to the vertices of the n-gons.
     """)

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -3145,8 +3145,8 @@
       field: "y",
     },
     radius: {
-      type: "field",
-      field: "radius",
+      type: "symbol",
+      name: "unset",
     },
     radius_dimension: "x",
     hit_dilation: 1.0,
@@ -4010,8 +4010,8 @@
       field: "y",
     },
     radius: {
-      type: "field",
-      field: "radius",
+      type: "symbol",
+      name: "unset",
     },
     angle: {
       type: "value",

--- a/tests/unit/bokeh/models/test_glyphs.py
+++ b/tests/unit/bokeh/models/test_glyphs.py
@@ -683,10 +683,10 @@ def test_Wedge() -> None:
 
 
 def test_Circle() -> None:
-    glyph = m.Circle()
+    glyph = m.Circle(radius=10)
     assert glyph.x == field("x")
     assert glyph.y == field("y")
-    assert glyph.radius == field("radius")
+    assert glyph.radius == 10
     check_line_properties(glyph)
     check_fill_properties(glyph)
     check_hatch_properties(glyph)


### PR DESCRIPTION
@mattpap here is a WIP PR as requested. There are many BokehJS tests that rely on circle having a default value. 

- [x] issues: fixes #13899 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
