### PR TITLE
Enhance bokeh settings command

### DIFF
--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -66,8 +66,8 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from difflib import get_close_matches
 from argparse import Namespace
+from difflib import get_close_matches
 from typing import Any
 
 # Bokeh imports

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -120,9 +120,9 @@ class Settings(Subcommand):
             help="Show detailed help for a specific setting",
         )),
 
-        ('setting_name', Argument(
-            nargs='?',
-            help="Name of a specific setting to show detailed help for (use with -v)",
+        ('setting_names', Argument(
+            nargs='*',
+            help="One or more specific settings to show info for (use with -v for details)",
         )),
 
     )
@@ -133,66 +133,67 @@ class Settings(Subcommand):
         all_settings = get_all_settings()
 
         # Case 1: Verbose requested without a specific setting -> print all with details
-        if args.verbose and not args.setting_name:
+        if args.verbose and not args.setting_names:
             for name, descriptor in all_settings.items():
                 self._print_setting_detail(name, descriptor)
             return
 
         # Case 2: Specific setting requested
-        if args.setting_name:
-            name = args.setting_name
-            matches = []
+        if args.setting_names:
+            for name in args.setting_names:
+                matches = []
 
-            if name in all_settings:
-                matches = [name]
-            else:
-                # substring matches (more intuitive than only difflib)
-                substring_matches = [k for k in all_settings if name.lower() in k.lower()]
-                if len(substring_matches) == 1:
-                    matches = substring_matches
-                elif len(substring_matches) > 1:
-                    print()
-                    print(f"Multiple matches found for '{name}':")
-                    for m in sorted(substring_matches):
-                        print(f"  {m}")
-                    print()
-                    return
+                if name in all_settings:
+                    matches = [name]
                 else:
-                    # fallback to fuzzy (difflib)
-                    close = get_close_matches(name, all_settings.keys(), n=3, cutoff=0.6)
-                    if close:
+                    # substring matches (more intuitive than only difflib)
+                    substring_matches = [k for k in all_settings if name.lower() in k.lower()]
+                    if len(substring_matches) == 1:
+                        matches = substring_matches
+                    elif len(substring_matches) > 1:
                         print()
-                        print("Did you mean one of these?")
-                        for c in close:
-                            print(f"  {c}")
+                        print(f"Multiple matches found for '{name}':")
+                        for m in sorted(substring_matches):
+                            print(f"  {m}")
                         print()
-                        return
+                        continue
+                    else:
+                        # fuzzy fallback
+                        close = get_close_matches(name, all_settings.keys(), n=3, cutoff=0.6)
+                        if close:
+                            print()
+                            print(f"Setting '{name}' not found.")
+                            print("Did you mean one of these?")
+                            for c in close:
+                                print(f"  {c}")
+                            print()
+                            continue
 
-            if matches:
-                setting_name = matches[0]
-                descriptor = all_settings[setting_name]
-                if args.verbose:
-                    # Verbose + setting -> detailed info
-                    self._print_setting_detail(setting_name, descriptor)
-                else:
-                    # Basic info
+                if matches:
+                    setting_name = matches[0]
+                    descriptor = all_settings[setting_name]
+                    if args.verbose:
+                        # Verbose + setting -> detailed info
+                        self._print_setting_detail(setting_name, descriptor)
+                    else:
+                        # Basic info
+                        print()
+                        print(f"Setting: {setting_name}")
+                        print("=" * 60)
+                        print(f"Current Value: {descriptor()}")
+                        print(f"Environment Variable: {descriptor.env_var}")
+                        print("\nHelp:")
+                        print(f"{descriptor.help.strip()}")
                     print()
-                    print(f"Setting: {setting_name}")
-                    print("=" * 60)
-                    print(f"Current Value: {descriptor()}")
-                    print(f"Environment Variable: {descriptor.env_var}")
-                    print("\nHelp:")
-                    print(f"{descriptor.help.strip()}")
-                return
-
-            # no matches at all
-            print()
-            print(f"Setting '{name}' not found.")
-            print()
-            print("Available settings:")
-            for n in sorted(all_settings):
-                print(f"  {n}")
-            print()
+                else:
+                    # no matches at all
+                    print()
+                    print(f"Setting '{name}' not found.")
+                    print()
+                    print("Available settings:")
+                    for n in sorted(all_settings):
+                        print(f"  {n}")
+                    print()
             return
 
         # Case 3: No args -> print summary table

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -66,9 +66,9 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from difflib import get_close_matches
 from argparse import Namespace
 from typing import Any
-from difflib import get_close_matches
 
 # Bokeh imports
 from bokeh.settings import PrioritizedSetting, _Unset

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -5,7 +5,6 @@
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 '''
-
 To display all available Bokeh settings and their current values,
 type ``bokeh settings`` on the command line.
 
@@ -13,7 +12,7 @@ type ``bokeh settings`` on the command line.
 
     bokeh settings
 
-This will print all settings to standard output, such as:
+This will print all settings to standard output in a table format, such as:
 
 .. code-block:: none
 
@@ -21,51 +20,37 @@ This will print all settings to standard output, such as:
     ==========================================================================
     Setting                      Environment Variable              Value
     --------------------------------------------------------------------------
-    allowed_ws_origin            BOKEH_ALLOW_WS_ORIGIN             []
-    auth_module                  BOKEH_AUTH_MODULE                 None
-    browser                      BOKEH_BROWSER                     None
-    cdn_version                  BOKEH_CDN_VERSION                 None
-    chromedriver_path            BOKEH_CHROMEDRIVER_PATH           None
-    compression_level            BOKEH_COMPRESSION_LEVEL           9
-    cookie_secret                BOKEH_COOKIE_SECRET               None
-    default_server_host          BOKEH_DEFAULT_SERVER_HOST         localhost
-    default_server_port          BOKEH_DEFAULT_SERVER_PORT         5006
-    docs_cdn                     BOKEH_DOCS_CDN                    None
-    docs_version                 BOKEH_DOCS_VERSION                None
-    ico_path                     BOKEH_ICO_PATH                    /path/to/ico
-    ignore_filename              BOKEH_IGNORE_FILENAME             False
     log_level                    BOKEH_LOG_LEVEL                   info
     minified                     BOKEH_MINIFIED                    True
-    nodejs_path                  BOKEH_NODEJS_PATH                 None
-    perform_document_validation  BOKEH_VALIDATE_DOC                True
-    pretty                       BOKEH_PRETTY                      False
-    py_log_level                 BOKEH_PY_LOG_LEVEL                None
-    resources                    BOKEH_RESOURCES                   cdn
-    rootdir                      BOKEH_ROOTDIR                     None
-    secret_key                   BOKEH_SECRET_KEY                  None
-    serialize_include_defaults   BOKEH_SERIALIZE_INCLUDE_DEFAULTS  False
-    sign_sessions                BOKEH_SIGN_SESSIONS               False
-    simple_ids                   BOKEH_SIMPLE_IDS                  True
-    ssl_certfile                 BOKEH_SSL_CERTFILE                None
-    ssl_keyfile                  BOKEH_SSL_KEYFILE                 None
-    ssl_password                 BOKEH_SSL_PASSWORD                None
-    validation_level             BOKEH_VALIDATION_LEVEL            none
-    xsrf_cookies                 BOKEH_XSRF_COOKIES                False
-    --------------------------------------------------------------------------
+    browser                      BOKEH_BROWSER                     None
+    ...
 
-This will display all available Bokeh settings in a table format with their
-current values and environment variables.
+To get detailed help for one or more specific settings, provide their names:
 
-To get detailed help for a specific setting, use the -v option:
+.. code-block:: sh
+
+    bokeh settings log_level minified
+
+This will show the current value, environment variable, and help text for
+each requested setting.
+
+Use the ``-v`` option for verbose output with additional details:
 
 .. code-block:: sh
 
     bokeh settings -v log_level
-    bokeh settings -v minified
+    bokeh settings -v log_level browser
 
-This will show detailed information about the specified setting including its
-help text, default values, and current value.
+If a setting name is not an exact match, substring and fuzzy matching
+will be used to suggest possible candidates:
 
+.. code-block:: sh
+
+    bokeh settings logg
+
+    Did you mean one of these?
+      log_level
+      py_log_level
 '''
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -83,6 +83,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from argparse import Namespace
 from typing import Any
+from difflib import get_close_matches
 
 # Bokeh imports
 from bokeh.settings import PrioritizedSetting, _Unset
@@ -139,28 +140,59 @@ class Settings(Subcommand):
 
         # Case 2: Specific setting requested
         if args.setting_name:
-            if args.setting_name in all_settings:
-                descriptor = all_settings[args.setting_name]
+            name = args.setting_name
+            matches = []
+
+            if name in all_settings:
+                matches = [name]
+            else:
+                # substring matches (more intuitive than only difflib)
+                substring_matches = [k for k in all_settings if name.lower() in k.lower()]
+                if len(substring_matches) == 1:
+                    matches = substring_matches
+                elif len(substring_matches) > 1:
+                    print()
+                    print(f"Multiple matches found for '{name}':")
+                    for m in sorted(substring_matches):
+                        print(f"  {m}")
+                    print()
+                    return
+                else:
+                    # fallback to fuzzy (difflib)
+                    close = get_close_matches(name, all_settings.keys(), n=3, cutoff=0.6)
+                    if close:
+                        print()
+                        print("Did you mean one of these?")
+                        for c in close:
+                            print(f"  {c}")
+                        print()
+                        return
+
+            if matches:
+                setting_name = matches[0]
+                descriptor = all_settings[setting_name]
                 if args.verbose:
                     # Verbose + setting -> detailed info
-                    self._print_setting_detail(args.setting_name, descriptor)
+                    self._print_setting_detail(setting_name, descriptor)
                 else:
                     # Basic info
                     print()
-                    print(f"Setting: {args.setting_name}")
+                    print(f"Setting: {setting_name}")
                     print("=" * 60)
                     print(f"Current Value: {descriptor()}")
                     print(f"Environment Variable: {descriptor.env_var}")
                     print("\nHelp:")
                     print(f"{descriptor.help.strip()}")
-            else:
-                print()
-                print(f"Setting '{args.setting_name}' not found.")
-                print()
-                print("Available settings:")
-                for name in sorted(all_settings):
-                    print(f"  {name}")
-                print()
+                return
+
+            # no matches at all
+            print()
+            print(f"Setting '{name}' not found.")
+            print()
+            print("Available settings:")
+            for n in sorted(all_settings):
+                print(f"  {n}")
+            print()
             return
 
         # Case 3: No args -> print summary table

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -69,6 +69,7 @@ log = logging.getLogger(__name__)
 from argparse import Namespace
 from dataclasses import dataclass, field
 from difflib import get_close_matches
+from jinja2 import Template
 from typing import Any
 
 # Bokeh imports
@@ -87,40 +88,57 @@ __all__ = (
 )
 
 #-----------------------------------------------------------------------------
-# Helpers
-#-----------------------------------------------------------------------------
-
-@dataclass
-class ResolutionResult:
-    exact_matches: list[str] = field(default_factory=list)
-    fuzzy_matches: dict[str, list[str]] = field(default_factory=dict)
-    not_found: list[str] = field(default_factory=list)
-
-
-def resolve_setting_names(input_names: list[str], all_settings: dict[str, Any]) -> ResolutionResult:
-    """Resolve user-supplied setting names into matches against all_settings."""
-    result = ResolutionResult()
-
-    for name in input_names:
-        if name in all_settings:
-            result.exact_matches.append(name)
-            continue
-
-        substring_matches = [k for k in all_settings if name.lower() in k.lower()]
-        if substring_matches:
-            result.exact_matches.extend(substring_matches)
-        else:
-            close = get_close_matches(name, all_settings.keys(), n=3, cutoff=0.6)
-            if close:
-                result.fuzzy_matches[name] = close
-            else:
-                result.not_found.append(name)
-
-    return result
-
-#-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+SETTINGS_TABLE_TEMPLATE = Template("""
+Bokeh Settings:
+{{ "=" * 80 }}
+{{ "{:<30} {:<35} {:<25}".format("Setting", "Environment Variable", "Value") }}
+{{ "-" * 80 }}
+{%- for name, env_var, value in rows %}
+{{ "{:<30} {:<35} {:<25}".format(name, env_var, value) }}
+{%- endfor %}
+{{ "-" * 80 }}
+
+""")
+
+SETTING_TEMPLATE = Template("""
+Setting: {{ name }}
+{{ "=" * 60 }}
+Current Value: {{ current_value }}
+{%- if verbose %}
+Source: {{ source }}
+Default Value: {{ default }}
+{%- if dev_default is not none %}
+Dev Default: {{ dev_default }}
+{%- endif %}
+{%- endif %}
+Environment Variable: {{ env_var }}
+
+Help:
+{{ help }}
+
+""")
+
+FUZZY_MATCH_TEMPLATE = Template("""
+Setting '{{ name }}' not found.
+Did you mean one of these?
+{%- for c in close %}
+  {{ c }}
+{%- endfor %}
+
+""")
+
+NOT_FOUND_TEMPLATE = Template("""
+Setting '{{ name }}' not found.
+
+Available settings:
+{%- for n in all_names %}
+  {{ n }}
+{%- endfor %}
+
+""")
 
 class Settings(Subcommand):
     ''' Subcommand to print information about Bokeh settings.
@@ -152,7 +170,7 @@ class Settings(Subcommand):
 
         if args.verbose and not args.setting_names:
             for name, descriptor in all_settings.items():
-                self._print_setting_detail(name, descriptor)
+                self._print_setting(name, descriptor, verbose=True)
 
         elif args.setting_names:
             resolved = resolve_setting_names(args.setting_names, all_settings)
@@ -167,79 +185,71 @@ class Settings(Subcommand):
     ) -> None:
         """Print results from resolve_setting_names()."""
 
-
         # Fuzzy matches
         for name, close in resolved.fuzzy_matches.items():
-            print()
-            print(f"Setting '{name}' not found.")
-            print("Did you mean one of these?")
-            for c in close:
-                print(f"  {c}")
-            print()
+            print(FUZZY_MATCH_TEMPLATE.render(name=name, close=close))
 
         # Not found
         for name in resolved.not_found:
-            print()
-            print(f"Setting '{name}' not found.")
-            print()
-            print("Available settings:")
-            for n in sorted(all_settings):
-                print(f"  {n}")
-            print()
+            print(NOT_FOUND_TEMPLATE.render(name=name, all_names=sorted(all_settings)))
 
+        # Exact matches
         to_print = sorted(set(resolved.exact_matches))
         for setting_name in to_print:
             descriptor = all_settings[setting_name]
-            if verbose:
-                self._print_setting_detail(setting_name, descriptor)
-            else:
-                self._print_setting_basic(setting_name, descriptor)
+            self._print_setting(setting_name, descriptor, verbose)
 
     def _print_settings_table(self, all_settings: dict[str, PrioritizedSetting[Any]]) -> None:
         ''' Print all settings in a table format.
         '''
-        print()
-        print("Bokeh Settings:")
-        print("=" * 80)
-        print(f"{'Setting':<30} {'Environment Variable':<35} {'Value':<25}")
-        print("-" * 80)
+        rows = [(name, desc.env_var, str(desc())) for name, desc in all_settings.items()]
+        print(SETTINGS_TABLE_TEMPLATE.render(rows=rows))
 
-        for name, descriptor in all_settings.items():
-            print(f"{name:<30} {descriptor.env_var:<35} {descriptor()!s:<25}")
-
-        print("-" * 80)
-        print()
-
-    def _print_setting_basic(self, setting_name: str, descriptor: PrioritizedSetting[Any]) -> None:
-        ''' Print basic info for a specific setting. '''
-        print()
-        print(f"Setting: {setting_name}")
-        print("=" * 60)
-        print(f"Current Value: {descriptor()}")
-        print(f"Environment Variable: {descriptor.env_var}")
-        print("\nHelp:")
-        print(f"{descriptor.help.strip()}")
-        print()
-
-    def _print_setting_detail(self, setting_name: str, descriptor: PrioritizedSetting[Any]) -> None:
-        ''' Print detailed help for a specific setting.
-        '''
-        print()
-        print(f"Setting: {setting_name}")
-        print("=" * 60)
-        print(f"Current Value: {descriptor()}")
-        print(f"Source: {descriptor.provenance_display}")
-        print(f"Default Value: {descriptor.default}")
-        if descriptor.dev_default is not _Unset:
-            print(f"Dev Default: {descriptor.dev_default}")
-        print(f"Environment Variable: {descriptor.env_var}")
-        print("\nHelp:")
-        print(f"{descriptor.help.strip()}")
-        print()
+    def _print_setting(self, setting_name: str, descriptor: PrioritizedSetting[Any], verbose: bool) -> None:
+        ''' Print info (basic or detailed) for a specific setting using one template. '''
+        context = {
+            "name": setting_name,
+            "current_value": descriptor(),
+            "source": descriptor.provenance_display,
+            "default": descriptor.default,
+            "dev_default": descriptor.dev_default if descriptor.dev_default is not _Unset else None,
+            "env_var": descriptor.env_var,
+            "help": descriptor.help.strip(),
+            "verbose": verbose,
+        }
+        print(SETTING_TEMPLATE.render(**context))
 
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
+
+@dataclass
+class ResolutionResult:
+    exact_matches: list[str] = field(default_factory=list)
+    fuzzy_matches: dict[str, list[str]] = field(default_factory=dict)
+    not_found: list[str] = field(default_factory=list)
+
+
+def resolve_setting_names(input_names: list[str], all_settings: dict[str, Any]) -> ResolutionResult:
+    """Resolve user-supplied setting names into matches against all_settings."""
+    result = ResolutionResult()
+
+    for name in input_names:
+        if name in all_settings:
+            result.exact_matches.append(name)
+            continue
+
+        substring_matches = [k for k in all_settings if name.lower() in k.lower()]
+        if substring_matches:
+            result.exact_matches.extend(substring_matches)
+        else:
+            close = get_close_matches(name, all_settings.keys(), n=3, cutoff=0.6)
+            if close:
+                result.fuzzy_matches[name] = close
+            else:
+                result.not_found.append(name)
+
+    return result
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -72,6 +72,9 @@ from difflib import get_close_matches
 from jinja2 import Template
 from typing import Any
 
+# External imports
+from jinja2 import Template
+
 # Bokeh imports
 from bokeh.settings import PrioritizedSetting, _Unset
 from bokeh.util.settings import get_all_settings

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -228,6 +228,7 @@ class Settings(Subcommand):
         print(f"Setting: {setting_name}")
         print("=" * 60)
         print(f"Current Value: {descriptor()}")
+        print(f"Source: {descriptor.provenance_display}")
         print(f"Default Value: {descriptor.default}")
         if descriptor.dev_default is not _Unset:
             print(f"Dev Default: {descriptor.dev_default}")

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -127,31 +127,49 @@ class Settings(Subcommand):
     )
 
     def invoke(self, args: Namespace) -> None:
-        '''
-
+        ''' Handle the "bokeh settings" command behavior.
         '''
         all_settings = get_all_settings()
 
+        # Case 1: Verbose requested without a specific setting -> print all with details
+        if args.verbose and not args.setting_name:
+            for name, descriptor in all_settings.items():
+                self._print_setting_detail(name, descriptor)
+            return
+
+        # Case 2: Specific setting requested
         if args.setting_name:
             if args.setting_name in all_settings:
+                descriptor = all_settings[args.setting_name]
                 if args.verbose:
-                    self._print_setting_detail(args.setting_name, all_settings[args.setting_name])
+                    # Verbose + setting -> detailed info
+                    self._print_setting_detail(args.setting_name, descriptor)
                 else:
-                    print("To get detailed help for a specific setting, use:")
-                    print("  bokeh settings [-v | --verbose] <setting_name>")
-                    print("\nFor a list of all settings, use:")
-                    print("  bokeh settings")
+                    # Basic info
+                    print()
+                    print(f"Setting: {args.setting_name}")
+                    print("=" * 60)
+                    print(f"Current Value: {descriptor()}")
+                    print(f"Environment Variable: {descriptor.env_var}")
+                    print("\nHelp:")
+                    print(f"{descriptor.help.strip()}")
             else:
+                print()
                 print(f"Setting '{args.setting_name}' not found.")
+                print()
                 print("Available settings:")
                 for name in sorted(all_settings):
                     print(f"  {name}")
-        else:
-            self._print_settings_table(all_settings)
+                print()
+            return
+
+        # Case 3: No args -> print summary table
+        self._print_settings_table(all_settings)
 
     def _print_settings_table(self, all_settings: dict[str, PrioritizedSetting[Any]]) -> None:
         ''' Print all settings in a table format.
         '''
+        print()
         print("Bokeh Settings:")
         print("=" * 80)
         print(f"{'Setting':<30} {'Environment Variable':<35} {'Value':<25}")
@@ -161,11 +179,13 @@ class Settings(Subcommand):
             print(f"{name:<30} {descriptor.env_var:<35} {descriptor()!s:<25}")
 
         print("-" * 80)
+        print()
 
     def _print_setting_detail(self, setting_name: str, descriptor: PrioritizedSetting[Any]) -> None:
         ''' Print detailed help for a specific setting.
         '''
         ''' Print all settings in a table format. '''
+        print()
         print(f"Setting: {setting_name}")
         print("=" * 60)
         print(f"Current Value: {descriptor()}")
@@ -175,6 +195,7 @@ class Settings(Subcommand):
         print(f"Environment Variable: {descriptor.env_var}")
         print("\nHelp:")
         print(f"{descriptor.help.strip()}")
+        print()
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -67,6 +67,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from argparse import Namespace
+from dataclasses import dataclass, field
 from difflib import get_close_matches
 from typing import Any
 
@@ -84,6 +85,38 @@ from ..subcommand import Argument, Subcommand
 __all__ = (
     'Settings',
 )
+
+#-----------------------------------------------------------------------------
+# Helpers
+#-----------------------------------------------------------------------------
+
+@dataclass
+class ResolutionResult:
+    exact_matches: list[str] = field(default_factory=list)
+    fuzzy_matches: dict[str, list[str]] = field(default_factory=dict)
+    not_found: list[str] = field(default_factory=list)
+
+
+def resolve_setting_names(input_names: list[str], all_settings: dict[str, Any]) -> ResolutionResult:
+    """Resolve user-supplied setting names into matches against all_settings."""
+    result = ResolutionResult()
+
+    for name in input_names:
+        if name in all_settings:
+            result.exact_matches.append(name)
+            continue
+
+        substring_matches = [k for k in all_settings if name.lower() in k.lower()]
+        if substring_matches:
+            result.exact_matches.extend(substring_matches)
+        else:
+            close = get_close_matches(name, all_settings.keys(), n=3, cutoff=0.6)
+            if close:
+                result.fuzzy_matches[name] = close
+            else:
+                result.not_found.append(name)
+
+    return result
 
 #-----------------------------------------------------------------------------
 # General API
@@ -117,72 +150,50 @@ class Settings(Subcommand):
         '''
         all_settings = get_all_settings()
 
-        # Case 1: Verbose requested without a specific setting -> print all with details
         if args.verbose and not args.setting_names:
             for name, descriptor in all_settings.items():
                 self._print_setting_detail(name, descriptor)
-            return
 
-        # Case 2: Specific setting requested
-        if args.setting_names:
-            for name in args.setting_names:
-                matches = []
+        elif args.setting_names:
+            resolved = resolve_setting_names(args.setting_names, all_settings)
+            self._print_resolved_settings(resolved, all_settings, args.verbose)
 
-                if name in all_settings:
-                    matches = [name]
-                else:
-                    # substring matches (more intuitive than only difflib)
-                    substring_matches = [k for k in all_settings if name.lower() in k.lower()]
-                    if len(substring_matches) == 1:
-                        matches = substring_matches
-                    elif len(substring_matches) > 1:
-                        print()
-                        print(f"Multiple matches found for '{name}':")
-                        for m in sorted(substring_matches):
-                            print(f"  {m}")
-                        print()
-                        continue
-                    else:
-                        # fuzzy fallback
-                        close = get_close_matches(name, all_settings.keys(), n=3, cutoff=0.6)
-                        if close:
-                            print()
-                            print(f"Setting '{name}' not found.")
-                            print("Did you mean one of these?")
-                            for c in close:
-                                print(f"  {c}")
-                            print()
-                            continue
+        else:
+            self._print_settings_table(all_settings)
 
-                if matches:
-                    setting_name = matches[0]
-                    descriptor = all_settings[setting_name]
-                    if args.verbose:
-                        # Verbose + setting -> detailed info
-                        self._print_setting_detail(setting_name, descriptor)
-                    else:
-                        # Basic info
-                        print()
-                        print(f"Setting: {setting_name}")
-                        print("=" * 60)
-                        print(f"Current Value: {descriptor()}")
-                        print(f"Environment Variable: {descriptor.env_var}")
-                        print("\nHelp:")
-                        print(f"{descriptor.help.strip()}")
-                    print()
-                else:
-                    # no matches at all
-                    print()
-                    print(f"Setting '{name}' not found.")
-                    print()
-                    print("Available settings:")
-                    for n in sorted(all_settings):
-                        print(f"  {n}")
-                    print()
-            return
 
-        # Case 3: No args -> print summary table
-        self._print_settings_table(all_settings)
+    def _print_resolved_settings(
+        self, resolved: ResolutionResult, all_settings: dict[str, PrioritizedSetting[Any]], verbose: bool,
+    ) -> None:
+        """Print results from resolve_setting_names()."""
+
+
+        # Fuzzy matches
+        for name, close in resolved.fuzzy_matches.items():
+            print()
+            print(f"Setting '{name}' not found.")
+            print("Did you mean one of these?")
+            for c in close:
+                print(f"  {c}")
+            print()
+
+        # Not found
+        for name in resolved.not_found:
+            print()
+            print(f"Setting '{name}' not found.")
+            print()
+            print("Available settings:")
+            for n in sorted(all_settings):
+                print(f"  {n}")
+            print()
+
+        to_print = sorted(set(resolved.exact_matches))
+        for setting_name in to_print:
+            descriptor = all_settings[setting_name]
+            if verbose:
+                self._print_setting_detail(setting_name, descriptor)
+            else:
+                self._print_setting_basic(setting_name, descriptor)
 
     def _print_settings_table(self, all_settings: dict[str, PrioritizedSetting[Any]]) -> None:
         ''' Print all settings in a table format.
@@ -199,10 +210,20 @@ class Settings(Subcommand):
         print("-" * 80)
         print()
 
+    def _print_setting_basic(self, setting_name: str, descriptor: PrioritizedSetting[Any]) -> None:
+        ''' Print basic info for a specific setting. '''
+        print()
+        print(f"Setting: {setting_name}")
+        print("=" * 60)
+        print(f"Current Value: {descriptor()}")
+        print(f"Environment Variable: {descriptor.env_var}")
+        print("\nHelp:")
+        print(f"{descriptor.help.strip()}")
+        print()
+
     def _print_setting_detail(self, setting_name: str, descriptor: PrioritizedSetting[Any]) -> None:
         ''' Print detailed help for a specific setting.
         '''
-        ''' Print all settings in a table format. '''
         print()
         print(f"Setting: {setting_name}")
         print("=" * 60)

--- a/src/bokeh/command/subcommands/settings.py
+++ b/src/bokeh/command/subcommands/settings.py
@@ -69,7 +69,6 @@ log = logging.getLogger(__name__)
 from argparse import Namespace
 from dataclasses import dataclass, field
 from difflib import get_close_matches
-from jinja2 import Template
 from typing import Any
 
 # External imports

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -117,6 +117,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from enum import Enum, auto
 import os
 from os.path import join
 from pathlib import Path
@@ -347,6 +348,18 @@ Unset: TypeAlias = T | type[_Unset]
 def is_dev() -> bool:
     return convert_bool(os.environ.get("BOKEH_DEV", False))
 
+class SettingProvenance(Enum):
+    IMMEDIATE = auto()
+    USER_SET = auto()
+    CONFIG_OVERRIDE = auto()
+    ENV_VAR = auto()
+    CONFIG_USER = auto()
+    CONFIG_SYSTEM = auto()
+    DEV_DEFAULT = auto()
+    DEFAULT = auto()
+    GLOBAL_DEFAULT = auto()
+    NONE = auto()
+
 class PrioritizedSetting(Generic[T]):
     ''' Return a value for a global setting according to configuration precedence.
 
@@ -390,6 +403,51 @@ class PrioritizedSetting(Generic[T]):
         self._parent = None
         self._user_value = _Unset
 
+    def get_value_with_provenance(
+        self,
+        value: T | str | None = None,
+        default: Unset[T] = _Unset,
+    ) -> tuple[T, SettingProvenance]:
+        """Return the setting value and where it came from."""
+
+        # 7. immediate values
+        if value is not None:
+            return self._convert(value), SettingProvenance.IMMEDIATE
+
+        # 6. previously user-set value
+        if self._user_value is not _Unset:
+            return self._convert(self._user_value), SettingProvenance.USER_SET
+
+        # 5. user-named config file
+        if self._parent and self._name in self._parent.config_override:
+            return self._convert(self._parent.config_override[self._name]), SettingProvenance.CONFIG_OVERRIDE
+
+        # 4. environment variable
+        if self._env_var and self._env_var in os.environ:
+            return self._convert(os.environ[self._env_var]), SettingProvenance.ENV_VAR
+
+        # 3. local config file
+        if self._parent and self._name in self._parent.config_user:
+            return self._convert(self._parent.config_user[self._name]), SettingProvenance.CONFIG_USER
+
+        # 2. global config file
+        if self._parent and self._name in self._parent.config_system:
+            return self._convert(self._parent.config_system[self._name]), SettingProvenance.CONFIG_SYSTEM
+
+        # 1.5 (undocumented) dev defaults take precedence over other defaults
+        if is_dev() and self._dev_default is not _Unset:
+            return self._convert(self._dev_default), SettingProvenance.DEV_DEFAULT
+
+        # 1. local defaults
+        if default is not _Unset:
+            return self._convert(default), SettingProvenance.DEFAULT
+
+        # 0. global defaults
+        if self._default is not _Unset:
+            return self._convert(self._default), SettingProvenance.GLOBAL_DEFAULT
+
+        raise RuntimeError(f"No configured value found for setting {self._name!r}")
+
     def __call__(self, value: T | str | None = None, default: Unset[T] = _Unset) -> T:
         '''Return the setting value according to the standard precedence.
 
@@ -409,43 +467,8 @@ class PrioritizedSetting(Generic[T]):
             RuntimeError
         '''
 
-        # 7. immediate values
-        if value is not None:
-            return self._convert(value)
-
-        # 6. previously user-set value
-        if self._user_value is not _Unset:
-            return self._convert(self._user_value)
-
-        # 5. user-named config file
-        if self._parent and self._name in self._parent.config_override:
-            return self._convert(self._parent.config_override[self._name])
-
-        # 4. environment variable
-        if self._env_var and self._env_var in os.environ:
-            return self._convert(os.environ[self._env_var])
-
-        # 3. local config file
-        if self._parent and self._name in self._parent.config_user:
-            return self._convert(self._parent.config_user[self._name])
-
-        # 2. global config file
-        if self._parent and self._name in self._parent.config_system:
-            return self._convert(self._parent.config_system[self._name])
-
-        # 1.5 (undocumented) dev defaults take precedence over other defaults
-        if is_dev() and self._dev_default is not _Unset:
-            return self._convert(self._dev_default)
-
-        # 1. local defaults
-        if default is not _Unset:
-            return self._convert(default)
-
-        # 0. global defaults
-        if self._default is not _Unset:
-            return self._convert(self._default)
-
-        raise RuntimeError(f"No configured value found for setting {self._name!r}")
+        val, _ = self.get_value_with_provenance(value=value, default=default)
+        return val
 
     def __get__(self, instance: Any, owner: type[Any]) -> PrioritizedSetting[T]:
         return self
@@ -524,6 +547,28 @@ class PrioritizedSetting(Generic[T]):
     @property
     def is_set(self) -> bool:
         return self._user_value is not _Unset and self._user_value != self._default
+
+    @property
+    def current_provenance(self) -> SettingProvenance:
+        """Return where the current value came from."""
+        _, provenance = self.get_value_with_provenance()
+        return provenance
+
+    @property
+    def provenance_display(self) -> str:
+        """Return a readable description of provenance."""
+        provenance_map = {
+            SettingProvenance.IMMEDIATE: "Immediate",
+            SettingProvenance.USER_SET: "User-set",
+            SettingProvenance.CONFIG_OVERRIDE: "Config override file",
+            SettingProvenance.ENV_VAR: "Environment variable",
+            SettingProvenance.CONFIG_USER: "User config file",
+            SettingProvenance.CONFIG_SYSTEM: "System config file",
+            SettingProvenance.DEV_DEFAULT: "Dev default",
+            SettingProvenance.DEFAULT: "Explicit default",
+            SettingProvenance.GLOBAL_DEFAULT: "Global default",
+        }
+        return provenance_map[self.current_provenance]
 
 _config_user_locations: Sequence[Path] = (
     Path.home() / ".bokeh" / "bokeh.yaml",

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -117,8 +117,8 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from enum import Enum, auto
 import os
+from enum import Enum, auto
 from os.path import join
 from pathlib import Path
 from typing import (

--- a/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
@@ -92,7 +92,7 @@ def test_run_shows_table(capsys: Capture) -> None:
     main(["bokeh", "settings"])
     out, err = capsys.readouterr()
     assert err == ""
-    assert out.startswith("Bokeh Settings:\n")
+    assert out.startswith("\nBokeh Settings:\n")
     assert "Setting" in out and "Environment Variable" in out and "Value" in out
 
     output_settings = parse_settings_table(out)
@@ -112,14 +112,18 @@ def test_run_shows_table(capsys: Capture) -> None:
         assert printed_value.strip() == current_value.strip(), f"Value mismatch for {name}"
 
 
-def test_run_guidance_when_name_without_detail(capsys: Capture) -> None:
+def test_run_basic_info_specific_setting(capsys: Capture) -> None:
     main(["bokeh", "settings", "log_level"])
     out, err = capsys.readouterr()
     assert err == ""
-    assert "To get detailed help for a specific setting, use:" in out
-    assert "  bokeh settings [-v | --verbose] <setting_name>" in out
-    assert "For a list of all settings, use:" in out
-    assert "bokeh settings" in out
+
+    assert "Setting: log_level" in out
+    assert "Current Value:" in out
+    assert "Environment Variable: BOKEH_LOG_LEVEL" in out
+    assert "Help:" in out
+
+    assert "Default Value:" not in out
+    assert "Dev Default:" not in out
 
 
 def test_run_detail_specific_setting(capsys: Capture) -> None:
@@ -133,6 +137,16 @@ def test_run_detail_specific_setting(capsys: Capture) -> None:
     assert "Dev Default: debug" in out
     assert "Help:" in out
 
+
+def test_run_detail_all_settings(capsys: Capture) -> None:
+    main(["bokeh", "settings", "-v"])
+    out, err = capsys.readouterr()
+    assert err == ""
+
+    assert "Setting: log_level" in out
+    assert "Default Value:" in out
+    assert "Environment Variable:" in out
+    assert "Help:" in out
 
 def test_run_detail_invalid_setting(capsys: Capture) -> None:
     main(["bokeh", "settings", "-v", "__does_not_exist__"])

--- a/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
@@ -61,9 +61,9 @@ def test_args() -> None:
             action="store_true",
             help="Show detailed help for a specific setting",
         )),
-        ('setting_name', Argument(
-            nargs='?',
-            help="Name of a specific setting to show detailed help for (use with -v)",
+        ('setting_names', Argument(
+            nargs='*',
+            help="One or more specific settings to show info for (use with -v for details)",
         )),
     )
 
@@ -184,9 +184,22 @@ def test_run_fuzzy_typo_match(capsys: Capture) -> None:
     out, err = capsys.readouterr()
     assert err == ""
 
+    assert "Setting 'lgo_levl' not found." in out
     assert "Did you mean one of these?" in out
     assert "log_level" in out
     assert "py_log_level" in out
+
+
+def test_run_multiple_inputs(capsys: Capture) -> None:
+    main(["bokeh", "settings", "log_level", "servr_hst"])
+    out, err = capsys.readouterr()
+    assert err == ""
+
+    assert "Setting: log_level" in out
+
+    assert "Setting 'servr_hst' not found." in out
+    assert "Did you mean one of these?" in out
+    assert "default_server_host" in out
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
@@ -132,9 +132,11 @@ def test_run_detail_specific_setting(capsys: Capture) -> None:
     assert err == ""
 
     assert "Setting: log_level" in out
-    assert "Environment Variable: BOKEH_LOG_LEVEL" in out
+    assert "Current Value: info" in out
+    assert "Source: Global default" in out
     assert "Default Value: info" in out
     assert "Dev Default: debug" in out
+    assert "Environment Variable: BOKEH_LOG_LEVEL" in out
     assert "Help:" in out
 
 
@@ -144,7 +146,10 @@ def test_run_detail_all_settings(capsys: Capture) -> None:
     assert err == ""
 
     assert "Setting: log_level" in out
+    assert "Current Value:" in out
+    assert "Source:" in out
     assert "Default Value:" in out
+    assert "Dev Default:" in out
     assert "Environment Variable:" in out
     assert "Help:" in out
 

--- a/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
@@ -174,7 +174,6 @@ def test_run_multiple_matches(capsys: Capture) -> None:
     out, err = capsys.readouterr()
     assert err == ""
 
-    assert "Multiple matches found for 'server':" in out
     assert "default_server_host" in out
     assert "default_server_port" in out
 

--- a/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
+++ b/tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
@@ -148,6 +148,7 @@ def test_run_detail_all_settings(capsys: Capture) -> None:
     assert "Environment Variable:" in out
     assert "Help:" in out
 
+
 def test_run_detail_invalid_setting(capsys: Capture) -> None:
     main(["bokeh", "settings", "-v", "__does_not_exist__"])
     out, err = capsys.readouterr()
@@ -156,6 +157,36 @@ def test_run_detail_invalid_setting(capsys: Capture) -> None:
     assert "Setting '__does_not_exist__' not found." in out
     assert "Available settings:" in out
     assert "log_level" in out
+
+
+def test_run_substring_match(capsys: Capture) -> None:
+    main(["bokeh", "settings", "host"])
+    out, err = capsys.readouterr()
+    assert err == ""
+
+    assert "Setting: default_server_host" in out
+    assert "Current Value:" in out
+    assert "Environment Variable: BOKEH_DEFAULT_SERVER_HOST" in out
+
+
+def test_run_multiple_matches(capsys: Capture) -> None:
+    main(["bokeh", "settings", "server"])
+    out, err = capsys.readouterr()
+    assert err == ""
+
+    assert "Multiple matches found for 'server':" in out
+    assert "default_server_host" in out
+    assert "default_server_port" in out
+
+
+def test_run_fuzzy_typo_match(capsys: Capture) -> None:
+    main(["bokeh", "settings", "lgo_levl"])
+    out, err = capsys.readouterr()
+    assert err == ""
+
+    assert "Did you mean one of these?" in out
+    assert "log_level" in out
+    assert "py_log_level" in out
 
 #-----------------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
# Fixes #14607

## Changes
- Adds three verbosity tiers:
  - `bokeh settings <setting>` → basic info for that setting
  - `bokeh settings -v <setting>` → detailed info (unchanged)
  - `bokeh settings -v` → detailed info for all settings
- Supporting fuzzy matching of setting names:
  - Matching now happens in layers:
    1. Exact match
    2. Substring match (case-insensitive)
       - Single or multiple substring matches → display directly
    3. Fuzzy match using `difflib.get_close_matches` (suggests up to 3 names)
    4. No matches → print all available settings
- Accepting multiple setting names in one invocation:
  - `bokeh settings <name1> <name2>` ... (with or without -v)

---

## Usage Examples

### Show basic info
```bash
bokeh settings log_level
```
**Example:**
```
Setting: log_level
============================================================
Current Value: info
Environment Variable: BOKEH_LOG_LEVEL

Help:
Set the log level for JavaScript BokehJS code.

    Valid values are, in order of increasing severity:

    - ``trace``
    - ``debug``
    - ``info``
    - ``warn``
    - ``error``
    - ``fatal``
```

---

### Show detailed info
```bash
bokeh settings -v log_level
```
**Example:**
```
Setting: log_level
============================================================
Current Value: info
Default Value: info
Dev Default: debug
Environment Variable: BOKEH_LOG_LEVEL

Help:
Set the log level for JavaScript BokehJS code.

    Valid values are, in order of increasing severity:

    - ``trace``
    - ``debug``
    - ``info``
    - ``warn``
    - ``error``
    - ``fatal``
```

---

### Show detailed info for all settings
```bash
bokeh settings -v
```
**Example (truncated):**
```
Setting: allowed_ws_origin
============================================================
Current Value: []
Default Value: []
Environment Variable: BOKEH_ALLOW_WS_ORIGIN

Help:
A comma-separated list of allowed websocket origins for Bokeh server applications.


Setting: auth_module
============================================================
Current Value: None
Default Value: None
Environment Variable: BOKEH_AUTH_MODULE

Help:
A path to a Python modules that implements user authentication functions for
    the Bokeh server.

    .. warning::
        The contents of this module will be executed!
```

---

### Substring match
```bash
bokeh settings lo
```
**Example:**
```
Setting: allowed_ws_origin
============================================================
Current Value: []
Environment Variable: BOKEH_ALLOW_WS_ORIGIN

Help:
A comma-separated list of allowed websocket origins for Bokeh server applications.


Setting: log_level
============================================================
Current Value: info
Environment Variable: BOKEH_LOG_LEVEL

Help:
Set the log level for JavaScript BokehJS code.

    Valid values are, in order of increasing severity:

    - ``trace``
    - ``debug``
    - ``info``
    - ``warn``
    - ``error``
    - ``fatal``


Setting: py_log_level
============================================================
Current Value: None
Environment Variable: BOKEH_PY_LOG_LEVEL

Help:
The log level for Python Bokeh code.

    Valid values are, in order of increasing severity:

    - ``trace``
    - ``debug``
    - ``info``
    - ``warn``
    - ``error``
    - ``fatal``
    - ``none``
```

---

### Fuzzy match (using difflib)
```bash
bokeh settings py_log_levels
```
**Example:**
```
Did you mean one of these?
  py_log_level
  log_level
```


---

### Multiple setting names
```bash
bokeh settings py log_level srver_host
```
**Example:**
```
Setting: py_log_level
============================================================
Current Value: None
Environment Variable: BOKEH_PY_LOG_LEVEL

Help:
The log level for Python Bokeh code.

    Valid values are, in order of increasing severity:

    - ``trace``
    - ``debug``
    - ``info``
    - ``warn``
    - ``error``
    - ``fatal``
    - ``none``


Setting: log_level
============================================================
Current Value: info
Environment Variable: BOKEH_LOG_LEVEL

Help:
Set the log level for JavaScript BokehJS code.

    Valid values are, in order of increasing severity:

    - ``trace``
    - ``debug``
    - ``info``
    - ``warn``
    - ``error``
    - ``fatal``


Setting 'srver_host' not found.
Did you mean one of these?
  default_server_host
```

---

## Testing

**Unit tests pass:**
```
tests/unit/bokeh/command/subcommands/test_settings__subcommands.py
```

---

## PR Checklist
- [x] issues: fixes #14607
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
