### PR TITLE
Validate test decriptions in bokehjs' tests

### DIFF
--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -327,6 +327,35 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
         shuffle(all_tests, random)
       }
 
+      function show_tree(suites: Suite[], test: Test): string[] {
+        const output = []
+        let depth = 0
+        for (const suite of [...suites, test]) {
+          const is_last = depth == suites.length
+          const prefix = depth == 0 ? chalk.red("\u2717") : `${" ".repeat(depth)}\u2514${is_last ? "\u2500" : "\u252c"}\u2500`
+          output.push(`${prefix} ${suite.description}`)
+          depth++
+        }
+        return output
+      }
+
+      const invalid_chars = ['"']
+      let has_invalid_chars = false
+      for (const [suites, test] of all_tests) {
+        const baseline_name = description(suites, test)
+        for (const c of invalid_chars) {
+          if (baseline_name.includes(c)) {
+            has_invalid_chars = true
+            const output = show_tree(suites, test)
+            output.push(`baseline name contains invalid characters: ${c}`)
+            console.log(output.join("\n"))
+          }
+        }
+      }
+      if (has_invalid_chars) {
+        fail("one or more baseline uses invalid characters")
+      }
+
       if (keyword != null || grep != null) {
         if (keyword != null) {
           const keywords = keyword
@@ -471,15 +500,7 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
         const [suites, test, status] = test_case
 
         if ((status.failure ?? false) || (status.timeout ?? false)) {
-          const output = []
-
-          let depth = 0
-          for (const suite of [...suites, test]) {
-            const is_last = depth == suites.length
-            const prefix = depth == 0 ? chalk.red("\u2717") : `${" ".repeat(depth)}\u2514${is_last ? "\u2500" : "\u252c"}\u2500`
-            output.push(`${prefix} ${suite.description}`)
-            depth++
-          }
+          const output = show_tree(suites, test)
 
           for (const error of status.errors) {
             output.push(error)

--- a/bokehjs/test/devtools/devtools.ts
+++ b/bokehjs/test/devtools/devtools.ts
@@ -342,18 +342,18 @@ async function run_tests(ctx: TestRunContext): Promise<boolean> {
       const invalid_chars = ['"']
       let has_invalid_chars = false
       for (const [suites, test] of all_tests) {
-        const baseline_name = description(suites, test)
+        const test_description = description(suites, test)
         for (const c of invalid_chars) {
-          if (baseline_name.includes(c)) {
+          if (test_description.includes(c)) {
             has_invalid_chars = true
             const output = show_tree(suites, test)
-            output.push(`baseline name contains invalid characters: ${c}`)
+            output.push(`test description contains invalid characters: ${c}`)
             console.log(output.join("\n"))
           }
         }
       }
       if (has_invalid_chars) {
-        fail("one or more baseline uses invalid characters")
+        fail("one or more test descriptions use invalid characters")
       }
 
       if (keyword != null || grep != null) {

--- a/bokehjs/test/unit/document/events.ts
+++ b/bokehjs/test/unit/document/events.ts
@@ -37,7 +37,7 @@ class TestModelWithProps extends Model {
   }
 
   static {
-    this.define<any>(({Float, List}) => ({
+    this.define<TestModelWithProps.Props>(({Float, List}) => ({
       foo: [ List(Float), [] ],
     }))
   }
@@ -48,7 +48,7 @@ describe("events module", () => {
   describe("exports", () => {
 
     for (const event of EVENTS) {
-      it(`"should have ${event}"`, () => {
+      it(`should have ${event}`, () => {
         expect(event in events).to.be.true
       })
     }

--- a/bokehjs/test/unit/models/annotations/box_annotation.ts
+++ b/bokehjs/test/unit/models/annotations/box_annotation.ts
@@ -48,7 +48,7 @@ describe("BoxAnnotation", () => {
       })
     }
 
-    it("should set cursor to \"grab\" inside box", async () => {
+    it("should set cursor to 'grab' inside box", async () => {
       const plot_view = await mkplot(mkbox())
       const ac = actions(plot_view, {units: "data"})
 
@@ -61,7 +61,7 @@ describe("BoxAnnotation", () => {
       expect(get_cursor(plot_view)).to.be.equal("default")
     })
 
-    it("should set cursor to \"grabbing\" when panning", async () => {
+    it("should set cursor to 'grabbing' when panning", async () => {
       const plot_view = await mkplot(mkbox())
       const ac = actions(plot_view, {units: "data"})
 
@@ -90,7 +90,7 @@ describe("BoxAnnotation", () => {
       })
     }
 
-    it("should set cursor to \"move\" in the middle", async () => {
+    it("should set cursor to 'move' in the middle", async () => {
       const plot_view = await mkplot(mkbox())
       const ac = actions(plot_view, {units: "data"})
 
@@ -103,7 +103,7 @@ describe("BoxAnnotation", () => {
       expect(get_cursor(plot_view)).to.be.equal("default")
     })
 
-    it("should set cursor to \"move\" when panning", async () => {
+    it("should set cursor to 'move' when panning", async () => {
       const plot_view = await mkplot(mkbox())
       const ac = actions(plot_view, {units: "data"})
 


### PR DESCRIPTION
The output will look like this:
```
[17:21:37] Starting 'test:unit'...
Running in Chrome/118.0.5993.88 using devtools protocol 1.3
✗ events module
 └┬─ exports
  └── "should have ColumnDataChangedEvent"
test description contains invalid characters: "
✗ events module
 └┬─ exports
  └── "should have ColumnsPatchedEvent"
test description contains invalid characters: "
✗ events module
 └┬─ exports
  └── "should have ColumnsStreamedEvent"
test description contains invalid characters: "
✗ events module
 └┬─ exports
  └── "should have DocumentChangedEvent"
test description contains invalid characters: "
✗ events module
 └┬─ exports
  └── "should have MessageSentEvent"
test description contains invalid characters: "
✗ events module
 └┬─ exports
  └── "should have ModelChangedEvent"
test description contains invalid characters: "
✗ events module
 └┬─ exports
  └── "should have TitleChangedEvent"
test description contains invalid characters: "
✗ events module
 └┬─ exports
  └── "should have RootAddedEvent"
test description contains invalid characters: "
✗ events module
 └┬─ exports
  └── "should have RootRemovedEvent"
test description contains invalid characters: "
one or more test descriptions use invalid characters
[17:21:38] Finished 'test:unit' after 1.55 s
[17:21:38] failed: tests failed
```
fixes #14386 