### PR TITLE
display color as hex string in color_sliders.py

### DIFF
--- a/examples/interaction/js_callbacks/color_sliders.py
+++ b/examples/interaction/js_callbacks/color_sliders.py
@@ -16,7 +16,7 @@ color = R, G, B = (75, 125, 125)
 text_color = (255, 255, 255)
 
 # create a data source to enable refreshing of fill & text color
-source = ColumnDataSource(data=dict(color=[color], text_color=[text_color]))
+source = ColumnDataSource(data=dict(color=[color], color_string=[color], text_color=[text_color]))
 
 # create first plot, as a rect() glyph and centered text label, with fill and text color taken from source
 p = figure(x_range=(-8, 8), y_range=(-4, 4),
@@ -45,8 +45,9 @@ callback = CustomJS(args=dict(source=source, red=red, blue=blue, green=green), c
     const B = blue.value | 0
 
     const color = "#" + toHex(R) + toHex(G) + toHex(B)
+    const color_string = `${R}, ${G}, ${B}`
     const text_color = ((R > 127) || (G > 127) || (B > 127)) ? '#000000' : '#ffffff'
-    source.data = { color: [color], text_color: [text_color] }
+    source.data = { color: [color], color_string: [color_string], text_color: [text_color] }
 """)
 
 red.js_on_change('value', callback)

--- a/examples/interaction/js_callbacks/color_sliders.py
+++ b/examples/interaction/js_callbacks/color_sliders.py
@@ -12,12 +12,12 @@ from bokeh.models import ColumnDataSource, CustomJS, Slider
 from bokeh.plotting import curdoc, figure, show
 from bokeh.themes import Theme
 
-color = R, G, B = (75, 125, 125)
-color_string = f"#{R:x}{G:x}{B:x}"
+R, G, B = (75, 125, 125)
+color = f"#{R:x}{G:x}{B:x}"
 text_color = (255, 255, 255)
 
 # create a data source to enable refreshing of fill & text color
-source = ColumnDataSource(data=dict(color=[color_string], text_color=[text_color]))
+source = ColumnDataSource(data=dict(color=[color], text_color=[text_color]))
 
 # create first plot, as a rect() glyph and centered text label, with fill and text color taken from source
 p = figure(x_range=(-8, 8), y_range=(-4, 4),

--- a/examples/interaction/js_callbacks/color_sliders.py
+++ b/examples/interaction/js_callbacks/color_sliders.py
@@ -14,7 +14,7 @@ from bokeh.themes import Theme
 
 R, G, B = (75, 125, 125)
 color = f"#{R:x}{G:x}{B:x}"
-text_color = (255, 255, 255)
+text_color = "#ffffff"
 
 # create a data source to enable refreshing of fill & text color
 source = ColumnDataSource(data=dict(color=[color], text_color=[text_color]))

--- a/examples/interaction/js_callbacks/color_sliders.py
+++ b/examples/interaction/js_callbacks/color_sliders.py
@@ -13,10 +13,11 @@ from bokeh.plotting import curdoc, figure, show
 from bokeh.themes import Theme
 
 color = R, G, B = (75, 125, 125)
+color_string = f"#{R:x}{G:x}{B:x}"
 text_color = (255, 255, 255)
 
 # create a data source to enable refreshing of fill & text color
-source = ColumnDataSource(data=dict(color=[color], color_string=[color], text_color=[text_color]))
+source = ColumnDataSource(data=dict(color=[color_string], text_color=[text_color]))
 
 # create first plot, as a rect() glyph and centered text label, with fill and text color taken from source
 p = figure(x_range=(-8, 8), y_range=(-4, 4),
@@ -45,9 +46,8 @@ callback = CustomJS(args=dict(source=source, red=red, blue=blue, green=green), c
     const B = blue.value | 0
 
     const color = "#" + toHex(R) + toHex(G) + toHex(B)
-    const color_string = `${R}, ${G}, ${B}`
     const text_color = ((R > 127) || (G > 127) || (B > 127)) ? '#000000' : '#ffffff'
-    source.data = { color: [color], color_string: [color_string], text_color: [text_color] }
+    source.data = { color: [color], text_color: [text_color] }
 """)
 
 red.js_on_change('value', callback)


### PR DESCRIPTION
The change results in showing color as RGB.

![grafik](https://github.com/user-attachments/assets/4b995cdc-0501-4588-b5de-2c6e17c98d6c)

- [x] issues: fixes #14393

~~@bryevdv Do you think it is a good idea to show color as rbg and hex? If not this is fixed and can be marked as ready.~~