### PR TITLE
Avoid re-appending views if order is unchanged

### DIFF
--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -6,6 +6,7 @@ import {Align, Dimensions, FlowMode, SizingMode} from "core/enums"
 import {px} from "core/dom"
 import type {Display, CSSStyles} from "core/css"
 import {isNumber, isArray} from "core/util/types"
+import {enumerate} from "core/util/iterator"
 import type * as p from "core/properties"
 
 import type {ViewStorage, IterViews} from "core/build_views"
@@ -175,8 +176,7 @@ export abstract class LayoutDOMView extends PaneView {
     // Since appending to a DOM node will move the node to the end if it has
     // already been added appending all the children in order will result in
     // correct ordering.
-    for (let i = 0; i < this.child_views.length; i++) {
-      const view = this.child_views[i]
+    for (const [view, i] of enumerate(this.child_views)) {
       const is_new = created_views.has(view)
       const target = view.rendering_target() ?? this.self_target
       if (is_new) {

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -164,9 +164,9 @@ export abstract class LayoutDOMView extends PaneView {
     let matching_index = null
     for (let i = 0; i < current_views.length; i++) {
       if (current_views[i] === this.child_views[i]) {
-	matching_index = i
+        matching_index = i
       } else {
-	break
+        break
       }
     }
 

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -153,18 +153,33 @@ export abstract class LayoutDOMView extends PaneView {
   protected _update_children(): void {}
 
   async update_children(): Promise<void> {
+    let current_views = [...this.child_views]
     const created = await this.build_child_views()
     const created_views = new Set(created)
+
+    // Find index up to which the order of the existing views
+    // matches the order of the new views. This allows us to
+    // skip re-inserting the views up to this point
+    current_views = current_views.filter((view) => this.child_views.includes(view))
+    let matching_index = null
+    for (let i = 0; i < current_views.length; i++) {
+      if (current_views[i] === this.child_views[i]) {
+	matching_index = i
+      } else {
+	break
+      }
+    }
 
     // Since appending to a DOM node will move the node to the end if it has
     // already been added appending all the children in order will result in
     // correct ordering.
-    for (const view of this.child_views) {
+    for (let i = 0; i < this.child_views.length; i++) {
+      const view = this.child_views[i]
       const is_new = created_views.has(view)
       const target = view.rendering_target() ?? this.self_target
       if (is_new) {
         view.render_to(target)
-      } else {
+      } else if (matching_index === null || i > matching_index) {
         target.append(view.el)
       }
     }

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -153,14 +153,16 @@ export abstract class LayoutDOMView extends PaneView {
   protected _update_children(): void {}
 
   async update_children(): Promise<void> {
-    let current_views = [...this.child_views]
     const created = await this.build_child_views()
     const created_views = new Set(created)
 
     // Find index up to which the order of the existing views
     // matches the order of the new views. This allows us to
     // skip re-inserting the views up to this point
-    current_views = current_views.filter((view) => this.child_views.includes(view))
+    const current_views = Array.from(this.shadow_el.children).flatMap(el => {
+      const view = this.child_views.find(view => view.el === el)
+      return view === undefined ? [] : [view]
+    })
     let matching_index = null
     for (let i = 0; i < current_views.length; i++) {
       if (current_views[i] === this.child_views[i]) {


### PR DESCRIPTION
A follow-up to https://github.com/bokeh/bokeh/issues/14458. While the approach in https://github.com/bokeh/bokeh/issues/14459 was fine, re-appending all the existing elements still has the potential to cause issues for mutation observers and virtual DOM libraries that track the position of DOM nodes. Since the most common case isn't inserting or re-ordering components, but appending or removing components this PR implements a solution that avoids mutating the children up to the point where the ordering changed.