### PR TITLE
set minimal version of sphinxext-opengraph to 0.11.0

### DIFF
--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -42,4 +42,4 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -74,7 +74,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - pandas-stubs >=2.2
     - ruff ==0.12.3

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -74,7 +74,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - pandas-stubs >=2.2
     - ruff ==0.12.3

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -74,7 +74,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - pandas-stubs >=2.2
     - ruff ==0.12.3

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -75,7 +75,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - pandas-stubs >=2.2
     - ruff ==0.12.3

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -62,7 +62,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - ruff ==0.11.6
     - types-boto3


### PR DESCRIPTION
To build the docs with the current bokeh code without a warning from `sphinxext-opengraph`, the minimal version of `sphinxext-opengraph` has to be at least `0.11.0`.

- [x] issues: fixes #14618

