### PR TITLE
Notify about connection lost and reconnection events

### DIFF
--- a/bokehjs/src/less/notifications.less
+++ b/bokehjs/src/less/notifications.less
@@ -1,0 +1,60 @@
+@import "./_mixins.less";
+
+:host {
+  position: fixed;
+  left: 50%;
+  top: 0.5em;
+  transform: translate(-50%, 0);
+  width: max-content;
+  height: max-content;
+  max-width: 50%;
+}
+:host > .entries:empty {
+  display: none;
+}
+.entries {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 0.5em;
+}
+.entries > * {
+  padding: 0.5em;
+  border: 1px solid gray;
+  border-radius: 0.5em;
+}
+.error {
+  background-color: var(--danger);
+  border-color: var(--danger-border);
+}
+.success {
+  background-color: var(--success);
+  border-color: var(--success-border);
+}
+.try {
+  font-weight: bold;
+  cursor: pointer;
+}
+.try:hover {
+  text-decoration: underline;
+}
+.close {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 1em;
+
+  width: 1em;
+  height: 1em;
+
+  cursor: pointer;
+
+  .mask-image(var(--bokeh-icon-x));
+  .mask-size(contain);
+  .mask-position(center center);
+  .mask-repeat(no-repeat);
+
+  background-color: black;
+  &:hover {
+    background-color: var(--hover-color);
+  }
+}

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -45,7 +45,11 @@ export class ClientConnection {
   closed_permanently: boolean = false
   readonly id: string
 
-  protected _reconnection_attempts = MAX_RECONNECTION_ATTEMPTS
+  protected _reconnection_attempts_left = MAX_RECONNECTION_ATTEMPTS
+
+  get reconnection_attempts(): number {
+    return MAX_RECONNECTION_ATTEMPTS - this._reconnection_attempts_left
+  }
 
   protected _current_handler: ((message: Message<unknown>) => void) | null = null
   protected _pending_replies: Map<string, PendingReply> = new Map()
@@ -112,23 +116,23 @@ export class ClientConnection {
     // TODO: after retries ended, show a button to try one last reconnect.
 
     const retry = () => {
-      if (this.closed_permanently || this._reconnection_attempts <= 0) {
+      if (this.closed_permanently || this._reconnection_attempts_left <= 0) {
         logger.info(`Websocket connection ${this._number} disconnected, will not attempt to reconnect`)
-        this.session?.document.event_manager.send_event(new ConnectionLost(this._reconnection_attempts, null))
+        this.session?.document.event_manager.send_event(new ConnectionLost(new WeakRef(this), this.reconnection_attempts, null))
       } else {
         if (this.socket?.readyState !== WebSocket.OPEN && this.socket?.readyState !== WebSocket.CONNECTING) {
-          logger.debug(`Attempting to reconnect websocket ${this._number} in ${milliseconds}ms, ${this._reconnection_attempts} attempts left`)
-          this.session?.document.event_manager.send_event(new ConnectionLost(this._reconnection_attempts, milliseconds))
+          logger.debug(`Attempting to reconnect websocket ${this._number} in ${milliseconds}ms, ${this._reconnection_attempts_left} attempts left`)
+          this.session?.document.event_manager.send_event(new ConnectionLost(new WeakRef(this), this.reconnection_attempts, milliseconds))
 
           this.connect().then(() => {
             logger.info(`Reconnected websocket ${this._number}`)
-            this._reconnection_attempts = MAX_RECONNECTION_ATTEMPTS
+            this._reconnection_attempts_left = MAX_RECONNECTION_ATTEMPTS
             this.session?.document.event_manager.send_event(new ClientReconnected())
           }).catch(err => {
             logger.debug(`Could not reconnect ${this._number}, ${err}`)
           })
 
-          this._reconnection_attempts -= 1
+          this._reconnection_attempts_left -= 1
         }
 
       }
@@ -240,7 +244,7 @@ export class ClientConnection {
    * first attempt is done immediately.
    */
   private _reconnect_delay(): number {
-    const retries = MAX_RECONNECTION_ATTEMPTS - this._reconnection_attempts
+    const retries = MAX_RECONNECTION_ATTEMPTS - this._reconnection_attempts_left
     return retries == 0 ? 0 : RECONNECT_BASE_DELAY * 2**retries
   }
 

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -64,11 +64,7 @@ export class ClientConnection {
   }
 
   async reconnect(): Promise<void> {
-    if (this.closed_permanently || this.socket != null) {
-      return
-    } else {
-      await this.connect()
-    }
+    this._try_reconnect(true)
   }
 
   async connect(): Promise<ClientSession> {
@@ -119,34 +115,37 @@ export class ClientConnection {
     }
   }
 
-  protected _schedule_reconnect(milliseconds: number): void {
-    // TODO: maybe also show notification we are retrying (which attempt, next attempt in x ms, ...)
-    // TODO: after retries ended, show a button to try one last reconnect.
+  protected _try_reconnect(force: boolean = false): void {
+    if (this.closed_permanently) {
+      logger.info(`Websocket connection ${this._number} permanently disconnected, will not attempt to reconnect`)
+    } else if (!force && this._reconnection_attempts_left <= 0) {
+      logger.info(`Websocket connection ${this._number} disconnected, will not attempt to automatically reconnect`)
+    } else {
+      if (this.socket?.readyState !== WebSocket.OPEN && this.socket?.readyState !== WebSocket.CONNECTING) {
+        this._reconnection_attempts_left -= 1
 
-    const retry = () => {
-      if (this.closed_permanently || this._reconnection_attempts_left <= 0) {
-        logger.info(`Websocket connection ${this._number} disconnected, will not attempt to reconnect`)
-        this.session?.document.event_manager.send_event(new ConnectionLost(new WeakRef(this), this.reconnection_attempts, null))
-      } else {
-        if (this.socket?.readyState !== WebSocket.OPEN && this.socket?.readyState !== WebSocket.CONNECTING) {
-          logger.debug(`Attempting to reconnect websocket ${this._number} in ${milliseconds}ms, ${this._reconnection_attempts_left} attempts left`)
-          this.session?.document.event_manager.send_event(new ConnectionLost(new WeakRef(this), this.reconnection_attempts, milliseconds))
+        logger.debug(`Attempting to reconnect websocket ${this._number}, ${this._reconnection_attempts_left} attempts left`)
 
-          this.connect().then(() => {
-            logger.info(`Reconnected websocket ${this._number}`)
-            this._reconnection_attempts_left = MAX_RECONNECTION_ATTEMPTS
-            this.session?.document.event_manager.send_event(new ClientReconnected())
-          }).catch(err => {
-            logger.debug(`Could not reconnect ${this._number}, ${err}`)
-          })
-
-          this._reconnection_attempts_left -= 1
-        }
-
+        this.connect().then(() => {
+          logger.info(`Reconnected websocket ${this._number}`)
+          this._reconnection_attempts_left = MAX_RECONNECTION_ATTEMPTS
+          this.session?.document.event_manager.send_event(new ClientReconnected())
+        }).catch(err => {
+          logger.debug(`Could not reconnect ${this._number}, ${err}`)
+        })
       }
     }
+  }
 
-    setTimeout(retry, milliseconds)
+  protected _schedule_reconnect(milliseconds: number): void {
+    const should_reconnect = this._reconnection_attempts_left > 0
+    const timeout = should_reconnect ? milliseconds : null
+    const event = new ConnectionLost(new WeakRef(this), this.reconnection_attempts, timeout)
+    this.session?.document.event_manager.send_event(event)
+
+    if (should_reconnect) {
+      setTimeout(() => this._try_reconnect(), milliseconds)
+    }
   }
 
   send(message: Message<unknown>): void {

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -108,13 +108,17 @@ export class ClientConnection {
   }
 
   protected _schedule_reconnect(milliseconds: number): void {
+    // TODO: maybe also show notification we are retrying (which attempt, next attempt in x ms, ...)
+    // TODO: after retries ended, show a button to try one last reconnect.
+
     const retry = () => {
       if (this.closed_permanently || this._reconnection_attempts <= 0) {
         logger.info(`Websocket connection ${this._number} disconnected, will not attempt to reconnect`)
-        this.session?.document.event_manager.send_event(new ConnectionLost()) // TODO ConnectionLostPermanently
+        this.session?.document.event_manager.send_event(new ConnectionLost(this._reconnection_attempts, null))
       } else {
         if (this.socket?.readyState !== WebSocket.OPEN && this.socket?.readyState !== WebSocket.CONNECTING) {
           logger.debug(`Attempting to reconnect websocket ${this._number} in ${milliseconds}ms, ${this._reconnection_attempts} attempts left`)
+          this.session?.document.event_manager.send_event(new ConnectionLost(this._reconnection_attempts, milliseconds))
 
           this.connect().then(() => {
             logger.info(`Reconnected websocket ${this._number}`)
@@ -130,11 +134,7 @@ export class ClientConnection {
       }
     }
 
-    // TODO: maybe also show notification we are retrying (which attempt, next attempt in x ms, ...)
-
     setTimeout(retry, milliseconds)
-
-    // TODO: after retries ended, show a button to try one last reconnect.
   }
 
   send(message: Message<unknown>): void {

--- a/bokehjs/src/lib/client/connection.ts
+++ b/bokehjs/src/lib/client/connection.ts
@@ -63,6 +63,14 @@ export class ClientConnection {
     logger.debug(`Creating websocket ${this._number} to '${this.url}' session '${this.id}'`)
   }
 
+  async reconnect(): Promise<void> {
+    if (this.closed_permanently || this.socket != null) {
+      return
+    } else {
+      await this.connect()
+    }
+  }
+
   async connect(): Promise<ClientSession> {
     if (this.closed_permanently) {
       throw new Error("Cannot connect() a closed ClientConnection")

--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -37,7 +37,8 @@ export type DocumentEventType =
   ConnectionEventType
 
 export type ConnectionEventType =
-  "connection_lost"
+  "connection_lost" |
+  "client_reconnected"
 
 export type ModelEventType =
   "axis_click" |
@@ -83,6 +84,7 @@ export type BokehEventMap = {
   button_click: ButtonClick
   clear_input: ClearInput
   connection_lost: ConnectionLost
+  client_reconnected: ClientReconnected
   document_ready: DocumentReady
   doubletap: DoubleTap
   legend_item_click: LegendItemClick

--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -236,7 +236,7 @@ export class ConnectionLost extends ConnectionEvent {
   }
 
   reconnect(): void {
-    void this.connection.deref()?.connect()
+    void this.connection.deref()?.reconnect()
   }
 }
 

--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -207,12 +207,24 @@ export class DocumentReady extends DocumentEvent {
 
 export abstract class ConnectionEvent extends DocumentEvent {}
 
+/**
+ * Announce when a WebSocket connection was disconnected.
+ *
+ * @member timestamp when the last connection attempt was made
+ * @member attempts  the number of times reconnection was attempted
+ * @member timeout   milliseconds till next reconnection attempt or `null`
+ *                   indicating that no further attempts will be made
+ */
 export class ConnectionLost extends ConnectionEvent {
-  readonly timestamp = new Date()
+  readonly timestamp = Date.now()
+
+  constructor(readonly attempts: number, readonly timeout: number | null) {
+    super()
+  }
 
   protected get event_values(): Attrs {
-    const {timestamp} = this
-    return {timestamp}
+    const {timestamp, attempts, timeout} = this
+    return {timestamp, attempts, timeout}
   }
 
   static {

--- a/bokehjs/src/lib/core/bokeh_events.ts
+++ b/bokehjs/src/lib/core/bokeh_events.ts
@@ -16,6 +16,7 @@ import type {Axis} from "../models/axes/axis"
 import type {LegendItem} from "../models/annotations/legend_item"
 import type {Factor} from "../models/ranges/factor_range"
 import type {ClearInput} from "../models/widgets/input_widget"
+import type {ClientConnection} from "../client/connection"
 
 Deserializer.register("event", (rep: BokehEventRep, deserializer: Deserializer): BokehEvent => {
   const cls = deserializable_events.get(rep.name)
@@ -220,7 +221,7 @@ export abstract class ConnectionEvent extends DocumentEvent {}
 export class ConnectionLost extends ConnectionEvent {
   readonly timestamp = Date.now()
 
-  constructor(readonly attempts: number, readonly timeout: number | null) {
+  constructor(private readonly connection: WeakRef<ClientConnection>, readonly attempts: number, readonly timeout: number | null) {
     super()
   }
 
@@ -232,6 +233,10 @@ export class ConnectionLost extends ConnectionEvent {
   static {
     this.prototype.event_name = "connection_lost"
     this.prototype.publish = false
+  }
+
+  reconnect(): void {
+    void this.connection.deref()?.connect()
   }
 }
 

--- a/bokehjs/src/lib/core/settings.ts
+++ b/bokehjs/src/lib/core/settings.ts
@@ -3,6 +3,7 @@ export class Settings {
   private _wireframe = false
   private _force_webgl = false
   private _force_fields = false
+  private _notifications = true
 
   set dev(dev: boolean) {
     this._dev = dev
@@ -34,6 +35,14 @@ export class Settings {
 
   get force_fields(): boolean {
     return this._force_fields
+  }
+
+  set notifications(notifications: boolean) {
+    this._notifications = notifications
+  }
+
+  get notifications(): boolean {
+    return this._notifications
   }
 }
 

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -30,6 +30,7 @@ import {DocumentReady, LODStart, LODEnd} from "core/bokeh_events"
 import type {DocumentEvent, DocumentChangedEvent, Decoded, DocumentChanged} from "./events"
 import {DocumentEventBatch, RootRemovedEvent, TitleChangedEvent, MessageSentEvent, RootAddedEvent} from "./events"
 import type {ViewManager} from "core/view_manager"
+import {Notifications} from "../models/ui/notifications"
 
 Deserializer.register("model", decode_def)
 
@@ -108,6 +109,7 @@ export class Document implements Equatable {
   protected _interactive_plot: Model | null
   protected _interactive_finalize: (() => void) | null
   protected _recompute_timeout: number
+  protected _notifications: Notifications
 
   constructor(options: DocumentOptions = {}) {
     documents.push(this)
@@ -134,6 +136,8 @@ export class Document implements Equatable {
       assert(event instanceof ModelEvent)
       this.event_manager.trigger(event)
     })
+    this._notifications = new Notifications()
+    this._notifications.attach_document(this)
   }
 
   [equals](that: this, _cmp: Comparator): boolean {
@@ -312,6 +316,10 @@ export class Document implements Equatable {
       }
     }
     this._schedule_recompute_all_models()
+  }
+
+  get all_roots(): HasProps[] {
+    return [...this._roots, this._notifications]
   }
 
   roots(): HasProps[] {

--- a/bokehjs/src/lib/embed/standalone.ts
+++ b/bokehjs/src/lib/embed/standalone.ts
@@ -57,7 +57,7 @@ export async function add_document_standalone(document: Document, element: Embed
     const view = await views.build_view(model)
 
     if (view instanceof DOMView) {
-      const i = document.roots().indexOf(model)
+      const i = document.all_roots.indexOf(model)
       const root_el = roots[i] ?? element
       view.build(root_el)
     }
@@ -78,7 +78,7 @@ export async function add_document_standalone(document: Document, element: Embed
     view?.remove()
   }
 
-  for (const model of document.roots()) {
+  for (const model of document.all_roots) {
     await render_model(model)
   }
 

--- a/bokehjs/src/lib/models/ui/examiner.ts
+++ b/bokehjs/src/lib/models/ui/examiner.ts
@@ -303,7 +303,7 @@ export class ExaminerView extends UIElementView {
       clear(models_list)
       empty(models_list_el)
 
-      const roots = doc != null ? new Set(doc.roots()) : new Set()
+      const roots = doc != null ? new Set(doc.all_roots) : new Set()
       for (const model of models) {
         const root = roots.has(model) ? span({class: "tag"}, "root") : null
         const ref_el = span({class: "model-ref", tabIndex: 0}, to_html(model), root)

--- a/bokehjs/src/lib/models/ui/notifications.ts
+++ b/bokehjs/src/lib/models/ui/notifications.ts
@@ -1,0 +1,107 @@
+import {UIElement, UIElementView} from "./ui_element"
+import type * as p from "core/properties"
+import {dom_ready, span, div, InlineStyleSheet} from "core/dom"
+
+import * as base_css from "styles/base.css"
+import * as icons_css from "styles/icons.css"
+import * as buttons_css from "styles/buttons.css"
+import * as notifications_css from "styles/notifications.css"
+
+export const notifications_el: HTMLElement = (() => {
+  const el = div()
+  const shadow_el = el.attachShadow({mode: "open"})
+  new InlineStyleSheet(base_css.default).install(shadow_el)
+  new InlineStyleSheet(icons_css.default).install(shadow_el)
+  new InlineStyleSheet(buttons_css.default).install(shadow_el)
+  new InlineStyleSheet(notifications_css.default).install(shadow_el)
+  const entries_el = div({class: "entries"})
+  shadow_el.append(entries_el)
+  void dom_ready().then(() => document.body.append(el))
+  return entries_el
+})()
+
+export class NotificationsView extends UIElementView {
+  declare model: Notifications
+
+  protected _connection_el: HTMLElement | null = null
+  protected _connection_timer: number | null = null
+
+  override initialize(): void {
+    super.initialize()
+
+    const {document} = this.model
+    if (document == null) {
+      return
+    }
+
+    document.on_event("connection_lost", (_, event) => {
+      this._connection_el?.remove()
+      if (this._connection_timer != null) {
+        clearTimeout(this._connection_timer)
+        this._connection_timer = null
+      }
+      const {timeout} = event
+      if (timeout == null) {
+        const try_el = span({class: "try"}, "Try")
+        try_el.addEventListener("click", () => {
+          this._connection_el?.remove()
+          event.reconnect()
+        })
+        const dismiss_el = div({class: "close", title: "Close"})
+        dismiss_el.addEventListener("click", () => this._connection_el?.remove())
+        this._connection_el = div({class: "error"}, "Client connection was lost permanently. ", try_el, " to reconnect manually.", dismiss_el)
+        notifications_el.append(this._connection_el)
+      } else {
+        let current_timeout = timeout
+        const timeout_el = span()
+        const set_timeout = () => {
+          const timeout = Math.max(0, Math.round(current_timeout / 1000))
+          if (timeout == 0) {
+            timeout_el.textContent = "Reconnecting now."
+          } else {
+            timeout_el.textContent = `Reconnection will be attempted in ${timeout} s.`
+          }
+        }
+        set_timeout()
+        this._connection_el = div({class: "error"}, "Client connection was lost. ", timeout_el)
+        notifications_el.append(this._connection_el)
+        this._connection_timer = setInterval(() => { current_timeout -= 1000; set_timeout() }, 1000)
+      }
+    })
+
+    document.on_event("client_reconnected", (_, _event) => {
+      this._connection_el?.remove()
+      if (this._connection_timer != null) {
+        clearTimeout(this._connection_timer)
+        this._connection_timer = null
+      }
+      this._connection_el = div({class: "success"}, "Client connect was reestablished.")
+      notifications_el.append(this._connection_el)
+      this._connection_timer = setTimeout(() => this._connection_el?.remove(), 5000)
+    })
+  }
+}
+
+export namespace Notifications {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = UIElement.Props & {}
+}
+
+export interface Notifications extends Notifications.Attrs {}
+
+export class Notifications extends UIElement {
+  declare properties: Notifications.Props
+  declare __view_type__: NotificationsView
+
+  constructor(attrs?: Partial<Notifications.Attrs>) {
+    super(attrs)
+  }
+
+  static {
+    this.prototype.default_view = NotificationsView
+
+    this.define<Notifications.Props>(() => ({
+    }))
+  }
+}

--- a/bokehjs/src/lib/models/ui/notifications.ts
+++ b/bokehjs/src/lib/models/ui/notifications.ts
@@ -1,6 +1,7 @@
 import {UIElement, UIElementView} from "./ui_element"
 import type * as p from "core/properties"
 import {dom_ready, span, div, InlineStyleSheet} from "core/dom"
+import {settings} from "core/settings"
 
 import * as base_css from "styles/base.css"
 import * as icons_css from "styles/icons.css"
@@ -35,6 +36,9 @@ export class NotificationsView extends UIElementView {
     }
 
     document.on_event("connection_lost", (_, event) => {
+      if (!settings.notifications) {
+        return
+      }
       this._connection_el?.remove()
       if (this._connection_timer != null) {
         clearTimeout(this._connection_timer)
@@ -70,6 +74,9 @@ export class NotificationsView extends UIElementView {
     })
 
     document.on_event("client_reconnected", (_, _event) => {
+      if (!settings.notifications) {
+        return
+      }
       this._connection_el?.remove()
       if (this._connection_timer != null) {
         clearTimeout(this._connection_timer)

--- a/bokehjs/test/unit/embed.ts
+++ b/bokehjs/test/unit/embed.ts
@@ -49,7 +49,7 @@ describe("embed", () => {
     const doc = new Document({roots: [new ModelWithView]})
     const views = await embed.add_document_standalone(doc, document.body)
     try {
-      expect(views.roots.length).to.be.equal(1)
+      expect(views.roots.length).to.be.equal(2) // root + notifications
       const [view] = views.roots
 
       expect(index[view.model.id]).to.be.equal(view)

--- a/docs/bokeh/source/docs/releases/3.8.0.rst
+++ b/docs/bokeh/source/docs/releases/3.8.0.rst
@@ -1,0 +1,8 @@
+.. _release-3-8-0:
+
+3.8.0
+=====
+
+Bokeh version ``3.8.0`` (August 2025) is a minor milestone of Bokeh project.
+
+* added support for session reconnect, connection events and UI notifications (:bokeh-pull:`14201`, :bokeh-pull:`14576`)


### PR DESCRIPTION
I improved `ConnectionLost` event to contain all the necessary information and added `reconnect()` method, which can be used to manually reconnect broken connection. I intend to add a very basic notification scheme in this PR to allow UI feedback for `ConenctionLost` and `ClientReconnected` events.

fixes #14564
addresses #14252 