### PR TITLE
Backports for 3.7.1

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -535,9 +535,9 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
         }
       }
 
-      for (const [prop, old_value, new_value] of changed) {
-        if (prop.may_have_refs && this._needs_invalidate(old_value, new_value)) {
-          document._invalidate_all_models()
+      for (const [prop, _, new_value] of changed) {
+        if (prop.may_have_refs) {
+          document.partially_update_all_models(new_value)
           break
         }
       }
@@ -634,30 +634,10 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
 
   detach_document(): void {
     // This should only be called by the Document implementation to unset the document field
-    this._doc_detached()
-    this.document = null
-  }
-
-  protected _needs_invalidate(old_value: unknown, new_value: unknown): boolean {
-    const new_refs = new Set<HasProps>()
-    HasProps._value_record_references(new_value, new_refs, {recursive: false})
-
-    const old_refs = new Set<HasProps>()
-    HasProps._value_record_references(old_value, old_refs, {recursive: false})
-
-    for (const new_id of new_refs) {
-      if (!old_refs.has(new_id)) {
-        return true
-      }
+    if (this.document != null) {
+      this._doc_detached()
+      this.document = null
     }
-
-    for (const old_id of old_refs) {
-      if (!new_refs.has(old_id)) {
-        return true
-      }
-    }
-
-    return false
   }
 
   protected _push_changes(changes: [Property, unknown, unknown][], sync: boolean): void {

--- a/bokehjs/src/lib/core/uniforms.ts
+++ b/bokehjs/src/lib/core/uniforms.ts
@@ -11,6 +11,7 @@ export abstract class Uniform<T = number> implements Equatable {
   abstract select(indices: Indices): Uniform<T>
   abstract [equals](that: this, cmp: Comparator): boolean
   abstract map<U>(fn: (v: T) => U): Uniform<U>
+  abstract unique(): T[]
 
   is_Scalar(): this is UniformScalar<T> {
     return this.is_scalar
@@ -49,6 +50,10 @@ export class UniformScalar<T> extends Uniform<T> {
   map<U>(fn: (v: T) => U): UniformScalar<U> {
     return new UniformScalar(fn(this.value), this.length)
   }
+
+  unique(): T[] {
+    return [this.value]
+  }
 }
 
 export class UniformVector<T> extends Uniform<T> {
@@ -79,6 +84,10 @@ export class UniformVector<T> extends Uniform<T> {
 
   map<U>(fn: (v: T) => U): UniformVector<U> {
     return new UniformVector(arrayable.map(this.array, fn))
+  }
+
+  unique(): T[] {
+    return [...new Set(this.array)]
   }
 }
 

--- a/bokehjs/src/lib/model.ts
+++ b/bokehjs/src/lib/model.ts
@@ -124,13 +124,16 @@ export abstract class Model extends HasProps {
   }
 
   protected override _doc_attached(): void {
+    super._doc_attached()
+
     if (this.js_event_callbacks.size != 0 || this.subscribed_events.size != 0) {
       this._update_event_callbacks()
     }
   }
 
   protected override _doc_detached(): void {
-    this.document!.event_manager.subscribed_models.delete(this)
+    super._doc_detached()
+    this.document?.event_manager.subscribed_models.delete(this)
   }
 
   select<T extends HasProps>(selector: ModelSelector<T>): T[] {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -401,7 +401,9 @@ export abstract class GlyphView extends DOMComponentView {
     // examine just the top level of a 2-d array to validate
     // that every subitem is an array of some kind, as expected
     if (prop instanceof p.CoordinateSeqSpec) {
-      if (!every(array, isArrayable)) {
+      // work around issues with empty data sources (see #14424)
+      const indeterminate_length = this.renderer.data_source.get_value().get_length() == null
+      if (!indeterminate_length && !every(array, isArrayable)) {
         const msg = `expected a 2-d array for ${this.model.type}.${prop.attr}`
         logger.error(msg)
         throw new Error(msg)

--- a/bokehjs/src/lib/models/glyphs/webgl/multi_marker.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/multi_marker.ts
@@ -87,7 +87,7 @@ export class MultiMarkerGL extends BaseMarkerGL {
     this._angles.set_from_prop(this.glyph.angle)
 
     this._marker_types = this.glyph.marker
-    this._unique_marker_types = [...new Set(this._marker_types)].filter((marker) => MarkerType.valid(marker))
+    this._unique_marker_types = this._marker_types.unique().filter((marker) => MarkerType.valid(marker))
   }
 
   protected override _set_once(): void {

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -199,7 +199,7 @@ describe("Document", () => {
   })
 
   it("tracks all_models", () => {
-    const d = new Document()
+    const d = new Document({recompute_timeout: NaN})
     expect(d.roots().length).to.be.equal(0)
     expect(d.all_models.size).to.be.equal(0)
     const m = new SomeModel()
@@ -220,7 +220,7 @@ describe("Document", () => {
   })
 
   it("tracks all_models with list property", () => {
-    const d = new Document()
+    const d = new Document({recompute_timeout: NaN})
     expect(d.roots().length).to.be.equal(0)
     expect(d.all_models.size).to.be.equal(0)
     const m = new SomeModelWithChildren()
@@ -247,7 +247,7 @@ describe("Document", () => {
   })
 
   it("tracks all_models with list property where list elements have a child", () => {
-    const d = new Document()
+    const d = new Document({recompute_timeout: NaN})
     expect(d.roots().length).to.be.equal(0)
     expect(d.all_models.size).to.be.equal(0)
     const m = new SomeModelWithChildren()
@@ -320,7 +320,7 @@ describe("Document", () => {
   })
 
   it("can have all_models with multiple references", () => {
-    const d = new Document()
+    const d = new Document({recompute_timeout: NaN})
     expect(d.roots().length).to.be.equal(0)
     expect(d.all_models.size).to.be.equal(0)
 
@@ -354,7 +354,7 @@ describe("Document", () => {
   })
 
   it("can have all_models with cycles", () => {
-    const d = new Document()
+    const d = new Document({recompute_timeout: NaN})
     expect(d.roots().length).to.be.equal(0)
     expect(d.all_models.size).to.be.equal(0)
 
@@ -380,7 +380,7 @@ describe("Document", () => {
   })
 
   it("can have all_models with cycles through lists", () => {
-    const d = new Document()
+    const d = new Document({recompute_timeout: NaN})
     expect(d.roots().length).to.be.equal(0)
     expect(d.all_models.size).to.be.equal(0)
 
@@ -750,7 +750,7 @@ describe("Document", () => {
   })
 
   it("can patch a reference property", () => {
-    const d = new Document()
+    const d = new Document({recompute_timeout: NaN})
     expect(d.roots().length).to.be.equal(0)
     expect(d.all_models.size).to.be.equal(0)
 

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -30,6 +30,7 @@ import {
   Node,
   PanTool,
   Pane,
+  Patches,
   Plot,
   Range1d,
   RangeTool,
@@ -1845,6 +1846,19 @@ describe("Bug", () => {
 <path fill="rgb(0,128,255)" stroke="none" paint-order="stroke" d="M 0 0 L 100 0 L 100 100 L 0 100 L 0 0 Z" fill-opacity="0.5"/>\
 </svg>\
 ')
+    })
+  })
+
+  describe("in issue #14424", () => {
+    it("doesn't allow render a plot with Patches glyph and an empty data source", async () => {
+      const data_source = new ColumnDataSource({data: {}})
+
+      const plot = new Plot()
+      const glyph = new Patches({xs: {field: "xs"}, ys: {field: "ys"}})
+      const renderer = new GlyphRenderer({data_source, glyph})
+      plot.renderers.push(renderer)
+
+      await display(plot)
     })
   })
 })

--- a/docs/bokeh/source/docs/releases/3.7.1.rst
+++ b/docs/bokeh/source/docs/releases/3.7.1.rst
@@ -1,0 +1,15 @@
+.. _release-3-7-1:
+
+3.7.1
+=====
+
+Bokeh version ``3.7.1`` (March 2025) is a patch release that fixes a number of
+minor bugs/regressions and documentation issues.
+
+Changes
+-------
+
+* Fixed a regression in detaching models from a document in bokehjs (:bokeh-pull:`14430`)
+* Fixed rendering of empty ``Patches`` glyph (:bokeh-pull:`14436`)
+* Improved performance of scatter plots using WebGL backend (:bokeh-pull:`14421`)
+* Improved quality of examples (:bokeh-pull:`14397`, :bokeh-pull:`14395`)

--- a/docs/bokeh/switcher.json
+++ b/docs/bokeh/switcher.json
@@ -1,14 +1,14 @@
 [
   {
-    "name": "3.7.0 (latest)",
-    "version": "3.7.0",
+    "name": "3.7.1 (latest)",
+    "version": "3.7.1",
     "url": "https://docs.bokeh.org/en/latest/",
     "preferred": true
   },
   {
-    "name": "3.6.2",
-    "version": "3.6.2",
-    "url": "https://docs.bokeh.org/en/3.6.2/"
+    "name": "3.6.3",
+    "version": "3.6.3",
+    "url": "https://docs.bokeh.org/en/3.6.3/"
   },
   {
     "version": "3.5.2",

--- a/examples/basic/annotations/span.py
+++ b/examples/basic/annotations/span.py
@@ -23,7 +23,7 @@ dst_end = Span(location=dt(2013, 10, 27, 3, 0, 0), dimension='height',
                line_color='#009E73', line_width=5)
 p.add_layout(dst_end)
 
-p.yaxis.formatter.days = "%Hh"
+p.yaxis.formatter.context = None
 p.xgrid.grid_line_color = None
 
 show(p)

--- a/examples/interaction/js_callbacks/color_sliders.py
+++ b/examples/interaction/js_callbacks/color_sliders.py
@@ -12,8 +12,9 @@ from bokeh.models import ColumnDataSource, CustomJS, Slider
 from bokeh.plotting import curdoc, figure, show
 from bokeh.themes import Theme
 
-color = R, G, B = (75, 125, 125)
-text_color = (255, 255, 255)
+R, G, B = (75, 125, 125)
+color = f"#{R:x}{G:x}{B:x}"
+text_color = "#ffffff"
 
 # create a data source to enable refreshing of fill & text color
 source = ColumnDataSource(data=dict(color=[color], text_color=[text_color]))


### PR DESCRIPTION
This PR collects bug-fixes and tasks for a 3.7.1 release:

- [x] #14430
- [x] #14436
- [x] #14421 
- [x] #14397
- [x] #14395
- [x] 3.7.1 release notes
- [x] updated `switcher.json`

Release checklist:

- [ ] do **not** squash merge
- [x] update milestone to `3.7.1` of relevant issues and PRs
- [x] remove `NEEDS BACKPORT` label