### PR TITLE
Improve corner case handling in datetime formatter

### DIFF
--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -24,8 +24,19 @@ export const DEFAULT_FORMATTERS: {[key in BuiltinFormatter]: FormatterFunc} = {
   raw:      (value: unknown, _format: string, _special_vars: Vars) => to_string(value),
   basic:    (value: unknown,  format: string,  special_vars: Vars) => basic_formatter(value, format, special_vars),
   numeral:  (value: unknown,  format: string, _special_vars: Vars) => Numbro.format(value, format),
-  datetime: (value: unknown,  format: string, _special_vars: Vars) => tz(value, format),
+  datetime: (value: unknown,  format: string, _special_vars: Vars) => datetime(value, format),
   printf:   (value: unknown,  format: string, _special_vars: Vars) => sprintf(format, value),
+}
+
+/**
+ * Format finite numbers as dates or return NaN.
+ */
+export function datetime(value: unknown, format?: string): string {
+  if (isNumber(value) && isFinite(value)) {
+    return tz(value, format)
+  } else {
+    return "NaN"
+  }
 }
 
 export function sprintf(format: string, ...args: unknown[]): string {

--- a/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
+++ b/bokehjs/src/lib/models/formatters/datetime_tick_formatter.ts
@@ -1,12 +1,11 @@
 import {ContextWhich, Location, ResolutionType} from "core/enums"
 import type * as p from "core/properties"
 import {assert} from "core/util/assert"
-import {sprintf} from "core/util/templating"
+import {datetime, sprintf} from "core/util/templating"
 import {isString, isArray, isBoolean, is_undefined} from "core/util/types"
 import type {Arrayable} from "core/types"
 import {TickFormatter} from "models/formatters/tick_formatter"
 import {ONE_DAY, ONE_HOUR, ONE_MILLI, ONE_MINUTE, ONE_MONTH, ONE_SECOND, ONE_YEAR} from "models/tickers/util"
-import tz from "timezone"
 
 export type {ResolutionType} from "core/enums"
 
@@ -74,7 +73,7 @@ export function _get_resolution(resolution_secs: number, span_secs: number): Res
 }
 
 export function _mktime(t: number): number[] {
-  return tz(t, "%Y %m %d %H %M %S").split(/\s+/).map(e => parseInt(e, 10))
+  return datetime(t, "%Y %m %d %H %M %S").split(/\s+/).map(e => parseInt(e, 10))
 }
 
 export function _strftime(t: number, format: string): string {
@@ -92,7 +91,7 @@ export function _strftime(t: number, format: string): string {
     return format
   }
 
-  return tz(t, format)
+  return datetime(t, format)
 }
 
 export function _us(t: number): number {

--- a/bokehjs/src/lib/models/widgets/sliders/date_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/sliders/date_range_slider.ts
@@ -1,10 +1,9 @@
-import tz from "timezone"
-
 import type {SliderSpec} from "./abstract_slider"
 import {NumericalRangeSlider, NumericalRangeSliderView} from "./numerical_range_slider"
 import type {TickFormatter} from "../../formatters/tick_formatter"
 import type * as p from "core/properties"
 import {isString} from "core/util/types"
+import {datetime} from "core/util/templating"
 
 export class DateRangeSliderView extends NumericalRangeSliderView {
   declare model: DateRangeSlider
@@ -20,7 +19,7 @@ export class DateRangeSliderView extends NumericalRangeSliderView {
 
   protected _formatter(value: number, format: string | TickFormatter): string {
     if (isString(format)) {
-      return tz(value, format)
+      return datetime(value, format)
     } else {
       return format.compute(value)
     }

--- a/bokehjs/src/lib/models/widgets/sliders/date_slider.ts
+++ b/bokehjs/src/lib/models/widgets/sliders/date_slider.ts
@@ -1,10 +1,9 @@
-import tz from "timezone"
-
 import type {SliderSpec} from "./abstract_slider"
 import {NumericalSlider, NumericalSliderView} from "./numerical_slider"
 import type {TickFormatter} from "../../formatters/tick_formatter"
 import type * as p from "core/properties"
 import {isString} from "core/util/types"
+import {datetime} from "core/util/templating"
 
 export class DateSliderView extends NumericalSliderView {
   declare model: DateSlider
@@ -20,7 +19,7 @@ export class DateSliderView extends NumericalSliderView {
 
   protected _formatter(value: number, format: string | TickFormatter): string {
     if (isString(format)) {
-      return tz(value, format)
+      return datetime(value, format)
     } else {
       return format.compute(value)
     }

--- a/bokehjs/src/lib/models/widgets/sliders/datetime_range_slider.ts
+++ b/bokehjs/src/lib/models/widgets/sliders/datetime_range_slider.ts
@@ -1,9 +1,8 @@
-import tz from "timezone"
-
 import {NumericalRangeSlider, NumericalRangeSliderView} from "./numerical_range_slider"
 import type {TickFormatter} from "../../formatters/tick_formatter"
 import type * as p from "core/properties"
 import {isString} from "core/util/types"
+import {datetime} from "core/util/templating"
 
 export class DatetimeRangeSliderView extends NumericalRangeSliderView {
   declare model: DatetimeRangeSlider
@@ -13,7 +12,7 @@ export class DatetimeRangeSliderView extends NumericalRangeSliderView {
 
   protected _formatter(value: number, format: string | TickFormatter): string {
     if (isString(format)) {
-      return tz(value, format)
+      return datetime(value, format)
     } else {
       return format.compute(value)
     }

--- a/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
+++ b/bokehjs/src/lib/models/widgets/tables/cell_formatters.ts
@@ -1,4 +1,3 @@
-import tz from "timezone"
 import * as Numbro from "@bokeh/numbro"
 import {_} from "underscore.template"
 
@@ -12,6 +11,7 @@ import {color2css, rgba2css} from "core/util/color"
 import {Model} from "../../../model"
 import {ColorMapper} from "../../mappers/color_mapper"
 import {unreachable} from "core/util/assert"
+import {datetime} from "core/util/templating"
 
 export namespace CellFormatter {
   export type Attrs = p.AttrsOf<Props>
@@ -395,7 +395,7 @@ export class DateFormatter extends StringFormatter {
       } else if (value == null) {
         return this.null_format
       } else {
-        return tz(epoch, this.getFormat())
+        return datetime(epoch, this.getFormat())
       }
     })()
 

--- a/bokehjs/test/unit/core/util/templating.ts
+++ b/bokehjs/test/unit/core/util/templating.ts
@@ -22,6 +22,11 @@ describe("templating module", () => {
     it("should have a datetime formatter", () => {
       const f = tmpl.DEFAULT_FORMATTERS.datetime
       expect(f(946684800000, "%m/%d/%Y", {})).to.be.equal("01/01/2000")
+
+      expect(f(NaN, "%m/%d/%Y", {})).to.be.equal("NaN")
+      expect(f(Infinity, "%m/%d/%Y", {})).to.be.equal("NaN")
+      expect(f(-Infinity, "%m/%d/%Y", {})).to.be.equal("NaN")
+      expect(f(null, "%m/%d/%Y", {})).to.be.equal("NaN")
     })
 
     it("should have a printf formatter", () => {


### PR DESCRIPTION
The formatter returns some bogus output when unsupported inputs are provided. This PR fixes that by intercepting arguments that aren't finite numbers and returns `"NaN"` in such cases.

fixes #14413