### PR TITLE
`scipy-stubs`

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -47,6 +47,7 @@ dependencies:
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - scipy
+  - scipy-stubs
   - pooch # required in scipy.datasets
   - selenium 4.2
   - toml

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -47,6 +47,7 @@ dependencies:
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - scipy
+  - scipy-stubs
   - pooch # required in scipy.datasets
   - selenium 4.2
   - toml

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -47,6 +47,7 @@ dependencies:
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - scipy
+  - scipy-stubs
   - pooch # required in scipy.datasets
   - selenium 4.2
   - toml

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -48,6 +48,7 @@ dependencies:
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - scipy
+  - scipy-stubs
   - pooch # required in scipy.datasets
   - selenium 4.2
   - toml


### PR DESCRIPTION
Seeing as `pandas-stubs` is already a test requirement, I'm sure you see the value in adding [`scipy-stubs`](https://github.com/scipy/scipy-stubs) there, as well :).

It's available on both [pypi](https://pypi.org/project/scipy-stubs/) and [conda-forge](https://anaconda.org/conda-forge/scipy-stubs), and chose the conda-forge option here. But since pandas-stubs is listed as pip dependency (which is also available on conda-forge), I'm not sure if that's what you'd want here.