### PR TITLE
update docs for DatetimeTickFormatter

### DIFF
--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -741,15 +741,32 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 #-----------------------------------------------------------------------------
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
-_dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the contextual formatter
+_dttf = CONTEXTUAL_DATETIME_FORMATTER()
 
-_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes',
-                'hourmin', 'hours', 'days', 'months', 'years',
-                'context', 'context_which', 'context_location', 'strip_leading_zeros',
-                'boundary_scaling', 'hide_repeats')  # Added all relevant fields
+_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
+                'hourmin', 'hours', 'days', 'months', 'years')
 
-_dttf_defaults = _dttf.properties_with_values()
-_dttf_defaults_string = "\n\n        ".join(f"{name} = {_dttf_defaults[name]!r}" for name in _dttf_fields)
+def create_format_table() -> str:
+    # Header
+    table = "Scale         Primary          Date Context    Year Context\n"
+    table += "-" * 56 + "\n"  # Separator line (?)
+    
+    # Get formatters for each context level
+    primary = _dttf
+    context1 = _dttf.context
+    context2 = _dttf.context.context if _dttf.context else None
+    
+    # Build table rows
+    for field in _dttf_fields:
+        scale = f"{field:<12}"  # Left align, 12 chars wide
+        p_fmt = f"{getattr(primary, field):<15}"  # Primary format
+        c1_fmt = f"{getattr(context1, field):<15}" if context1 else " "*15
+        c2_fmt = f"{getattr(context2, field):<15}" if context2 else " "*15
+        table += f"{scale} {p_fmt} {c1_fmt} {c2_fmt}\n"
+    
+    return table
+
+_dttf_defaults_string = create_format_table()
 
 DatetimeTickFormatter.__doc__ = format_docstring(DatetimeTickFormatter.__doc__, defaults=_dttf_defaults_string)
-del _dttf, _dttf_fields, _dttf_defaults, _dttf_defaults_string
+del _dttf, _dttf_fields, _dttf_defaults_string

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -748,8 +748,8 @@ _dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes',
 
 def create_format_table() -> str:
     # Header
-    table = "Scale         Primary          Date Context    Year Context\n"
-    table += "-" * 56 + "\n"  # Separator line (?)
+    table = "Scale         Format           1st Context    2nd Context\n"
+    table += "-" * 56 + "\n"  # Separator line
     
     # Get formatters for each context level
     primary = _dttf

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -743,7 +743,7 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
 _dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the contextual formatter
 
-_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
+_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes',
                 'hourmin', 'hours', 'days', 'months', 'years',
                 'context', 'context_which', 'context_location', 'strip_leading_zeros',
                 'boundary_scaling', 'hide_repeats')  # Added all relevant fields

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -52,6 +52,7 @@ from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model
 from ..util.strings import format_docstring
 from .tickers import Ticker
+from ..models.formatters import CONTEXTUAL_DATETIME_FORMATTER
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -741,8 +742,10 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 #-----------------------------------------------------------------------------
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
-_dttf = DatetimeTickFormatter()
-_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 'hourmin', 'hours', 'days', 'months', 'years')
+_dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the new default formatter
+_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
+                'hourmin', 'hours', 'days', 'months', 'years',
+                'context', 'context_which', 'context_location')  # Add context-related fields
 _dttf_defaults = _dttf.properties_with_values()
 _dttf_defaults_string = "\n\n        ".join(f"{name} = {_dttf_defaults[name]!r}" for name in _dttf_fields)
 

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -52,7 +52,6 @@ from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model
 from ..util.strings import format_docstring
 from .tickers import Ticker
-from ..models.formatters import CONTEXTUAL_DATETIME_FORMATTER
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -742,10 +741,13 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 #-----------------------------------------------------------------------------
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
-_dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the new default formatter
+_dttf = CONTEXTUAL_DATETIME_FORMATTER()  # Use the contextual formatter
+
 _dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
                 'hourmin', 'hours', 'days', 'months', 'years',
-                'context', 'context_which', 'context_location')  # Add context-related fields
+                'context', 'context_which', 'context_location', 'strip_leading_zeros',
+                'boundary_scaling', 'hide_repeats')  # Added all relevant fields
+
 _dttf_defaults = _dttf.properties_with_values()
 _dttf_defaults_string = "\n\n        ".join(f"{name} = {_dttf_defaults[name]!r}" for name in _dttf_fields)
 

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -758,8 +758,8 @@ def create_format_table() -> str:
     
     # Build table rows
     for field in _dttf_fields:
-        scale = f"{field:<12}"  # Left align, 12 chars wide
-        p_fmt = f"{getattr(primary, field):<15}"  # Primary format
+        scale = f"{field:<12}" 
+        p_fmt = f"{getattr(primary, field):<15}"
         c1_fmt = f"{getattr(context1, field):<15}" if context1 else " "*15
         c2_fmt = f"{getattr(context2, field):<15}" if context2 else " "*15
         table += f"{scale} {p_fmt} {c1_fmt} {c2_fmt}\n"

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -394,195 +394,154 @@ class DatetimeTickFormatter(TickFormatter):
     with their default values) that can be used to control the formatting
     of axis ticks at different scales:
 
-    .. code-block:: python
-
-        {defaults}
+    {defaults}
 
     Each scale property can be set to format or list of formats to use for
-    formatting datetime tick values that fall in in that "time scale".
+    formatting datetime tick values that fall in that "time scale".
     By default, only the first format string passed for each time scale
     will be used. By default, all leading zeros are stripped away from
     the formatted labels.
 
     This list of supported `strftime`_ formats is reproduced below.
 
