### PR TITLE
Attempt to resolve layout collapse issues

### DIFF
--- a/bokehjs/src/lib/models/layouts/css_grid_box.ts
+++ b/bokehjs/src/lib/models/layouts/css_grid_box.ts
@@ -126,7 +126,15 @@ export abstract class CSSGridBoxView extends LayoutDOMView {
     for (const [[, row, col], i] of enumerate(this._children)) {
       const view = this.child_views[i]
 
-      const {halign, valign} = view.box_sizing()
+      const {width_policy, height_policy, halign, valign} = view.box_sizing()
+
+      if (height_policy == "max" && rows_template[row].size == null) {
+        rows_template[row].size = "1fr"
+      }
+      if (width_policy == "max" && cols_template[col].size == null) {
+        cols_template[col].size = "1fr"
+      }
+
       view.parent_style.append(":host", {
         justify_self: halign ?? cols_template[col].align,
         align_self: valign ?? rows_template[row].align,

--- a/bokehjs/src/lib/models/layouts/flex_box.ts
+++ b/bokehjs/src/lib/models/layouts/flex_box.ts
@@ -1,4 +1,4 @@
-import type {FullDisplay} from "./layout_dom"
+import type {FullDisplay, CSSSizeKeyword} from "./layout_dom"
 import {LayoutDOM, LayoutDOMView} from "./layout_dom"
 import {GridAlignmentLayout} from "./alignments"
 import {Container} from "core/layout/grid"
@@ -24,6 +24,21 @@ export abstract class FlexBoxView extends LayoutDOMView {
 
   protected override _intrinsic_display(): FullDisplay {
     return {inner: this.model.flow_mode, outer: "flex"}
+  }
+
+  protected override get _auto_width(): CSSSizeKeyword {
+    if (this.layoutable_views.map((view) => view.box_sizing().width_policy).some((policy) => policy == "max")) {
+      return "auto"
+    } else {
+      return "max-content"
+    }
+  }
+  protected override get _auto_height(): CSSSizeKeyword {
+    if (this.layoutable_views.map((view) => view.box_sizing().height_policy).some((policy) => policy == "max")) {
+      return "auto"
+    } else {
+      return "max-content"
+    }
   }
 
   override _update_layout(): void {

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -191,8 +191,8 @@ export abstract class LayoutDOMView extends PaneView {
     this.invalidate_layout()
   }
 
-  protected readonly _auto_width: CSSSizeKeyword = "fit-content"
-  protected readonly _auto_height: CSSSizeKeyword = "fit-content"
+  protected get _auto_width(): CSSSizeKeyword { return "max-content" }
+  protected get _auto_height(): CSSSizeKeyword { return "max-content" }
 
   protected _intrinsic_display(): FullDisplay {
     return {inner: this.model.flow_mode, outer: "flow"}
@@ -204,7 +204,7 @@ export abstract class LayoutDOMView extends PaneView {
         case "auto":
           return size != null ? px(size) : auto_size
         case "fixed":
-          return size != null ? px(size) : "fit-content"
+          return size != null ? px(size) : auto_size
         case "fit":
           return "fit-content"
         case "min":

--- a/bokehjs/src/lib/models/layouts/spacer.ts
+++ b/bokehjs/src/lib/models/layouts/spacer.ts
@@ -1,4 +1,5 @@
 import {LayoutDOM, LayoutDOMView} from "./layout_dom"
+import type {CSSSizeKeyword} from "./layout_dom"
 import type * as p from "core/properties"
 
 export class SpacerView extends LayoutDOMView {
@@ -8,8 +9,8 @@ export class SpacerView extends LayoutDOMView {
     return []
   }
 
-  protected override readonly _auto_width = "auto"
-  protected override readonly _auto_height = "auto"
+  protected override get _auto_width(): CSSSizeKeyword { return "auto" }
+  protected override get _auto_height(): CSSSizeKeyword { return "auto" }
 }
 
 export namespace Spacer {

--- a/bokehjs/src/lib/models/widgets/markup.ts
+++ b/bokehjs/src/lib/models/widgets/markup.ts
@@ -1,3 +1,4 @@
+import type {CSSSizeKeyword} from "../layouts/layout_dom"
 import type {StyleSheetLike} from "core/dom"
 import {div} from "core/dom"
 import type * as p from "core/properties"
@@ -10,8 +11,8 @@ export abstract class MarkupView extends WidgetView {
 
   protected markup_el: HTMLElement
 
-  protected override readonly _auto_width = "fit-content"
-  protected override readonly _auto_height = "auto"
+  protected override get _auto_width(): CSSSizeKeyword { return "fit-content" }
+  protected override get _auto_height(): CSSSizeKeyword { return "auto" }
 
   override async lazy_initialize() {
     await super.lazy_initialize()

--- a/bokehjs/src/lib/models/widgets/sliders/abstract_slider.ts
+++ b/bokehjs/src/lib/models/widgets/sliders/abstract_slider.ts
@@ -9,6 +9,7 @@ import {repeat} from "core/util/array"
 import {color2css} from "core/util/color"
 
 import {OrientedControl, OrientedControlView} from "../oriented_control"
+import type {CSSSizeKeyword} from "../../layouts/layout_dom"
 
 import sliders_css, * as sliders from "styles/widgets/sliders.css"
 import nouislider_css from "styles/widgets/nouislider.css"
@@ -34,8 +35,8 @@ export abstract class AbstractSliderView<T extends number | string> extends Orie
   protected slider_el?: HTMLElement
   protected title_el: HTMLElement
 
-  protected override readonly _auto_width = "auto"
-  protected override readonly _auto_height = "auto"
+  protected override get _auto_width(): CSSSizeKeyword { return "auto" }
+  protected override get _auto_height(): CSSSizeKeyword { return "auto" }
 
   public *controls() {
     yield this.slider_el as HTMLInputElement


### PR DESCRIPTION
Early work in progress. This PR is an attempt to resolve various issues with layout collapsing. The problem I'm currently facing is that what works for non-plot children of flex and grid layouts, often doesn't translate to plots, because they are still too reliant on "computed" layout, which often interferes with CSS layout.

- [ ] fixes #13077
- [ ] fixes #13784
- [ ] fixes #14100