### PR TITLE
Fix default formatter in ColorBar and update related test. Fix issue (bug ) #12618

### DIFF
--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -12,6 +12,9 @@
 # Boilerplate
 #-----------------------------------------------------------------------------
 from __future__ import annotations
+from ...core.properties import Instance, InstanceDefault
+from ..formatters import TickFormatter, NumeralTickFormatter
+
 
 import logging # isort:skip
 log = logging.getLogger(__name__)
@@ -280,6 +283,12 @@ class ColorBar(BaseColorBar):
     The highest value to display in the color bar. The whole of the color entry
     containing this value is shown.
     """)
+   
+
+    formatter = Override(default=lambda: NumeralTickFormatter(format="0.00"))
+
+
+
 
 
 class ContourColorBar(BaseColorBar):

--- a/tests/unit/bokeh/models/test_annotations.py
+++ b/tests/unit/bokeh/models/test_annotations.py
@@ -10,6 +10,7 @@
 #-----------------------------------------------------------------------------
 from __future__ import annotations # isort:skip
 
+
 import pytest ; pytest
 
 #-----------------------------------------------------------------------------
@@ -49,6 +50,7 @@ from bokeh.models import (
 )
 from bokeh.models.annotations.dimensional import CustomDimensional, Metric
 from bokeh.util.serialization import convert_datetime_type
+from bokeh.models.formatters import NumeralTickFormatter
 
 from _util_models import (
     ABOVE_FILL,
@@ -190,7 +192,8 @@ def test_ColorBar() -> None:
     assert color_bar.title is None
     assert color_bar.title_standoff == 2
     assert color_bar.ticker == "auto"
-    assert color_bar.formatter == "auto"
+    assert isinstance(color_bar.formatter, NumeralTickFormatter)
+    assert color_bar.formatter.format == '0.00'
     assert color_bar.color_mapper == color_mapper
     assert color_bar.margin == 30
     assert color_bar.padding == 10


### PR DESCRIPTION
This PR fixes an issue where ColorBar tick labels showed overly precise decimal values (like 0.7000000000000001) when no formatter was provided. To improve the default output, we added a NumeralTickFormatter(format="0.00") as the default formatter using the Override method in the ColorBar class. This ensures cleaner and more readable tick labels. As a result of this fix, the test test_ColorBar in test_annotations.py was failing since it expected the formatter to be "auto". The test was updated to assert that the default formatter is a NumeralTickFormatter and its format is "0.00".
