### PR TITLE
Add 3.7.x release notes

### DIFF
--- a/docs/bokeh/source/docs/releases/3.7.1.rst
+++ b/docs/bokeh/source/docs/releases/3.7.1.rst
@@ -1,0 +1,15 @@
+.. _release-3-7-1:
+
+3.7.1
+=====
+
+Bokeh version ``3.7.1`` (March 2025) is a patch release that fixes a number of
+minor bugs/regressions and documentation issues.
+
+Changes
+-------
+
+* Fixed a regression in detaching models from a document in bokehjs (:bokeh-pull:`14430`)
+* Fixed rendering of empty ``Patches`` glyph (:bokeh-pull:`14436`)
+* Improved performance of scatter plots using WebGL backend (:bokeh-pull:`14421`)
+* Improved quality of examples (:bokeh-pull:`14397`, :bokeh-pull:`14395`)

--- a/docs/bokeh/source/docs/releases/3.7.2.rst
+++ b/docs/bokeh/source/docs/releases/3.7.2.rst
@@ -1,0 +1,12 @@
+.. _release-3-7-2:
+
+3.7.2
+=====
+
+Bokeh version ``3.7.2`` (March 2025) is a patch release that fixes a number of
+minor bugs/regressions and documentation issues.
+
+Changes
+-------
+
+* Fixed a regression in application of layout styles during updates (:bokeh-pull:`14437`)

--- a/docs/bokeh/source/docs/releases/3.7.3.rst
+++ b/docs/bokeh/source/docs/releases/3.7.3.rst
@@ -1,0 +1,19 @@
+.. _release-3-7-3:
+
+3.7.3
+=====
+
+Bokeh version ``3.7.3`` (May 2025) is a patch release that fixes a number of
+minor bugs/regressions and documentation issues.
+
+Changes
+-------
+
+* Fixed Legend's rendering when scaling or on high DPI displays (:bokeh-pull:`14443`)
+* Fixed Legend's inactive visuals in CSS mode (:bokeh-pull:`14454`)
+* Fixed Legend's positioning in side panels (:bokeh-pull:`14457`)
+* Allowed to update child views without removing their elements (:bokeh-pull:`14459`)
+* Updated `DatetimeTickFormatter`'s documentation (:bokeh-pull:`14452`)
+* Fixed CodePen template in the documentation (:bokeh-pull:`14471`)
+* Fixed type declarations of ``Figure``'s properties (:bokeh-pull:`14401`)
+* Improved corner case handling in datetime formatter (:bokeh-pull:`14473`)


### PR DESCRIPTION
This PR cherry-picks the release notes from the releases `3.7.1`, `3.7.2` and `3.7.3` in preperation for the comming `3.8.0` release. This addresses more or less #14601.
