### PR TITLE
compress base64 buffers

### DIFF
--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -23,6 +23,7 @@
         "@types/proj4": "^2.5.5",
         "@types/sprintf-js": "^1.1.4",
         "choices.js": "^10.2.0",
+        "fflate": "^0.8.2",
         "flatbush": "^4.2.0",
         "flatpickr": "^4.6.13",
         "mathjax-full": "^3.2.2",
@@ -2078,6 +2079,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -47,6 +47,7 @@
     "@types/proj4": "^2.5.5",
     "@types/sprintf-js": "^1.1.4",
     "choices.js": "^10.2.0",
+    "fflate": "^0.8.2",
     "flatbush": "^4.2.0",
     "flatpickr": "^4.6.13",
     "mathjax-full": "^3.2.2",

--- a/bokehjs/test/unit/core/serialization.ts
+++ b/bokehjs/test/unit/core/serialization.ts
@@ -182,7 +182,7 @@ describe("core/serialization module", () => {
           type: "bytes",
           data: new Base64Buffer(buf0),
         },
-        json: '{"type":"bytes","data":"AAECAwQFBg=="}',
+        json: '{"type":"bytes","data":"H4sIAAAAAAAAA2NgZGJmYWUDAPkJWK0HAAAA"}',
       })
     })
 
@@ -199,7 +199,7 @@ describe("core/serialization module", () => {
           order: BYTE_ORDER,
           dtype: "int32",
         },
-        json: `{"type":"typed_array","array":{"type":"bytes","data":"AQAAAAIAAAADAAAA"},"order":"${BYTE_ORDER}","dtype":"int32"}`,
+        json: `{"type":"typed_array","array":{"type":"bytes","data":"H4sIAAAAAAAAA2NkYGBgAmJmIAYAkyLgsAwAAAA="},"order":"${BYTE_ORDER}","dtype":"int32"}`,
       })
 
       const arr1 = new Float64Array([1.1, 2.1, 3.1, 4.1, 5.1, 6.1])
@@ -214,7 +214,7 @@ describe("core/serialization module", () => {
           order: BYTE_ORDER,
           dtype: "float64",
         },
-        json: `{"type":"typed_array","array":{"type":"bytes","data":"mpmZmZmZ8T/NzMzMzMwAQM3MzMzMzAhAZmZmZmZmEEBmZmZmZmYUQGZmZmZmZhhA"},"order":"${BYTE_ORDER}","dtype":"float64"}`,
+        json: `{"type":"typed_array","array":{"type":"bytes","data":"H4sIAAAAAAAAA5s1EwQ+2p89AwIMDhCawyENDASgtAiUlnAAALssYAAwAAAA"},"order":"${BYTE_ORDER}","dtype":"float64"}`,
       })
     })
 
@@ -232,7 +232,7 @@ describe("core/serialization module", () => {
           dtype: "int32",
           shape: [1, 3],
         },
-        json: `{"type":"ndarray","array":{"type":"bytes","data":"AQAAAAIAAAADAAAA"},"order":"${BYTE_ORDER}","dtype":"int32","shape":[1,3]}`,
+        json: `{"type":"ndarray","array":{"type":"bytes","data":"H4sIAAAAAAAAA2NkYGBgAmJmIAYAkyLgsAwAAAA="},"order":"${BYTE_ORDER}","dtype":"int32","shape":[1,3]}`,
       })
 
       const nd1 = ndarray([1.1, 2.1, 3.1, 4.1, 5.1, 6.1], {dtype: "float64", shape: [2, 3]})
@@ -248,7 +248,7 @@ describe("core/serialization module", () => {
           dtype: "float64",
           shape: [2, 3],
         },
-        json: `{"type":"ndarray","array":{"type":"bytes","data":"mpmZmZmZ8T/NzMzMzMwAQM3MzMzMzAhAZmZmZmZmEEBmZmZmZmYUQGZmZmZmZhhA"},"order":"${BYTE_ORDER}","dtype":"float64","shape":[2,3]}`,
+        json: `{"type":"ndarray","array":{"type":"bytes","data":"H4sIAAAAAAAAA5s1EwQ+2p89AwIMDhCawyENDASgtAiUlnAAALssYAAwAAAA"},"order":"${BYTE_ORDER}","dtype":"float64","shape":[2,3]}`,
       })
     })
 

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -67,7 +67,7 @@ import {linspace, logspace, range} from "@bokehjs/core/util/array"
 import {keys} from "@bokehjs/core/util/object"
 import {ndarray} from "@bokehjs/core/util/ndarray"
 import {BitSet} from "@bokehjs/core/util/bitset"
