### PR TITLE
fix links to code pen

### DIFF
--- a/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
+++ b/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
@@ -1,6 +1,6 @@
 <div id="codepen-html">
 <!--
-{%- include 'bokehjs_html_template.html' -%}
+{%- include 'bokehjs_html_template.html' %}
 -->
 </div>
 {% for css_file in css_files %}
@@ -23,7 +23,7 @@
       if (form === null) { return; }
 
       const data = {
-        title: el.dataset["data-codepen-title"],
+        title: el.getAttribute("data-codepen-title"),
         description: "",
         html: HTML,
         html_pre_processor: "none",

--- a/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
+++ b/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
@@ -10,65 +10,63 @@
 {% for js_file in js_files %}
 <script type="text/javascript" src="{{js_file}}"></script>{% endfor %}
 
+
+
 <script>
-    (function () {
+  (function () {
 
-        // this monkey patches Plotting.show to insert the plot below
-        // the script block
+    // this monkey patches Plotting.show to insert the plot below
+    // the script block
 
-        const originalPltShow = Bokeh.Plotting.show;
-        const newPlotShow = function(layoutDomObj, target) {
-            if(typeof target === "undefined"){
-                target = document.currentScript.parentElement;
-            }
-            return originalPltShow(layoutDomObj, target);
-        };
-        Bokeh.Plotting.show = newPlotShow;
-    })()
-    $(function() {
+    const originalPltShow = Bokeh.Plotting.show;
+    const newPlotShow = function(layoutDomObj, target) {
+      if(typeof target === "undefined"){
+        target = document.currentScript.parentElement;
+      }
+      return originalPltShow(layoutDomObj, target);
+    };
+    Bokeh.Plotting.show = newPlotShow;
+  })()
 
+  document.addEventListener("DOMContentLoaded", () => {
+    let HTML = ""
+    const html_el = document.getElementById("codepen-html")
+    for (const child_el of html_el.childNodes) {
+      // nodeType == 8 is the special number for comment nodes
+      if (child_el.nodeType == 8) {
+        HTML = child_el.textContent
+      }
+    }
+    document.querySelectorAll(".codepen-wrap").forEach((el) => {
+      let form = el.querySelector("form")
+      // do nothing of no form tag exists
+      if (form === null){return;}
 
-        let HTML = "";
-        const htmlEl = document.getElementById("codepen-html");
-        for(let i=0; i < htmlEl.childNodes.length; i++){
-            //nodeType == 8 is the special number for comment nodes
-            if(htmlEl.childNodes[i].nodeType == 8){
-                HTML = htmlEl.childNodes[i].textContent;
-            }
-        }
-        $(".codepen-wrap ").each(function(iterEl) {
-                const el = $(this),
-                        codeInside = el.find('.codepen-content')[0].innerText,
-                        CSS = "",
-                        JS = codeInside;
+      const JS = el.querySelector(".codepen-content").innerText
 
-                const data = {
-                  title              : el.attr('data-codepen-title'),
-                  description        : "",
-                  html               : HTML,
-                  html_pre_processor : "none",
-                  css                : CSS,
-                  css_pre_processor  : "none",
-                  css_starter        : "neither",
-                  css_prefix_free    : false,
-                  js                 : JS,
-                  js_pre_processor   : "none",
-                  js_modernizr       : false,
-                  js_library         : "",
-                  html_classes       : "",
-                  css_external       : "",
-                  js_external        : "",
-                  template           : true
-                };
-                const JSONstring =
-                  JSON.stringify(data)
-                  // Quotes will screw up the JSON
-                  .replace(/"/g, "&quot;")
-                  .replace(/'/g, "&apos;");
-                const jsonInput ='<input type="hidden" name="data" value=\'' +
-                          JSONstring + '\'>';
-                el.find('form').append(jsonInput);
-          });
-        });
+      const data = {
+        title: el.dataset["data-codepen-title"],
+        description: "",
+        html: HTML,
+        html_pre_processor: "none",
+        css: "",
+        css_pre_processor: "none",
+        css_starter: "neither",
+        css_prefix_free: false,
+        js: JS,
+        js_pre_processor: "none",
+        js_modernizr: false,
+        js_library: "",
+        html_classes: "",
+        css_external: "",
+        js_external: "",
+        template: true,
+      }
+      // Quotes will screw up the JSON
+      const json_string = JSON.stringify(data).replace(/"/g, "&quot;").replace(/'/g, "&apos;")
+      const json_input = `<input type="hidden" name="data" value="${json_string}">`
+      form.innerHTML += json_input
+    })
+  })
 
 </script>

--- a/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
+++ b/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
@@ -1,32 +1,26 @@
 <div id="codepen-html">
-
-
 <!--
-{% include 'bokehjs_html_template.html' %}
+{%- include 'bokehjs_html_template.html' -%}
 -->
 </div>
 {% for css_file in css_files %}
 <link rel="stylesheet" href="{{css_file}}" type="text/css" />{% endfor %}
 {% for js_file in js_files %}
 <script type="text/javascript" src="{{js_file}}"></script>{% endfor %}
-
-
-
 <script>
   document.addEventListener("DOMContentLoaded", () => {
     let HTML = ""
     const html_el = document.getElementById("codepen-html")
     for (const child_el of html_el.childNodes) {
       if (child_el.nodeType === Node.COMMENT_NODE) {
-        HTML = child_el.textContent
+        // remove first line break to avoid an empty line in the html section of code pen
+        HTML = child_el.textContent.replace(/\n/, "")
       }
     }
     document.querySelectorAll(".codepen-wrap").forEach((el) => {
       let form = el.querySelector("form")
-      // do nothing of no form tag exists
-      if (form === null){return;}
-
-      const JS = el.querySelector(".codepen-content").innerText
+      // do nothing if no form tag exists
+      if (form === null) { return; }
 
       const data = {
         title: el.dataset["data-codepen-title"],
@@ -37,7 +31,7 @@
         css_pre_processor: "none",
         css_starter: "neither",
         css_prefix_free: false,
-        js: JS,
+        js: el.querySelector(".codepen-content").innerText,
         js_pre_processor: "none",
         js_modernizr: false,
         js_library: "",
@@ -52,5 +46,4 @@
       form.innerHTML += json_input
     })
   })
-
 </script>

--- a/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
+++ b/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
@@ -13,21 +13,6 @@
 
 
 <script>
-  (function () {
-
-    // this monkey patches Plotting.show to insert the plot below
-    // the script block
-
-    const originalPltShow = Bokeh.Plotting.show;
-    const newPlotShow = function(layoutDomObj, target) {
-      if(typeof target === "undefined"){
-        target = document.currentScript.parentElement;
-      }
-      return originalPltShow(layoutDomObj, target);
-    };
-    Bokeh.Plotting.show = newPlotShow;
-  })()
-
   document.addEventListener("DOMContentLoaded", () => {
     let HTML = ""
     const html_el = document.getElementById("codepen-html")

--- a/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
+++ b/src/bokeh/sphinxext/_templates/bokehjs_codepen_init.html
@@ -17,8 +17,7 @@
     let HTML = ""
     const html_el = document.getElementById("codepen-html")
     for (const child_el of html_el.childNodes) {
-      // nodeType == 8 is the special number for comment nodes
-      if (child_el.nodeType == 8) {
+      if (child_el.nodeType === Node.COMMENT_NODE) {
         HTML = child_el.textContent
       }
     }

--- a/src/bokeh/sphinxext/_templates/bokehjs_content_epilogue.html
+++ b/src/bokeh/sphinxext/_templates/bokehjs_content_epilogue.html
@@ -1,16 +1,14 @@
   </div>
    {% if enable_codepen %}
    <form action="https://codepen.io/pen/define" method="POST" target="_blank">
-     <input
-       value="Try {{ heading }} on CodePen"
-       type="submit" class="codepen-open"/>
+     <input value="Try '{{ title }}' on CodePen" type="submit" class="codepen-open"/>
    </form>
    {% endif %}
 
    <p>The code above generates the following plot:</p>
    <script>
-     (function () {
-         {{js_source}}
+     (function() {
+         {{ js_source }}
      })();
    </script>
 </div>

--- a/src/bokeh/sphinxext/_templates/bokehjs_html_template.html
+++ b/src/bokeh/sphinxext/_templates/bokehjs_html_template.html
@@ -1,23 +1,9 @@
-<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Complete Example</title>
 {% for css_file in css_files %}
-<link rel="stylesheet" href="{{css_file}}" type="text/css" />{% endfor %}
+<link rel="stylesheet" href="{{css_file}}" type="text/css" />
+{% endfor %}
 {%- for js_file in js_files %}
 <script type="text/javascript" src="{{ js_file }}"></script>
 {%- endfor %}
-
-<script>
-//The order of CSS and JS imports above is important.
-</script>
-{% if bjs_script %}<script>
-{{ bjs_script }}
-</script>{% endif %}
-</head>
-
-<body>
-</body>
-
-</html>
+{% if bjs_script %}
+<script>{{ bjs_script }}</script>
+{% endif %}

--- a/src/bokeh/sphinxext/_templates/bokehjs_html_template.html
+++ b/src/bokeh/sphinxext/_templates/bokehjs_html_template.html
@@ -1,9 +1,9 @@
-{% for css_file in css_files %}
+{%- for css_file in css_files %}
 <link rel="stylesheet" href="{{css_file}}" type="text/css" />
-{% endfor %}
+{%- endfor %}
 {%- for js_file in js_files %}
 <script type="text/javascript" src="{{ js_file }}"></script>
 {%- endfor %}
-{% if bjs_script %}
+{%- if bjs_script %}
 <script>{{ bjs_script }}</script>
-{% endif %}
+{%- endif %}

--- a/src/bokeh/sphinxext/bokehjs_content.py
+++ b/src/bokeh/sphinxext/bokehjs_content.py
@@ -251,6 +251,8 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_node(bokehjs_content, html=bokehjs_content.html)
     app.add_directive("bokehjs-content", BokehJSContent)
+    # add jquery from CDN to activate working links to code pen online editor, see GitHub issue #14468
+    app.add_js_file("https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js")
 
     return PARALLEL_SAFE
 

--- a/src/bokeh/sphinxext/bokehjs_content.py
+++ b/src/bokeh/sphinxext/bokehjs_content.py
@@ -251,8 +251,6 @@ def setup(app):
     """ Required Sphinx extension setup function. """
     app.add_node(bokehjs_content, html=bokehjs_content.html)
     app.add_directive("bokehjs-content", BokehJSContent)
-    # add jquery from CDN to activate working links to code pen online editor, see GitHub issue #14468
-    app.add_js_file("https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js")
 
     return PARALLEL_SAFE
 


### PR DESCRIPTION
It turns out that the code was working but an import of `jquery` was missing. Without this js library an `Uncaught ReferenceError: $ is not defined` error is raised.

The missing link to `jquery` is added to the `bokehjs-content` extention for sphinx. The broken links to code pen were mentioned in #13867 for the first time.

- [ ] issues: fixes #14468

After loading the missing `jquery` library and also cleaning unnecessary html code for code pen the result on my local docs is shown below:

![fix_link_to_codepen](https://github.com/user-attachments/assets/bbbb6f01-96f8-42d7-8b5b-a5613896cb3c)

It think this is a candidate for a point release. Maybe it is to late for `3.7.3` but I will tag this with `NEEDS BACK PORT` for the moment.
