### PR TITLE
Add support for scalar uint color values

### DIFF
--- a/examples/advanced/extensions/gears/gear.py
+++ b/examples/advanced/extensions/gears/gear.py
@@ -1,6 +1,6 @@
-from bokeh.core.properties import AngleSpec, Include, NumberSpec
+from bokeh.core.properties import AngleSpec, BoolSpec, Include, NumberSpec
 from bokeh.core.property_mixins import FillProps, HatchProps, LineProps
-from bokeh.models import Glyph
+from bokeh.models.glyph import Glyph
 
 
 class Gear(Glyph):
@@ -52,7 +52,7 @@ class Gear(Glyph):
     size. [float]
     """)
 
-    internal = NumberSpec(default=False, help="""
+    internal = BoolSpec(default=False, help="""
     Whether the gear teeth are internal. [bool]
     """)
 

--- a/src/bokeh/core/properties.py
+++ b/src/bokeh/core/properties.py
@@ -124,6 +124,7 @@ DataSpec Properties
 
 .. autoclass:: AlphaSpec
 .. autoclass:: AngleSpec
+.. autoclass:: BoolSpec
 .. autoclass:: ColorSpec
 .. autoclass:: DataSpec
 .. autoclass:: DistanceSpec
@@ -207,6 +208,7 @@ __all__ = (
     'Array',
     'Auto',
     'Bool',
+    'BoolSpec',
     'Byte',
     'Bytes',
     'CSSLength',
@@ -331,6 +333,7 @@ from .property.container import RestrictedDict
 
 from .property.dataspec import AlphaSpec
 from .property.dataspec import AngleSpec
+from .property.dataspec import BoolSpec
 from .property.dataspec import ColorSpec
 from .property.dataspec import DashPatternSpec
 from .property.dataspec import DataSpec

--- a/src/bokeh/core/property/bases.py
+++ b/src/bokeh/core/property/bases.py
@@ -542,11 +542,12 @@ class PrimitiveProperty(Property[T]):
     """
 
     _underlying_type: ClassVar[tuple[type[Any], ...]]
+    _not_underlying_type: ClassVar[tuple[type[Any], ...]] = ()
 
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
 
-        if isinstance(value, self._underlying_type):
+        if isinstance(value, self._underlying_type) and not isinstance(value, self._not_underlying_type):
             return
 
         if not detail:

--- a/src/bokeh/core/property/color.py
+++ b/src/bokeh/core/property/color.py
@@ -32,6 +32,7 @@ from .container import Tuple
 from .either import Either
 from .enum import Enum
 from .numeric import Byte, Percent
+from .primitive import Int
 from .singletons import Undefined
 from .string import Regex
 
@@ -134,6 +135,7 @@ class Color(Either):
                        r"\s*?){2}(25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*?\)"),
                  Tuple(Byte, Byte, Byte),
                  Tuple(Byte, Byte, Byte, Percent),
+                 Int,
                  RGB)
         help = f"{help or ''}\n{COLOR_DEFAULT_HELP}"
         super().__init__(*types, default=default, help=help)

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -38,6 +38,7 @@ from .instance import Instance
 from .nothing import Nothing
 from .nullable import Nullable
 from .primitive import (
+    Bool,
     Float,
     Int,
     Null,
@@ -71,6 +72,7 @@ if TYPE_CHECKING:
 __all__ = (
     'AlphaSpec',
     'AngleSpec',
+    'BoolSpec',
     'ColorSpec',
     'DashPatternSpec',
     'DataSpec',
@@ -244,6 +246,10 @@ class DataSpec(Either):
             return Field(val)
 
         return val
+
+class BoolSpec(DataSpec):
+    def __init__(self, default, *, help: str | None = None) -> None:
+        super().__init__(Bool, default=default, help=help)
 
 class IntSpec(DataSpec):
     def __init__(self, default, *, help: str | None = None) -> None:

--- a/src/bokeh/core/property/primitive.py
+++ b/src/bokeh/core/property/primitive.py
@@ -108,6 +108,7 @@ class Complex(PrimitiveProperty[complex]):
     """
 
     _underlying_type = (numbers.Complex,)
+    _not_underlying_type = bokeh_bool_types
 
     def __init__(self, default: Init[complex] = 0j, *, help: str | None = None) -> None:
         super().__init__(default=default, help=help)
@@ -141,6 +142,7 @@ class Int(PrimitiveProperty[int]):
     """
 
     _underlying_type = bokeh_integer_types
+    _not_underlying_type = bokeh_bool_types
 
     def __init__(self, default: Init[int] = 0, *, help: str | None = None) -> None:
         super().__init__(default=default, help=help)
@@ -175,6 +177,7 @@ class Float(PrimitiveProperty[float]):
     """
 
     _underlying_type = (numbers.Real,)
+    _not_underlying_type = bokeh_bool_types
 
     def __init__(self, default: Init[float] = 0.0, *, help: str | None = None) -> None:
         super().__init__(default=default, help=help)

--- a/tests/unit/bokeh/core/property/test_aliases.py
+++ b/tests/unit/bokeh/core/property/test_aliases.py
@@ -62,12 +62,12 @@ class Test_CoordinateLike:
         assert prop.is_valid("")
         assert prop.is_valid(("", ""))
         assert prop.is_valid(("", "", ""))
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
 
     def test_invalid(self) -> None:
         prop = bcpc.CoordinateLike()
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(1.0+1.0j)
         assert not prop.is_valid(())
         assert not prop.is_valid([])

--- a/tests/unit/bokeh/core/property/test_color__property.py
+++ b/tests/unit/bokeh/core/property/test_color__property.py
@@ -61,13 +61,13 @@ class Test_Color:
 
         assert prop.is_valid(RGB(10, 20, 30))
 
+        assert prop.is_valid(0xFFFF0088)
+
     def test_invalid(self) -> None:
         prop = bcpc.Color()
         assert not prop.is_valid(None)
         assert not prop.is_valid(False)
         assert not prop.is_valid(True)
-        assert not prop.is_valid(0)
-        assert not prop.is_valid(1)
         assert not prop.is_valid(0.0)
         assert not prop.is_valid(1.0)
         assert not prop.is_valid(1.0 + 1.0j)
@@ -106,6 +106,8 @@ class Test_Color:
         assert not prop.is_valid("#00AaFff")
 
         assert not prop.is_valid("foobar")
+
+        assert not prop.is_valid(3.14)
 
     def test_transform(self) -> None:
         prop = bcpc.Color()

--- a/tests/unit/bokeh/core/property/test_dataspec.py
+++ b/tests/unit/bokeh/core/property/test_dataspec.py
@@ -46,6 +46,7 @@ import bokeh.core.property.dataspec as bcpd # isort:skip
 ALL = (
     'AlphaSpec',
     'AngleSpec',
+    'BoolSpec',
     'ColorSpec',
     'DashPatternSpec',
     'DataSpec',
@@ -143,6 +144,16 @@ class Test_AngleSpec:
 
         assert new_value_copy == new_value
 
+
+class Test_BoolSpec:
+    def test_is_valid(self) -> None:
+        prop = bcpd.BoolSpec(default=True)
+
+        assert prop.is_valid(False)
+        assert prop.is_valid(True)
+
+        assert not prop.is_valid(0)
+        assert not prop.is_valid(1)
 
 class Test_ColorSpec:
     def test_field(self) -> None:

--- a/tests/unit/bokeh/core/property/test_either.py
+++ b/tests/unit/bokeh/core/property/test_either.py
@@ -63,14 +63,13 @@ class Test_Either:
         assert prop.is_valid([1, 2, 3])
         assert prop.is_valid(100)
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
     def test_invalid(self) -> None:
         prop = bcpe.Either(Interval(Int, 0, 100), Regex("^x*$"), List(Int))
 
         assert not prop.is_valid(None)
+
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
 
         assert not prop.is_valid(0.0)
         assert not prop.is_valid(1.0)

--- a/tests/unit/bokeh/core/property/test_numeric.py
+++ b/tests/unit/bokeh/core/property/test_numeric.py
@@ -48,10 +48,6 @@ class Test_Angle:
     def test_valid(self) -> None:
         prop = bcpn.Angle()
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
         assert prop.is_valid(0)
         assert prop.is_valid(1)
         assert prop.is_valid(0.0)
@@ -61,6 +57,8 @@ class Test_Angle:
         prop = bcpn.Angle()
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(1.0+1.0j)
         assert not prop.is_valid("")
         assert not prop.is_valid(())
@@ -89,10 +87,6 @@ class Test_Interval:
     def test_valid_int(self) -> None:
         prop = bcpn.Interval(Int, 0, 255)
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
         assert prop.is_valid(0)
         assert prop.is_valid(1)
         assert prop.is_valid(127)
@@ -101,6 +95,8 @@ class Test_Interval:
         prop = bcpn.Interval(Int, 0, 255)
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(0.0)
         assert not prop.is_valid(1.0)
         assert not prop.is_valid(1.0+1.0j)
@@ -117,10 +113,6 @@ class Test_Interval:
     def test_valid_float(self) -> None:
         prop = bcpn.Interval(Float, 0.0, 1.0)
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
         assert prop.is_valid(0)
         assert prop.is_valid(1)
         assert prop.is_valid(0.0)
@@ -131,6 +123,8 @@ class Test_Interval:
         prop = bcpn.Interval(Float, 0.0, 1.0)
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(1.0+1.0j)
         assert not prop.is_valid("")
         assert not prop.is_valid(())
@@ -155,10 +149,6 @@ class Test_Size:
     def test_valid(self) -> None:
         prop = bcpn.Size()
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
         assert prop.is_valid(0)
         assert prop.is_valid(1)
         assert prop.is_valid(0.0)
@@ -170,6 +160,8 @@ class Test_Size:
         prop = bcpn.Size()
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(1.0+1.0j)
         assert not prop.is_valid("")
         assert not prop.is_valid(())
@@ -194,10 +186,6 @@ class Test_Percent:
     def test_valid(self) -> None:
         prop = bcpn.Percent()
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
         assert prop.is_valid(0)
         assert prop.is_valid(1)
         assert prop.is_valid(0.0)
@@ -208,6 +196,8 @@ class Test_Percent:
         prop = bcpn.Percent()
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(1.0+1.0j)
         assert not prop.is_valid("")
         assert not prop.is_valid(())
@@ -232,10 +222,6 @@ class Test_NonNegative:
     def test_valid(self) -> None:
         prop0 = bcpn.NonNegative(Int)
 
-        # TODO (bev) should fail
-        assert prop0.is_valid(False)
-        assert prop0.is_valid(True)
-
         assert prop0.is_valid(0)
         assert prop0.is_valid(1)
         assert prop0.is_valid(2)
@@ -252,6 +238,8 @@ class Test_NonNegative:
         prop = bcpn.NonNegative(Int)
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(-1)
         assert not prop.is_valid(0.0)
         assert not prop.is_valid(1.0)
@@ -281,9 +269,6 @@ class Test_PositiveInt:
     def test_valid(self) -> None:
         prop0 = bcpn.Positive(Int)
 
-        # TODO (bev) should fail
-        assert prop0.is_valid(True)
-
         assert prop0.is_valid(1)
         assert prop0.is_valid(2)
         assert prop0.is_valid(100)
@@ -297,6 +282,7 @@ class Test_PositiveInt:
         prop = bcpn.Positive(Int)
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(False)
         assert not prop.is_valid(-1)
         assert not prop.is_valid(0)

--- a/tests/unit/bokeh/core/property/test_primitive.py
+++ b/tests/unit/bokeh/core/property/test_primitive.py
@@ -153,14 +153,12 @@ class Test_Complex:
         if hasattr(np, "complex256"):
             assert prop.is_valid(np.complex256(1.0+1.0j))
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
     def test_invalid(self) -> None:
         prop = bcpp.Complex()
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid("")
         assert not prop.is_valid(())
         assert not prop.is_valid([])
@@ -216,14 +214,12 @@ class Test_Float:
         assert prop.is_valid(np.float64(0))
         assert prop.is_valid(np.float64(1))
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
     def test_invalid(self) -> None:
         prop = bcpp.Float()
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(1.0+1.0j)
         assert not prop.is_valid("")
         assert not prop.is_valid(())
@@ -345,14 +341,12 @@ class Test_Int:
         assert prop.is_valid(np.uint64(0))
         assert prop.is_valid(np.uint64(1))
 
-        # TODO (bev) should fail
-        assert prop.is_valid(False)
-        assert prop.is_valid(True)
-
     def test_invalid(self) -> None:
         prop = bcpp.Int()
 
         assert not prop.is_valid(None)
+        assert not prop.is_valid(False)
+        assert not prop.is_valid(True)
         assert not prop.is_valid(0.0)
         assert not prop.is_valid(1.0)
         assert not prop.is_valid(1.0+1.0j)

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -58,6 +58,7 @@ ALL = (
     'Array',
     'Auto',
     'Bool',
+    'BoolSpec',
     'Byte',
     'Bytes',
     'CSSLength',


### PR DESCRIPTION
As a side effect I disallowed booleans as input to numerical properties (`Int`, `Float`, `Complex` and their derivatives and composites).

fixes #14554 