-import {base64_to_buffer} from "@bokehjs/core/util/buffer"
+import {b64decode} from "@bokehjs/core/util/buffer"
 import type {XY} from "@bokehjs/core/util/bbox"
 import {div} from "@bokehjs/core/dom"
 import type {Color, Arrayable} from "@bokehjs/core/types"
@@ -327,7 +327,7 @@ describe("Bug", () => {
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "AAAAAAAAAACHROdKGFfWP4dE50oYV+Y/ZXMtOFLB8D+HROdKGFf2P6kVoV3e7Ps/ZXMtOFLBAED2W4pBNYwDQIdE50oYVwZAGC1EVPshCUA=",
+                          data: "H4sIAAAAAAACE2NggIB2l+deEuHX7CH0M/vUYl2LoIMfoPxv9itFF8bee/MbKs7g8C26y9G0h9kBIs/mIKHrEvJbkdMBAOE1l61QAAAA",
                         },
                         dtype: "float64",
                         order: "little",
@@ -337,7 +337,7 @@ describe("Bug", () => {
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "AAAAAAAA8D+Mcwt+GjrGPxstUkL2Ee6/BAAAAAAA4L83UM+ib4PoPzpQz6Jvg+g/8v//////378eLVJC9hHuv3NzC34aOsY/AAAAAAAA8D8=",
+                          data: "H4sIAAAAAAACE2NgAIEP9j3F3HVSVsfspXWDnL4JvtvPAhZ/sN884Pyi/OYX9lZQ+tN/ELi/Xw6qrhiqjwFqDgAXT+ECUAAAAA==",
                         },
                         dtype: "float64",
                         order: "little",
@@ -347,7 +347,7 @@ describe("Bug", () => {
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "AAAAAAAAAAAcFjxSt5HkPxccgYyLg+8/q0xY6Hq26z/4C4p0qOPVP/QLinSo49W/qExY6Hq2678YHIGMi4Pvvx8WPFK3keS/B1wUMyamsbw=",
+                          data: "H4sIAAAAAAACE2NggAAZMZug7ROf2IvLNPZ0N7+3X+0T8aJq22v7H9xdJSseX7X/AqH3r4CI75eAqNsvD9G3nz1GxFht2cY9ABjYpdhQAAAA",
                         },
                         dtype: "float64",
                         order: "little",
@@ -464,7 +464,7 @@ describe("Bug", () => {
       expect(render.callCount).to.be.equal(1)
       render.resetHistory()
 
-      const url = URL.createObjectURL(new Blob([base64_to_buffer(png)]))
+      const url = URL.createObjectURL(new Blob([b64decode(png)]))
       const p2 = fig([200, 200])
       p2.image_url([url], 0, 0, 10, 10)
       await display(p2)

--- a/examples/topics/images/image_rgba.py
+++ b/examples/topics/images/image_rgba.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from bokeh.plotting import figure, show
 
-N = 20
+N = 500
 img = np.empty((N,N), dtype=np.uint32)
 view = img.view(dtype=np.uint8).reshape((N, N, 4))
 for i in range(N):

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import base64
 import datetime as dt
+import gzip
 import sys
 from array import array as TypedArray
 from math import isinf, isnan
@@ -174,8 +175,13 @@ class Buffer:
     def to_bytes(self) -> bytes:
         return self.data.tobytes() if isinstance(self.data, memoryview) else self.data
 
+    def to_compressed_bytes(self) -> bytes:
+        # we do not want the result to be different depending on mtime, since that is
+        # irrelevant and also makes things harder to test, so set mtime=0 here
+        return gzip.compress(self.to_bytes(), mtime=0)
+
     def to_base64(self) -> str:
-        return base64.b64encode(self.data).decode("utf-8")
+        return base64.b64encode(self.to_compressed_bytes()).decode("utf-8")
 
 T = TypeVar("T")
 
@@ -604,7 +610,7 @@ class Deserializer:
         data = obj["data"]
 
         if isinstance(data, str):
-            return base64.b64decode(data)
+            return gzip.decompress(base64.b64decode(data))
         elif isinstance(data, Buffer):
             buffer = data # in case of decode(encode(obj))
         else:

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -45,6 +45,7 @@ from typing import (
 import numpy as np
 
 # Bokeh imports
+from ..settings import settings
 from ..util.dataclasses import (
     Unspecified,
     dataclass,
@@ -176,11 +177,12 @@ class Buffer:
         return self.data.tobytes() if isinstance(self.data, memoryview) else self.data
 
     def to_compressed_bytes(self) -> bytes:
+        level = settings.compression_level()
         # we do not want the result to be different depending on mtime, since that is
         # irrelevant and also makes things harder to test, but Python 3.11 and 3.12 have
         # bug where using mtime=0 results in the Gzip header OS field varies by platforam
         # instead of getting set to a fixed value of 255. So, for now use mtime=1 instead.
-        return gzip.compress(self.to_bytes(), mtime=1)
+        return gzip.compress(self.to_bytes(), mtime=1, compresslevel=level)
 
     def to_base64(self) -> str:
         return base64.b64encode(self.to_compressed_bytes()).decode("utf-8")

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -177,8 +177,10 @@ class Buffer:
 
     def to_compressed_bytes(self) -> bytes:
         # we do not want the result to be different depending on mtime, since that is
-        # irrelevant and also makes things harder to test, so set mtime=0 here
-        return gzip.compress(self.to_bytes(), mtime=0)
+        # irrelevant and also makes things harder to test, but Python 3.11 and 3.12 have
+        # bug where using mtime=0 results in the Gzip header OS field varies by platforam
+        # instead of getting set to a fixed value of 255. So, for now use mtime=1 instead.
+        return gzip.compress(self.to_bytes(), mtime=1)
 
     def to_base64(self) -> str:
         return base64.b64encode(self.to_compressed_bytes()).decode("utf-8")

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -169,6 +169,16 @@ def convert_int(value: int | str) -> int:
     '''
     return int(value)
 
+def convert_compression(value: int | str) -> int:
+    ''' Convert a string to a gzip compression level value.
+    '''
+    level = int(value)
+
+    if 0 <= level <= 9:
+        return level
+
+    raise ValueError(f"Compression level must be an integer in [0, 9], got {value!r}")
+
 def convert_bool(value: bool | str) -> bool:
     ''' Convert a string to True or False.
 
@@ -499,6 +509,8 @@ class PrioritizedSetting(Generic[T]):
             return "Bool"
         if self._convert is convert_int:
             return "Int"
+        if self._convert is convert_compression:
+            return "Compression Level (0-9)"
         if self._convert is convert_logging:
             return "Log Level"
         if self._convert is convert_str_seq:
@@ -581,6 +593,16 @@ class Settings:
     different name for ``chromedriver``, like ``chromedriver-binary`` or
     ``chromium.chromedriver`` (or its variant, which is used for example
     by Snap package manager; see https://snapcraft.io/).
+    """)
+
+    compression_level: PrioritizedSetting[int] = PrioritizedSetting("compression_level", "BOKEH_COMPRESSION_LEVEL", default=9, convert=convert_compression, help="""
+    In contexts where array buffers are base64-encoded (e.g. to embed inside
+    an HTML file), the buffer will first be compressed to save space.
+
+    Valid values are the standard gzip compression levels 0-9. A setting of 9
+    (the default) will result in the highest compression. A setting of 1 will
+    result in the least compression, but be faster. A setting of 0 will result
+    in no compression.
     """)
 
     cookie_secret: PrioritizedSetting[str | None] = PrioritizedSetting("cookie_secret", "BOKEH_COOKIE_SECRET", default=None, help="""

--- a/tests/baselines/cross/regressions/issue_13134.json5
+++ b/tests/baselines/cross/regressions/issue_13134.json5
@@ -64,7 +64,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "AQAAAAIAAAADAAAABAAAAAUAAAA=",
+                            data: "H4sIAAAAAAACE2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -79,7 +79,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "AQAAAAIAAAADAAAABAAAAAUAAAA=",
+                            data: "H4sIAAAAAAACE2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -106,7 +106,7 @@
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "AAAAAAIAAAAEAAAA",
+                          data: "H4sIAAAAAAACE2NgYGBgAmIWIAYARVaStgwAAAA=",
                         },
                         shape: [
                           3,

--- a/tests/baselines/cross/regressions/issue_13134.json5
+++ b/tests/baselines/cross/regressions/issue_13134.json5
@@ -64,7 +64,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "H4sIAAAAAAACE2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
+                            data: "H4sIAAEAAAAC/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -79,7 +79,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "H4sIAAAAAAACE2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
+                            data: "H4sIAAEAAAAC/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -106,7 +106,7 @@
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "H4sIAAAAAAACE2NgYGBgAmIWIAYARVaStgwAAAA=",
+                          data: "H4sIAAEAAAAC/2NgYGBgAmIWIAYARVaStgwAAAA=",
                         },
                         shape: [
                           3,

--- a/tests/baselines/cross/regressions/issue_13660.json5
+++ b/tests/baselines/cross/regressions/issue_13660.json5
@@ -64,7 +64,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "AQAAAAIAAAADAAAABAAAAAUAAAA=",
+                            data: "H4sIAAAAAAACE2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -79,7 +79,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "AQAAAAIAAAADAAAABAAAAAUAAAA=",
+                            data: "H4sIAAAAAAACE2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -106,7 +106,7 @@
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "AAEAAQA=",
+                          data: "H4sIAAAAAAACE2NgZGBkAAA5oYVnBQAAAA==",
                         },
                         shape: [
                           5,

--- a/tests/baselines/cross/regressions/issue_13660.json5
+++ b/tests/baselines/cross/regressions/issue_13660.json5
@@ -64,7 +64,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "H4sIAAAAAAACE2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
+                            data: "H4sIAAEAAAAC/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -79,7 +79,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "H4sIAAAAAAACE2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
+                            data: "H4sIAAEAAAAC/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -106,7 +106,7 @@
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "H4sIAAAAAAACE2NgZGBkAAA5oYVnBQAAAA==",
+                          data: "H4sIAAEAAAAC/2NgZGBkAAA5oYVnBQAAAA==",
                         },
                         shape: [
                           5,

--- a/tests/unit/bokeh/core/test_json_encoder.py
+++ b/tests/unit/bokeh/core/test_json_encoder.py
@@ -24,6 +24,7 @@ from math import nan
 # Bokeh imports
 from bokeh.core.json_encoder import serialize_json
 from bokeh.core.serialization import Serializer
+from bokeh.settings import settings
 
 #-----------------------------------------------------------------------------
 # Setup
@@ -87,7 +88,8 @@ def test_json_encoder_bytes():
     assert rep.buffers is not None and len(rep.buffers) == 1
 
     # Note mtime=1 is a workaround for an issue with Python 3.11 and 3.12
-    encoded_bytes = b64encode(gzip.compress(val["key"], mtime=1)).decode("utf-8")
+    compressed_bytes = gzip.compress(val["key"], mtime=1, compresslevel=settings.compression_level())
+    encoded_bytes = b64encode(compressed_bytes).decode("utf-8")
 
     assert serialize_json(rep.content) == f"""\
 {{"type":"map","entries":[["key",{{"type":"bytes","data":"{encoded_bytes}"}}]]}}\

--- a/tests/unit/bokeh/core/test_json_encoder.py
+++ b/tests/unit/bokeh/core/test_json_encoder.py
@@ -17,6 +17,8 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import gzip
+from base64 import b64encode
 from math import nan
 
 # Bokeh imports
@@ -32,17 +34,17 @@ from bokeh.core.serialization import Serializer
 #-----------------------------------------------------------------------------
 
 def test_json_encoder():
-    val0 = [None, True, False, -128, -1, 0, 1, 128, nan, {"key_0": b"uvw"}]
+    val0 = [None, True, False, -128, -1, 0, 1, 128, nan]
     rep0 = Serializer().serialize(val0)
 
-    assert rep0.buffers is not None and len(rep0.buffers) == 1
+    assert rep0.buffers is not None and len(rep0.buffers) == 0
 
     assert serialize_json(rep0.content) == """\
-[null,true,false,-128,-1,0,1,128,{"type":"number","value":"nan"},{"type":"map","entries":[["key_0",{"type":"bytes","data":"H4sIAAAAAAACEystKwcARkl/GgMAAAA="}]]}]\
+[null,true,false,-128,-1,0,1,128,{"type":"number","value":"nan"}]\
 """
 
-    assert serialize_json(rep0) == f"""\
-[null,true,false,-128,-1,0,1,128,{{"type":"number","value":"nan"}},{{"type":"map","entries":[["key_0",{{"type":"bytes","data":{{"id":"{rep0.buffers[0].id}"}}}}]]}}]\
+    assert serialize_json(rep0) == """\
+[null,true,false,-128,-1,0,1,128,{"type":"number","value":"nan"}]\
 """
 
     assert serialize_json(rep0.content, pretty=True) == """\
@@ -58,23 +60,11 @@ def test_json_encoder():
   {
     "type": "number",
     "value": "nan"
-  },
-  {
-    "type": "map",
-    "entries": [
-      [
-        "key_0",
-        {
-          "type": "bytes",
-          "data": "H4sIAAAAAAACEystKwcARkl/GgMAAAA="
-        }
-      ]
-    ]
   }
 ]\
 """
 
-    assert serialize_json(rep0, pretty=True) == f"""\
+    assert serialize_json(rep0, pretty=True) == """\
 [
   null,
   true,
@@ -84,25 +74,22 @@ def test_json_encoder():
   0,
   1,
   128,
-  {{
+  {
     "type": "number",
     "value": "nan"
-  }},
-  {{
-    "type": "map",
-    "entries": [
-      [
-        "key_0",
-        {{
-          "type": "bytes",
-          "data": {{
-            "id": "{rep0.buffers[0].id}"
-          }}
-        }}
-      ]
-    ]
-  }}
+  }
 ]\
+"""
+
+def test_json_encoder_bytes():
+    val = {"key": b"uvw"}
+    rep = Serializer().serialize(val)
+    assert rep.buffers is not None and len(rep.buffers) == 1
+
+    encoded_bytes = b64encode(gzip.compress(val["key"], mtime=0)).decode("utf-8")
+
+    assert serialize_json(rep.content) == f"""\
+{{"type":"map","entries":[["key",{{"type":"bytes","data":"{encoded_bytes}"}}]]}}\
 """
 
 def test_json_encoder_dict_no_sort():

--- a/tests/unit/bokeh/core/test_json_encoder.py
+++ b/tests/unit/bokeh/core/test_json_encoder.py
@@ -86,7 +86,8 @@ def test_json_encoder_bytes():
     rep = Serializer().serialize(val)
     assert rep.buffers is not None and len(rep.buffers) == 1
 
-    encoded_bytes = b64encode(gzip.compress(val["key"], mtime=0)).decode("utf-8")
+    # Note mtime=1 is a workaround for an issue with Python 3.11 and 3.12
+    encoded_bytes = b64encode(gzip.compress(val["key"], mtime=1)).decode("utf-8")
 
     assert serialize_json(rep.content) == f"""\
 {{"type":"map","entries":[["key",{{"type":"bytes","data":"{encoded_bytes}"}}]]}}\

--- a/tests/unit/bokeh/core/test_json_encoder.py
+++ b/tests/unit/bokeh/core/test_json_encoder.py
@@ -38,7 +38,7 @@ def test_json_encoder():
     assert rep0.buffers is not None and len(rep0.buffers) == 1
 
     assert serialize_json(rep0.content) == """\
-[null,true,false,-128,-1,0,1,128,{"type":"number","value":"nan"},{"type":"map","entries":[["key_0",{"type":"bytes","data":"dXZ3"}]]}]\
+[null,true,false,-128,-1,0,1,128,{"type":"number","value":"nan"},{"type":"map","entries":[["key_0",{"type":"bytes","data":"H4sIAAAAAAACEystKwcARkl/GgMAAAA="}]]}]\
 """
 
     assert serialize_json(rep0) == f"""\
@@ -66,7 +66,7 @@ def test_json_encoder():
         "key_0",
         {
           "type": "bytes",
-          "data": "dXZ3"
+          "data": "H4sIAAAAAAACEystKwcARkl/GgMAAAA="
         }
       ]
     ]

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -25,6 +25,7 @@ from base64 import b64decode
 from math import inf, nan
 from types import SimpleNamespace
 from typing import Any, Sequence
+from unittest.mock import patch
 
 # External imports
 import numpy as np
@@ -98,6 +99,74 @@ class SomeDataClass:
     f3: NotRequired[bool | None] = Unspecified
     f4: NotRequired[SomeProps] = Unspecified
     f5: NotRequired[SomeModel] = Unspecified
+
+class TestBuffer:
+
+    def test_ref(self) -> None:
+        buf = Buffer(10, b"\x001\xefabc\x12")
+        assert buf.ref == {'id': 10}
+
+    def test_to_bytes_from_bytes(self) -> None:
+        val = b"\x001\xefabc\x12"
+        buf = Buffer(10, val)
+        ret = buf.to_bytes()
+        assert isinstance(ret, bytes)
+        assert ret == val
+
+    def test_to_bytes_from_memoryview(self) -> None:
+        val = b"\x001\xefabc\x12"
+        view = memoryview(val)
+        buf = Buffer(10, view)
+        ret = buf.to_bytes()
+        assert isinstance(ret, bytes)
+        assert ret == val
+
+    def test_to_compressed_bytes_from_bytes(self) -> None:
+        val = b"\x001\xefabc\x12"
+        buf = Buffer(10, val)
+
+        ret = buf.to_compressed_bytes()
+
+        assert isinstance(ret, bytes)
+
+        # make sure the gzip header "OS" field is *always* set to "unknown" (255)
+        assert ret[9] == 255
+
+        assert gzip.decompress(ret) == val
+
+    def test_to_compressed_bytes_from_memoryview(self) -> None:
+        val = b"\x001\xefabc\x12"
+        view = memoryview(val)
+        buf = Buffer(10, view)
+
+        ret = buf.to_compressed_bytes()
+
+        assert isinstance(ret, bytes)
+
+        # make sure the gzip header "OS" field is *always* set to "unknown" (255)
+        assert ret[9] == 255
+
+        assert gzip.decompress(ret) == val
+
+    @pytest.mark.parametrize("level", range(0, 10))
+    @patch("gzip.compress")
+    def test_to_compressed_compression_level(self, compress, level: int, monkeypatch: pytest.MonkeyPatch) -> None:
+        val = b"\x001\xefabc\x12"
+        buf = Buffer(10, val)
+
+        monkeypatch.setenv("BOKEH_COMPRESSION_LEVEL", f"{level}")
+        buf.to_compressed_bytes()
+
+        compress.assert_called_once_with(val, mtime=1, compresslevel=level)
+
+    def test_to_base64(self):
+        val = b"\x001\xefabc\x12"
+        buf = Buffer(10, val)
+
+        ret = buf.to_base64()
+
+        assert isinstance(ret, str)
+        assert b64decode(ret) == buf.to_compressed_bytes()
 
 class TestSerializer:
 

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -311,7 +311,7 @@ class TestSerializer:
         rep = encoder.encode(val)
         assert rep == BytesRep(
             type="bytes",
-            data="/wAX/gA=",
+            data="H4sIAAAAAAACE/vPIP6PAQBXSRCfBQAAAA==",
         )
         assert encoder.buffers == []
 
@@ -340,7 +340,7 @@ class TestSerializer:
             type="typed_array",
             array=BytesRep(
                 type="bytes",
-                data="AAAAAAEAAAACAAAAAwAAAAQAAAAFAAAA",
+                data="H4sIAAAAAAACE2NgYGBgBGImIGYGYhYgZgViAD34DIUYAAAA",
             ),
             order=sys.byteorder,
             dtype="int32",
@@ -373,7 +373,7 @@ class TestSerializer:
             type="ndarray",
             array=BytesRep(
                 type="bytes",
-                data="AAAAAAEAAAACAAAAAwAAAAQAAAAFAAAA",
+                data="H4sIAAAAAAACE2NgYGBgBGImIGYGYhYgZgViAD34DIUYAAAA",
             ),
             order=sys.byteorder,
             shape=[6],

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -18,8 +18,10 @@ import pytest ; pytest
 
 # Standard library imports
 import datetime as dt
+import gzip
 import sys
 from array import array as TypedArray
+from base64 import b64decode
 from math import inf, nan
 from types import SimpleNamespace
 from typing import Any, Sequence
@@ -309,10 +311,8 @@ class TestSerializer:
         encoder = Serializer(deferred=False)
         val = bytes([0xFF, 0x00, 0x17, 0xFE, 0x00])
         rep = encoder.encode(val)
-        assert rep == BytesRep(
-            type="bytes",
-            data="H4sIAAAAAAACE/vPIP6PAQBXSRCfBQAAAA==",
-        )
+        assert rep["type"] == "bytes"
+        assert gzip.decompress(b64decode(rep["data"])) == val
         assert encoder.buffers == []
 
     def test_typed_array(self) -> None:
@@ -336,15 +336,13 @@ class TestSerializer:
         encoder = Serializer(deferred=False)
         val = TypedArray("i", [0, 1, 2, 3, 4, 5])
         rep = encoder.encode(val)
-        assert rep == TypedArrayRep(
-            type="typed_array",
-            array=BytesRep(
-                type="bytes",
-                data="H4sIAAAAAAACE2NgYGBgBGImIGYGYhYgZgViAD34DIUYAAAA",
-            ),
-            order=sys.byteorder,
-            dtype="int32",
-        )
+        # isinstance not supported for typed dicts, alas
+        # assert isinstance(rep, TypedArrayRep)
+        assert rep.keys() == {"type", "order", "dtype", "array"}
+        assert rep["type"] == "typed_array"
+        assert rep["order"] == sys.byteorder
+        assert rep["dtype"] == "int32"
+        assert rep["array"] == encoder._encode_bytes(memoryview(val))
         assert encoder.buffers == []
 
     def test_ndarray(self) -> None:
@@ -369,16 +367,14 @@ class TestSerializer:
         encoder = Serializer(deferred=False)
         val = np.array([0, 1, 2, 3, 4, 5], dtype="int32")
         rep = encoder.encode(val)
-        assert rep == NDArrayRep(
-            type="ndarray",
-            array=BytesRep(
-                type="bytes",
-                data="H4sIAAAAAAACE2NgYGBgBGImIGYGYhYgZgViAD34DIUYAAAA",
-            ),
-            order=sys.byteorder,
-            shape=[6],
-            dtype="int32",
-        )
+        # isinstance not supported for typed dicts, alas
+        # assert isinstance(rep, NDArrayRep)
+        assert rep.keys() == {"type", "order", "shape", "dtype", "array"}
+        assert rep["type"] == "ndarray"
+        assert rep["order"] == sys.byteorder
+        assert rep["shape"] == [6]
+        assert rep["dtype"] == "int32"
+        assert rep["array"] == encoder._encode_bytes(memoryview(val))
         assert encoder.buffers == []
 
     def test_ndarray_dtypes_shape(self) -> None:

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -48,6 +48,7 @@ _expected_settings = (
     'browser',
     'cdn_version',
     'chromedriver_path',
+    'compression_level',
     'cookie_secret',
     'default_server_host',
     'default_server_port',
@@ -99,6 +100,8 @@ class TestSettings:
 
         assert bs.settings.default_server_port.convert_type == "Int"
 
+        assert bs.settings.compression_level.convert_type == "Compression Level (0-9)"
+
         assert bs.settings.py_log_level.convert_type == "Log Level"
 
         assert bs.settings.validation_level.convert_type == "Validation Level"
@@ -108,15 +111,16 @@ class TestSettings:
         assert bs.settings.ico_path.convert_type == "Ico Path"
 
         default_typed = set(_expected_settings) - {
+            'allowed_ws_origin',
+            'compression_level',
+            'default_server_port',
             'ico_path',
             'ignore_filename',
             'minified',
-            'default_server_port',
             'perform_document_validation',
+            'py_log_level',
             'simple_ids',
             'validation_level',
-            'py_log_level',
-            'allowed_ws_origin',
             'xsrf_cookies',
         }
         for name in default_typed:


### PR DESCRIPTION
- [x] issues: fixes #14460
- [x] tests added / passed

This PR adds support to transparently compress and decompress any data that would currently be transmitted as a base64 buffer. 

In order to easily support synchronous gzip compress and uncompress on the BokehJS side, [`fflate`](https://github.com/101arrowz/fflate) was added as a dependency. 