### PR TITLE
Add support for UI hints in plots

### DIFF
--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -192,6 +192,12 @@ export function replace_placeholders(content: string | {html: string}, data_sour
   }
 }
 
+export function parse_html(html: string): Node[] {
+  const parser = new DOMParser()
+  const document = parser.parseFromString(html, "text/html")
+  return [...document.body.childNodes]
+}
+
 /**
  * This supports the following:
  *

--- a/bokehjs/src/lib/models/dom/value_of.ts
+++ b/bokehjs/src/lib/models/dom/value_of.ts
@@ -1,7 +1,7 @@
 import {DOMElement, DOMElementView} from "./dom_element"
 import {HasProps} from "core/has_props"
 import {CustomJS} from "../callbacks/customjs"
-import {DEFAULT_FORMATTERS} from "core/util/templating"
+import {DEFAULT_FORMATTERS, parse_html} from "core/util/templating"
 import {execute} from "core/util/callbacks"
 import {isArray} from "core/util/types"
 import type * as p from "core/properties"
@@ -61,8 +61,12 @@ export class ValueOfView extends DOMElementView {
       })()
       this._await_ready(promise)
     } else {
-      const contents = DEFAULT_FORMATTERS[formatter](value, format ?? "", vars)
-      render(contents)
+      if (formatter == "raw" && format == "html") {
+        render(parse_html(`${value}`))
+      } else {
+        const contents = DEFAULT_FORMATTERS[formatter](value, format ?? "", vars)
+        render(contents)
+      }
     }
   }
 

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -34,6 +34,7 @@ export abstract class LayoutDOMView extends PaneView {
   layout?: Layoutable
 
   readonly mouseenter = new Signal<MouseEvent, this>(this, "mouseenter")
+  readonly mousemove = new Signal<MouseEvent, this>(this, "mousemove")
   readonly mouseleave = new Signal<MouseEvent, this>(this, "mouseleave")
 
   readonly disabled = new Signal<boolean, this>(this, "disabled")
@@ -73,6 +74,9 @@ export abstract class LayoutDOMView extends PaneView {
 
     this.el.addEventListener("mouseenter", (event) => {
       this.mouseenter.emit(event)
+    })
+    this.el.addEventListener("mousemove", (event) => {
+      this.mousemove.emit(event)
     })
     this.el.addEventListener("mouseleave", (event) => {
       this.mouseleave.emit(event)

--- a/bokehjs/src/lib/models/plots/plot.ts
+++ b/bokehjs/src/lib/models/plots/plot.ts
@@ -98,6 +98,9 @@ export namespace Plot {
     hold_render: p.Property<boolean>
 
     attribution: p.Property<(string | HTML)[]>
+
+    // internal
+    hints: p.Property<string>
   } & Mixins
 
   export type Mixins =
@@ -204,6 +207,10 @@ export class Plot extends LayoutDOM {
       hold_render:       [ Bool, false ],
 
       attribution:       [ List(Or(Str, Ref(HTML))), [] ],
+    }))
+
+    this.internal<Plot.Props>(({Str}) => ({
+      hints: [ Str, "" ],
     }))
 
     this.override<Plot.Props>({

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -951,6 +951,26 @@ export class PlotView extends LayoutDOMView implements Paintable {
         }
       })
     }
+
+    this.mousemove.connect((event) => {
+      const bbox = this.el.getBoundingClientRect()
+      const {pageX, pageY} = event
+      const pt = {sx: pageX - bbox.left, sy: pageY - bbox.top}
+      const hints = []
+      for (const tool_view of this.tool_views.values()) {
+        if (tool_view.model.active) {
+          const hint = tool_view.ui_hint(pt)
+          if (hint != null) {
+            hints.push(hint)
+          }
+        }
+      }
+      this.model.hints = hints.join("; ")
+    })
+
+    this.mouseleave.connect(() => {
+      this.model.hints = ""
+    })
   }
 
   protected _update_touch_action(): void {

--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -8,7 +8,7 @@ import type {SelectionMode, CoordinateUnits} from "core/enums"
 import {Dimensions, BoxOrigin} from "core/enums"
 import type {PanEvent, KeyEvent} from "core/ui_events"
 import type {HitTestRect} from "core/geometry"
-import type {CoordinateMapper, LRTB} from "core/util/bbox"
+import type {CoordinateMapper, LRTB, SXY} from "core/util/bbox"
 import * as icons from "styles/icons.css"
 
 export class BoxSelectToolView extends RegionSelectToolView {
@@ -181,6 +181,15 @@ export class BoxSelectToolView extends RegionSelectToolView {
     const {greedy} = this.model
     const geometry: HitTestRect = {type: "rect", sx0, sx1, sy0, sy1, greedy}
     this._select(geometry, final, mode)
+  }
+
+  override ui_hint(pt: SXY/*, modifiers: KeyModifiers*/): string | null {
+    const {sx, sy} = pt
+    if (this.plot_view.frame.bbox.contains(sx, sy)) {
+      return "Pan for box selection; with <b>Shift</b> for append mode; with <b>Ctrl</b> intersection mode; with <b>Ctrl</b>+<b>Shift</b> for subtraction mode"
+    } else {
+      return super.ui_hint(pt)
+    }
   }
 }
 