-    %a
-        The abbreviated name of the day of the week according to the
-        current locale.
-
-    %A
-        The full name of the day of the week according to the current
-        locale.
-
-    %b
-        The abbreviated month name according to the current locale.
-
-    %B
-        The full month name according to the current locale.
-
-    %c
-        The preferred date and time representation for the current
-        locale.
-
-    %C
-        The century number (year/100) as a 2-digit integer.
-
-    %d
-        The day of the month as a decimal number (range 01 to 31).
-
-    %D
-        Equivalent to **%m/%d/%y**.  (Americans should note that in many
-        other countries **%d/%m/%y** is rather common. This means that in
-        international context this format is ambiguous and should not
-        be used.)
-
-    %e
-        Like %d, the day of the month as a decimal number, but a
-        leading zero is replaced by a space.
-
-    %f
-        Microsecond as a decimal number, zero-padded on the left (range
-        000000-999999). This is an extension to the set of directives
-        available to `timezone`_.
-
-    %F
-        Equivalent to **%Y-%m-%d** (the ISO 8601 date format).
-
-    %G
-        The ISO 8601 week-based year with century as a decimal number.
-        The 4-digit year corresponding to the ISO week number (see %V).
-        This has the same format and value as %Y, except that if the
-        ISO week number belongs to the previous or next year, that year
-        is used instead.
-
-    %g
-        Like **%G**, but without century, that is, with a 2-digit year (00-99).
-
-    %h
-        Equivalent to **%b**.
-
-    %H
-        The hour as a decimal number using a 24-hour clock (range 00
-        to 23).
-
-    %I
-        The hour as a decimal number using a 12-hour clock (range 01
-        to 12).
-
-    %j
-        The day of the year as a decimal number (range 001 to 366).
-
-    %k
-        The hour (24-hour clock) as a decimal number (range 0 to 23).
-        Single digits are preceded by a blank. See also **%H**.
-
-    %l
-        The hour (12-hour clock) as a decimal number (range 1 to 12).
-        Single digits are preceded by a blank. See also **%I**.
-
-    %m
-        The month as a decimal number (range 01 to 12).
-
-    %M
-        The minute as a decimal number (range 00 to 59).
-
-    %n
-        A newline character. Bokeh text does not currently support
-        newline characters.
-
-    %N
-        Nanosecond as a decimal number, zero-padded on the left (range
-        000000000-999999999). Supports a padding width specifier, i.e.
-        %3N displays 3 leftmost digits. However, this is only accurate
-        to the millisecond level of precision due to limitations of
-        `timezone`_.
-
-    %p
-        Either "AM" or "PM" according to the given time value, or the
-        corresponding strings for the current locale.  Noon is treated
-        as "PM" and midnight as "AM".
-
-    %P
-        Like %p but in lowercase: "am" or "pm" or a corresponding
-        string for the current locale.
-
-    %r
-        The time in a.m. or p.m. notation.  In the POSIX locale this
-        is equivalent to **%I:%M:%S %p**.
-
-    %R
-        The time in 24-hour notation (**%H:%M**). For a version including
-        the seconds, see **%T** below.
-
-    %s
-        The number of seconds since the Epoch, 1970-01-01 00:00:00
-        +0000 (UTC).
-
-    %S
-        The second as a decimal number (range 00 to 60).  (The range
-        is up to 60 to allow for occasional leap seconds.)
-
-    %t
-        A tab character. Bokeh text does not currently support tab
-        characters.
-
-    %T
-        The time in 24-hour notation (**%H:%M:%S**).
-
-    %u
-        The day of the week as a decimal, range 1 to 7, Monday being 1.
-        See also %w.
-
-    %U
-        The week number of the current year as a decimal number, range
-        00 to 53, starting with the first Sunday as the first day of
-        week 01.  See also **%V** and **%W**.
-
-    %V
-        The ISO 8601 week number (see NOTES) of the current year as a
-        decimal number, range 01 to 53, where week 1 is the first week
-        that has at least 4 days in the new year.  See also %U and %W.
-
-    %w
-        The day of the week as a decimal, range 0 to 6, Sunday being 0.
-        See also %u.
-
-    %W
-        The week number of the current year as a decimal number, range
-        00 to 53, starting with the first Monday as the first day of
-        week 01.
-
-    %x
-        The preferred date representation for the current locale
-        without the time.
-
-    %X
-        The preferred time representation for the current locale
-        without the date.
-
-    %y
-        The year as a decimal number without a century (range 00 to 99).
-
-    %Y
-        The year as a decimal number including the century.
-
-    %z
-        The +hhmm or -hhmm numeric timezone (that is, the hour and
-        minute offset from UTC).
-
-    %Z
-        The timezone name or abbreviation.
-
-    %%
-        A literal '%' character.
+    +----+------------------------------------------------------------------+
+    | %a | The abbreviated name of the day of the week according to the     |
+    |    | current locale.                                                  |
+    +----+------------------------------------------------------------------+
+    | %A | The full name of the day of the week according to the current    |
+    |    | locale.                                                          |
+    +----+------------------------------------------------------------------+
+    | %b | The abbreviated month name according to the current locale.      |
+    +----+------------------------------------------------------------------+
+    | %B | The full month name according to the current locale.             |
+    +----+------------------------------------------------------------------+
+    | %c | The preferred date and time representation for the current       |
+    |    | locale.                                                          |
+    +----+------------------------------------------------------------------+
+    | %C | The century number (year/100) as a 2-digit integer.              |
+    +----+------------------------------------------------------------------+
+    | %d | The day of the month as a decimal number (range 01 to 31).       |
+    +----+------------------------------------------------------------------+
+    | %D | Equivalent to **%m/%d/%y**. (Americans should note that in many  |
+    |    | other countries **%d/%m/%y** is rather common. This means that   |
+    |    | in international context this format is ambiguous and should not |
+    |    | be used.)                                                        |
+    +----+------------------------------------------------------------------+
+    | %e | Like **%d**, the day of the month as a decimal number, but a     |
+    |    | leading zero is replaced by a space.                             |
+    +----+------------------------------------------------------------------+
+    | %f | Microsecond as a decimal number, zero-padded on the left (range  |
+    |    | 000000-999999). This is an extension to the set of directives    |
+    |    | available to `timezone`_.                                        |
+    +----+------------------------------------------------------------------+
+    | %F | Equivalent to **%Y-%m-%d** (the ISO 8601 date format).           |
+    +----+------------------------------------------------------------------+
+    | %G | The ISO 8601 week-based year with century as a decimal number.   |
+    |    | The 4-digit year corresponding to the ISO week number (see       |
+    |    | **%V**). This has the same format and value as **%Y**, except    |
+    |    | that if the ISO week number belongs to the previous or next      |
+    |    | year, that year is used instead.                                 |
+    +----+------------------------------------------------------------------+
+    | %g | Like **%G**, but without century, that is, with a 2-digit year   |
+    |    | (00-99).                                                         |
+    +----+------------------------------------------------------------------+
+    | %h | Equivalent to **%b**.                                            |
+    +----+------------------------------------------------------------------+
+    | %H | The hour as a decimal number using a 24-hour clock (range 00 to  |
+    |    | 23).                                                             |
+    +----+------------------------------------------------------------------+
+    | %I | The hour as a decimal number using a 12-hour clock (range 01 to  |
+    |    | 12).                                                             |
+    +----+------------------------------------------------------------------+
+    | %j | The day of the year as a decimal number (range 001 to 366).      |
+    +----+------------------------------------------------------------------+
+    | %k | The hour (24-hour clock) as a decimal number (range 0 to 23).    |
+    |    | Single digits are preceded by a blank. See also **%H**.          |
+    +----+------------------------------------------------------------------+
+    | %l | The hour (12-hour clock) as a decimal number (range 1 to 12).    |
+    |    | Single digits are preceded by a blank. See also **%I**.          |
+    +----+------------------------------------------------------------------+
+    | %m | The month as a decimal number (range 01 to 12).                  |
+    +----+------------------------------------------------------------------+
+    | %M | The minute as a decimal number (range 00 to 59).                 |
+    +----+------------------------------------------------------------------+
+    | %n | A newline character. Bokeh text does not currently support       |
+    |    | newline characters.                                              |
+    +----+------------------------------------------------------------------+
+    | %N | Nanosecond as a decimal number, zero-padded on the left (range   |
+    |    | 000000000-999999999). Supports a padding width specifier, i.e.   |
+    |    | **%3N** displays 3 leftmost digits. However, this is only        |
+    |    | accurate to the millisecond level of precision due to            |
+    |    | limitations of `timezone`_.                                      |
+    +----+------------------------------------------------------------------+
+    | %p | Either "AM" or "PM" according to the given time value, or the    |
+    |    | corresponding strings for the current locale.  Noon is treated   |
+    |    | as "PM" and midnight as "AM".                                    |
+    +----+------------------------------------------------------------------+
+    | %P | Like **%p** but in lowercase: "am" or "pm" or a corresponding    |
+    |    | string for the current locale.                                   |
+    +----+------------------------------------------------------------------+
+    | %r | The time in a.m. or p.m. notation. In the POSIX locale this is   |
+    |    | equivalent to **%I:%M:%S %p**.                                   |
+    +----+------------------------------------------------------------------+
+    | %R | The time in 24-hour notation (**%H:%M**). For a version          |
+    |    | including the seconds, see **%T** below.                         |
+    +----+------------------------------------------------------------------+
+    | %s | The number of seconds since the Epoch, 1970-01-01 00:00:00+0000  |
+    |    | (UTC).                                                           |
+    +----+------------------------------------------------------------------+
+    | %S | The second as a decimal number (range 00 to 60).  (The range is  |
+    |    | up to 60 to allow for occasional leap seconds.)                  |
+    +----+------------------------------------------------------------------+
+    | %t | A tab character. Bokeh text does not currently support tab       |
+    |    | characters.                                                      |
+    +----+------------------------------------------------------------------+
+    | %T | The time in 24-hour notation (**%H:%M:%S**).                     |
+    +----+------------------------------------------------------------------+
+    | %u | The day of the week as a decimal, range 1 to 7, Monday being 1.  |
+    |    | See also **%w**.                                                 |
+    +----+------------------------------------------------------------------+
+    | %U | The week number of the current year as a decimal number, range   |
+    |    | 00 to 53, starting with the first Sunday as the first day of     |
+    |    | week 01.  See also **%V** and **%W**.                            |
+    +----+------------------------------------------------------------------+
+    | %V | The ISO 8601 week number (see NOTES) of the current year as a    |
+    |    | decimal number, range 01 to 53, where week 1 is the first week   |
+    |    | that has at least 4 days in the new year. See also **%U** and    |
+    |    | **%W.**                                                          |
+    +----+------------------------------------------------------------------+
+    | %w | The day of the week as a decimal, range 0 to 6, Sunday being 0.  |
+    |    | See also **%u**.                                                 |
+    +----+------------------------------------------------------------------+
+    | %W | The week number of the current year as a decimal number, range   |
+    |    | 00 to 53, starting with the first Monday as the first day of     |
+    |    | week 01.                                                         |
+    +----+------------------------------------------------------------------+
+    | %x | The preferred date representation for the current locale without |
+    |    | the time.                                                        |
+    +----+------------------------------------------------------------------+
+    | %X | The preferred time representation for the current locale without |
+    |    | the date.                                                        |
+    +----+------------------------------------------------------------------+
+    | %y | The year as a decimal number without a century (range 00 to 99). |
+    +----+------------------------------------------------------------------+
+    | %Y | The year as a decimal number including the century.              |
+    +----+------------------------------------------------------------------+
+    | %z | The +hhmm or -hhmm numeric timezone (that is, the hour and       |
+    |    | minute offset from UTC).                                         |
+    +----+------------------------------------------------------------------+
+    | %Z | The timezone name or abbreviation.                               |
+    +----+------------------------------------------------------------------+
+    | %% | A literal '%' character.                                         |
+    +----+------------------------------------------------------------------+
 
     .. warning::
         The client library BokehJS uses the `timezone`_ library to
         format datetimes. The inclusion of the list below is based on the
-        claim that `timezone`_ makes to support "the full compliment
+        claim that `timezone`_ makes to support "the full complement
         of GNU date format specifiers." However, this claim has not
         been tested exhaustively against this list. If you find formats
-        that do not function as expected, please submit a `github issue`_,
+        that do not function as expected, please submit a `GitHub issue`_,
         so that the documentation can be updated appropriately.
 
     .. _strftime: http://man7.org/linux/man-pages/man3/strftime.3.html
@@ -647,7 +606,7 @@ class DatetimeTickFormatter(TickFormatter):
     For example, an initial set of ticks ``["06/07", "06/07", "06/07", "06/08",
     "06/08"]`` will become ``["06/07", "", "", "06/08", ""]``. Only the base
     label, without any additional context, is considered when determining
