### PR TITLE
Temporarily disable circular reference chcking during serialization

### DIFF
--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -223,12 +223,14 @@ class Serializer:
 
     _references: dict[ObjID, Ref]
     _deferred: bool
+    _check_circular: bool
     _circular: dict[ObjID, Any]
     _buffers: list[Buffer]
 
-    def __init__(self, *, references: set[Model] = set(), deferred: bool = True) -> None:
+    def __init__(self, *, references: set[Model] = set(), deferred: bool = True, check_circular: bool = True) -> None:
         self._references = {id(obj): obj.ref for obj in references}
         self._deferred = deferred
+        self._check_circular = check_circular
         self._circular = {}
         self._buffers = []
 
@@ -255,14 +257,15 @@ class Serializer:
             return ref
 
         ident = id(obj)
-        if ident in self._circular:
+        if self._check_circular and ident in self._circular:
             self.error("circular reference")
 
         self._circular[ident] = obj
         try:
             return self._encode(obj)
         finally:
-            del self._circular[ident]
+            if ident in self._circular:
+                del self._circular[ident]
 
     def encode_struct(self, **fields: Any) -> dict[str, AnyRep]:
         return {key: self.encode(val) for key, val in fields.items() if val is not Unspecified}

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -227,7 +227,7 @@ class Serializer:
     _circular: dict[ObjID, Any]
     _buffers: list[Buffer]
 
-    def __init__(self, *, references: set[Model] = set(), deferred: bool = True, check_circular: bool = True) -> None:
+    def __init__(self, *, references: set[Model] = set(), deferred: bool = True, check_circular: bool = False) -> None:
         self._references = {id(obj): obj.ref for obj in references}
         self._deferred = deferred
         self._check_circular = check_circular

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -739,7 +739,7 @@ side of a communications channel while it was being removed on the other end.\
             self.callbacks.trigger_on_change(TitleChangedEvent(self, title, setter))
 
     def to_json(self, *, deferred: bool = True) -> DocJson:
-        ''' Convert this document to a JSON-serializble object.
+        ''' Convert this document to a JSON-serializable object.
 
         Return:
             DocJson

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -261,12 +261,20 @@ class TestSerializer:
         ]
         assert encoder.buffers == []
 
-    def test_list_circular(self) -> None:
+    def test_list_circular_with_checking(self) -> None:
         val: Sequence[Any] = [1, 2, 3]
-        val.insert(2, val)
+        val.append(val)
 
-        encoder = Serializer()
-        with pytest.raises(SerializationError):
+        encoder = Serializer(check_circular=True)
+        with pytest.raises(SerializationError, match="circular reference"):
+            encoder.encode(val)
+
+    def test_list_circular_without_checking(self) -> None:
+        val: Sequence[Any] = [1, 2, 3]
+        val.append(val)
+
+        encoder = Serializer(check_circular=False)
+        with pytest.raises(RecursionError):
             encoder.encode(val)
 
     def test_dict_empty(self) -> None:

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -303,12 +303,20 @@ class TestSerializer:
         )
         assert encoder.buffers == []
 
-    def test_dict_circular(self) -> None:
+    def test_dict_circular_with_checking(self) -> None:
         val: dict[Any, Any] = {nan: [1, 2]}
         val[inf] = val
 
-        encoder = Serializer()
-        with pytest.raises(SerializationError):
+        encoder = Serializer(check_circular=True)
+        with pytest.raises(SerializationError, match="circular reference"):
+            encoder.encode(val)
+
+    def test_dict_circular_without_checking(self) -> None:
+        val: dict[Any, Any] = {nan: [1, 2]}
+        val[inf] = val
+
+        encoder = Serializer(check_circular=False)
+        with pytest.raises(RecursionError):
             encoder.encode(val)
 
     def test_dict_ColumnData(self) -> None:
@@ -932,6 +940,20 @@ class TestSerializer:
         )
 
         assert rep1["array"]["data"].data == rep2["array"]["data"].data
+
+    def test_self_referential_issue_14383(self) -> None:
+        from bokeh.models import CustomJS
+        from bokeh.plotting import figure
+
+        p = figure()
+        lines = [p.line([1, 2, 3], [1, 2, 3]) for _ in range(3)]
+
+        for line in lines:
+            handler = CustomJS(args=dict(lines=lines), code="")
+            line.js_on_change("muted", handler)
+
+        encoder = Serializer()
+        encoder.encode(p) # no SerializationError("circular reference") error raised here
 
 class TestDeserializer:
 


### PR DESCRIPTION
The current approach to circular reference checking, though useful in general, is too limiting for potential data structures supported by bokeh, which results in it discarding valid object graphs. The best solution would be to implement the same method for encoding lists, dicts, etc. as we do for models, but this requires changes that probably can only be done in bokeh 4.0. Thus for the time being, I disabled circular reference checking and I will revisit this issue later.

The good thing is that this mechanism wasn't actually triggered before, because bokeh would fail on circular data structures with recursion error long before it would reach serialization stage.

- [x] fixes #14383