### PR TITLE
Updated formatters.py

### DIFF
--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -741,15 +741,32 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 #-----------------------------------------------------------------------------
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
-_dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the contextual formatter
+_dttf = CONTEXTUAL_DATETIME_FORMATTER()
 
-_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes',
-                'hourmin', 'hours', 'days', 'months', 'years',
-                'context', 'context_which', 'context_location', 'strip_leading_zeros',
-                'boundary_scaling', 'hide_repeats')  # Added all relevant fields
+_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
+                'hourmin', 'hours', 'days', 'months', 'years')
 
-_dttf_defaults = _dttf.properties_with_values()
-_dttf_defaults_string = "\n\n        ".join(f"{name} = {_dttf_defaults[name]!r}" for name in _dttf_fields)
+def create_format_table() -> str:
+    # Header
+    table = "Scale         Primary          Date Context    Year Context\n"
+    table += "-" * 56 + "\n"  # Separator line (?)
+    
+    # Get formatters for each context level
+    primary = _dttf
+    context1 = _dttf.context
+    context2 = _dttf.context.context if _dttf.context else None
+    
+    # Build table rows
+    for field in _dttf_fields:
+        scale = f"{field:<12}"  # Left align, 12 chars wide
+        p_fmt = f"{getattr(primary, field):<15}"  # Primary format
+        c1_fmt = f"{getattr(context1, field):<15}" if context1 else " "*15
+        c2_fmt = f"{getattr(context2, field):<15}" if context2 else " "*15
+        table += f"{scale} {p_fmt} {c1_fmt} {c2_fmt}\n"
+    
+    return table
+
+_dttf_defaults_string = create_format_table()
 
 DatetimeTickFormatter.__doc__ = format_docstring(DatetimeTickFormatter.__doc__, defaults=_dttf_defaults_string)
-del _dttf, _dttf_fields, _dttf_defaults, _dttf_defaults_string
+del _dttf, _dttf_fields, _dttf_defaults_string

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -748,8 +748,8 @@ _dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes',
 
 def create_format_table() -> str:
     # Header
-    table = "Scale         Primary          Date Context    Year Context\n"
-    table += "-" * 56 + "\n"  # Separator line (?)
+    table = "Scale         Format           1st Context    2nd Context\n"
+    table += "-" * 56 + "\n"  # Separator line
     
     # Get formatters for each context level
     primary = _dttf

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -743,7 +743,7 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
 _dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the contextual formatter
 
-_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
+_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes',
                 'hourmin', 'hours', 'days', 'months', 'years',
                 'context', 'context_which', 'context_location', 'strip_leading_zeros',
                 'boundary_scaling', 'hide_repeats')  # Added all relevant fields

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -52,6 +52,7 @@ from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model
 from ..util.strings import format_docstring
 from .tickers import Ticker
+from ..models.formatters import CONTEXTUAL_DATETIME_FORMATTER
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -741,8 +742,10 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 #-----------------------------------------------------------------------------
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
-_dttf = DatetimeTickFormatter()
-_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 'hourmin', 'hours', 'days', 'months', 'years')
+_dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the new default formatter
+_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
+                'hourmin', 'hours', 'days', 'months', 'years',
+                'context', 'context_which', 'context_location')  # Add context-related fields
 _dttf_defaults = _dttf.properties_with_values()
 _dttf_defaults_string = "\n\n        ".join(f"{name} = {_dttf_defaults[name]!r}" for name in _dttf_fields)
 

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -52,7 +52,6 @@ from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model
 from ..util.strings import format_docstring
 from .tickers import Ticker
-from ..models.formatters import CONTEXTUAL_DATETIME_FORMATTER
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -742,10 +741,13 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 #-----------------------------------------------------------------------------
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
-_dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the new default formatter
+_dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the contextual formatter
+
 _dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
                 'hourmin', 'hours', 'days', 'months', 'years',
-                'context', 'context_which', 'context_location')  # Add context-related fields
+                'context', 'context_which', 'context_location', 'strip_leading_zeros',
+                'boundary_scaling', 'hide_repeats')  # Added all relevant fields
+
 _dttf_defaults = _dttf.properties_with_values()
 _dttf_defaults_string = "\n\n        ".join(f"{name} = {_dttf_defaults[name]!r}" for name in _dttf_fields)
 

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -758,8 +758,8 @@ def create_format_table() -> str:
     
     # Build table rows
     for field in _dttf_fields:
-        scale = f"{field:<12}"  # Left align, 12 chars wide
-        p_fmt = f"{getattr(primary, field):<15}"  # Primary format
+        scale = f"{field:<12}" 
+        p_fmt = f"{getattr(primary, field):<15}"
         c1_fmt = f"{getattr(context1, field):<15}" if context1 else " "*15
         c2_fmt = f"{getattr(context2, field):<15}" if context2 else " "*15
         table += f"{scale} {p_fmt} {c1_fmt} {c2_fmt}\n"


### PR DESCRIPTION
Update DatetimeTickFormatter documentation defaults

* Update automated documentation to reflect contextual datetime defaults
* Add context-related fields to documentation (_dttf_fields)
* Include all formatter properties in documentation string
* Set up formatter with current default values
* Follows up on PR #14248

- [ ] issues: fixes #14248 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)


@mosc9575 @bryevdv @mattpap 
