### PR TITLE
fix: Don't trigger `document_ready` event twice

### DIFF
--- a/bokehjs/src/less/tooltips.less
+++ b/bokehjs/src/less/tooltips.less
@@ -107,6 +107,10 @@
   display: inline-block;
 }
 
+:host(.bk-closable) {
+  padding-right: 17px; // 5px + close button width
+}
+
 :host(:not(.bk-closable)) {
   .bk-close {
     display: none;

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -318,8 +318,12 @@ export class Document implements Equatable {
     this._schedule_recompute_all_models()
   }
 
+  get internal_roots(): HasProps[] {
+    return [this._notifications]
+  }
+
   get all_roots(): HasProps[] {
-    return [...this._roots, this._notifications]
+    return [...this._roots, ...this.internal_roots]
   }
 
   roots(): HasProps[] {

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -150,7 +150,7 @@ export class Document implements Equatable {
 
   get is_idle(): boolean {
     // TODO: models without views, e.g. data models
-    for (const root of this._roots) {
+    for (const root of this.all_roots) {
       if (!this._idle_roots.has(root)) {
         return false
       }

--- a/bokehjs/src/lib/models/ui/tooltip.ts
+++ b/bokehjs/src/lib/models/ui/tooltip.ts
@@ -282,7 +282,12 @@ export class TooltipView extends UIElementView {
       height: window.innerHeight,
     })
 
-    const arrow_size = box_size(this.arrow_el)
+    // TODO box_size(this.arrow_el), but currently doesn't work reliably
+    const el_style = getComputedStyle(this.el)
+    const arrow_size = {
+      width: parseFloat(el_style.getPropertyValue("--tooltip-arrow-width")),
+      height: parseFloat(el_style.getPropertyValue("--tooltip-arrow-height")),
+    }
 
     const side = (() => {
       const attachment = (() => {

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -418,6 +418,8 @@ describe("Document", () => {
     doc.add_root(root)
     doc.notify_idle(root)
 
+    doc.internal_roots.forEach((root) => doc.notify_idle(root))
+
     expect(signals).to.be.equal(1)
     expect(events).to.be.equal([
       new ev.RootAddedEvent(doc, root),

--- a/bokehjs/test/unit/embed.ts
+++ b/bokehjs/test/unit/embed.ts
@@ -6,6 +6,7 @@ import {Document} from "@bokehjs/document"
 import {HasProps} from "@bokehjs/core/has_props"
 import {DOMElementView} from "@bokehjs/core/dom_view"
 import {is_equal} from "@bokehjs/core/util/eq"
+import {defer} from "@bokehjs/core/util/defer"
 
 class SomeView extends DOMElementView {
   render(): void {
@@ -37,6 +38,7 @@ describe("embed", () => {
       doc.add_root(new ModelWithoutView())
       doc.add_root(new ModelWithView())
       const views = await embed.add_document_standalone(doc, document.body)
+      await defer() // wait one full loop for NotificationsView; unfortunately view.ready isn't in sync
       try {
         expect(doc.is_idle).to.be.true
       } finally {


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [x] issues: fixes #14597
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)

Not sure how to test it. 