-    repeats. If the context itself is a ``DateTimeTickformatter``, then this
+    repeats. If the context itself is a ``DatetimeTickFormatter``, then this
     property may also be set for the context separately, if desired.
     """)
 
@@ -672,36 +631,38 @@ class DatetimeTickFormatter(TickFormatter):
     rendered. Valid values are: `"below"`, `"above"`, `"left"`, and `"right"`.
     """)
 
+
 def RELATIVE_DATETIME_CONTEXT() -> DatetimeTickFormatter:
     return DatetimeTickFormatter(
-        microseconds = "%T",
-        milliseconds = "%T",
-        seconds = "%H:%M",
-        minsec = "%Hh",
-        minutes = "%Hh",
-        hourmin = "%F",
-        hours = "%F",
-        days = "%Y",
-        months = "",
-        years = "",
+        microseconds="%T",
+        milliseconds="%T",
+        seconds="%H:%M",
+        minsec="%Hh",
+        minutes="%Hh",
+        hourmin="%F",
+        hours="%F",
+        days="%Y",
+        months="",
+        years="",
     )
+
 
 def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
     return DatetimeTickFormatter(
-        microseconds = "%fus",
-        milliseconds = "%3Nms",
-        seconds = "%T",
-        minsec = "%T",
-        minutes = "%H:%M",
-        hourmin = "%H:%M",
-        hours = "%H:%M",
-        days = "%b %d",
-        months = "%b %Y",
-        years = "%Y",
-        strip_leading_zeros = ["microseconds", "milliseconds", "seconds"],
-        boundary_scaling = False,
-        context_which = "all",
-        context = DatetimeTickFormatter(
+        microseconds="%fus",
+        milliseconds="%3Nms",
+        seconds="%T",
+        minsec="%T",
+        minutes="%H:%M",
+        hourmin="%H:%M",
+        hours="%H:%M",
+        days="%b %d",
+        months="%b %Y",
+        years="%Y",
+        strip_leading_zeros=["microseconds", "milliseconds", "seconds"],
+        boundary_scaling=False,
+        context_which="all",
+        context=DatetimeTickFormatter(
             microseconds="%T",
             milliseconds="%T",
             seconds="%b %d, %Y",
@@ -741,32 +702,46 @@ def CONTEXTUAL_DATETIME_FORMATTER() -> DatetimeTickFormatter:
 #-----------------------------------------------------------------------------
 
 # This is to automate documentation of DatetimeTickFormatter formats and their defaults
-_dttf = CONTEXTUAL_DATETIME_FORMATTER()
 
-_dttf_fields = ('microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 
-                'hourmin', 'hours', 'days', 'months', 'years')
 
 def create_format_table() -> str:
-    # Header
-    table = "Scale         Format           1st Context    2nd Context\n"
-    table += "-" * 56 + "\n"  # Separator line
-    
+    fields = (
+        'microseconds', 'milliseconds', 'seconds', 'minsec', 'minutes', 'hourmin', 'hours', 'days', 'months', 'years',
+    )
+
+    def extended_join(character, iterable):
+        return f"{character}{character.join(iterable)}{character}"
+
+    def add_row_item(obj, name, string_length):
+        value = getattr(obj, name) if obj else ""
+        return f"{value:<{string_length}}"
+
+    def create_separator_line(character):
+        return extended_join("+", [character*col_len for col_len in lens])
+    column_names = ["Scale", "Format", "1st Context", "2nd Context"]
+    lens = [len(name) for name in column_names]
+    lens[0] = max(map(len, fields))
+    separator = create_separator_line("-")
+    rows = [
+        separator,
+        extended_join("|", [f"{value:<{n}}" for value, n in zip(column_names, lens)]),
+        create_separator_line("="),
+    ]
+
     # Get formatters for each context level
-    primary = _dttf
-    context1 = _dttf.context
-    context2 = _dttf.context.context if _dttf.context else None
-    
+    primary = CONTEXTUAL_DATETIME_FORMATTER()
+    secondary = primary.context
+    tertiary = secondary.context
     # Build table rows
-    for field in _dttf_fields:
-        scale = f"{field:<12}" 
-        p_fmt = f"{getattr(primary, field):<15}"
-        c1_fmt = f"{getattr(context1, field):<15}" if context1 else " "*15
-        c2_fmt = f"{getattr(context2, field):<15}" if context2 else " "*15
-        table += f"{scale} {p_fmt} {c1_fmt} {c2_fmt}\n"
-    
-    return table
+    for field in fields:
+        scale = f"{field:<{lens[0]}}"
+        p_fmt = add_row_item(primary, field, lens[1])
+        c1_fmt = add_row_item(secondary, field, lens[2])
+        c2_fmt = add_row_item(tertiary, field, lens[3])
+        rows.append(extended_join("|", [scale, p_fmt, c1_fmt, c2_fmt]))
+        rows.append(separator)
+    indent = " "*4
+    return f"\n{indent}".join(rows)
 
-_dttf_defaults_string = create_format_table()
 
-DatetimeTickFormatter.__doc__ = format_docstring(DatetimeTickFormatter.__doc__, defaults=_dttf_defaults_string)
-del _dttf, _dttf_fields, _dttf_defaults_string
+DatetimeTickFormatter.__doc__ = format_docstring(DatetimeTickFormatter.__doc__, defaults=create_format_table())

--- a/tests/baselines/cross/regressions/issue_11694.json5
+++ b/tests/baselines/cross/regressions/issue_11694.json5
@@ -3,7 +3,7 @@
     {
       type: "object",
       name: "Plot",
-      id: "p1001",
+      id: "p1003",
       attributes: {
         tags: [
           {
@@ -19,22 +19,22 @@
         x_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1002",
+          id: "p1004",
         },
         y_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1003",
+          id: "p1005",
         },
         x_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1004",
+          id: "p1006",
         },
         y_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1005",
+          id: "p1007",
         },
         title: {
           type: "object",
@@ -44,7 +44,7 @@
         toolbar: {
           type: "object",
           name: "Toolbar",
-          id: "p1007",
+          id: "p1009",
         },
       },
     },

--- a/tests/baselines/cross/regressions/issue_11694.json5
+++ b/tests/baselines/cross/regressions/issue_11694.json5
@@ -39,7 +39,7 @@
         title: {
           type: "object",
           name: "Title",
-          id: "p1006",
+          id: "p1008",
         },
         toolbar: {
           type: "object",

--- a/tests/baselines/cross/regressions/issue_11930.json5
+++ b/tests/baselines/cross/regressions/issue_11930.json5
@@ -3,50 +3,50 @@
     {
       type: "object",
       name: "Plot",
-      id: "p1008",
+      id: "p1010",
       attributes: {
         width: 200,
         height: 200,
         x_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1009",
+          id: "p1011",
         },
         y_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1010",
+          id: "p1012",
         },
         x_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1011",
+          id: "p1013",
         },
         y_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1012",
+          id: "p1014",
         },
         title: {
           type: "object",
           name: "Title",
-          id: "p1013",
+          id: "p1015",
         },
         renderers: [
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1005",
+            id: "p1007",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1001",
+                id: "p1003",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1002",
+                    id: "p1004",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -55,7 +55,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1003",
+                    id: "p1005",
                   },
                   data: {
                     type: "map",
@@ -83,19 +83,19 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1006",
+                id: "p1008",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1007",
+                    id: "p1009",
                   },
                 },
               },
               glyph: {
                 type: "object",
                 name: "Line",
-                id: "p1004",
+                id: "p1006",
               },
             },
           },