--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -10,6 +10,8 @@ import {Dimensions} from "core/enums"
 import type {SXY} from "core/util/bbox"
 import type {Scale} from "models/scales/scale"
 import * as icons from "styles/icons.css"
+import type {Axis} from "../../axes/axis"
+import type {ViewOf} from "core/build_views"
 
 export function update_ranges(scales: Map<string, Scale>, p0: number, p1: number): RangeState {
   const r: RangeState = new Map()
@@ -42,10 +44,27 @@ export class PanToolView extends GestureToolView {
     return super.cursor(sx, sy)
   }
 
-  protected _interactive_dims({sx, sy}: SXY): Dimensions | null {
+  protected _hits_axis({sx, sy}: SXY): ViewOf<Axis> | undefined {
+    return this.plot_view.axis_views.find((view) => view.bbox.contains(sx, sy))
+  }
+
+  protected _hits_frame({sx, sy}: SXY): boolean {
+    return this.plot_view.frame.bbox.contains(sx, sy)
+  }
+
+  override ui_hint(pt: SXY): string | null {
+    const dims = this._interactive_dims(pt)
+    switch (dims) {
+      case "width":  return "Drag horizontally to pan"
+      case "height": return "Drag vertically to pan"
+      case "both":   return "Drag in any direction to pan"
+      case null:     return super.ui_hint(pt)
+    }
+  }
+
+  protected _interactive_dims(pt: SXY): Dimensions | null {
     const {dimensions} = this.model
-    const {plot_view} = this
-    const axis_view = plot_view.axis_views.find((view) => view.bbox.contains(sx, sy))
+    const axis_view = this._hits_axis(pt)
     if (axis_view != null) {
       switch (axis_view.dimension) {
         case 0: {
@@ -61,7 +80,7 @@ export class PanToolView extends GestureToolView {
           break
         }
       }
-    } else if (plot_view.frame.bbox.contains(sx, sy)) {
+    } else if (this._hits_frame(pt)) {
       return "both"
     }
 

--- a/bokehjs/src/lib/models/tools/tool.ts
+++ b/bokehjs/src/lib/models/tools/tool.ts
@@ -36,6 +36,7 @@ import type {HelpTool} from "./actions/help_tool"
 import type {ToolButtonView} from "./tool_button"
 import {IconLike} from "../common/kinds"
 import type {ToolLike} from "./tool_proxy"
+import type {SXY} from "core/util/bbox"
 
 export type ToolAliases = {
   pan:          PanTool
@@ -91,6 +92,10 @@ export abstract class ToolView extends View {
 
   get overlays(): Renderer[] {
     return []
+  }
+
+  ui_hint(_pt: SXY): string | null {
+    return null
   }
 
   // activate is triggered by toolbar ui actions

--- a/examples/basic/scatters/color_scatter.py
+++ b/examples/basic/scatters/color_scatter.py
@@ -17,12 +17,26 @@ y = np.random.random(size=N) * 100
 radii = np.random.random(size=N) * 1.5
 colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype=np.uint8)
 
-TOOLS="hover,crosshair,pan,wheel_zoom,zoom_in,zoom_out,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select,examine,fullscreen,help"
+TOOLS="crosshair,pan,wheel_zoom,zoom_in,zoom_out,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select,examine,fullscreen,help"
 
-p = figure(tools=TOOLS)
+p = figure(tools=TOOLS, width=400, height=400)
+p.circle(x, y, radius=radii, fill_color=colors, fill_alpha=0.6, line_color=None)
 
-p.circle(x, y, radius=radii,
-         fill_color=colors, fill_alpha=0.6,
-         line_color=None)
+from bokeh.models import Panel, Node
+from bokeh.models.dom import ValueOf
+
+hints = Panel(
+    elements=[ValueOf(obj=p, attr="hints", formatter="raw", format="html")],
+    position=Node(target="frame", symbol="bottom_left"),
+    anchor="bottom_left",
+    stylesheets=["""
+    :host {
+        background-color: white;
+        border: 1px solid black;
+    }
+    """,
+    ],
+)
+p.elements.append(hints)
 
 show(p)

--- a/src/bokeh/models/ui/panels.pyi
+++ b/src/bokeh/models/ui/panels.pyi
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 # Bokeh imports
 from ...core.enums import AutoType as Auto
-from ...core.property_aliases import Anchor
+from ...core.property_aliases import AnchorType as Anchor
 from ..nodes import Coordinate, Node
 from .panes import Pane
 


### PR DESCRIPTION
Early work in progress. This PR adds support for displaying UI hints for tools and other interactive components.

[Screencast from 2025-03-03 03-45-22.webm](https://github.com/user-attachments/assets/2555948e-501a-440b-a3b2-6b58bbc537d7)

fixes #8512
