### PR TITLE
Robustify serialization tests involving `RuntimeError`

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -65,7 +65,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=1.15
+    - mypy >=1.17
     # docs
     - bokeh_sampledata
     - pydata_sphinx_theme

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -77,7 +77,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs >=2.2
-    - ruff ==0.11.6
+    - ruff ==0.12.3
     - types-boto3
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -65,7 +65,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=1.15
+    - mypy >=1.17
     # docs
     - bokeh_sampledata
     - pydata_sphinx_theme

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -77,7 +77,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs >=2.2
-    - ruff ==0.11.6
+    - ruff ==0.12.3
     - types-boto3
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -65,7 +65,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=1.15
+    - mypy >=1.17
     # docs
     - bokeh_sampledata
     - pydata_sphinx_theme

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -77,7 +77,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs >=2.2
-    - ruff ==0.11.6
+    - ruff ==0.12.3
     - types-boto3
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -78,7 +78,7 @@ dependencies:
     - sphinxext-opengraph
     # tests
     - pandas-stubs >=2.2
-    - ruff ==0.11.6
+    - ruff ==0.12.3
     - types-boto3
     - types-colorama
     - types-mock

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -66,7 +66,7 @@ dependencies:
   # pip dependencies
   - pip
   - pip:
-    - mypy >=1.15
+    - mypy >=1.17
     # docs
     - bokeh_sampledata
     - pydata_sphinx_theme

--- a/examples/topics/pie/donut.py
+++ b/examples/topics/pie/donut.py
@@ -38,7 +38,7 @@ browsers = selected.index.tolist()
 angles = selected.Share.map(lambda x: 2*pi*(x/100)).cumsum().tolist()
 
 browsers_source = ColumnDataSource(dict(
-    start  = [0] + angles[:-1],
+    start  = [0, *angles[:-1]],
     end    = angles,
     colors = [colors[browser] for browser in browsers],
 ))

--- a/src/bokeh/core/property/data_frame.py
+++ b/src/bokeh/core/property/data_frame.py
@@ -60,7 +60,7 @@ class EagerDataFrame(Property["IntoDataFrame"]):
         super().validate(value, detail)
 
         if nw.dependencies.is_into_dataframe(value):
-            return # type: ignore[unreachable] # https://github.com/bokeh/bokeh/issues/14342
+            return
 
         msg = "" if not detail else f"expected object convertible to Narwhals DataFrame, got {value!r}"
         raise ValueError(msg)
@@ -78,7 +78,7 @@ class EagerSeries(Property["IntoSeries"]):
         super().validate(value, detail)
 
         if nw.dependencies.is_into_series(value):
-            return # type: ignore[unreachable] # https://github.com/bokeh/bokeh/issues/14342
+            return
 
         msg = "" if not detail else f"expected object convertible to Narwhals Series, got {value!r}"
         raise ValueError(msg)

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -446,10 +446,10 @@ class BokehTornado(TornadoApplication):
                         "index": self._index,
                         "use_redirect": redirect_root,
                     }
-                    prefixed_pat = (self._prefix + p[0],) + p[1:] + (data,)
+                    prefixed_pat = (self._prefix + p[0], *p[1:], data)
                     all_patterns.append(prefixed_pat) # type: ignore[arg-type] # TODO: easy to fix types, but also easy to break logic
             else:
-                prefixed_pat = (self._prefix + p[0],) + p[1:]
+                prefixed_pat = (self._prefix + p[0], *p[1:])
                 all_patterns.append(prefixed_pat) # type: ignore[arg-type] # TODO: easy to fix types, but also easy to break logic
 
         log.debug("Patterns are:")

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -447,10 +447,10 @@ class BokehTornado(TornadoApplication):
                         "use_redirect": redirect_root,
                     }
                     prefixed_pat = (self._prefix + p[0], *p[1:], data)
-                    all_patterns.append(prefixed_pat) # type: ignore[arg-type] # TODO: easy to fix types, but also easy to break logic
+                    all_patterns.append(prefixed_pat)
             else:
                 prefixed_pat = (self._prefix + p[0], *p[1:])
-                all_patterns.append(prefixed_pat) # type: ignore[arg-type] # TODO: easy to fix types, but also easy to break logic
+                all_patterns.append(prefixed_pat)
 
         log.debug("Patterns are:")
         for line in pformat(all_patterns, width=60).split("\n"):

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -269,6 +269,7 @@ class TestSerializer:
         with pytest.raises(SerializationError, match="circular reference"):
             encoder.encode(val)
 
+    @pytest.mark.skipif(sys.platform == "win32" and sys.version_info < (3, 11), reason="stack overflow instead of RecursionError")
     def test_list_circular_without_checking(self) -> None:
         val: Sequence[Any] = [1, 2, 3]
         val.append(val)
@@ -311,6 +312,7 @@ class TestSerializer:
         with pytest.raises(SerializationError, match="circular reference"):
             encoder.encode(val)
 
+    @pytest.mark.skipif(sys.platform == "win32" and sys.version_info < (3, 11), reason="stack overflow instead of RecursionError")
     def test_dict_circular_without_checking(self) -> None:
         val: dict[Any, Any] = {nan: [1, 2]}
         val[inf] = val


### PR DESCRIPTION
Given that Python 3.10 is on its way out, I'm not going to spend time trying to figure out why Windows and Python 3.10 combination behaves as it does. Instead, I just skipped relevant tests for this setup.

fixes #14540