### PR TITLE
Allow redefinition of models with only a warning

### DIFF
--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 # Bokeh imports
 from ..settings import settings
 from ..util.strings import append_docstring, nice_join
-from ..util.warnings import warn
+from ..util.warnings import BokehUserWarning, warn
 from .property.descriptor_factory import PropertyDescriptorFactory
 from .property.descriptors import PropertyDescriptor, UnsetValueError
 from .property.override import Override
@@ -138,7 +138,7 @@ def _generators(class_dict: dict[str, Any]):
     return generators
 
 class _ModelResolver:
-    """ """
+    """ A class responsible for tracking of models and how to resolve them. """
 
     _known_models: dict[str, type[HasProps]]
 
@@ -150,7 +150,8 @@ class _ModelResolver:
             # update the mapping of view model names to classes, checking for any duplicates
             previous = self._known_models.get(cls.__qualified_model__, None)
             if previous is not None and not hasattr(cls, "__implementation__"):
-                raise Warning(f"Duplicate qualified model declaration of '{cls.__qualified_model__}'. Previous definition: {previous}")
+                warn(f"Duplicate qualified model definition of '{cls.__qualified_model__}'. " \
+                     f"Previous definition was {previous} (@{hex(id(previous))}), the new is {cls} (@{hex(id(cls))}).", BokehUserWarning)
             self._known_models[cls.__qualified_model__] = cls
 
     def remove(self, cls: type[HasProps]) -> None:

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -18,6 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 from types import MethodType
+from unittest.mock import MagicMock, patch
 
 # Bokeh imports
 from bokeh.core.properties import (
@@ -40,6 +41,7 @@ from bokeh.core.property.descriptors import (
 )
 from bokeh.core.property.singletons import Intrinsic, Undefined
 from bokeh.core.property.vectorization import field, value
+from bokeh.util.warnings import BokehUserWarning
 
 # Module under test
 import bokeh.core.has_props as hp # isort:skip
@@ -701,6 +703,20 @@ def test_HasProps_clone_with_unset_properties() -> None:
 
     assert obj1 is not obj0
     assert obj1.properties_with_values(include_defaults=False, include_undefined=True) == dict(f0=Undefined, f1=1, f2=2)
+
+@patch("warnings.warn")
+def test_HasProps_model_redefinition(mock_warn: MagicMock) -> None:
+    class Foo1(hp.HasProps):
+        __qualified_model__ = "Foo"
+
+    class Foo2(hp.HasProps):
+        __qualified_model__ = "Foo"
+
+    assert mock_warn.called
+
+    msg, cls = mock_warn.call_args[0]
+    assert msg.startswith("Duplicate qualified model definition of 'Foo'.")
+    assert cls is BokehUserWarning
 
 #-----------------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
This PR allows to redefine non-extension models. This is useful when e.g. implementing auto-reload mechanisms.

fixes #14525 