@@ -103,18 +103,18 @@
         toolbar: {
           type: "object",
           name: "Toolbar",
-          id: "p1014",
+          id: "p1016",
         },
         below: [
           {
             type: "object",
             name: "LinearAxis",
-            id: "p1016",
+            id: "p1018",
             attributes: {
               ticker: {
                 type: "object",
                 name: "FixedTicker",
-                id: "p1015",
+                id: "p1017",
                 attributes: {
                   ticks: [
                     1,
@@ -127,7 +127,7 @@
               formatter: {
                 type: "object",
                 name: "BasicTickFormatter",
-                id: "p1018",
+                id: "p1020",
               },
               axis_label: "int overrides",
               major_label_overrides: {
@@ -146,19 +146,19 @@
               major_label_policy: {
                 type: "object",
                 name: "AllLabels",
-                id: "p1019",
+                id: "p1021",
               },
             },
           },
           {
             type: "object",
             name: "LinearAxis",
-            id: "p1021",
+            id: "p1023",
             attributes: {
               ticker: {
                 type: "object",
                 name: "FixedTicker",
-                id: "p1020",
+                id: "p1022",
                 attributes: {
                   ticks: [
                     1,
@@ -171,7 +171,7 @@
               formatter: {
                 type: "object",
                 name: "BasicTickFormatter",
-                id: "p1023",
+                id: "p1025",
               },
               axis_label: "float overrides",
               major_label_overrides: {
@@ -190,7 +190,7 @@
               major_label_policy: {
                 type: "object",
                 name: "AllLabels",
-                id: "p1024",
+                id: "p1026",
               },
             },
           },

--- a/tests/baselines/cross/regressions/issue_13134.json5
+++ b/tests/baselines/cross/regressions/issue_13134.json5
@@ -3,48 +3,48 @@
     {
       type: "object",
       name: "Plot",
-      id: "p1011",
+      id: "p1013",
       attributes: {
         x_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1012",
+          id: "p1014",
         },
         y_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1013",
+          id: "p1015",
         },
         x_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1014",
+          id: "p1016",
         },
         y_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1015",
+          id: "p1017",
         },
         title: {
           type: "object",
           name: "Title",
-          id: "p1016",
+          id: "p1018",
         },
         renderers: [
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1008",
+            id: "p1010",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1001",
+                id: "p1003",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1002",
+                    id: "p1004",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -53,7 +53,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1003",
+                    id: "p1005",
                   },
                   data: {
                     type: "map",
@@ -95,12 +95,12 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1005",
+                id: "p1007",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "IndexFilter",
-                    id: "p1004",
+                    id: "p1006",
                     attributes: {
                       indices: {
                         type: "ndarray",
@@ -121,7 +121,7 @@
               glyph: {
                 type: "object",
                 name: "Scatter",
-                id: "p1007",
+                id: "p1009",
                 attributes: {
                   size: {
                     type: "value",
@@ -135,7 +135,7 @@
         toolbar: {
           type: "object",
           name: "Toolbar",
-          id: "p1017",
+          id: "p1019",
         },
       },
     },

--- a/tests/baselines/cross/regressions/issue_13637.json5
+++ b/tests/baselines/cross/regressions/issue_13637.json5
@@ -3,43 +3,43 @@
     {
       type: "object",
       name: "Plot",
-      id: "p1050",
+      id: "p1052",
       attributes: {
         x_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1051",
+          id: "p1053",
         },
         y_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1052",
+          id: "p1054",
         },
         x_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1053",
+          id: "p1055",
         },
         y_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1054",
+          id: "p1056",
         },
         title: {
           type: "object",
           name: "Title",
-          id: "p1055",
+          id: "p1057",
         },
         renderers: [
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1011",
+            id: "p1013",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1008",
+                id: "p1010",
                 attributes: {
                   selected: {
                     type: "object",
@@ -53,7 +53,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1010",
+                    id: "p1012",
                   },
                   data: {
                     type: "map",
@@ -63,19 +63,19 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1012",
+                id: "p1014",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1013",
+                    id: "p1015",
                   },
                 },
               },
               glyph: {
                 type: "object",
                 name: "Rect",
-                id: "p1001",
+                id: "p1003",
                 attributes: {
                   x: {
                     type: "value",
@@ -105,7 +105,7 @@
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1017",
+            id: "p1019",
             attributes: {
               data_source: {
                 type: "object",
@@ -124,7 +124,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1016",
+                    id: "p1018",
                   },
                   data: {
                     type: "map",
@@ -134,19 +134,19 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1018",
+                id: "p1020",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1019",
+                    id: "p1021",
                   },
                 },
               },
               glyph: {
                 type: "object",
                 name: "Rect",
-                id: "p1002",
+                id: "p1004",
                 attributes: {
                   x: {
                     type: "value",
@@ -192,17 +192,17 @@
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1023",
+            id: "p1025",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1020",
+                id: "p1022",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1021",
+                    id: "p1023",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -211,7 +211,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1022",
+                    id: "p1024",
                   },
                   data: {
                     type: "map",
@@ -221,19 +221,19 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1024",
+                id: "p1026",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1025",
+                    id: "p1027",
                   },
                 },
               },
               glyph: {
                 type: "object",
                 name: "Rect",
-                id: "p1003",
+                id: "p1005",
                 attributes: {
                   x: {
                     type: "value",
@@ -279,17 +279,17 @@
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1029",
+            id: "p1031",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1026",
+                id: "p1028",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1027",
+                    id: "p1029",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -298,7 +298,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1028",
+                    id: "p1030",
                   },
                   data: {
                     type: "map",
@@ -308,19 +308,19 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1030",
+                id: "p1032",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1031",
+                    id: "p1033",
                   },
                 },
               },
               glyph: {
                 type: "object",
                 name: "Rect",
-                id: "p1004",
+                id: "p1006",
                 attributes: {
                   x: {
                     type: "value",
@@ -366,17 +366,17 @@
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1035",
+            id: "p1037",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1032",
+                id: "p1034",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1033",
+                    id: "p1035",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -385,7 +385,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1034",
+                    id: "p1036",
                   },
                   data: {
                     type: "map",
@@ -395,19 +395,19 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1036",
+                id: "p1038",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1037",
+                    id: "p1039",
                   },
                 },
               },
               glyph: {
                 type: "object",
                 name: "Rect",
-                id: "p1005",
+                id: "p1007",
                 attributes: {
                   x: {
                     type: "value",
@@ -453,17 +453,17 @@
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1041",
+            id: "p1043",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1038",
+                id: "p1040",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1039",
+                    id: "p1041",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -472,7 +472,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1040",
+                    id: "p1042",
                   },
                   data: {
                     type: "map",
@@ -482,19 +482,19 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1042",
+                id: "p1044",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1043",
+                    id: "p1045",
                   },
                 },
               },
               glyph: {
                 type: "object",
                 name: "Rect",
-                id: "p1006",
+                id: "p1008",
                 attributes: {
                   x: {
                     type: "value",
@@ -529,17 +529,17 @@
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1047",
+            id: "p1049",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1044",
+                id: "p1046",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1045",
+                    id: "p1047",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -548,7 +548,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1046",
+                    id: "p1048",
                   },
                   data: {
                     type: "map",
@@ -558,19 +558,19 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1048",
+                id: "p1050",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1049",
+                    id: "p1051",
                   },
                 },
               },
               glyph: {
                 type: "object",
                 name: "Rect",
-                id: "p1007",
+                id: "p1009",
                 attributes: {
                   x: {
                     type: "value",
@@ -606,7 +606,7 @@
         toolbar: {
           type: "object",
           name: "Toolbar",
-          id: "p1056",
+          id: "p1058",
         },
       },
     },

--- a/tests/baselines/cross/regressions/issue_13637.json5
+++ b/tests/baselines/cross/regressions/issue_13637.json5
@@ -44,7 +44,7 @@
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1009",
+                    id: "p1011",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -110,12 +110,12 @@
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1014",
+                id: "p1016",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1015",
+                    id: "p1017",
                     attributes: {
                       indices: [],
                       line_indices: [],

--- a/tests/baselines/cross/regressions/issue_13637_empty_map.json5
+++ b/tests/baselines/cross/regressions/issue_13637_empty_map.json5
@@ -3,7 +3,7 @@
     {
       type: "object",
       name: "Plot",
-      id: "p1016",
+      id: "p1018",
       attributes: {
         name: null,
         tags: [],
@@ -50,7 +50,7 @@
         x_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1017",
+          id: "p1019",
           attributes: {
             name: null,
             tags: [],
@@ -88,7 +88,7 @@
         y_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1018",
+          id: "p1020",
           attributes: {
             name: null,
             tags: [],
@@ -126,7 +126,7 @@
         x_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1019",
+          id: "p1021",
           attributes: {
             name: null,
             tags: [],
@@ -145,7 +145,7 @@
         y_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1020",
+          id: "p1022",
           attributes: {
             name: null,
             tags: [],
@@ -178,7 +178,7 @@
         title: {
           type: "object",
           name: "Title",
-          id: "p1021",
+          id: "p1023",
           attributes: {
             name: null,
             tags: [],
@@ -261,7 +261,7 @@
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1005",
+            id: "p1007",
             attributes: {
               name: null,
               tags: [],
@@ -298,7 +298,7 @@
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1002",
+                id: "p1004",
                 attributes: {
                   name: null,
                   tags: [],
@@ -315,7 +315,7 @@
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1003",
+                    id: "p1005",
                     attributes: {
                       name: null,
                       tags: [],
@@ -343,7 +343,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1004",
+                    id: "p1006",
                     attributes: {
                       name: null,
                       tags: [],
@@ -367,7 +367,7 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1006",
+                id: "p1008",
                 attributes: {
                   name: null,
                   tags: [],
@@ -384,7 +384,7 @@
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1007",
+                    id: "p1009",
                     attributes: {
                       name: null,
                       tags: [],
@@ -405,7 +405,7 @@
               glyph: {
                 type: "object",
                 name: "Rect",
-                id: "p1001",
+                id: "p1003",
                 attributes: {
                   name: null,
                   tags: [],
@@ -513,7 +513,7 @@
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1013",
+            id: "p1015",
             attributes: {
               name: null,
               tags: [],
@@ -550,7 +550,7 @@
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1010",
+                id: "p1012",
                 attributes: {
                   name: null,
                   tags: [],
@@ -567,7 +567,7 @@
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1009",
+                    id: "p1011",
                     attributes: {
                       name: null,
                       tags: [],
@@ -595,7 +595,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1012",
+                    id: "p1014",
                     attributes: {
                       name: null,
                       tags: [],
@@ -619,7 +619,7 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1014",
+                id: "p1016",
                 attributes: {
                   name: null,
                   tags: [],
@@ -636,7 +636,7 @@
                   filter: {
                     type: "object",
                     name: "AllIndices",
-                    id: "p1015",
+                    id: "p1017",
                     attributes: {
                       name: null,
                       tags: [],
@@ -657,7 +657,7 @@
               glyph: {
                 type: "object",
                 name: "MultiLine",
-                id: "p1008",
+                id: "p1010",
                 attributes: {
                   name: null,
                   tags: [],
@@ -729,7 +729,7 @@
         toolbar: {
           type: "object",
           name: "Toolbar",
-          id: "p1022",
+          id: "p1024",
           attributes: {
             name: null,
             tags: [],

--- a/tests/baselines/cross/regressions/issue_13660.json5
+++ b/tests/baselines/cross/regressions/issue_13660.json5
@@ -3,48 +3,48 @@
     {
       type: "object",
       name: "Plot",
-      id: "p1011",
+      id: "p1013",
       attributes: {
         x_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1012",
+          id: "p1014",
         },
         y_range: {
           type: "object",
           name: "DataRange1d",
-          id: "p1013",
+          id: "p1015",
         },
         x_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1014",
+          id: "p1016",
         },
         y_scale: {
           type: "object",
           name: "LinearScale",
-          id: "p1015",
+          id: "p1017",
         },
         title: {
           type: "object",
           name: "Title",
-          id: "p1016",
+          id: "p1018",
         },
         renderers: [
           {
             type: "object",
             name: "GlyphRenderer",
-            id: "p1008",
+            id: "p1010",
             attributes: {
               data_source: {
                 type: "object",
                 name: "ColumnDataSource",
-                id: "p1001",
+                id: "p1003",
                 attributes: {
                   selected: {
                     type: "object",
                     name: "Selection",
-                    id: "p1002",
+                    id: "p1004",
                     attributes: {
                       indices: [],
                       line_indices: [],
@@ -53,7 +53,7 @@
                   selection_policy: {
                     type: "object",
                     name: "UnionRenderers",
-                    id: "p1003",
+                    id: "p1005",
                   },
                   data: {
                     type: "map",
@@ -95,12 +95,12 @@
               view: {
                 type: "object",
                 name: "CDSView",
-                id: "p1005",
+                id: "p1007",
                 attributes: {
                   filter: {
                     type: "object",
                     name: "BooleanFilter",
-                    id: "p1004",
+                    id: "p1006",
                     attributes: {
                       booleans: {
                         type: "ndarray",
@@ -121,7 +121,7 @@
               glyph: {
                 type: "object",
                 name: "Scatter",
-                id: "p1007",
+                id: "p1009",
                 attributes: {
                   size: {
                     type: "value",
@@ -135,7 +135,7 @@
         toolbar: {
           type: "object",
           name: "Toolbar",
-          id: "p1017",
+          id: "p1019",
         },
       },
     },

--- a/tests/baselines/cross/regressions/issue_13964.json5
+++ b/tests/baselines/cross/regressions/issue_13964.json5
@@ -3,7 +3,7 @@
     {
       type: "object",
       name: "TextInput",
-      id: "p1001",
+      id: "p1003",
       attributes: {
         js_property_callbacks: {
           type: "map",
@@ -14,7 +14,7 @@
                 {
                   type: "object",
                   name: "CustomJS",
-                  id: "p1002",
+                  id: "p1004",
                   attributes: {
                     args: {
                       type: "map",

--- a/tests/baselines/cross/regressions/issue_8766.json5
+++ b/tests/baselines/cross/regressions/issue_8766.json5
@@ -848,7 +848,7 @@
                     id: "p1057",
                     attributes: {
                       axis: {
-                        id: "p1051",
+                        id: "p1053",
                       },
                     },
                   },

--- a/tests/baselines/cross/regressions/issue_8766.json5
+++ b/tests/baselines/cross/regressions/issue_8766.json5
@@ -3,36 +3,36 @@
     {
       type: "object",
       name: "GridPlot",
-      id: "p1121",
+      id: "p1123",
       attributes: {
         rows: null,
         cols: null,
         toolbar: {
           type: "object",
           name: "Toolbar",
-          id: "p1120",
+          id: "p1122",
           attributes: {
             tools: [
               {
                 type: "object",
                 name: "ToolProxy",
-                id: "p1118",
+                id: "p1120",
                 attributes: {
                   tools: [
                     {
                       type: "object",
                       name: "PanTool",
-                      id: "p1022",
+                      id: "p1024",
                     },
                     {
                       type: "object",
                       name: "PanTool",
-                      id: "p1061",
+                      id: "p1063",
                     },
                     {
                       type: "object",
                       name: "PanTool",
-                      id: "p1100",
+                      id: "p1102",
                     },
                   ],
                 },
@@ -40,19 +40,19 @@
               {
                 type: "object",
                 name: "ToolProxy",
-                id: "p1119",
+                id: "p1121",
                 attributes: {
                   tools: [
                     {
                       type: "object",
                       name: "BoxSelectTool",
-                      id: "p1023",
+                      id: "p1025",
                       attributes: {
                         renderers: "auto",
                         overlay: {
                           type: "object",
                           name: "BoxAnnotation",
-                          id: "p1024",
+                          id: "p1026",
                           attributes: {
                             syncable: false,
                             line_color: "black",
@@ -86,12 +86,12 @@
                             handles: {
                               type: "object",
                               name: "BoxInteractionHandles",
-                              id: "p1030",
+                              id: "p1032",
                               attributes: {
                                 all: {
                                   type: "object",
                                   name: "AreaVisuals",
-                                  id: "p1029",
+                                  id: "p1031",
                                   attributes: {
                                     fill_color: "white",
                                     hover_fill_color: "lightgray",
@@ -106,13 +106,13 @@
                     {
                       type: "object",
                       name: "BoxSelectTool",
-                      id: "p1062",
+                      id: "p1064",
                       attributes: {
                         renderers: "auto",
                         overlay: {
                           type: "object",
                           name: "BoxAnnotation",
-                          id: "p1063",
+                          id: "p1065",
                           attributes: {
                             syncable: false,
                             line_color: "black",
@@ -146,12 +146,12 @@
                             handles: {
                               type: "object",
                               name: "BoxInteractionHandles",
-                              id: "p1069",
+                              id: "p1071",
                               attributes: {
                                 all: {
                                   type: "object",
                                   name: "AreaVisuals",
-                                  id: "p1068",
+                                  id: "p1070",
                                   attributes: {
                                     fill_color: "white",
                                     hover_fill_color: "lightgray",
@@ -166,13 +166,13 @@
                     {
                       type: "object",
                       name: "BoxSelectTool",
-                      id: "p1101",
+                      id: "p1103",
                       attributes: {
                         renderers: "auto",
                         overlay: {
                           type: "object",
                           name: "BoxAnnotation",
-                          id: "p1102",
+                          id: "p1104",
                           attributes: {
                             syncable: false,
                             line_color: "black",
@@ -206,12 +206,12 @@
                             handles: {
                               type: "object",
                               name: "BoxInteractionHandles",
-                              id: "p1108",
+                              id: "p1110",
                               attributes: {
                                 all: {
                                   type: "object",
                                   name: "AreaVisuals",
-                                  id: "p1107",
+                                  id: "p1109",
                                   attributes: {
                                     fill_color: "white",
                                     hover_fill_color: "lightgray",
@@ -228,7 +228,7 @@
               },
             ],
             active_drag: {
-              id: "p1119",
+              id: "p1121",
             },
           },
         },
@@ -237,50 +237,50 @@
             {
               type: "object",
               name: "Figure",
-              id: "p1001",
+              id: "p1003",
               attributes: {
                 width: 300,
                 height: 300,
                 x_range: {
                   type: "object",
                   name: "DataRange1d",
-                  id: "p1002",
+                  id: "p1004",
                 },
                 y_range: {
                   type: "object",
                   name: "DataRange1d",
-                  id: "p1003",
+                  id: "p1005",
                 },
                 x_scale: {
                   type: "object",
                   name: "LinearScale",
-                  id: "p1010",
+                  id: "p1012",
                 },
                 y_scale: {
                   type: "object",
                   name: "LinearScale",
-                  id: "p1011",
+                  id: "p1013",
                 },
                 title: {
                   type: "object",
                   name: "Title",
-                  id: "p1008",
+                  id: "p1010",
                 },
                 renderers: [
                   {
                     type: "object",
                     name: "GlyphRenderer",
-                    id: "p1037",
+                    id: "p1039",
                     attributes: {
                       data_source: {
                         type: "object",
                         name: "ColumnDataSource",
-                        id: "p1031",
+                        id: "p1033",
                         attributes: {
                           selected: {
                             type: "object",
                             name: "Selection",
-                            id: "p1032",
+                            id: "p1034",
                             attributes: {
                               indices: [],
                               line_indices: [],
@@ -289,7 +289,7 @@
                           selection_policy: {
                             type: "object",
                             name: "UnionRenderers",
-                            id: "p1033",
+                            id: "p1035",
                           },
                           data: {
                             type: "map",
@@ -325,82 +325,16 @@
                       view: {
                         type: "object",
                         name: "CDSView",
-                        id: "p1038",
+                        id: "p1040",
                         attributes: {
                           filter: {
                             type: "object",
                             name: "AllIndices",
-                            id: "p1039",
+                            id: "p1041",
                           },
                         },
                       },
                       glyph: {
-                        type: "object",
-                        name: "Scatter",
-                        id: "p1034",
-                        attributes: {
-                          x: {
-                            type: "field",
-                            field: "x",
-                          },
-                          y: {
-                            type: "field",
-                            field: "y",
-                          },
-                          size: {
-                            type: "value",
-                            value: 10,
-                          },
-                          line_color: {
-                            type: "value",
-                            value: "#1f77b4",
-                          },
-                          fill_color: {
-                            type: "field",
-                            field: "fill_color",
-                          },
-                        },
-                      },
-                      nonselection_glyph: {
-                        type: "object",
-                        name: "Scatter",
-                        id: "p1035",
-                        attributes: {
-                          x: {
-                            type: "field",
-                            field: "x",
-                          },
-                          y: {
-                            type: "field",
-                            field: "y",
-                          },
-                          size: {
-                            type: "value",
-                            value: 10,
-                          },
-                          line_color: {
-                            type: "value",
-                            value: "#1f77b4",
-                          },
-                          line_alpha: {
-                            type: "value",
-                            value: 0.1,
-                          },
-                          fill_color: {
-                            type: "field",
-                            field: "fill_color",
-                          },
-                          fill_alpha: {
-                            type: "value",
-                            value: 0.1,
-                          },
-                          hatch_alpha: {
-                            type: "value",
-                            value: 0.1,
-                          },
-                        },
-                      },
-                      muted_glyph: {
                         type: "object",
                         name: "Scatter",
                         id: "p1036",
@@ -421,258 +355,6 @@
                             type: "value",
                             value: "#1f77b4",
                           },
-                          line_alpha: {
-                            type: "value",
-                            value: 0.2,
-                          },
-                          fill_color: {
-                            type: "field",
-                            field: "fill_color",
-                          },
-                          fill_alpha: {
-                            type: "value",
-                            value: 0.2,
-                          },
-                          hatch_alpha: {
-                            type: "value",
-                            value: 0.2,
-                          },
-                        },
-                      },
-                    },
-                  },
-                ],
-                toolbar: {
-                  type: "object",
-                  name: "Toolbar",
-                  id: "p1009",
-                  attributes: {
-                    tools: [
-                      {
-                        id: "p1022",
-                      },
-                      {
-                        id: "p1023",
-                      },
-                    ],
-                    active_drag: {
-                      id: "p1023",
-                    },
-                  },
-                },
-                toolbar_location: null,
-                left: [
-                  {
-                    type: "object",
-                    name: "LinearAxis",
-                    id: "p1017",
-                    attributes: {
-                      ticker: {
-                        type: "object",
-                        name: "BasicTicker",
-                        id: "p1018",
-                        attributes: {
-                          mantissas: [
-                            1,
-                            2,
-                            5,
-                          ],
-                        },
-                      },
-                      formatter: {
-                        type: "object",
-                        name: "BasicTickFormatter",
-                        id: "p1019",
-                      },
-                      major_label_policy: {
-                        type: "object",
-                        name: "AllLabels",
-                        id: "p1020",
-                      },
-                    },
-                  },
-                ],
-                below: [
-                  {
-                    type: "object",
-                    name: "LinearAxis",
-                    id: "p1012",
-                    attributes: {
-                      ticker: {
-                        type: "object",
-                        name: "BasicTicker",
-                        id: "p1013",
-                        attributes: {
-                          mantissas: [
-                            1,
-                            2,
-                            5,
-                          ],
-                        },
-                      },
-                      formatter: {
-                        type: "object",
-                        name: "BasicTickFormatter",
-                        id: "p1014",
-                      },
-                      major_label_policy: {
-                        type: "object",
-                        name: "AllLabels",
-                        id: "p1015",
-                      },
-                    },
-                  },
-                ],
-                center: [
-                  {
-                    type: "object",
-                    name: "Grid",
-                    id: "p1016",
-                    attributes: {
-                      axis: {
-                        id: "p1012",
-                      },
-                    },
-                  },
-                  {
-                    type: "object",
-                    name: "Grid",
-                    id: "p1021",
-                    attributes: {
-                      dimension: 1,
-                      axis: {
-                        id: "p1017",
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-            0,
-            0,
-          ],
-          [
-            {
-              type: "object",
-              name: "Figure",
-              id: "p1040",
-              attributes: {
-                width: 300,
-                height: 300,
-                x_range: {
-                  type: "object",
-                  name: "DataRange1d",
-                  id: "p1041",
-                },
-                y_range: {
-                  type: "object",
-                  name: "DataRange1d",
-                  id: "p1042",
-                },
-                x_scale: {
-                  type: "object",
-                  name: "LinearScale",
-                  id: "p1049",
-                },
-                y_scale: {
-                  type: "object",
-                  name: "LinearScale",
-                  id: "p1050",
-                },
-                title: {
-                  type: "object",
-                  name: "Title",
-                  id: "p1047",
-                },
-                renderers: [
-                  {
-                    type: "object",
-                    name: "GlyphRenderer",
-                    id: "p1076",
-                    attributes: {
-                      data_source: {
-                        type: "object",
-                        name: "ColumnDataSource",
-                        id: "p1070",
-                        attributes: {
-                          selected: {
-                            type: "object",
-                            name: "Selection",
-                            id: "p1071",
-                            attributes: {
-                              indices: [],
-                              line_indices: [],
-                            },
-                          },
-                          selection_policy: {
-                            type: "object",
-                            name: "UnionRenderers",
-                            id: "p1072",
-                          },
-                          data: {
-                            type: "map",
-                            entries: [
-                              [
-                                "x",
-                                [
-                                  0,
-                                  1,
-                                  2,
-                                ],
-                              ],
-                              [
-                                "y",
-                                [
-                                  0,
-                                  1,
-                                  2,
-                                ],
-                              ],
-                              [
-                                "fill_color",
-                                [
-                                  "red",
-                                  "green",
-                                  "blue",
-                                ],
-                              ],
-                            ],
-                          },
-                        },
-                      },
-                      view: {
-                        type: "object",
-                        name: "CDSView",
-                        id: "p1077",
-                        attributes: {
-                          filter: {
-                            type: "object",
-                            name: "AllIndices",
-                            id: "p1078",
-                          },
-                        },
-                      },
-                      glyph: {
-                        type: "object",
-                        name: "Scatter",
-                        id: "p1073",
-                        attributes: {
-                          x: {
-                            type: "field",
-                            field: "x",
-                          },
-                          y: {
-                            type: "field",
-                            field: "y",
-                          },
-                          size: {
-                            type: "value",
-                            value: 10,
-                          },
-                          line_color: {
-                            type: "value",
-                            value: "#1f77b4",
-                          },
                           fill_color: {
                             type: "field",
                             field: "fill_color",
@@ -682,7 +364,7 @@
                       nonselection_glyph: {
                         type: "object",
                         name: "Scatter",
-                        id: "p1074",
+                        id: "p1037",
                         attributes: {
                           x: {
                             type: "field",
@@ -719,6 +401,258 @@
                         },
                       },
                       muted_glyph: {
+                        type: "object",
+                        name: "Scatter",
+                        id: "p1038",
+                        attributes: {
+                          x: {
+                            type: "field",
+                            field: "x",
+                          },
+                          y: {
+                            type: "field",
+                            field: "y",
+                          },
+                          size: {
+                            type: "value",
+                            value: 10,
+                          },
+                          line_color: {
+                            type: "value",
+                            value: "#1f77b4",
+                          },
+                          line_alpha: {
+                            type: "value",
+                            value: 0.2,
+                          },
+                          fill_color: {
+                            type: "field",
+                            field: "fill_color",
+                          },
+                          fill_alpha: {
+                            type: "value",
+                            value: 0.2,
+                          },
+                          hatch_alpha: {
+                            type: "value",
+                            value: 0.2,
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+                toolbar: {
+                  type: "object",
+                  name: "Toolbar",
+                  id: "p1011",
+                  attributes: {
+                    tools: [
+                      {
+                        id: "p1024",
+                      },
+                      {
+                        id: "p1025",
+                      },
+                    ],
+                    active_drag: {
+                      id: "p1025",
+                    },
+                  },
+                },
+                toolbar_location: null,
+                left: [
+                  {
+                    type: "object",
+                    name: "LinearAxis",
+                    id: "p1019",
+                    attributes: {
+                      ticker: {
+                        type: "object",
+                        name: "BasicTicker",
+                        id: "p1020",
+                        attributes: {
+                          mantissas: [
+                            1,
+                            2,
+                            5,
+                          ],
+                        },
+                      },
+                      formatter: {
+                        type: "object",
+                        name: "BasicTickFormatter",
+                        id: "p1021",
+                      },
+                      major_label_policy: {
+                        type: "object",
+                        name: "AllLabels",
+                        id: "p1022",
+                      },
+                    },
+                  },
+                ],
+                below: [
+                  {
+                    type: "object",
+                    name: "LinearAxis",
+                    id: "p1014",
+                    attributes: {
+                      ticker: {
+                        type: "object",
+                        name: "BasicTicker",
+                        id: "p1015",
+                        attributes: {
+                          mantissas: [
+                            1,
+                            2,
+                            5,
+                          ],
+                        },
+                      },
+                      formatter: {
+                        type: "object",
+                        name: "BasicTickFormatter",
+                        id: "p1016",
+                      },
+                      major_label_policy: {
+                        type: "object",
+                        name: "AllLabels",
+                        id: "p1017",
+                      },
+                    },
+                  },
+                ],
+                center: [
+                  {
+                    type: "object",
+                    name: "Grid",
+                    id: "p1018",
+                    attributes: {
+                      axis: {
+                        id: "p1014",
+                      },
+                    },
+                  },
+                  {
+                    type: "object",
+                    name: "Grid",
+                    id: "p1023",
+                    attributes: {
+                      dimension: 1,
+                      axis: {
+                        id: "p1019",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+            0,
+            0,
+          ],
+          [
+            {
+              type: "object",
+              name: "Figure",
+              id: "p1042",
+              attributes: {
+                width: 300,
+                height: 300,
+                x_range: {
+                  type: "object",
+                  name: "DataRange1d",
+                  id: "p1043",
+                },
+                y_range: {
+                  type: "object",
+                  name: "DataRange1d",
+                  id: "p1044",
+                },
+                x_scale: {
+                  type: "object",
+                  name: "LinearScale",
+                  id: "p1051",
+                },
+                y_scale: {
+                  type: "object",
+                  name: "LinearScale",
+                  id: "p1052",
+                },
+                title: {
+                  type: "object",
+                  name: "Title",
+                  id: "p1049",
+                },
+                renderers: [
+                  {
+                    type: "object",
+                    name: "GlyphRenderer",
+                    id: "p1078",
+                    attributes: {
+                      data_source: {
+                        type: "object",
+                        name: "ColumnDataSource",
+                        id: "p1072",
+                        attributes: {
+                          selected: {
+                            type: "object",
+                            name: "Selection",
+                            id: "p1073",
+                            attributes: {
+                              indices: [],
+                              line_indices: [],
+                            },
+                          },
+                          selection_policy: {
+                            type: "object",
+                            name: "UnionRenderers",
+                            id: "p1074",
+                          },
+                          data: {
+                            type: "map",
+                            entries: [
+                              [
+                                "x",
+                                [
+                                  0,
+                                  1,
+                                  2,
+                                ],
+                              ],
+                              [
+                                "y",
+                                [
+                                  0,
+                                  1,
+                                  2,
+                                ],
+                              ],
+                              [
+                                "fill_color",
+                                [
+                                  "red",
+                                  "green",
+                                  "blue",
+                                ],
+                              ],
+                            ],
+                          },
+                        },
+                      },
+                      view: {
+                        type: "object",
+                        name: "CDSView",
+                        id: "p1079",
+                        attributes: {
+                          filter: {
+                            type: "object",
+                            name: "AllIndices",
+                            id: "p1080",
+                          },
+                        },
+                      },
+                      glyph: {
                         type: "object",
                         name: "Scatter",
                         id: "p1075",
@@ -739,258 +673,6 @@
                             type: "value",
                             value: "#1f77b4",
                           },
-                          line_alpha: {
-                            type: "value",
-                            value: 0.2,
-                          },
-                          fill_color: {
-                            type: "field",
-                            field: "fill_color",
-                          },
-                          fill_alpha: {
-                            type: "value",
-                            value: 0.2,
-                          },
-                          hatch_alpha: {
-                            type: "value",
-                            value: 0.2,
-                          },
-                        },
-                      },
-                    },
-                  },
-                ],
-                toolbar: {
-                  type: "object",
-                  name: "Toolbar",
-                  id: "p1048",
-                  attributes: {
-                    tools: [
-                      {
-                        id: "p1061",
-                      },
-                      {
-                        id: "p1062",
-                      },
-                    ],
-                    active_drag: {
-                      id: "p1062",
-                    },
-                  },
-                },
-                toolbar_location: null,
-                left: [
-                  {
-                    type: "object",
-                    name: "LinearAxis",
-                    id: "p1056",
-                    attributes: {
-                      ticker: {
-                        type: "object",
-                        name: "BasicTicker",
-                        id: "p1057",
-                        attributes: {
-                          mantissas: [
-                            1,
-                            2,
-                            5,
-                          ],
-                        },
-                      },
-                      formatter: {
-                        type: "object",
-                        name: "BasicTickFormatter",
-                        id: "p1058",
-                      },
-                      major_label_policy: {
-                        type: "object",
-                        name: "AllLabels",
-                        id: "p1059",
-                      },
-                    },
-                  },
-                ],
-                below: [
-                  {
-                    type: "object",
-                    name: "LinearAxis",
-                    id: "p1051",
-                    attributes: {
-                      ticker: {
-                        type: "object",
-                        name: "BasicTicker",
-                        id: "p1052",
-                        attributes: {
-                          mantissas: [
-                            1,
-                            2,
-                            5,
-                          ],
-                        },
-                      },
-                      formatter: {
-                        type: "object",
-                        name: "BasicTickFormatter",
-                        id: "p1053",
-                      },
-                      major_label_policy: {
-                        type: "object",
-                        name: "AllLabels",
-                        id: "p1054",
-                      },
-                    },
-                  },
-                ],
-                center: [
-                  {
-                    type: "object",
-                    name: "Grid",
-                    id: "p1055",
-                    attributes: {
-                      axis: {
-                        id: "p1051",
-                      },
-                    },
-                  },
-                  {
-                    type: "object",
-                    name: "Grid",
-                    id: "p1060",
-                    attributes: {
-                      dimension: 1,
-                      axis: {
-                        id: "p1056",
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-            1,
-            0,
-          ],
-          [
-            {
-              type: "object",
-              name: "Figure",
-              id: "p1079",
-              attributes: {
-                width: 300,
-                height: 300,
-                x_range: {
-                  type: "object",
-                  name: "DataRange1d",
-                  id: "p1080",
-                },
-                y_range: {
-                  type: "object",
-                  name: "DataRange1d",
-                  id: "p1081",
-                },
-                x_scale: {
-                  type: "object",
-                  name: "LinearScale",
-                  id: "p1088",
-                },
-                y_scale: {
-                  type: "object",
-                  name: "LinearScale",
-                  id: "p1089",
-                },
-                title: {
-                  type: "object",
-                  name: "Title",
-                  id: "p1086",
-                },
-                renderers: [
-                  {
-                    type: "object",
-                    name: "GlyphRenderer",
-                    id: "p1115",
-                    attributes: {
-                      data_source: {
-                        type: "object",
-                        name: "ColumnDataSource",
-                        id: "p1109",
-                        attributes: {
-                          selected: {
-                            type: "object",
-                            name: "Selection",
-                            id: "p1110",
-                            attributes: {
-                              indices: [],
-                              line_indices: [],
-                            },
-                          },
-                          selection_policy: {
-                            type: "object",
-                            name: "UnionRenderers",
-                            id: "p1111",
-                          },
-                          data: {
-                            type: "map",
-                            entries: [
-                              [
-                                "x",
-                                [
-                                  0,
-                                  1,
-                                  2,
-                                ],
-                              ],
-                              [
-                                "y",
-                                [
-                                  0,
-                                  1,
-                                  2,
-                                ],
-                              ],
-                              [
-                                "fill_color",
-                                [
-                                  "red",
-                                  "green",
-                                  "blue",
-                                ],
-                              ],
-                            ],
-                          },
-                        },
-                      },
-                      view: {
-                        type: "object",
-                        name: "CDSView",
-                        id: "p1116",
-                        attributes: {
-                          filter: {
-                            type: "object",
-                            name: "AllIndices",
-                            id: "p1117",
-                          },
-                        },
-                      },
-                      glyph: {
-                        type: "object",
-                        name: "Scatter",
-                        id: "p1112",
-                        attributes: {
-                          x: {
-                            type: "field",
-                            field: "x",
-                          },
-                          y: {
-                            type: "field",
-                            field: "y",
-                          },
-                          size: {
-                            type: "value",
-                            value: 10,
-                          },
-                          line_color: {
-                            type: "value",
-                            value: "#1f77b4",
-                          },
                           fill_color: {
                             type: "field",
                             field: "fill_color",
@@ -1000,7 +682,7 @@
                       nonselection_glyph: {
                         type: "object",
                         name: "Scatter",
-                        id: "p1113",
+                        id: "p1076",
                         attributes: {
                           x: {
                             type: "field",
@@ -1039,7 +721,7 @@
                       muted_glyph: {
                         type: "object",
                         name: "Scatter",
-                        id: "p1114",
+                        id: "p1077",
                         attributes: {
                           x: {
                             type: "field",
@@ -1081,18 +763,18 @@
                 toolbar: {
                   type: "object",
                   name: "Toolbar",
-                  id: "p1087",
+                  id: "p1050",
                   attributes: {
                     tools: [
                       {
-                        id: "p1100",
+                        id: "p1063",
                       },
                       {
-                        id: "p1101",
+                        id: "p1064",
                       },
                     ],
                     active_drag: {
-                      id: "p1101",
+                      id: "p1064",
                     },
                   },
                 },
@@ -1101,12 +783,12 @@
                   {
                     type: "object",
                     name: "LinearAxis",
-                    id: "p1095",
+                    id: "p1058",
                     attributes: {
                       ticker: {
                         type: "object",
                         name: "BasicTicker",
-                        id: "p1096",
+                        id: "p1059",
                         attributes: {
                           mantissas: [
                             1,
@@ -1118,12 +800,12 @@
                       formatter: {
                         type: "object",
                         name: "BasicTickFormatter",
-                        id: "p1097",
+                        id: "p1060",
                       },
                       major_label_policy: {
                         type: "object",
                         name: "AllLabels",
-                        id: "p1098",
+                        id: "p1061",
                       },
                     },
                   },
@@ -1132,12 +814,12 @@
                   {
                     type: "object",
                     name: "LinearAxis",
-                    id: "p1090",
+                    id: "p1053",
                     attributes: {
                       ticker: {
                         type: "object",
                         name: "BasicTicker",
-                        id: "p1091",
+                        id: "p1054",
                         attributes: {
                           mantissas: [
                             1,
@@ -1149,12 +831,12 @@
                       formatter: {
                         type: "object",
                         name: "BasicTickFormatter",
-                        id: "p1092",
+                        id: "p1055",
                       },
                       major_label_policy: {
                         type: "object",
                         name: "AllLabels",
-                        id: "p1093",
+                        id: "p1056",
                       },
                     },
                   },
@@ -1163,21 +845,339 @@
                   {
                     type: "object",
                     name: "Grid",
-                    id: "p1094",
+                    id: "p1057",
                     attributes: {
                       axis: {
-                        id: "p1090",
+                        id: "p1051",
                       },
                     },
                   },
                   {
                     type: "object",
                     name: "Grid",
-                    id: "p1099",
+                    id: "p1062",
                     attributes: {
                       dimension: 1,
                       axis: {
+                        id: "p1058",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+            1,
+            0,
+          ],
+          [
+            {
+              type: "object",
+              name: "Figure",
+              id: "p1081",
+              attributes: {
+                width: 300,
+                height: 300,
+                x_range: {
+                  type: "object",
+                  name: "DataRange1d",
+                  id: "p1082",
+                },
+                y_range: {
+                  type: "object",
+                  name: "DataRange1d",
+                  id: "p1083",
+                },
+                x_scale: {
+                  type: "object",
+                  name: "LinearScale",
+                  id: "p1090",
+                },
+                y_scale: {
+                  type: "object",
+                  name: "LinearScale",
+                  id: "p1091",
+                },
+                title: {
+                  type: "object",
+                  name: "Title",
+                  id: "p1088",
+                },
+                renderers: [
+                  {
+                    type: "object",
+                    name: "GlyphRenderer",
+                    id: "p1117",
+                    attributes: {
+                      data_source: {
+                        type: "object",
+                        name: "ColumnDataSource",
+                        id: "p1111",
+                        attributes: {
+                          selected: {
+                            type: "object",
+                            name: "Selection",
+                            id: "p1112",
+                            attributes: {
+                              indices: [],
+                              line_indices: [],
+                            },
+                          },
+                          selection_policy: {
+                            type: "object",
+                            name: "UnionRenderers",
+                            id: "p1113",
+                          },
+                          data: {
+                            type: "map",
+                            entries: [
+                              [
+                                "x",
+                                [
+                                  0,
+                                  1,
+                                  2,
+                                ],
+                              ],
+                              [
+                                "y",
+                                [
+                                  0,
+                                  1,
+                                  2,
+                                ],
+                              ],
+                              [
+                                "fill_color",
+                                [
+                                  "red",
+                                  "green",
+                                  "blue",
+                                ],
+                              ],
+                            ],
+                          },
+                        },
+                      },
+                      view: {
+                        type: "object",
+                        name: "CDSView",
+                        id: "p1118",
+                        attributes: {
+                          filter: {
+                            type: "object",
+                            name: "AllIndices",
+                            id: "p1119",
+                          },
+                        },
+                      },
+                      glyph: {
+                        type: "object",
+                        name: "Scatter",
+                        id: "p1114",
+                        attributes: {
+                          x: {
+                            type: "field",
+                            field: "x",
+                          },
+                          y: {
+                            type: "field",
+                            field: "y",
+                          },
+                          size: {
+                            type: "value",
+                            value: 10,
+                          },
+                          line_color: {
+                            type: "value",
+                            value: "#1f77b4",
+                          },
+                          fill_color: {
+                            type: "field",
+                            field: "fill_color",
+                          },
+                        },
+                      },
+                      nonselection_glyph: {
+                        type: "object",
+                        name: "Scatter",
+                        id: "p1115",
+                        attributes: {
+                          x: {
+                            type: "field",
+                            field: "x",
+                          },
+                          y: {
+                            type: "field",
+                            field: "y",
+                          },
+                          size: {
+                            type: "value",
+                            value: 10,
+                          },
+                          line_color: {
+                            type: "value",
+                            value: "#1f77b4",
+                          },
+                          line_alpha: {
+                            type: "value",
+                            value: 0.1,
+                          },
+                          fill_color: {
+                            type: "field",
+                            field: "fill_color",
+                          },
+                          fill_alpha: {
+                            type: "value",
+                            value: 0.1,
+                          },
+                          hatch_alpha: {
+                            type: "value",
+                            value: 0.1,
+                          },
+                        },
+                      },
+                      muted_glyph: {
+                        type: "object",
+                        name: "Scatter",
+                        id: "p1116",
+                        attributes: {
+                          x: {
+                            type: "field",
+                            field: "x",
+                          },
+                          y: {
+                            type: "field",
+                            field: "y",
+                          },
+                          size: {
+                            type: "value",
+                            value: 10,
+                          },
+                          line_color: {
+                            type: "value",
+                            value: "#1f77b4",
+                          },
+                          line_alpha: {
+                            type: "value",
+                            value: 0.2,
+                          },
+                          fill_color: {
+                            type: "field",
+                            field: "fill_color",
+                          },
+                          fill_alpha: {
+                            type: "value",
+                            value: 0.2,
+                          },
+                          hatch_alpha: {
+                            type: "value",
+                            value: 0.2,
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+                toolbar: {
+                  type: "object",
+                  name: "Toolbar",
+                  id: "p1089",
+                  attributes: {
+                    tools: [
+                      {
+                        id: "p1102",
+                      },
+                      {
+                        id: "p1103",
+                      },
+                    ],
+                    active_drag: {
+                      id: "p1103",
+                    },
+                  },
+                },
+                toolbar_location: null,
+                left: [
+                  {
+                    type: "object",
+                    name: "LinearAxis",
+                    id: "p1097",
+                    attributes: {
+                      ticker: {
+                        type: "object",
+                        name: "BasicTicker",
+                        id: "p1098",
+                        attributes: {
+                          mantissas: [
+                            1,
+                            2,
+                            5,
+                          ],
+                        },
+                      },
+                      formatter: {
+                        type: "object",
+                        name: "BasicTickFormatter",
+                        id: "p1099",
+                      },
+                      major_label_policy: {
+                        type: "object",
+                        name: "AllLabels",
+                        id: "p1100",
+                      },
+                    },
+                  },
+                ],
+                below: [
+                  {
+                    type: "object",
+                    name: "LinearAxis",
+                    id: "p1092",
+                    attributes: {
+                      ticker: {
+                        type: "object",
+                        name: "BasicTicker",
+                        id: "p1093",
+                        attributes: {
+                          mantissas: [
+                            1,
+                            2,
+                            5,
+                          ],
+                        },
+                      },
+                      formatter: {
+                        type: "object",
+                        name: "BasicTickFormatter",
+                        id: "p1094",
+                      },
+                      major_label_policy: {
+                        type: "object",
+                        name: "AllLabels",
                         id: "p1095",
+                      },
+                    },
+                  },
+                ],
+                center: [
+                  {
+                    type: "object",
+                    name: "Grid",
+                    id: "p1096",
+                    attributes: {
+                      axis: {
+                        id: "p1092",
+                      },
+                    },
+                  },
+                  {
+                    type: "object",
+                    name: "Grid",
+                    id: "p1101",
+                    attributes: {
+                      dimension: 1,
+                      axis: {
+                        id: "p1097",
                       },
                     },
                   },


### PR DESCRIPTION
This is based on https://github.com/bokeh/bokeh/pull/14423 to get the task finished. I was not allowed to push to the original PR.

- [x] issues: fixes #14248 

In this PR the defaults of the DatetimeTickFormatter are printed as a table.

![grafik](https://github.com/user-attachments/assets/6277255e-b36d-45ad-9a64-896fedee72ca)

I also changed the list for the format strings to a table, too.

![grafik](https://github.com/user-attachments/assets/b972696d-46a5-4799-8d72-b0bec294c076)

And I fixed a few typos.

In my opinion, this should be part of the upcoming release `3.7.3`, because the braking changes for the DatetimeTickFormatter made in `3.7.0` are not documented yet.



