### PR TITLE
add copy and delete for svg icons to make.bat

### DIFF
--- a/docs/bokeh/Makefile
+++ b/docs/bokeh/Makefile
@@ -17,7 +17,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 	-rm -rf source/docs/gallery/*
 	-rm -rf source/docs/examples/*
-	-rm -rf source/_images/icons/*
+	-rm -rf source/_images/icons/*.svg
 
 html:
 	@start=$$(date +%s) \

--- a/docs/bokeh/make.bat
+++ b/docs/bokeh/make.bat
@@ -39,7 +39,7 @@ if "%1" == "all" (
 )
 
 if "%1" == "html" (
-	xcopy ..\..\bokehjs\src\less\icons\* source\_images\icons\
+	xcopy ..\..\bokehjs\src\less\icons\* source\_images\icons\ /y
 	%SPHINXBUILD% -W -b html %ALLSPHINXOPTS% %BUILDDIR%\html
 	xcopy ..\bokeh\server\static %BUILDDIR%\html\static\ /s /e /h /y
 	if errorlevel 1 exit /b 1

--- a/docs/bokeh/make.bat
+++ b/docs/bokeh/make.bat
@@ -30,6 +30,7 @@ if "%1" == "clean" (
 	rmdir %BUILDDIR% /s /q
 	del /q /s source\docs\gallery\*
 	del /q /s source\docs\examples\*
+	del /q /s source\_images\icons\*.svg
 	goto end
 )
 
@@ -38,6 +39,7 @@ if "%1" == "all" (
 )
 
 if "%1" == "html" (
+	xcopy ..\..\bokehjs\src\less\icons\* source\_images\icons\
 	%SPHINXBUILD% -W -b html %ALLSPHINXOPTS% %BUILDDIR%\html
 	xcopy ..\bokeh\server\static %BUILDDIR%\html\static\ /s /e /h /y
 	if errorlevel 1 exit /b 1


### PR DESCRIPTION
This PR allows do build the documentation on Windows with the new svg icons. This copies the changes from the Makefile to the make.bat file.

- [x] issues: fixes #14626
