### PR TITLE
Improve `Image` property and use it in `ImageURLTexture.url`

### DIFF
--- a/docs/bokeh/source/docs/releases/3.7.0.rst
+++ b/docs/bokeh/source/docs/releases/3.7.0.rst
@@ -23,6 +23,7 @@ Bokeh version ``3.7.0`` (January 2025) is a minor milestone of Bokeh project.
 * Added support for value formatting to ``ValueOf(obj, attr)`` (:bokeh-pull:`14358`)
 * Added support for determinate and indeterminate ``Progress`` widgets (:bokeh-pull:`13546`)
 * Improved cursor handling in editable/movable ``BoxAnnotation`` (:bokeh-pull:`14151`)
+* Changed type of ``ImageURLTexture.url`` from ``String`` to ``Image`` (:bokeh-pull:`14371`)
 
 Deprecations
 ------------

--- a/src/bokeh/_specs.pyi
+++ b/src/bokeh/_specs.pyi
@@ -20,7 +20,6 @@ import numpy.typing as npt
 # Bokeh imports
 from ._types import (
     Color,
-    DashPattern,
     Datetime,
     FontSize,
     FontStyle,
@@ -40,6 +39,7 @@ from .core.enums import (
     TextBaselineType as TextBaseline,
 )
 from .core.property.vectorization import Expr, Field, Value
+from .core.property.visual import DashPatternType as DashPattern
 from .core.property_aliases import TextAnchorType as TextAnchor
 from .models.expressions import Expression
 from .models.transforms import Transform

--- a/src/bokeh/_types.pyi
+++ b/src/bokeh/_types.pyi
@@ -7,18 +7,8 @@
 
 # Standard library imports
 import datetime
-from pathlib import Path
-from typing import TYPE_CHECKING, Sequence
-
-# External imports
-import numpy as np
-import numpy.typing as npt
-
-if TYPE_CHECKING:
-    import PIL.Image
 
 # Bokeh imports
-from .core.enums import DashPatternType
 from .models.nodes import Node
 from .models.ranges import Factor
 from .models.text import BaseText
@@ -46,10 +36,6 @@ type FontSize = str
 type FontStyle = str
 
 type Regex = str
-
-type DashPattern = DashPatternType | str | Sequence[int]
-
-type Image = str | Path | PIL.Image.Image | npt.NDArray[np.uint8]
 
 type Bytes = bytes
 type JSON = str

--- a/src/bokeh/core/property/visual.pyi
+++ b/src/bokeh/core/property/visual.pyi
@@ -1,0 +1,46 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+from datetime import datetime as DateTime, timedelta as TimeDelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Sequence
+
+# External imports
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    import PIL.Image
+
+# Bokeh imports
+from .. import enums
+from ..enums import AutoType as Auto
+from .bases import Property
+
+type DashPatternType = enums.DashPatternType | str | Sequence[int]
+DashPattern = Property[DashPatternType]
+
+type ImageType = str | Path | PIL.Image.Image | npt.NDArray[np.uint8]
+Image = Property[ImageType]
+
+type HatchPatternTypeType = enums.HatchPatternType | enums.HatchPatternAbbreviationType
+HatchPatternType = Property[HatchPatternTypeType]
+
+type Bounds[T] = tuple[T, T] | tuple[T | None, T] | tuple[T, T | None]
+
+type MinMaxBoundsType = Auto | Bounds[float] | Bounds[DateTime] | Bounds[TimeDelta]
+MinMaxBounds = Property[MinMaxBoundsType]
+
+type CSSLengthType = str
+CSSLength = Property[CSSLengthType]
+
+type FontSizeType = str
+FontSize = Property[FontSizeType]
+
+type MarkerTypeType = enums.MarkerTypeType
+MarkerType = Property[MarkerTypeType]

--- a/src/bokeh/core/property_aliases.pyi
+++ b/src/bokeh/core/property_aliases.pyi
@@ -9,7 +9,7 @@
 from typing import Literal, NotRequired, TypedDict
 
 # Bokeh imports
-from .._types import Image, NonNegative
+from .._types import NonNegative
 from ..core.enums import (
     AlignType as Align,
     AnchorType as Anchor_,
@@ -19,6 +19,7 @@ from ..core.enums import (
     VAlignType as VAlign,
 )
 from ..core.property.bases import Property
+from ..core.property.visual import ImageType as Image
 
 type CSSLengthType = str
 CSSLength = Property[CSSLengthType]     # 10px 1.2em, etc.

--- a/src/bokeh/core/property_mixins.pyi
+++ b/src/bokeh/core/property_mixins.pyi
@@ -28,7 +28,6 @@ from .._specs import (
 from .._types import (
     Alpha,
     Color,
-    DashPattern,
     FontSize,
     Size,
 )
@@ -41,6 +40,7 @@ from .enums import (
     TextBaselineType as TextBaseline,
 )
 from .has_props import HasProps
+from .property.visual import DashPatternType as DashPattern
 
 ## Vector
 

--- a/src/bokeh/models/mappers.pyi
+++ b/src/bokeh/models/mappers.pyi
@@ -11,12 +11,9 @@ from typing import Sequence
 
 # Bokeh imports
 from .._types import Color
-from ..core.enums import (
-    HatchPatternType as HatchPattern,
-    MarkerTypeType as MarkerType,
-    PaletteType as Palette,
-)
+from ..core.enums import MarkerTypeType as MarkerType, PaletteType as Palette
 from ..core.has_props import abstract
+from ..core.property.visual import HatchPatternType as HatchPattern
 from .glyphs import Glyph
 from .ranges import FactorSeq
 from .renderers import GlyphRenderer

--- a/src/bokeh/models/ranges.pyi
+++ b/src/bokeh/models/ranges.pyi
@@ -18,15 +18,13 @@ from ..core.enums import (
     StartEndType as StartEnd,
 )
 from ..core.has_props import abstract
+from ..core.property.visual import Bounds, MinMaxBoundsType as MinMaxBounds
 from ..model import Model
 
 type Value = float | DateTime | TimeDelta
 
 type Interval = float | TimeDelta
 
-type Bounds[T] = tuple[T, T] | tuple[T | None, T] | tuple[T, T | None]
-
-type MinMaxBounds = Auto | Bounds[float] | Bounds[DateTime] | Bounds[TimeDelta]
 type MinMaxInterval = Auto | Bounds[float] | Bounds[TimeDelta]
 
 type L1Factor = str

--- a/src/bokeh/models/textures.py
+++ b/src/bokeh/models/textures.py
@@ -26,7 +26,12 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import TextureRepetition
 from ..core.has_props import abstract
-from ..core.properties import Enum, Required, String
+from ..core.properties import (
+    Enum,
+    Image,
+    Required,
+    String,
+)
 from ..model import Model
 
 #-----------------------------------------------------------------------------
@@ -68,7 +73,6 @@ class CanvasTexture(Texture):
 
     code = Required(String, help="""
     A snippet of JavaScript code to execute in the browser.
-
     """)
 
 class ImageURLTexture(Texture):
@@ -80,9 +84,14 @@ class ImageURLTexture(Texture):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    url = Required(String, help="""
+    url = Required(Image, help="""
     A URL to a drawable resource like image, video, etc.
 
+    If provided with a file path, the file will be encoded using ``data:``
+    protocol (utf-8 encoding for ``*.svg`` and base64 for ``*.png`` and
+    other binary formats).
+
+    NumPy 2D arrays are also supported and use ``data:`` encoding as well.
     """)
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/textures.pyi
+++ b/src/bokeh/models/textures.pyi
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 # Bokeh imports
 from ..core.enums import TextureRepetitionType as TextureRepetition
 from ..core.has_props import abstract
+from ..core.property.visual import ImageType as Image
 from ..model import Model
 
 @abstract
@@ -27,4 +28,4 @@ class CanvasTexture(Texture):
 @dataclass
 class ImageURLTexture(Texture):
 
-    url: str = ...
+    url: Image = ...

--- a/tests/unit/bokeh/core/property/test_visual.py
+++ b/tests/unit/bokeh/core/property/test_visual.py
@@ -23,6 +23,7 @@ import tempfile
 from io import BytesIO
 from pathlib import Path
 from typing import Literal
+from urllib.parse import quote
 
 # External imports
 import numpy as np
@@ -223,9 +224,15 @@ class Test_Image:
         prop = bcpv.Image()
         assert not prop.is_valid(None)
 
-    def test_validate_data_url(self) -> None:
+    def test_validate_data_urls(self) -> None:
         prop = bcpv.Image()
         assert prop.is_valid("data:image/png;base64,")
+        assert prop.is_valid("data:image/svg+xml;utf8,")
+
+    def test_validate_urls(self) -> None:
+        prop = bcpv.Image()
+        assert prop.is_valid("http://static.bokeh.org/branding/logos/bokeh-logo.svg")
+        assert prop.is_valid("https://static.bokeh.org/branding/logos/bokeh-logo.svg")
 
     def test_validate_Path(self) -> None:
         prop = bcpv.Image()
@@ -289,6 +296,18 @@ class Test_Image:
             image.save(file, "png")
             prop = bcpv.Image()
             assert prop.transform(file).startswith("data:image/png")
+
+    def test_transform_svg_file(self) -> None:
+        with tempfile.NamedTemporaryFile("w+", suffix=".svg") as file:
+            svg = """
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="6" />
+</svg>
+"""
+            file.write(svg)
+            file.flush()
+            prop = bcpv.Image()
+            assert prop.transform(file.name) == f"data:image/svg+xml;utf8,{quote(svg)}"
 
     def test_transform_string(self) -> None:
         prop = bcpv.Image()

--- a/tests/unit/bokeh/core/property/test_visual.py
+++ b/tests/unit/bokeh/core/property/test_visual.py
@@ -298,16 +298,17 @@ class Test_Image:
             assert prop.transform(file).startswith("data:image/png")
 
     def test_transform_svg_file(self) -> None:
-        with tempfile.NamedTemporaryFile("w+", suffix=".svg") as file:
+        with tempfile.TemporaryDirectory() as dir:
             svg = """
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
   <circle cx="12" cy="12" r="6" />
 </svg>
 """
-            file.write(svg)
-            file.flush()
+            path = Path(dir) / "Test_Image__test_transform_svg_file.svg"
+            with path.open(mode="w") as file:
+                file.write(svg)
             prop = bcpv.Image()
-            assert prop.transform(file.name) == f"data:image/svg+xml;utf8,{quote(svg)}"
+            assert prop.transform(path) == f"data:image/svg+xml;utf8,{quote(svg)}"
 
     def test_transform_string(self) -> None:
         prop = bcpv.Image()


### PR DESCRIPTION
I changed `Image.transform()` to better reflect its docstring and promised functionality. I also changed `ImageURLTexture.url` to use `Image` instead of plain string. This way locally referenced resources can be inlined.

fixes #14375