### PR TITLE
Misc import updates

### DIFF
--- a/docs/bokeh/docserver.py
+++ b/docs/bokeh/docserver.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     browser.start()
 
     try:
-        input("Press <ENTER> to exit...\n")  # lgtm [py/use-of-input]
+        input("Press <ENTER> to exit...\n")
     except KeyboardInterrupt:
         pass
 

--- a/examples/output/apis/server_document/flask_server.py
+++ b/examples/output/apis/server_document/flask_server.py
@@ -59,4 +59,4 @@ def visualization(batchid):
     return render_template_string(app_html, bokeh_script=bokeh_script)
 
 if __name__ == '__main__':
-    app.run(debug=True)  # lgtm [py/flask-debug]
+    app.run(debug=True)

--- a/src/bokeh/__init__.py
+++ b/src/bokeh/__init__.py
@@ -97,21 +97,23 @@ del importlib_metadata
 from .util import logconfig # isort:skip
 del logconfig
 
-# Configure warnings to always show nice messages, despite Python's active
-# efforts to hide them from users.
-import warnings # isort:skip
-from .util.warnings import BokehDeprecationWarning, BokehUserWarning # isort:skip
-warnings.simplefilter('always', BokehDeprecationWarning)
-warnings.simplefilter('always', BokehUserWarning)
+def _configure_warnings() -> None:
+    # Configure warnings to always show nice messages, despite Python's active
+    # efforts to hide them from users.
+    import warnings
 
-original_formatwarning = warnings.formatwarning
-def _formatwarning(message, category, filename, lineno, line=None):
     from .util.warnings import BokehDeprecationWarning, BokehUserWarning
-    if category not in (BokehDeprecationWarning, BokehUserWarning):
-        return original_formatwarning(message, category, filename, lineno, line)
-    return f"{category.__name__}: {message}\n"
-warnings.formatwarning = _formatwarning
 
-del _formatwarning
-del BokehDeprecationWarning, BokehUserWarning
-del warnings
+    warnings.simplefilter('always', BokehDeprecationWarning)
+    warnings.simplefilter('always', BokehUserWarning)
+
+    original_formatwarning = warnings.formatwarning
+    def _formatwarning(message, category, filename, lineno, line=None):
+        from .util.warnings import BokehDeprecationWarning, BokehUserWarning
+        if category not in (BokehDeprecationWarning, BokehUserWarning):
+            return original_formatwarning(message, category, filename, lineno, line)
+        return f"{category.__name__}: {message}\n"
+    warnings.formatwarning = _formatwarning
+
+_configure_warnings()
+del _configure_warnings

--- a/src/bokeh/application/application.py
+++ b/src/bokeh/application/application.py
@@ -40,13 +40,13 @@ from typing import (
 )
 
 # Bokeh imports
-from ..core.types import ID
 from ..document import Document
 from ..settings import settings
 
 if TYPE_CHECKING:
     from tornado.httputil import HTTPServerRequest
 
+    from ..core.types import ID
     from ..server.session import ServerSession
     from .handlers.handler import Handler
 

--- a/src/bokeh/application/handlers/code.py
+++ b/src/bokeh/application/handlers/code.py
@@ -46,7 +46,6 @@ from typing import (
 )
 
 # Bokeh imports
-from ...document import Document
 from ...io.doc import curdoc, patch_curdoc
 from .code_runner import CodeRunner
 from .handler import Handler
@@ -55,6 +54,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from ...core.types import PathLike
+    from ...document import Document
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/application/handlers/code.py
+++ b/src/bokeh/application/handlers/code.py
@@ -38,15 +38,23 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from contextlib import contextmanager
 from os.path import basename, splitext
-from types import ModuleType
-from typing import Any, Callable, ClassVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+)
 
 # Bokeh imports
-from ...core.types import PathLike
 from ...document import Document
 from ...io.doc import curdoc, patch_curdoc
 from .code_runner import CodeRunner
 from .handler import Handler
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from ...core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/application/handlers/code_runner.py
+++ b/src/bokeh/application/handlers/code_runner.py
@@ -26,13 +26,16 @@ import os
 import sys
 import traceback
 from os.path import basename
-from types import CodeType, ModuleType
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 # Bokeh imports
-from ...core.types import PathLike
 from ...util.serialization import make_globally_unique_id
 from .handler import handle_exception
+
+if TYPE_CHECKING:
+    from types import CodeType, ModuleType
+
+    from ...core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -172,6 +175,8 @@ class CodeRunner:
             Module
 
         '''
+        from types import ModuleType
+
         self.reset_run_errors()
 
         if self._code is None:

--- a/src/bokeh/application/handlers/directory.py
+++ b/src/bokeh/application/handlers/directory.py
@@ -61,8 +61,6 @@ from typing import TYPE_CHECKING, Any, Coroutine
 from jinja2 import Environment, FileSystemLoader, Template
 
 # Bokeh imports
-from ...document import Document
-from ..application import ServerContext, SessionContext
 from .code_runner import CodeRunner
 from .handler import Handler
 from .notebook import NotebookHandler
@@ -76,7 +74,9 @@ if TYPE_CHECKING:
     from tornado.httputil import HTTPServerRequest
 
     from ...core.types import PathLike
+    from ...document import Document
     from ...themes import Theme
+    from ..application import ServerContext, SessionContext
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/application/handlers/directory.py
+++ b/src/bokeh/application/handlers/directory.py
@@ -55,14 +55,12 @@ from os.path import (
     exists,
     join,
 )
-from types import ModuleType
 from typing import TYPE_CHECKING, Any, Coroutine
 
 # External imports
 from jinja2 import Environment, FileSystemLoader, Template
 
 # Bokeh imports
-from ...core.types import PathLike
 from ...document import Document
 from ..application import ServerContext, SessionContext
 from .code_runner import CodeRunner
@@ -73,8 +71,11 @@ from .server_lifecycle import ServerLifecycleHandler
 from .server_request_handler import ServerRequestHandler
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from tornado.httputil import HTTPServerRequest
 
+    from ...core.types import PathLike
     from ...themes import Theme
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/application/handlers/document_lifecycle.py
+++ b/src/bokeh/application/handlers/document_lifecycle.py
@@ -21,9 +21,14 @@ log = logging.getLogger(__name__)
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from typing import TYPE_CHECKING
+
 # Bokeh imports
-from ..application import SessionContext
 from .lifecycle import LifecycleHandler
+
+if TYPE_CHECKING:
+    from ..application import SessionContext
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/application/handlers/function.py
+++ b/src/bokeh/application/handlers/function.py
@@ -38,12 +38,17 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 # Bokeh imports
 from ...document import Document
 from ...util.callback_manager import _check_callback
 from .handler import Handler, handle_exception
+
+if TYPE_CHECKING:
+    from ...document import Document
+
+    ModifyDoc = Callable[[Document], None]
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -60,8 +65,6 @@ __all__ = (
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
-
-ModifyDoc = Callable[[Document], None]
 
 class FunctionHandler(Handler):
     ''' A Handler that accepts a plain python function to use for modifying

--- a/src/bokeh/application/handlers/handler.py
+++ b/src/bokeh/application/handlers/handler.py
@@ -48,13 +48,11 @@ import sys
 import traceback
 from typing import TYPE_CHECKING, Any
 
-# Bokeh imports
-from ...document import Document
-from ..application import ServerContext, SessionContext
-
 if TYPE_CHECKING:
     from tornado.httputil import HTTPServerRequest
 
+    from ...document import Document
+    from ..application import ServerContext, SessionContext
     from .code_runner import CodeRunner
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/application/handlers/lifecycle.py
+++ b/src/bokeh/application/handlers/lifecycle.py
@@ -22,12 +22,15 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 # Bokeh imports
-from ...document import Document
-from ..application import ServerContext, SessionContext
 from .handler import Handler
+
+if TYPE_CHECKING:
+    from ...document import Document
+    from ..application import ServerContext, SessionContext
+
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/application/handlers/notebook.py
+++ b/src/bokeh/application/handlers/notebook.py
@@ -30,12 +30,16 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import re
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 # Bokeh imports
-from ...core.types import PathLike
 from ...util.dependencies import import_required
 from .code import CodeHandler
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from ...core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/application/handlers/script.py
+++ b/src/bokeh/application/handlers/script.py
@@ -46,11 +46,15 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 # Bokeh imports
-from ...core.types import PathLike
 from .code import CodeHandler
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from ...core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/application/handlers/server_lifecycle.py
+++ b/src/bokeh/application/handlers/server_lifecycle.py
@@ -23,13 +23,17 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import os
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 # Bokeh imports
-from ...core.types import PathLike
 from ...util.callback_manager import _check_callback
 from .code_runner import CodeRunner
 from .lifecycle import LifecycleHandler
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from ...core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/application/handlers/server_request_handler.py
+++ b/src/bokeh/application/handlers/server_request_handler.py
@@ -23,13 +23,17 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import os
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 # Bokeh imports
-from ...core.types import PathLike
 from ...util.callback_manager import _check_callback
 from .code_runner import CodeRunner
 from .request_handler import RequestHandler
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from ...core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/client/connection.py
+++ b/src/bokeh/client/connection.py
@@ -33,7 +33,6 @@ from tornado.ioloop import IOLoop
 from tornado.websocket import WebSocketError, websocket_connect
 
 # Bokeh imports
-from ..core.types import ID
 from ..protocol import Protocol
 from ..protocol.exceptions import MessageError, ProtocolError, ValidationError
 from ..protocol.receiver import Receiver
@@ -51,6 +50,7 @@ from .states import (
 from .websocket import WebSocketClientConnectionWrapper
 
 if TYPE_CHECKING:
+    from ..core.types import ID
     from ..document import Document
     from ..document.events import DocumentChangedEvent
     from ..protocol.message import Message

--- a/src/bokeh/client/session.py
+++ b/src/bokeh/client/session.py
@@ -38,17 +38,16 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote_plus
 
 # Bokeh imports
-from ..document import Document
 from ..resources import DEFAULT_SERVER_HTTP_URL, SessionCoordinates
-from ..util.browser import NEW_PARAM, BrowserLike, BrowserTarget
+from ..util.browser import NEW_PARAM
 from ..util.token import generate_jwt_token, generate_session_id
-from .states import ErrorReason
 from .util import server_url_for_websocket_url, websocket_url_for_server_url
 
 if TYPE_CHECKING:
     from tornado.ioloop import IOLoop
 
     from ..core.types import ID
+    from ..document import Document
     from ..document.events import (
         DocumentPatchedEvent,
         SessionCallbackAdded,
@@ -58,7 +57,10 @@ if TYPE_CHECKING:
     from ..protocol.messages.patch_doc import patch_doc
     from ..protocol.messages.server_info_reply import ServerInfo
     from ..server.callbacks import DocumentCallbackGroup
+    from ..util.browser import BrowserLike, BrowserTarget
     from .connection import ClientConnection
+    from .states import ErrorReason
+
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -407,6 +409,8 @@ class ClientSession:
 
         '''
         if not self.connected:
+            from .states import ErrorReason
+
             if self.error_reason is ErrorReason.HTTP_ERROR:
                 if self.error_code == 404:
                     raise OSError(f"Check your application path! The given Path is not valid: {self.url}")
@@ -426,6 +430,8 @@ class ClientSession:
         self.check_connection_errors()
 
         if self.document is None:
+            from ..document import Document
+
             doc = Document()
         else:
             doc = self.document
@@ -450,6 +456,8 @@ class ClientSession:
         '''
         if self.document is None:
             if document is None:
+                from ..document import Document
+
                 doc = Document()
             else:
                 doc = document

--- a/src/bokeh/client/session.py
+++ b/src/bokeh/client/session.py
@@ -37,12 +37,7 @@ log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote_plus
 
-## External imports
-if TYPE_CHECKING:
-    from tornado.ioloop import IOLoop
-
 # Bokeh imports
-from ..core.types import ID
 from ..document import Document
 from ..resources import DEFAULT_SERVER_HTTP_URL, SessionCoordinates
 from ..util.browser import NEW_PARAM, BrowserLike, BrowserTarget
@@ -51,6 +46,9 @@ from .states import ErrorReason
 from .util import server_url_for_websocket_url, websocket_url_for_server_url
 
 if TYPE_CHECKING:
+    from tornado.ioloop import IOLoop
+
+    from ..core.types import ID
     from ..document.events import (
         DocumentPatchedEvent,
         SessionCallbackAdded,

--- a/src/bokeh/client/states.py
+++ b/src/bokeh/client/states.py
@@ -26,10 +26,8 @@ from abc import ABCMeta, abstractmethod
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
-# Bokeh imports
-from ..core.types import ID
-
 if TYPE_CHECKING:
+    from ..core.types import ID
     from ..protocol.message import Message
     from .connection import ClientConnection
 

--- a/src/bokeh/command/bootstrap.py
+++ b/src/bokeh/command/bootstrap.py
@@ -50,7 +50,6 @@ from typing import Sequence
 # Bokeh imports
 from bokeh import __version__
 from bokeh.settings import settings
-from bokeh.util.strings import nice_join
 
 # Bokeh imports
 from . import subcommands
@@ -92,6 +91,8 @@ def main(argv: Sequence[str]) -> None:
 
     '''
     if len(argv) == 1:
+        from bokeh.util.strings import nice_join
+
         die(f"Must specify subcommand, one of: {nice_join(x.name for x in subcommands.all)}")
 
     parser = argparse.ArgumentParser(

--- a/src/bokeh/command/subcommand.py
+++ b/src/bokeh/command/subcommand.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from abc import ABCMeta, abstractmethod
 from argparse import ArgumentParser, Namespace
+from dataclasses import dataclass
 from typing import (
     Any,
     ClassVar,
@@ -36,7 +37,6 @@ from typing import (
 from ..util.dataclasses import (
     NotRequired,
     Unspecified,
-    dataclass,
     entries,
 )
 

--- a/src/bokeh/command/subcommand.py
+++ b/src/bokeh/command/subcommand.py
@@ -34,11 +34,7 @@ from typing import (
 )
 
 # Bokeh imports
-from ..util.dataclasses import (
-    NotRequired,
-    Unspecified,
-    entries,
-)
+from ..util.dataclasses import NotRequired, Unspecified, entries
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/command/subcommands/secret.py
+++ b/src/bokeh/command/subcommands/secret.py
@@ -72,8 +72,7 @@ class Secret(Subcommand):
         '''
         key = generate_secret_key()
 
-        # suppress LGTM, since the intent is precisesly to output a secret
-        print(key)  # lgtm [py/clear-text-logging-sensitive-data]
+        print(key)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/command/util.py
+++ b/src/bokeh/command/util.py
@@ -26,18 +26,14 @@ import os
 import sys
 from typing import TYPE_CHECKING, Iterator
 
-if TYPE_CHECKING:
-    # External imports
-    from typing_extensions import Never
-
 # Bokeh imports
 from bokeh.application import Application
-from bokeh.application.handlers import (
-    DirectoryHandler,
-    Handler,
-    NotebookHandler,
-    ScriptHandler,
-)
+from bokeh.application.handlers import DirectoryHandler, NotebookHandler, ScriptHandler
+
+if TYPE_CHECKING:
+    from typing_extensions import Never
+
+    from bokeh.application.handlers import Handler
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/command/util.py
+++ b/src/bokeh/command/util.py
@@ -38,7 +38,6 @@ from bokeh.application.handlers import (
     NotebookHandler,
     ScriptHandler,
 )
-from bokeh.util.warnings import warn
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -131,6 +130,8 @@ def build_single_handler_application(path: str, argv: list[str] | None = None) -
             handler = NotebookHandler(filename=path, argv=argv)
         elif path.endswith(".py"):
             if path.endswith("main.py"):
+                from bokeh.util.warnings import warn
+
                 warn(DIRSTYLE_MAIN_WARNING)
             handler = ScriptHandler(filename=path, argv=argv)
         else:

--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -79,7 +79,6 @@ from typing import (
 
 # Bokeh imports
 from .. import colors, palettes
-from ..util.strings import nice_join
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -249,9 +248,13 @@ def enumeration(*values: Any, case_sensitive: bool = True, quote: bool = False) 
     if not (values and
             (all(isinstance(value, str) and value for value in values) or
              all(isinstance(value, int) for value in values))):
+        from ..util.strings import nice_join
+
         raise ValueError(f"expected a non-empty heterogenous sequence of strings or integers, got {nice_join(values)}")
 
     if len(values) != len(set(values)):
+        from ..util.strings import nice_join
+
         raise ValueError(f"enumeration items must be unique, got {nice_join(values)}")
 
     attrs: dict[str, Any] = {value: value for value in values if isinstance(value, str)}

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -50,9 +50,6 @@ if TYPE_CHECKING:
 else:
     from functools import lru_cache
 
-if TYPE_CHECKING:
-    from typing_extensions import NotRequired, Self
-
 # Bokeh imports
 from ..settings import settings
 from ..util.strings import append_docstring, nice_join
@@ -69,6 +66,8 @@ from .serialization import (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import NotRequired, Self
+
     from ..client.session import ClientSession
     from ..server.session import ServerSession
     from .property.bases import Property

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -52,7 +52,7 @@ else:
 
 # Bokeh imports
 from ..settings import settings
-from ..util.strings import append_docstring, nice_join
+from ..util.strings import append_docstring
 from .property.descriptor_factory import PropertyDescriptorFactory
 from .property.descriptors import PropertyDescriptor, UnsetValueError
 from .property.override import Override
@@ -377,6 +377,8 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
         if not matches:
             matches, text = sorted(properties), "possible"
+
+        from ..util.strings import nice_join
 
         raise AttributeError(f"unexpected attribute {name!r} to {self.__class__.__name__}, {text} attributes are {nice_join(matches)}")
 

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -67,7 +67,6 @@ from .serialization import (
     Serializable,
     Serializer,
 )
-from .types import ID
 
 if TYPE_CHECKING:
     from ..client.session import ClientSession
@@ -778,6 +777,7 @@ class ModelDef(TypedDict):
 
 def _HasProps_to_serializable(cls: type[HasProps], serializer: Serializer) -> Ref | ModelDef:
     from ..model import DataModel, Model
+    from .types import ID
 
     ref = Ref(id=ID(cls.__qualified_model__))
     serializer.add_ref(cls, ref)

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -56,7 +56,6 @@ if TYPE_CHECKING:
 # Bokeh imports
 from ..settings import settings
 from ..util.strings import append_docstring, nice_join
-from ..util.warnings import BokehUserWarning, warn
 from .property.descriptor_factory import PropertyDescriptorFactory
 from .property.descriptors import PropertyDescriptor, UnsetValueError
 from .property.override import Override
@@ -150,6 +149,8 @@ class _ModelResolver:
             # update the mapping of view model names to classes, checking for any duplicates
             previous = self._known_models.get(cls.__qualified_model__, None)
             if previous is not None and not hasattr(cls, "__implementation__"):
+                from ..util.warnings import BokehUserWarning, warn
+
                 warn(f"Duplicate qualified model definition of '{cls.__qualified_model__}'. " \
                      f"Previous definition was {previous} (@{hex(id(previous))}), the new is {cls} (@{hex(id(cls))}).", BokehUserWarning)
             self._known_models[cls.__qualified_model__] = cls
@@ -221,6 +222,8 @@ class MetaHasProps(type):
         own_properties = {k: v for k, v in cls.__dict__.items() if isinstance(v, PropertyDescriptor)}
         redeclared = own_properties.keys() & base_properties.keys()
         if redeclared:
+            from ..util.warnings import warn
+
             warn(f"Properties {redeclared!r} in class {cls.__name__} were previously declared on a parent "
                  "class. It never makes sense to do this. Redundant properties should be deleted here, or on "
                  "the parent class. Override() can be used to change a default value of a base class property.",
@@ -229,6 +232,8 @@ class MetaHasProps(type):
         # Check for no-op Overrides
         unused_overrides = cls.__overridden_defaults__.keys() - cls.properties(_with_props=True).keys()
         if unused_overrides:
+            from ..util.warnings import warn
+
             warn(f"Overrides of {unused_overrides} in class {cls.__name__} does not override anything.", RuntimeWarning)
 
     @property

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -706,7 +706,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
         old_dict = self.themed_values()
 
         # if the same theme is set again, it should reuse the same dict
-        if old_dict is property_values:  # lgtm [py/comparison-using-is]
+        if old_dict is property_values:
             return
 
         removed: set[str] = set()

--- a/src/bokeh/core/property/alias.py
+++ b/src/bokeh/core/property/alias.py
@@ -25,16 +25,15 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import ClassVar, TypeVar
+from typing import TYPE_CHECKING, ClassVar, TypeVar
 
 # Bokeh imports
-from ...util.deprecation import Version
 from .bases import Property
-from .descriptors import (
-    AliasPropertyDescriptor,
-    DeprecatedAliasPropertyDescriptor,
-    PropertyDescriptor,
-)
+from .descriptors import AliasPropertyDescriptor, DeprecatedAliasPropertyDescriptor
+
+if TYPE_CHECKING:
+    from ...util.deprecation import Version
+    from .descriptors import PropertyDescriptor
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/core/property/alias.py
+++ b/src/bokeh/core/property/alias.py
@@ -51,7 +51,7 @@ T = TypeVar("T")
 # General API
 #-----------------------------------------------------------------------------
 
-class Alias(Property[T]): # lgtm [py/missing-call-to-init]
+class Alias(Property[T]):
     """
     Alias another property of a model.
 

--- a/src/bokeh/core/property/bases.py
+++ b/src/bokeh/core/property/bases.py
@@ -40,7 +40,6 @@ from typing import (
 # Bokeh imports
 from ...util.dependencies import uses_pandas
 from ...util.strings import nice_join
-from ..has_props import HasProps
 from ._sphinx import property_link, register_type_link, type_link
 from .descriptor_factory import PropertyDescriptorFactory
 from .descriptors import PropertyDescriptor
@@ -53,6 +52,7 @@ from .singletons import (
 
 if TYPE_CHECKING:
     from ...document.events import DocumentPatchedEvent
+    from ..has_props import HasProps
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -355,6 +355,8 @@ class Property(PropertyDescriptorFactory[T]):
                     break
             else:
                 error = e
+
+        from ..has_props import HasProps
 
         if error is None:
             value = self.transform(value)

--- a/src/bokeh/core/property/bases.py
+++ b/src/bokeh/core/property/bases.py
@@ -39,7 +39,6 @@ from typing import (
 
 # Bokeh imports
 from ...util.dependencies import uses_pandas
-from ...util.strings import nice_join
 from ._sphinx import property_link, register_type_link, type_link
 from .descriptor_factory import PropertyDescriptorFactory
 from .descriptors import PropertyDescriptor
@@ -554,6 +553,8 @@ class PrimitiveProperty(Property[T]):
 
         if not detail:
             raise ValueError("")
+
+        from ...util.strings import nice_join
 
         expected_type = nice_join([ cls.__name__ for cls in self._underlying_type ])
         msg = f"expected a value of type {expected_type}, got {value} of type {type(value).__name__}"

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING, Any
 # Bokeh imports
 from ...util.dataclasses import Unspecified
 from ...util.serialization import convert_datetime_type, convert_timedelta_type
-from ...util.strings import nice_join
 from .. import enums
 from .color import ALPHA_DEFAULT_HELP, COLOR_DEFAULT_HELP, Color
 from .datetime import Datetime, TimeDelta
@@ -430,6 +429,8 @@ class UnitsSpec(NumberSpec):
 
     def __init__(self, default, units_enum, units_default, *, help: str | None = None) -> None:
         super().__init__(default=default, help=help)
+
+        from ...util.strings import nice_join
 
         units_type = NotSerialized(Enum(units_enum), default=units_default, help=f"""
         Units to use for the associated property: {nice_join(units_enum)}

--- a/src/bokeh/core/property/dataspec.py
+++ b/src/bokeh/core/property/dataspec.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from ...util.dataclasses import Unspecified
-from ...util.deprecation import deprecated
 from ...util.serialization import convert_datetime_type, convert_timedelta_type
 from ...util.strings import nice_join
 from .. import enums
@@ -286,11 +285,15 @@ class NumberSpec(DataSpec):
         if accept_timedelta:
             self.accepts(TimeDelta, convert_timedelta_type)
         else:
+            from ...util.deprecation import deprecated
+
             deprecated((3, 7, 0), "NumberSpec(..., accept_datetime=False)", "FloatSpec()")
 
         if accept_datetime:
             self.accepts(Datetime, convert_datetime_type)
         else:
+            from ...util.deprecation import deprecated
+
             deprecated((3, 7, 0), "NumberSpec(..., accept_timedelta=False)", "FloatSpec()")
 
 class AlphaSpec(FloatSpec):

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -91,7 +91,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from copy import copy
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -478,6 +477,8 @@ class PropertyDescriptor(Generic[T]):
 
     @classmethod
     def is_unstable(cls, value: Any) -> TypeGuard[Callable[[], Any]]:
+        from types import FunctionType
+
         from .instance import InstanceDefault
         return isinstance(value, FunctionType | InstanceDefault)
 

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -102,7 +102,6 @@ from typing import (
 )
 
 # Bokeh imports
-from ...util.deprecation import deprecated
 from .singletons import Undefined
 from .wrappers import PropertyValueColumnData, PropertyValueContainer
 
@@ -199,6 +198,8 @@ This is a backwards compatibility alias for the {self.aliased_name!r} property.
 """
 
     def _warn(self) -> None:
+        from ...util.deprecation import deprecated
+
         deprecated(self.alias.since, self.name, self.aliased_name, self.alias.extra)
 
     def __get__(self, obj: HasProps | None, owner: type[HasProps] | None) -> T:

--- a/src/bokeh/core/property/either.py
+++ b/src/bokeh/core/property/either.py
@@ -27,7 +27,6 @@ log = logging.getLogger(__name__)
 from typing import Any, TypeVar
 
 # Bokeh imports
-from ...util.strings import nice_join
 from ._sphinx import property_link, register_type_link, type_link
 from .bases import (
     Init,
@@ -96,6 +95,8 @@ class Either(ParameterizedProperty[Any]):
 
         if any(param.is_valid(value) for param in self.type_params):
             return
+
+        from ...util.strings import nice_join
 
         msg = "" if not detail else f"expected an element of either {nice_join([ str(param) for param in self.type_params ])}, got {value!r}"
         raise ValueError(msg)

--- a/src/bokeh/core/property/enum.py
+++ b/src/bokeh/core/property/enum.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 from typing import Any, overload
 
 # Bokeh imports
-from ...util.strings import nice_join
 from .. import enums
 from ._sphinx import model_link, property_link, register_type_link
 from .bases import Init, Property
@@ -99,6 +98,8 @@ class Enum(Either):
 
         if value in self._enum:
             return
+
+        from ...util.strings import nice_join
 
         msg = "" if not detail else f"invalid value: {value!r}; allowed values are {nice_join(self.allowed_values)}"
         raise ValueError(msg)

--- a/src/bokeh/core/property/include.py
+++ b/src/bokeh/core/property/include.py
@@ -22,12 +22,14 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from copy import copy
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 # Bokeh imports
 from ..has_props import HasProps
 from .descriptor_factory import PropertyDescriptorFactory
-from .descriptors import PropertyDescriptor
+
+if TYPE_CHECKING:
+    from .descriptors import PropertyDescriptor
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/core/property/nullable.py
+++ b/src/bokeh/core/property/nullable.py
@@ -19,16 +19,14 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 # Bokeh imports
 from ._sphinx import property_link, register_type_link, type_link
-from .bases import (
-    Init,
-    Property,
-    SingleParameterizedProperty,
-    TypeOrInst,
-)
+from .bases import SingleParameterizedProperty
+
+if TYPE_CHECKING:
+    from .bases import Init, Property, TypeOrInst
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/core/property/vectorization.py
+++ b/src/bokeh/core/property/vectorization.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -30,7 +31,7 @@ from typing import (
 )
 
 # Bokeh imports
-from ...util.dataclasses import NotRequired, Unspecified, dataclass
+from ...util.dataclasses import NotRequired, Unspecified
 from ..serialization import (
     AnyRep,
     Deserializer,

--- a/src/bokeh/core/property/visual.py
+++ b/src/bokeh/core/property/visual.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import base64
-import datetime  # lgtm [py/import-and-import-from]
+import datetime
 import re
 import tempfile
 from io import BytesIO

--- a/src/bokeh/core/query.py
+++ b/src/bokeh/core/query.py
@@ -23,14 +23,15 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Iterable,
     TypeAlias,
 )
 
-# Bokeh imports
-from ..model import Model
+if TYPE_CHECKING:
+    from ..model import Model
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -59,7 +59,6 @@ from ..util.serialization import (
     transform_array,
     transform_series,
 )
-from ..util.warnings import BokehUserWarning, warn
 from .types import ID
 
 if TYPE_CHECKING:
@@ -317,6 +316,8 @@ class Serializer:
         if -_MAX_SAFE_INT < obj <= _MAX_SAFE_INT:
             return obj
         else:
+            from ..util.warnings import BokehUserWarning, warn
+
             warn("out of range integer may result in loss of precision", BokehUserWarning)
             return self._encode_float(float(obj))
 
@@ -691,6 +692,8 @@ class Deserializer:
         id = obj["id"]
         instance = self._references.get(id)
         if instance is not None:
+            from ..util.warnings import BokehUserWarning, warn
+
             warn(f"reference already known '{id}'", BokehUserWarning)
             return instance
 

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -24,6 +24,7 @@ import datetime as dt
 import gzip
 import sys
 from array import array as TypedArray
+from dataclasses import dataclass
 from math import isinf, isnan
 from types import SimpleNamespace
 from typing import (
@@ -46,12 +47,7 @@ import numpy as np
 
 # Bokeh imports
 from ..settings import settings
-from ..util.dataclasses import (
-    Unspecified,
-    dataclass,
-    entries,
-    is_dataclass,
-)
+from ..util.dataclasses import Unspecified, entries, is_dataclass
 from ..util.dependencies import uses_pandas
 from ..util.serialization import (
     array_encoding_disabled,

--- a/src/bokeh/core/validation/check.py
+++ b/src/bokeh/core/validation/check.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import contextlib
+from dataclasses import dataclass, field
 from typing import (
     Iterable,
     Iterator,
@@ -32,7 +33,6 @@ from typing import (
 # Bokeh imports
 from ...model import Model
 from ...settings import settings
-from ...util.dataclasses import dataclass, field
 from .issue import Warning
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/core/validation/issue.py
+++ b/src/bokeh/core/validation/issue.py
@@ -20,10 +20,8 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from dataclasses import dataclass
 from typing import ClassVar
-
-# Bokeh imports
-from ...util.dataclasses import dataclass
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/document/callbacks.py
+++ b/src/bokeh/document/callbacks.py
@@ -28,18 +28,16 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
 # Bokeh imports
-from ..core.enums import HoldPolicy, HoldPolicyType
+from ..core.enums import HoldPolicy
 from ..events import (
     _CONCRETE_EVENT_CLASSES,
     DocumentEvent,
     Event,
     ModelEvent,
 )
-from ..model import Model
 from ..models.callbacks import Callback as JSEventCallback
 from ..util.callback_manager import _check_callback
 from .events import (
-    DocumentPatchedEvent,
     MessageSentEvent,
     ModelChangedEvent,
     RootAddedEvent,
@@ -52,10 +50,17 @@ from .locking import UnlockedDocumentProxy
 
 if TYPE_CHECKING:
     from ..application.application import SessionDestroyedCallback
+    from ..core.enums import HoldPolicyType
     from ..core.has_props import Setter
+    from ..model import Model
     from ..server.callbacks import SessionCallback
     from .document import Document
-    from .events import DocumentChangeCallback, DocumentChangedEvent, Invoker
+    from .events import (
+        DocumentChangeCallback,
+        DocumentChangedEvent,
+        DocumentPatchedEvent,
+        Invoker,
+    )
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -54,8 +54,6 @@ from ..core.serialization import (
 )
 from ..core.templates import FILE
 from ..core.validation import check_integrity, process_validation_issues
-from ..events import Event
-from ..model import Model
 from ..themes import Theme, built_in_themes, default as default_theme
 from ..util.serialization import make_id
 from ..util.strings import nice_join
@@ -74,7 +72,6 @@ from .events import (
     RootRemovedEvent,
     TitleChangedEvent,
 )
-from .json import DocJson, PatchJson
 from .models import DocumentModelManager
 from .modules import DocumentModuleManager
 
@@ -83,6 +80,8 @@ if TYPE_CHECKING:
     from ..core.has_props import Setter
     from ..core.query import SelectorType
     from ..core.types import ID
+    from ..events import Event
+    from ..model import Model
     from ..server.callbacks import (
         NextTickCallback,
         PeriodicCallback,
@@ -90,6 +89,7 @@ if TYPE_CHECKING:
         TimeoutCallback,
     )
     from .events import DocumentChangeCallback
+    from .json import DocJson, PatchJson
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -735,6 +735,8 @@ side of a communications channel while it was being removed on the other end.\
             None
 
         '''
+        from ..model import Model
+
         if isinstance(selector, type) and issubclass(selector, Model):
             selector = dict(type=selector)
         for obj in self.select(selector):
@@ -758,6 +760,9 @@ side of a communications channel while it was being removed on the other end.\
             DocJson
 
         '''
+        from ..model import Model
+        from .json import DocJson
+
         data_models = [ model for model in Model.model_class_reverse_map.values() if is_DataModel(model) ]
 
         serializer = Serializer(deferred=deferred)

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -56,7 +56,6 @@ from ..core.templates import FILE
 from ..core.validation import check_integrity, process_validation_issues
 from ..themes import Theme, built_in_themes, default as default_theme
 from ..util.serialization import make_id
-from ..util.strings import nice_join
 from ..util.version import __version__
 from .callbacks import (
     Callback,
@@ -230,6 +229,8 @@ class Document:
             try:
                 theme = built_in_themes[theme]
             except KeyError:
+                from ..util.strings import nice_join
+
                 raise ValueError(f"{theme} is not a built-in theme; available themes are {nice_join(built_in_themes)}")
 
         if not isinstance(theme, Theme):

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -53,7 +53,6 @@ from ..core.serialization import (
     UnknownReferenceError,
 )
 from ..core.templates import FILE
-from ..core.types import ID
 from ..core.validation import check_integrity, process_validation_issues
 from ..events import Event
 from ..model import Model
@@ -83,6 +82,7 @@ if TYPE_CHECKING:
     from ..application.application import SessionContext, SessionDestroyedCallback
     from ..core.has_props import Setter
     from ..core.query import SelectorType
+    from ..core.types import ID
     from ..server.callbacks import (
         NextTickCallback,
         PeriodicCallback,

--- a/src/bokeh/document/events.py
+++ b/src/bokeh/document/events.py
@@ -66,7 +66,7 @@ from typing import (
 )
 
 # Bokeh imports
-from ..core.serialization import Serializable, Serializer
+from ..core.serialization import Serializable
 from .json import (
     ColumnDataChanged,
     ColumnsPatched,
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from ..core.has_props import Setter
+    from ..core.serialization import Serializer
     from ..model import Model
     from ..models.sources import DataDict
     from ..protocol.message import BufferRef

--- a/src/bokeh/document/models.py
+++ b/src/bokeh/document/models.py
@@ -32,11 +32,11 @@ from typing import (
 )
 
 # Bokeh imports
-from ..core.types import ID
 from ..model import Model
 from ..util.datatypes import MultiValuedDict
 
 if TYPE_CHECKING:
+    from ..core.types import ID
     from .document import Document
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/document/models.py
+++ b/src/bokeh/document/models.py
@@ -32,11 +32,11 @@ from typing import (
 )
 
 # Bokeh imports
-from ..model import Model
 from ..util.datatypes import MultiValuedDict
 
 if TYPE_CHECKING:
     from ..core.types import ID
+    from ..model import Model
     from .document import Document
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/document/modules.py
+++ b/src/bokeh/document/modules.py
@@ -110,8 +110,8 @@ class DocumentModuleManager:
             # leaked. Here we perform a detailed check that the only referrers are expected
             # ones. Otherwise issue an error log message with details.
             referrers = get_referrers(module)
-            referrers = [x for x in referrers if x is not sys.modules]  # lgtm [py/comparison-using-is]
-            referrers = [x for x in referrers if x is not self._modules]  # lgtm [py/comparison-using-is]
+            referrers = [x for x in referrers if x is not sys.modules]
+            referrers = [x for x in referrers if x is not self._modules]
             referrers = [x for x in referrers if not isinstance(x, FrameType)]
             if len(referrers) != 0:
                 log.error(f"Module {module!r} has extra unexpected referrers! This could indicate a serious memory leak. Extra referrers: {referrers!r}")

--- a/src/bokeh/document/modules.py
+++ b/src/bokeh/document/modules.py
@@ -24,10 +24,11 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import sys
 import weakref
-from types import ModuleType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from .document import Document
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/embed/elements.py
+++ b/src/bokeh/embed/elements.py
@@ -40,13 +40,13 @@ from ..core.templates import (
 from ..document.document import DEFAULT_TITLE
 from ..settings import settings
 from ..util.serialization import make_globally_unique_css_safe_id
-from .util import RenderItem
 from .wrappers import wrap_in_onload, wrap_in_safely, wrap_in_script_tag
 
 if TYPE_CHECKING:
     from ..core.types import ID
     from ..document.document import DocJson
     from .bundle import Bundle
+    from .util import RenderItem
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/embed/server.py
+++ b/src/bokeh/embed/server.py
@@ -24,10 +24,6 @@ log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote_plus, urlparse
 
-## External imports
-if TYPE_CHECKING:
-    from jinja2 import Template
-
 # Bokeh imports
 from ..core.templates import AUTOLOAD_REQUEST_TAG, FILE
 from ..resources import DEFAULT_SERVER_HTTP_URL
@@ -38,6 +34,8 @@ from .elements import html_page_for_render_items
 from .util import RenderItem
 
 if TYPE_CHECKING:
+    from jinja2 import Template
+
     from ..core.types import ID
     from ..model import Model
     from ..resources import Resources

--- a/src/bokeh/embed/standalone.py
+++ b/src/bokeh/embed/standalone.py
@@ -44,7 +44,6 @@ from ..core.templates import (
 from ..document.document import DEFAULT_TITLE, Document
 from ..model import Model
 from ..resources import Resources, ResourcesLike
-from ..themes import Theme
 from .bundle import Script, bundle_for_objs_and_resources
 from .elements import html_page_for_render_items, script_for_render_items
 from .util import (
@@ -61,6 +60,12 @@ if TYPE_CHECKING:
 
     from ..core.types import ID
     from ..document.document import DocJson
+    from ..themes import Theme
+
+    ModelLike: TypeAlias = Model | Document
+    ModelLikeCollection: TypeAlias = Sequence[ModelLike] | dict[str, ModelLike]
+
+    ThemeLike: TypeAlias = None | Theme | type[FromCurdoc]
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -73,14 +78,9 @@ __all__ = (
     'json_item',
 )
 
-ModelLike: TypeAlias = Model | Document
-ModelLikeCollection: TypeAlias = Sequence[ModelLike] | dict[str, ModelLike]
-
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
-
-ThemeLike: TypeAlias = None | Theme | type[FromCurdoc]
 
 def autoload_static(model: Model | Document, resources: Resources, script_path: str) -> tuple[str, str]:
     ''' Return JavaScript code and a script tag that can be used to embed

--- a/src/bokeh/embed/util.py
+++ b/src/bokeh/embed/util.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import re
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -37,7 +38,6 @@ from ..document.document import Document
 from ..model import Model, collect_models
 from ..settings import settings
 from ..themes.theme import Theme
-from ..util.dataclasses import dataclass, field
 from ..util.serialization import (
     make_globally_unique_css_safe_id,
     make_globally_unique_id,

--- a/src/bokeh/embed/util.py
+++ b/src/bokeh/embed/util.py
@@ -33,7 +33,6 @@ from typing import (
 from weakref import WeakKeyDictionary
 
 # Bokeh imports
-from ..core.types import ID
 from ..document.document import Document
 from ..model import Model, collect_models
 from ..settings import settings
@@ -44,6 +43,7 @@ from ..util.serialization import (
 )
 
 if TYPE_CHECKING:
+    from ..core.types import ID
     from ..document.document import DocJson
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/embed/util.py
+++ b/src/bokeh/embed/util.py
@@ -163,7 +163,7 @@ def OutputDocumentFor(objs: Sequence[Model], apply_theme: Theme | type[FromCurdo
                 doc = _create_temp_doc(objs)
 
             # we are using all the roots of a single doc, just use doc as-is
-            pass  # lgtm [py/unnecessary-pass]
+            pass
 
         # models have mixed docs, just make a quick clone
         else:

--- a/src/bokeh/ext.py
+++ b/src/bokeh/ext.py
@@ -20,12 +20,15 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from os import fspath
 from subprocess import Popen
+from typing import TYPE_CHECKING
 
 # Bokeh imports
 from . import __version__
-from .core.types import PathLike
 from .settings import settings
 from .util.compiler import _nodejs_path
+
+if TYPE_CHECKING:
+    from .core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/io/export.py
+++ b/src/bokeh/io/export.py
@@ -34,12 +34,9 @@ from typing import (
 )
 
 # Bokeh imports
-from ..document import Document
 from ..embed import file_html
-from ..model import Model
-from ..resources import INLINE, Resources
-from ..themes import Theme
-from .state import State, curstate
+from ..resources import INLINE
+from .state import curstate
 from .util import default_filename
 
 if TYPE_CHECKING:
@@ -47,8 +44,13 @@ if TYPE_CHECKING:
     from selenium.webdriver.remote.webdriver import WebDriver
 
     from ..core.types import PathLike
+    from ..document import Document
+    from ..model import Model
     from ..models.plots import Plot
     from ..models.ui import UIElement
+    from ..resources import Resources
+    from ..themes import Theme
+    from .state import State
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -486,6 +488,8 @@ return [...collect_svgs(Bokeh.index)]
 """
 
 def _SVG_SCRIPT(obj: Model | Document) -> str:
+    from ..document import Document
+
     if isinstance(obj, Document):
         ids = [root.id for root in obj.roots]
     else:

--- a/src/bokeh/io/export.py
+++ b/src/bokeh/io/export.py
@@ -33,11 +33,7 @@ from typing import (
     cast,
 )
 
-if TYPE_CHECKING:
-    from selenium.webdriver.remote.webdriver import WebDriver
-
 # Bokeh imports
-from ..core.types import PathLike
 from ..document import Document
 from ..embed import file_html
 from ..model import Model
@@ -48,7 +44,9 @@ from .util import default_filename
 
 if TYPE_CHECKING:
     from PIL import Image
+    from selenium.webdriver.remote.webdriver import WebDriver
 
+    from ..core.types import PathLike
     from ..models.plots import Plot
     from ..models.ui import UIElement
 

--- a/src/bokeh/io/export.py
+++ b/src/bokeh/io/export.py
@@ -43,7 +43,6 @@ from ..embed import file_html
 from ..model import Model
 from ..resources import INLINE, Resources
 from ..themes import Theme
-from ..util.warnings import warn
 from .state import State, curstate
 from .util import default_filename
 
@@ -355,6 +354,8 @@ def get_layout_html(obj: UIElement | Document, *, resources: Resources = INLINE,
         # Defer this import, it is expensive
         from ..models.plots import Plot
         if not isinstance(obj, Plot):
+            from ..util.warnings import warn
+
             warn("Export method called with width or height argument on a non-Plot model. The size values will be ignored.")
         else:
             with _resized(obj, width, height):

--- a/src/bokeh/io/notebook.py
+++ b/src/bokeh/io/notebook.py
@@ -37,17 +37,15 @@ from typing import (
 )
 from uuid import uuid4
 
-## External imports
-if TYPE_CHECKING:
-    from ipykernel.comm import Comm
-
 # Bokeh imports
-from ..core.types import ID
 from ..util.serialization import make_id
 from .state import curstate
 
 if TYPE_CHECKING:
+    from ipykernel.comm import Comm
+
     from ..application.application import Application
+    from ..core.types import ID
     from ..document.document import Document
     from ..document.events import (
         ColumnDataChangedEvent,
@@ -557,6 +555,7 @@ def show_app(
 
     from tornado.ioloop import IOLoop
 
+    from ..core.types import ID
     from ..server.server import Server
 
     loop = IOLoop.current()

--- a/src/bokeh/io/notebook.py
+++ b/src/bokeh/io/notebook.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
 # Bokeh imports
 from ..core.types import ID
 from ..util.serialization import make_id
-from ..util.warnings import warn
 from .state import curstate
 
 if TYPE_CHECKING:
@@ -313,6 +312,8 @@ def push_notebook(*, document: Document | None = None, state: State | None = Non
         document = state.document
 
     if not document:
+        from ..util.warnings import warn
+
         warn("No document to push")
         return
 
@@ -320,6 +321,8 @@ def push_notebook(*, document: Document | None = None, state: State | None = Non
         handle = state.last_comms_handle
 
     if not handle:
+        from ..util.warnings import warn
+
         warn("Cannot find a last shown plot to update. Call output_notebook() and show(..., notebook_handle=True) before push_notebook()")
         return
 

--- a/src/bokeh/io/saving.py
+++ b/src/bokeh/io/saving.py
@@ -22,20 +22,22 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from os.path import abspath, expanduser
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 # External imports
 from jinja2 import Template
 
 # Bokeh imports
 from ..core.templates import FILE
-from ..core.types import PathLike
 from ..models.ui import UIElement
 from ..resources import Resources, ResourcesLike
 from ..settings import settings
 from ..themes import Theme
 from .state import State, curstate
 from .util import default_filename
+
+if TYPE_CHECKING:
+    from ..core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/io/saving.py
+++ b/src/bokeh/io/saving.py
@@ -34,7 +34,6 @@ from ..models.ui import UIElement
 from ..resources import Resources, ResourcesLike
 from ..settings import settings
 from ..themes import Theme
-from ..util.warnings import warn
 from .state import State, curstate
 from .util import default_filename
 
@@ -139,6 +138,8 @@ def _get_save_resources(state: State, resources: ResourcesLike | None, suppress_
         return state.file.resources
 
     if not suppress_warning:
+        from ..util.warnings import warn
+
         warn("save() called but no resources were supplied and output_file(...) was never called, defaulting to resources.CDN")
 
     return Resources(mode=settings.resources())
@@ -151,6 +152,8 @@ def _get_save_title(state: State, title: str | None, suppress_warning: bool) -> 
         return state.file.title
 
     if not suppress_warning:
+        from ..util.warnings import warn
+
         warn("save() called but no title was supplied and output_file(...) was never called, using default title 'Bokeh Plot'")
 
     return DEFAULT_TITLE

--- a/src/bokeh/io/saving.py
+++ b/src/bokeh/io/saving.py
@@ -29,15 +29,17 @@ from jinja2 import Template
 
 # Bokeh imports
 from ..core.templates import FILE
-from ..models.ui import UIElement
-from ..resources import Resources, ResourcesLike
+from ..resources import Resources
 from ..settings import settings
-from ..themes import Theme
-from .state import State, curstate
+from .state import curstate
 from .util import default_filename
 
 if TYPE_CHECKING:
     from ..core.types import PathLike
+    from ..models.ui import UIElement
+    from ..resources import ResourcesLike
+    from ..themes import Theme
+    from .state import State
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/io/showing.py
+++ b/src/bokeh/io/showing.py
@@ -29,17 +29,17 @@ from typing import (
 )
 
 # Bokeh imports
-from ..models.ui import UIElement
 from ..util.browser import NEW_PARAM, get_browser_controller
-from .notebook import DEFAULT_JUPYTER_URL, ProxyUrlFunc, run_notebook_hook
+from .notebook import DEFAULT_JUPYTER_URL, run_notebook_hook
 from .saving import save
 from .state import curstate
 
 if TYPE_CHECKING:
     from ..application.application import Application
     from ..application.handlers.function import ModifyDoc
+    from ..models.ui import UIElement
     from ..util.browser import BrowserLike, BrowserTarget
-    from .notebook import CommsHandle
+    from .notebook import CommsHandle, ProxyUrlFunc
     from .state import State
 
 #-----------------------------------------------------------------------------
@@ -151,6 +151,8 @@ def show(
         ``push_notebook``, None otherwise.
 
     '''
+    from ..models.ui import UIElement
+
     state = curstate()
 
     if isinstance(obj, UIElement) or isinstance(obj, Sequence):

--- a/src/bokeh/io/state.py
+++ b/src/bokeh/io/state.py
@@ -49,12 +49,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 # Bokeh imports
-from ..core.types import PathLike
-from ..document import Document
 from ..resources import Resources, ResourcesMode
 
 if TYPE_CHECKING:
-    from ..core.types import ID
+    from ..core.types import ID, PathLike
+    from ..document import Document
     from ..server.server import Server
     from .notebook import CommsHandle, NotebookType
 
@@ -201,6 +200,8 @@ class State:
             None
 
         '''
+        from ..document import Document
+
         self._reset_with_doc(Document())
 
     # Private methods ---------------------------------------------------------

--- a/src/bokeh/layouts.py
+++ b/src/bokeh/layouts.py
@@ -38,8 +38,8 @@ from typing import (
 )
 
 # Bokeh imports
-from .core.enums import Location, LocationType, SizingModeType
-from .core.property.singletons import Undefined, UndefinedType
+from .core.enums import Location
+from .core.property.singletons import Undefined
 from .models import (
     Column,
     CopyTool,
@@ -59,6 +59,12 @@ from .models import (
     UIElement,
 )
 
+if TYPE_CHECKING:
+    from .core.enums import LocationType, SizingModeType
+    from .core.property.singletons import UndefinedType
+
+    ToolbarOptions = Literal["logo", "autohide", "active_drag", "active_inspect", "active_scroll", "active_tap", "active_multi"]
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -71,9 +77,6 @@ __all__ = (
     'row',
     'Spacer',
 )
-
-if TYPE_CHECKING:
-    ToolbarOptions = Literal["logo", "autohide", "active_drag", "active_inspect", "active_scroll", "active_tap", "active_multi"]
 
 #-----------------------------------------------------------------------------
 # General API

--- a/src/bokeh/layouts.py
+++ b/src/bokeh/layouts.py
@@ -58,7 +58,6 @@ from .models import (
     ToolProxy,
     UIElement,
 )
-from .util.warnings import warn
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -364,6 +363,8 @@ def gridplot(
         if n == 0:
             return Undefined
         elif n > 1:
+            from .util.warnings import warn
+
             warn(f"found multiple competing values for 'toolbar.{name}' property; using the latest value")
         return values[-1]
 

--- a/src/bokeh/layouts.py
+++ b/src/bokeh/layouts.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import math
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -57,7 +58,6 @@ from .models import (
     ToolProxy,
     UIElement,
 )
-from .util.dataclasses import dataclass
 from .util.warnings import warn
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -30,7 +30,6 @@ from ..core.has_props import HasProps, _default_resolver, abstract
 from ..core.property._sphinx import type_link
 from ..core.property.validation import without_property_validation
 from ..core.serialization import ObjectRefRep, Ref, Serializer
-from ..core.types import ID
 from ..events import Event
 from ..themes import default as default_theme
 from ..util.callback_manager import EventCallbackManager, PropertyCallbackManager
@@ -47,6 +46,7 @@ if TYPE_CHECKING:
 
     from ..core.has_props import Setter
     from ..core.query import SelectorType
+    from ..core.types import ID
     from ..document import Document
     from ..document.events import DocumentPatchedEvent
     from ..models.callbacks import (

--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -25,8 +25,17 @@ from inspect import Parameter, Signature, isclass
 from typing import TYPE_CHECKING, Any, Iterable
 
 # Bokeh imports
-from ..core import properties as p
 from ..core.has_props import HasProps, _default_resolver, abstract
+from ..core.properties import (
+    AnyRef,
+    Bool,
+    Dict,
+    Instance,
+    List,
+    Nullable,
+    Set,
+    String,
+)
 from ..core.property._sphinx import type_link
 from ..core.property.validation import without_property_validation
 from ..core.serialization import ObjectRefRep, Ref, Serializer
@@ -137,7 +146,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
     def id(self) -> ID:
         return self._id
 
-    name = p.Nullable(p.String, help="""
+    name = Nullable(String, help="""
     An arbitrary, user-supplied name for this model.
 
     This name can be useful when querying the document to retrieve specific
@@ -156,7 +165,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     """)
 
-    tags = p.List(p.AnyRef, help="""
+    tags = List(AnyRef, help="""
     An optional list of arbitrary, user-supplied values to attach to this
     model.
 
@@ -180,7 +189,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     """)
 
-    js_event_callbacks = p.Dict(p.String, p.List(p.Instance("bokeh.models.callbacks.Callback")), help="""
+    js_event_callbacks = Dict(String, List(Instance("bokeh.models.callbacks.Callback")), help="""
     A mapping of event names to lists of ``CustomJS`` callbacks.
 
     Typically, rather then modifying this property directly, callbacks should be
@@ -192,7 +201,7 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
         plot.js_on_event('tap', callback)
     """)
 
-    js_property_callbacks = p.Dict(p.String, p.List(p.Instance("bokeh.models.callbacks.Callback")), help="""
+    js_property_callbacks = Dict(String, List(Instance("bokeh.models.callbacks.Callback")), help="""
     A mapping of attribute names to lists of ``CustomJS`` callbacks, to be set up on
     BokehJS side when the document is created.
 
@@ -206,13 +215,13 @@ class Model(HasProps, HasDocumentRef, PropertyCallbackManager, EventCallbackMana
 
     """)
 
-    subscribed_events = p.Set(p.String, help="""
+    subscribed_events = Set(String, help="""
     Collection of events that are subscribed to by Python callbacks. This is
     the set of events that will be communicated from BokehJS back to Python
     for this model.
     """)
 
-    syncable: bool = p.Bool(default=True, help="""
+    syncable: bool = Bool(default=True, help="""
     Indicates whether this model should be synchronized back to a Bokeh server when
     updated in a web browser. Setting to ``False`` may be useful to reduce network
     traffic when dealing with frequently updated objects whose updated values we

--- a/src/bokeh/models/plots.py
+++ b/src/bokeh/models/plots.py
@@ -73,7 +73,6 @@ from ..core.validation.errors import (
 )
 from ..core.validation.warnings import MISSING_RENDERERS
 from ..model import Model
-from ..util.strings import nice_join
 from .annotations import Annotation, Legend, Title
 from .axes import Axis
 from .dom import HTML
@@ -302,6 +301,8 @@ class Plot(LayoutDOM):
 
         '''
         if place not in Place:
+            from ..util.strings import nice_join
+
             raise ValueError(
                 f"Invalid place '{place}' specified. Valid place values are: {nice_join(Place)}",
             )
@@ -347,6 +348,8 @@ class Plot(LayoutDOM):
             if not isinstance(tool, Tool):
                 raise ValueError("All arguments to remove_tool must be Tool subclasses.")
             elif tool not in self.toolbar.tools:
+                from ..util.strings import nice_join
+
                 raise ValueError(f"Invalid tool {tool} specified. Available tools are {nice_join(self.toolbar.tools)}")
             self.toolbar.tools.remove(tool)
 

--- a/src/bokeh/models/plots.py
+++ b/src/bokeh/models/plots.py
@@ -74,7 +74,6 @@ from ..core.validation.errors import (
 from ..core.validation.warnings import MISSING_RENDERERS
 from ..model import Model
 from ..util.strings import nice_join
-from ..util.warnings import warn
 from .annotations import Annotation, Legend, Title
 from .axes import Axis
 from .dom import HTML
@@ -992,6 +991,8 @@ Before legend properties can be set, you must add a Legend explicitly, or call a
 class _legend_attr_splat(_list_attr_splat):
     def __setattr__(self, attr, value):
         if not len(self):
+            from ..util.warnings import warn
+
             warn(_LEGEND_EMPTY_WARNING % attr)
         return super().__setattr__(attr, value)
 

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -51,7 +51,6 @@ from ..core.properties import (
 from ..core.property.data_frame import EagerDataFrame, PandasGroupBy
 from ..model import Model
 from ..util.serialization import convert_datetime_array
-from ..util.warnings import BokehUserWarning, warn
 from .callbacks import CustomJS
 from .filters import AllIndices, Filter
 from .selections import Selection, SelectionPolicy, UnionRenderers
@@ -128,6 +127,15 @@ class ColumnarDataSource(DataSource):
     selection_policy = Instance(SelectionPolicy, default=InstanceDefault(UnionRenderers), help="""
     An instance of a ``SelectionPolicy`` that determines how selections are set.
     """)
+
+def _cds_lengths_warning(_, __, data: dict[str, Any]) -> None:
+    from ..util.warnings import BokehUserWarning, warn
+
+    current_lengths = ', '.join(sorted(str((k, len(v))) for k, v in data.items()))
+    warn(
+        f"ColumnDataSource's columns must be of the same length. Current lengths: {current_lengths}",
+        BokehUserWarning,
+    )
 
 class ColumnDataSource(ColumnarDataSource):
     ''' Maps names of columns to sequences or arrays.
@@ -211,10 +219,7 @@ class ColumnDataSource(ColumnarDataSource):
         EagerDataFrame, lambda x: ColumnDataSource._data_from_df(x),
      ).accepts(
         PandasGroupBy, lambda x: ColumnDataSource._data_from_groupby(x),
-    ).asserts(lambda _, data: len({len(x) for x in data.values()}) <= 1,
-                 lambda obj, name, data: warn(
-                    "ColumnDataSource's columns must be of the same length. " +
-                    f"Current lengths: {', '.join(sorted(str((k, len(v))) for k, v in data.items()))}", BokehUserWarning))
+    ).asserts(lambda _, data: len({len(x) for x in data.values()}) <= 1, _cds_lengths_warning)
 
     @overload
     def __init__(self, data: DataDict | pd.DataFrame | pd.core.groupby.GroupBy, **kwargs: Any) -> None: ...
@@ -447,6 +452,8 @@ class ColumnDataSource(ColumnarDataSource):
         try:
             del self.data[name]
         except (ValueError, KeyError):
+            from ..util.warnings import warn
+
             warn(f"Unable to find column '{name}' in data source")
 
     def stream(self, new_data: DataDict, rollover: int | None = None) -> None:

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -93,7 +93,6 @@ from ..core.property_aliases import IconLike
 from ..core.validation import error
 from ..core.validation.errors import NO_RANGE_TOOL_RANGES
 from ..model import Model
-from ..util.strings import nice_join
 from .annotations import BoxAnnotation, PolyAnnotation, Span
 from .callbacks import Callback, CustomJS
 from .common.properties import GlyphRendererOf
@@ -235,6 +234,9 @@ class Tool(Model):
             matches, text = difflib.get_close_matches(name.lower(), known_names), "similar"
             if not matches:
                 matches, text = known_names, "possible"
+
+            from ..util.strings import nice_join
+
             raise ValueError(f"unexpected tool name '{name}', {text} tools are {nice_join(matches)}")
 
     @classmethod

--- a/src/bokeh/models/ui/menus.py
+++ b/src/bokeh/models/ui/menus.py
@@ -34,7 +34,6 @@ from ...core.properties import (
 )
 from ...core.property_aliases import IconLike
 from ...model import Model
-from ...util.deprecation import deprecated
 from ..callbacks import Callback
 from .ui_element import UIElement
 
@@ -110,6 +109,8 @@ class ActionItem(MenuItem):
 
     # explicit __init__ to support Init signatures
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        from ...util.deprecation import deprecated
+
         deprecated((3, 7, 0), "ActionItem", "MenuItem")
         super().__init__(*args, **kwargs)
 
@@ -118,6 +119,8 @@ class CheckableItem(MenuItem):
 
     # explicit __init__ to support Init signatures
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        from ...util.deprecation import deprecated
+
         deprecated((3, 7, 0), "CheckableItem", "ActionItem.checked")
         super().__init__(*args, **kwargs)
 

--- a/src/bokeh/models/widgets/inputs.py
+++ b/src/bokeh/models/widgets/inputs.py
@@ -53,7 +53,6 @@ from ...core.properties import (
 )
 from ...core.property_aliases import IconLike
 from ...events import ModelEvent
-from ...util.deprecation import deprecated
 from ..dom import HTML
 from ..formatters import TickFormatter
 from ..ui import Tooltip
@@ -614,6 +613,8 @@ def ColorMap(*args: Any, **kwargs: Any) -> PaletteSelect:
     .. deprecated:: 3.4.0
         Use ``PaletteSelect`` widget instead.
     '''
+    from ...util.deprecation import deprecated
+
     deprecated((3, 4, 0), "ColorMap widget", "PaletteSelect widget")
     return PaletteSelect(*args, **kwargs)
 

--- a/src/bokeh/plotting/_decorators.py
+++ b/src/bokeh/plotting/_decorators.py
@@ -22,7 +22,6 @@ from functools import wraps
 from inspect import Parameter, Signature, signature
 
 # Bokeh imports
-from ..util.deprecation import deprecated
 from ._docstring import generate_docstring
 from ._renderer import create_renderer
 
@@ -55,6 +54,8 @@ def marker_method():
 
         @wraps(func)
         def wrapped(self, *args, **kwargs):
+            from ..util.deprecation import deprecated
+
             deprecated((3, 4, 0), f"{func.__name__}() method", f"scatter(marker={func.__name__!r}, ...) instead")
             if len(args) > len(glyphclass._args):
                 raise TypeError(f"{func.__name__} takes {len(glyphclass._args)} positional argument but {len(args)} were given")

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -69,11 +69,13 @@ from ._graph import get_graph_kwargs
 from ._plot import get_range, get_scale, process_axis_and_grid
 from ._stack import double_stack, single_stack
 from ._tools import process_active_tools, process_tools_arg
-from .contour import ContourRenderer, from_contour
+from .contour import from_contour
 from .glyph_api import _MARKER_SHORTCUTS, GlyphAPI
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
+
+    from .models.renderer import ContourRenderer
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/plotting/_legends.py
+++ b/src/bokeh/plotting/_legends.py
@@ -26,7 +26,6 @@ import numpy as np
 # Bokeh imports
 from ..core.properties import field, value
 from ..models import Legend, LegendItem
-from ..util.strings import nice_join
 
 if TYPE_CHECKING:
     from ..core.property.dataspec import DataSpec
@@ -55,6 +54,8 @@ LEGEND_ARGS = ['legend', 'legend_label', 'legend_field', 'legend_group']
 def pop_legend_kwarg(kwargs: dict[str, Any]) -> tuple[Any, str]:
     result = {attr: kwargs.pop(attr) for attr in LEGEND_ARGS if attr in kwargs}
     if len(result) > 1:
+        from ..util.strings import nice_join
+
         raise ValueError(f"Only one of {nice_join(LEGEND_ARGS)} may be provided, got: {nice_join(result.keys())}")
     legend_name = kwargs.pop("legend_name", None)
     return result, legend_name

--- a/src/bokeh/plotting/_legends.py
+++ b/src/bokeh/plotting/_legends.py
@@ -29,7 +29,7 @@ from ..models import Legend, LegendItem
 from ..util.strings import nice_join
 
 if TYPE_CHECKING:
-    from .._specs import DataSpec
+    from ..core.property.dataspec import DataSpec
     from ..models import GlyphRenderer, Plot
     from ..models.glyph import Glyph
 

--- a/src/bokeh/plotting/_renderer.py
+++ b/src/bokeh/plotting/_renderer.py
@@ -28,7 +28,6 @@ import numpy as np
 # Bokeh imports
 from ..core.properties import ColorSpec
 from ..models import ColumnarDataSource, ColumnDataSource, GlyphRenderer
-from ..util.strings import nice_join
 from ._legends import pop_legend_kwarg, update_legend
 
 if TYPE_CHECKING:
@@ -96,6 +95,8 @@ def create_renderer(glyphclass: type[Glyph], plot: Plot, **kwargs: Any) -> Glyph
     incompatible_literal_spec_values += _process_sequence_literals(glyphclass, kwargs, source, is_user_source)
     incompatible_literal_spec_values += _process_sequence_literals(glyphclass, glyph_visuals, source, is_user_source)
     if incompatible_literal_spec_values:
+        from ..util.strings import nice_join
+
         raise RuntimeError(_GLYPH_SOURCE_MSG % nice_join(incompatible_literal_spec_values, conjunction="and"))
 
     # handle the nonselection glyph, we always set one

--- a/src/bokeh/plotting/_tools.py
+++ b/src/bokeh/plotting/_tools.py
@@ -45,7 +45,6 @@ from ..models.tools import (
     Scroll,
     Tap,
 )
-from ..util.warnings import warn
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -148,6 +147,8 @@ def process_tools_arg(plot: Plot, tools: str | Sequence[Tool | str],
 
     repeated_tools = [ str(obj) for obj in _collect_repeated_tools(tool_objs) ]
     if repeated_tools:
+        from ..util.warnings import warn
+
         warn(f"{','.join(repeated_tools)} are being repeated")
 
     if tooltips is not None:

--- a/src/bokeh/plotting/contour.py
+++ b/src/bokeh/plotting/contour.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Sequence,
@@ -35,7 +36,7 @@ from ..models.renderers import ContourRenderer, GlyphRenderer
 from ..models.sources import ColumnDataSource
 from ..palettes import interp_palette
 from ..plotting._renderer import _process_sequence_literals
-from ..util.dataclasses import dataclass, entries
+from ..util.dataclasses import entries
 
 if TYPE_CHECKING:
     from contourpy._contourpy import FillReturn_OuterOffset, LineReturn_ChunkCombinedNan

--- a/src/bokeh/plotting/glyph_api.py
+++ b/src/bokeh/plotting/glyph_api.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from ..models import glyphs
-from ..util.deprecation import deprecated
 from ._decorators import glyph_method, marker_method
 
 if TYPE_CHECKING:
@@ -141,6 +140,8 @@ Examples:
 
         """
         if "size" in kwargs:
+            from ..util.deprecation import deprecated
+
             deprecated((3, 4, 0), "circle() method with size value", "scatter(size=...) instead")
             if "radius" in kwargs:
                 raise ValueError("can only provide one of size or radius")
@@ -1143,6 +1144,8 @@ Examples:
             marker_type = _MARKER_SHORTCUTS[marker_type]
 
         if marker_type == "circle" and "radius" in kwargs:
+            from ..util.deprecation import deprecated
+
             deprecated((3, 4, 0), "scatter(radius=...)", "circle(radius=...) instead")
             if "size" in kwargs:
                 raise ValueError("can only provide one of size or radius")

--- a/src/bokeh/plotting/graph.py
+++ b/src/bokeh/plotting/graph.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, Sequence
 # Bokeh imports
 from ..models.graphs import StaticLayoutProvider
 from ..models.renderers import GraphRenderer
-from ..util.warnings import warn
 
 if TYPE_CHECKING:
     import networkx as nx
@@ -86,6 +85,8 @@ def from_networkx(graph: nx.Graph, layout_function: dict[int | str, Sequence[flo
             node_dict[attr_key] = values
 
         if 'index' in node_attr_keys:
+            from ..util.warnings import warn
+
             warn("Converting node attributes labeled 'index' are skipped. "
                  "If you want to convert these attributes, please re-label with other names.")
 
@@ -106,6 +107,8 @@ def from_networkx(graph: nx.Graph, layout_function: dict[int | str, Sequence[flo
             edge_dict[attr_key] = values
 
         if 'start' in edge_attr_keys or 'end' in edge_attr_keys:
+            from ..util.warnings import warn
+
             warn("Converting edge attributes labeled 'start' or 'end' are skipped. "
                  "If you want to convert these attributes, please re-label them with other names.")
 
@@ -123,6 +126,8 @@ def from_networkx(graph: nx.Graph, layout_function: dict[int | str, Sequence[flo
 
             node_keys = graph_renderer.node_renderer.data_source.data['index']
             if set(node_keys) != set(layout_function.keys()):
+                from ..util.warnings import warn
+
                 warn("Node keys in 'layout_function' don't match node keys in the graph. "
                      "These nodes may not be displayed correctly.")
 

--- a/src/bokeh/protocol/messages/error.py
+++ b/src/bokeh/protocol/messages/error.py
@@ -20,11 +20,13 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import sys
 from traceback import format_exception
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 # Bokeh imports
-from ...core.types import ID
 from ..message import Message
+
+if TYPE_CHECKING:
+    from ...core.types import ID
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/protocol/messages/ok.py
+++ b/src/bokeh/protocol/messages/ok.py
@@ -18,11 +18,13 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
-from ...core.types import ID
 from ..message import Empty, Message
+
+if TYPE_CHECKING:
+    from ...core.types import ID
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/protocol/messages/pull_doc_reply.py
+++ b/src/bokeh/protocol/messages/pull_doc_reply.py
@@ -21,11 +21,11 @@ log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Any, TypedDict
 
 # Bokeh imports
-from ...core.types import ID
 from ..exceptions import ProtocolError
 from ..message import Message
 
 if TYPE_CHECKING:
+    from ...core.types import ID
     from ...document.document import DocJson, Document
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/protocol/messages/server_info_reply.py
+++ b/src/bokeh/protocol/messages/server_info_reply.py
@@ -18,14 +18,16 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 # Bokeh imports
 from bokeh import __version__
 
 # Bokeh imports
-from ...core.types import ID
 from ..message import Message
+
+if TYPE_CHECKING:
+    from ...core.types import ID
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -38,6 +38,7 @@ log = logging.getLogger(__name__)
 import json
 import os
 import re
+from dataclasses import dataclass, field
 from os.path import relpath
 from pathlib import Path
 from typing import (
@@ -57,7 +58,6 @@ from .core.templates import CSS_RESOURCES, JS_RESOURCES
 from .core.types import ID, PathLike
 from .model import Model
 from .settings import LogLevel, settings
-from .util.dataclasses import dataclass, field
 from .util.paths import ROOT_DIR
 from .util.token import generate_session_id
 from .util.version import is_full_release

--- a/src/bokeh/resources.py
+++ b/src/bokeh/resources.py
@@ -42,6 +42,7 @@ from dataclasses import dataclass, field
 from os.path import relpath
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Callable,
     ClassVar,
     Literal,
@@ -55,12 +56,14 @@ from typing import (
 # Bokeh imports
 from . import __version__
 from .core.templates import CSS_RESOURCES, JS_RESOURCES
-from .core.types import ID, PathLike
 from .model import Model
 from .settings import LogLevel, settings
 from .util.paths import ROOT_DIR
 from .util.token import generate_session_id
 from .util.version import is_full_release
+
+if TYPE_CHECKING:
+    from .core.types import ID, PathLike
 
 # -----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/sampledata/__init__.py
+++ b/src/bokeh/sampledata/__init__.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 import logging # isort:skip
 log = logging.getLogger(__name__)
 
-from ..util.warnings import BokehUserWarning, warn
-
 #-----------------------------------------------------------------------------
 # Import
 #-----------------------------------------------------------------------------
@@ -75,6 +73,8 @@ except ImportError:
     )
 
 if Version(_mod.__version__) < Version(SAMPLEDATA_MIN_VERSION):
+    from ..util.warnings import BokehUserWarning, warn
+
     warn(
         f"The installed bokeh_sampledata version ({_mod.__version__}) is too "
         f"old. At least version {SAMPLEDATA_MIN_VERSION} is needed to run all "

--- a/src/bokeh/server/auth_provider.py
+++ b/src/bokeh/server/auth_provider.py
@@ -17,7 +17,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import importlib.util
 from os.path import isfile
-from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Awaitable,
@@ -33,6 +32,8 @@ from tornado.web import RequestHandler
 from ..util.serialization import make_globally_unique_id
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from ..core.types import PathLike
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/server/callbacks.py
+++ b/src/bokeh/server/callbacks.py
@@ -25,11 +25,12 @@ log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Callable, Sequence
 
 # Bokeh imports
-from ..core.types import ID
 from ..util.tornado import _CallbackGroup
 
 if TYPE_CHECKING:
     from tornado.ioloop import IOLoop
+
+    from ..core.types import ID
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -48,10 +48,10 @@ from tornado.ioloop import IOLoop
 
 # Bokeh imports
 from .. import __version__
-from ..core import properties as p
 from ..core.properties import (
     Bool,
     Int,
+    List,
     Nullable,
     String,
 )
@@ -530,7 +530,7 @@ class _ServerOpts(Options):
     A path to a Jinja2 template to use for the index "/"
     """)  # type: ignore[assignment]
 
-    allow_websocket_origin: list[str] | None = Nullable(p.List(String), help="""
+    allow_websocket_origin: list[str] | None = Nullable(List(String), help="""
     A list of hosts that can connect to the websocket.
 
     This is typically required when embedding a Bokeh server app in an external

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -39,7 +39,6 @@ import atexit
 import signal
 import socket
 import sys
-from types import FrameType
 from typing import TYPE_CHECKING, Any, Mapping
 
 # External imports
@@ -62,6 +61,8 @@ from .tornado import DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, BokehTornado
 from .util import bind_sockets, create_hosts_allowlist
 
 if TYPE_CHECKING:
+    from types import FrameType
+
     from ..application.application import Application
     from ..application.handlers.function import ModifyDoc
     from ..core.types import ID

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
 
 # Bokeh imports
 from ..application import Application
-from ..document import Document
 from ..model import Model
 from ..resources import Resources
 from ..settings import settings
@@ -52,7 +51,6 @@ from ..util.tornado import fixup_windows_event_loop_policy
 from .auth_provider import NullAuth
 from .connection import ServerConnection
 from .contexts import ApplicationContext
-from .session import ServerSession
 from .urls import per_app_patterns, toplevel_patterns
 from .views.ico_handler import IcoHandler
 from .views.root_handler import RootHandler
@@ -64,6 +62,7 @@ if TYPE_CHECKING:
     from ..core.types import ID
     from ..protocol import Protocol
     from .auth_provider import AuthProvider
+    from .session import ServerSession
     from .urls import RouteContext, URLRoutes
 
 #-----------------------------------------------------------------------------
@@ -754,6 +753,9 @@ class BokehTornado(TornadoApplication):
         # pprint.pprint(Counter([str(type(x)) for x in gc.get_objects() if "DataFrame" in str(type(x))]).most_common(30))
 
         all_objs = gc.get_objects()
+
+        from ..document import Document
+        from .session import ServerSession
 
         for name, typ in [('Documents', Document), ('Sessions', ServerSession), ('Models', Model)]:
             objs = [x for x in all_objs if isinstance(x, typ)]

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 import gc
 import os
 from pprint import pformat
-from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -765,6 +764,8 @@ class BokehTornado(TornadoApplication):
             #     import pprint
             #     for i in range(10):
             #         print(i, objs[i], gc.get_referents(objs[i]))
+
+        from types import ModuleType
 
         objs = [x for x in gc.get_objects() if isinstance(x, ModuleType) and "bokeh_app_" in str(x)]
         log.debug(f"  uncollected modules: {len(objs)}")

--- a/src/bokeh/server/views/multi_root_static_handler.py
+++ b/src/bokeh/server/views/multi_root_static_handler.py
@@ -23,12 +23,13 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 # External imports
 from tornado.web import HTTPError, StaticFileHandler
 
-# Bokeh imports
-from ...core.types import PathLike
+if TYPE_CHECKING:
+    from ...core.types import PathLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/server/views/ws.py
+++ b/src/bokeh/server/views/ws.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import calendar
 import datetime as dt
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
 
@@ -39,7 +40,6 @@ from ...protocol import Protocol
 from ...protocol.exceptions import MessageError, ProtocolError, ValidationError
 from ...protocol.message import Message
 from ...protocol.receiver import Receiver
-from ...util.dataclasses import dataclass
 from ..protocol_handler import ProtocolHandler
 from .auth_request_handler import AuthRequestHandler
 

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -472,7 +472,7 @@ class PrioritizedSetting(Generic[T]):
         # are shared among all instances, it is usually not avised to store any
         # data directly on them. But in our case we only ever have one single
         # instance of a Settings object.
-        self._user_value = value  # lgtm [py/mutable-descriptor]
+        self._user_value = value
 
     def unset_value(self) -> None:
         ''' Unset the previous user value such that the priority is reset.

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -136,7 +136,6 @@ from typing import (
 import yaml
 
 # Bokeh imports
-from .util.deprecation import deprecated
 from .util.paths import bokehjs_path, server_path
 
 if TYPE_CHECKING:
@@ -808,6 +807,8 @@ class Settings:
         .. deprecated:: 3.4.0
             Use ``bokehjs_path()`` method instead.
         '''
+        from .util.deprecation import deprecated
+
         deprecated((3, 4, 0), "bokehjsdir()", "bokehjs_path() method")
         return str(self.bokehjs_path())
 

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -880,9 +880,11 @@ settings = Settings()
 _secret_key = settings.secret_key()
 if _secret_key is not None and len(_secret_key) < 32:
     from .util.warnings import warn
+
     warn("BOKEH_SECRET_KEY is recommended to have at least 32 bytes of entropy chosen with a cryptographically-random algorithm")
 del _secret_key
 
 if settings.sign_sessions() and settings.secret_key() is None:
     from .util.warnings import warn
+
     warn("BOKEH_SECRET_KEY must be set if BOKEH_SIGN_SESSIONS is set to True")

--- a/src/bokeh/sphinxext/_internal/example_handler.py
+++ b/src/bokeh/sphinxext/_internal/example_handler.py
@@ -92,7 +92,7 @@ class ExampleHandler(Handler):
         # so we have to patch them all. Assumption is that no other patching
         # has occurred, i.e. we can just save the funcs being patched once,
         # from io, and use those as the originals to replace everywhere
-        import bokeh.io as io  # lgtm [py/import-and-import-from]
+        import bokeh.io as io
         import bokeh.plotting as p
 
         mods = [io, p]
@@ -115,7 +115,7 @@ class ExampleHandler(Handler):
         return old_io, old_doc
 
     def _unmonkeypatch(self, old_io, old_doc):
-        import bokeh.io as io  # lgtm [py/import-and-import-from]
+        import bokeh.io as io
         import bokeh.plotting as p
 
         mods = [io, p]

--- a/src/bokeh/sphinxext/_internal/example_handler.py
+++ b/src/bokeh/sphinxext/_internal/example_handler.py
@@ -23,10 +23,10 @@ from typing import TYPE_CHECKING
 # Bokeh imports
 from bokeh.application.handlers.code_runner import CodeRunner
 from bokeh.application.handlers.handler import Handler
-from bokeh.core.types import PathLike
 from bokeh.io.doc import curdoc, set_curdoc
 
 if TYPE_CHECKING:
+    from bokeh.core.types import PathLike
     from bokeh.document import Document
 
 # -----------------------------------------------------------------------------

--- a/src/bokeh/themes/theme.py
+++ b/src/bokeh/themes/theme.py
@@ -28,9 +28,9 @@ import yaml
 
 # Bokeh imports
 from ..core.has_props import HasProps
-from ..core.types import PathLike
 
 if TYPE_CHECKING:
+    from ..core.types import PathLike
     from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/util/dataclasses.py
+++ b/src/bokeh/util/dataclasses.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from dataclasses import dataclass, field, fields
+from dataclasses import fields
 from typing import (
     Any,
     Iterable,
@@ -36,10 +36,7 @@ from typing import (
 __all__ = (
     "NotRequired",
     "Unspecified",
-    "dataclass",
     "entries",
-    "field",
-    "fields",
     "is_dataclass",
 )
 

--- a/src/bokeh/util/dependencies.py
+++ b/src/bokeh/util/dependencies.py
@@ -22,8 +22,10 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 from importlib import import_module
-from types import ModuleType
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/util/deprecation.py
+++ b/src/bokeh/util/deprecation.py
@@ -20,9 +20,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 from typing import TypeAlias, overload
 
-# Bokeh imports
-from .warnings import BokehDeprecationWarning, warn
-
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -66,6 +63,8 @@ def deprecated(since_or_msg: Version | str,
             raise ValueError("deprecated(message) signature doesn't allow extra arguments")
 
         message = since_or_msg
+
+    from .warnings import BokehDeprecationWarning, warn
 
     warn(message, BokehDeprecationWarning)
 

--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -38,13 +38,14 @@ from typing import TYPE_CHECKING, Any, TypeGuard
 import numpy as np
 
 # Bokeh imports
-from ..core.types import ID
 from ..settings import settings
 from .strings import format_docstring
 
 if TYPE_CHECKING:
     import numpy.typing as npt
     import pandas as pd
+
+    from ..core.types import ID
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -259,6 +260,8 @@ def make_id() -> ID:
     '''
     global _simple_id
 
+    from ..core.types import ID
+
     if settings.simple_ids():
         with _simple_id_lock:
             _simple_id += 1
@@ -276,6 +279,8 @@ def make_globally_unique_id() -> ID:
         str
 
     '''
+    from ..core.types import ID
+
     return ID(str(uuid.uuid4()))
 
 def make_globally_unique_css_safe_id() -> ID:
@@ -289,6 +294,8 @@ def make_globally_unique_css_safe_id() -> ID:
         str
 
     '''
+    from ..core.types import ID
+
     max_iter = 100
 
     for _i in range(0, max_iter):

--- a/src/bokeh/util/token.py
+++ b/src/bokeh/util/token.py
@@ -34,11 +34,13 @@ import hmac
 import json
 import time
 import zlib
-from typing import Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 # Bokeh imports
-from ..core.types import ID
 from ..settings import settings
+
+if TYPE_CHECKING:
+    from ..core.types import ID
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -79,6 +81,8 @@ def generate_session_id(secret_key: bytes | None = settings.secret_key_bytes(),
     random and unguessable - otherwise users of the app could interfere with one
     another.
     '''
+    from ..core.types import ID
+
     session_id = _get_random_string()
     if signed:
         session_id = '.'.join([session_id, _signature(session_id, secret_key)])

--- a/src/bokeh/util/token.py
+++ b/src/bokeh/util/token.py
@@ -39,7 +39,6 @@ from typing import Any, TypeAlias
 # Bokeh imports
 from ..core.types import ID
 from ..settings import settings
-from .warnings import warn
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -254,6 +253,8 @@ def _get_sysrandom() -> tuple[Any, bool]:
         using_sysrandom = True
         return sysrandom, using_sysrandom
     except NotImplementedError:
+        from .warnings import warn
+
         warn('A secure pseudo-random number generator is not available '
              'on your system. Falling back to Mersenne Twister.')
         if settings.secret_key() is None:

--- a/src/bokeh/util/warnings.py
+++ b/src/bokeh/util/warnings.py
@@ -26,7 +26,6 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import inspect
 import os
-import warnings  # lgtm [py/import-and-import-from]
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -60,6 +59,7 @@ class BokehUserWarning(UserWarning):
 def warn(message: str, category: type[Warning] | None = None, stacklevel: int | None = None) -> None:
     if stacklevel is None:
         stacklevel = find_stack_level()
+    import warnings
 
     warnings.warn(message, category, stacklevel=stacklevel)
 

--- a/tests/support/plugins/file_server.py
+++ b/tests/support/plugins/file_server.py
@@ -61,7 +61,7 @@ class HtmlOnlyHandler(BaseHTTPRequestHandler):
         # depending on Python version, leading / may be present or not
         path = self.path.split("?")[0].removeprefix("/")
         try:
-            with open(HTML_ROOT / path, mode="rb") as f:  # lgtm [py/path-injection]
+            with open(HTML_ROOT / path, mode="rb") as f:
                 self.send_response(200)
                 self.send_header("Content-type", "text/html")
                 self.end_headers()

--- a/tests/unit/bokeh/core/property/test_dataspec.py
+++ b/tests/unit/bokeh/core/property/test_dataspec.py
@@ -33,7 +33,7 @@ from bokeh.core.property.vectorization import (
     field,
     value,
 )
-from bokeh.util.deprecation import BokehDeprecationWarning
+from bokeh.util.warnings import BokehDeprecationWarning
 from tests.support.util.api import verify_all
 
 # Module under test

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -22,6 +22,7 @@ import gzip
 import sys
 from array import array as TypedArray
 from base64 import b64decode
+from dataclasses import dataclass
 from math import inf, nan
 from types import SimpleNamespace
 from typing import Any, Sequence
@@ -62,7 +63,7 @@ from bokeh.core.serialization import (
     TypedArrayRep,
 )
 from bokeh.model import Model
-from bokeh.util.dataclasses import NotRequired, Unspecified, dataclass
+from bokeh.util.dataclasses import NotRequired, Unspecified
 from bokeh.util.warnings import BokehUserWarning
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/io/test_saving.py
+++ b/tests/unit/bokeh/io/test_saving.py
@@ -75,7 +75,7 @@ def test__get_save_args_default_resources() -> None:
     _, resources, _ = bis._get_save_args(curstate(), "filename", None, "title")
     assert resources == r
 
-@patch('bokeh.io.saving.warn')
+@patch('bokeh.util.warnings.warn')
 def test__get_save_args_missing_resources(mock_warn: MagicMock) -> None:
     curstate().reset()
     _, resources, _ = bis._get_save_args(curstate(), "filename", None, "title")
@@ -99,7 +99,7 @@ def test__get_save_args_default_title() -> None:
     _, _, title = bis._get_save_args(curstate(), "filename", "inline", None)
     assert title == "title"
 
-@patch('bokeh.io.saving.warn')
+@patch('bokeh.util.warnings.warn')
 def test__get_save_args_missing_title(mock_warn: MagicMock) -> None:
     curstate().reset()
     _, _, title = bis._get_save_args(curstate(), "filename", "inline", None)

--- a/tests/unit/bokeh/model/test_model.py
+++ b/tests/unit/bokeh/model/test_model.py
@@ -23,7 +23,7 @@ from bokeh.core.types import ID
 from bokeh.models import *  # noqa: F403
 from bokeh.models import CustomJS
 from bokeh.plotting import *  # noqa: F403
-from bokeh.util.deprecation import BokehDeprecationWarning
+from bokeh.util.warnings import BokehDeprecationWarning
 
 from bokeh.document import document # isort:skip
 

--- a/tests/unit/bokeh/util/test_dataclasses.py
+++ b/tests/unit/bokeh/util/test_dataclasses.py
@@ -16,6 +16,9 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from dataclasses import dataclass
+
 # Module under test
 import bokeh.util.dataclasses as dc # isort:skip
 
@@ -27,7 +30,7 @@ import bokeh.util.dataclasses as dc # isort:skip
 # Dev API
 #-----------------------------------------------------------------------------
 
-@dc.dataclass
+@dataclass
 class X:
     f0: int
     f1: list[int]

--- a/tests/unit/bokeh/util/test_deprecation.py
+++ b/tests/unit/bokeh/util/test_deprecation.py
@@ -19,6 +19,9 @@ import pytest ; pytest
 # Standard library imports
 from unittest.mock import MagicMock, patch
 
+# Bokeh imports
+from bokeh.util.warnings import BokehDeprecationWarning
+
 # Module under test
 import bokeh.util.deprecation as dep # isort:skip
 
@@ -35,7 +38,7 @@ def foo(): pass
 @patch('warnings.warn')
 def test_message(mock_warn: MagicMock) -> None:
     dep.deprecated('test')
-    mock_warn.assert_called_once_with("test", dep.BokehDeprecationWarning, stacklevel=3)
+    mock_warn.assert_called_once_with("test", BokehDeprecationWarning, stacklevel=3)
 
 def test_message_no_extra_args() -> None:
     with pytest.raises(ValueError):
@@ -72,7 +75,7 @@ def test_since(mock_warn: MagicMock) -> None:
     dep.deprecated((1, 2, 3), old="foo", new="bar")
     mock_warn.assert_called_once_with(
         "'foo' was deprecated in Bokeh 1.2.3 and will be removed, use 'bar' instead.",
-        dep.BokehDeprecationWarning,
+        BokehDeprecationWarning,
         stacklevel=3,
     )
 
@@ -81,7 +84,7 @@ def test_since_with_extra(mock_warn: MagicMock) -> None:
     dep.deprecated((1, 2, 3), old="foo", new="bar", extra="baz")
     mock_warn.assert_called_once_with(
         "'foo' was deprecated in Bokeh 1.2.3 and will be removed, use 'bar' instead. baz",
-        dep.BokehDeprecationWarning,
+        BokehDeprecationWarning,
         stacklevel=3,
     )
 


### PR DESCRIPTION
closes #14643

I was reminded of the many CodeQL warnings about potential circular imports and decided to do a bit of a dive into that, mostly for curiosity. Potential circular imports are obviously less of an issue than actual ones but I do know that we have run into issues in the past on occasion where some delicate balance got disturbed and it caused a scramble to get fixed. 

Anyway I don't want to submit a much-larger branch for that at the moment. I'll leave some observations at the bottom. But there was a smaller set of cleanup that seemed reasonable to collect and submit.

* Transitive use of stdlib `dataclass` APIs from our own modules was fixed
* Old "LGTM" comments that are now cruft were removed
* A few imports were deferred:
  * deprecation imports are easier to remove later when everything is co-located
  * imports only needed for errors or warnings were deferred unless the error or warning condition happened
 * Quite a few imports that only needed for `mypy` were moved behind `TYPE_CHECKING`
   * in a couple of places, heavy imports like `Model` or `Document` that had only one non-mypy use were also deferred

---

#### deferred imports

In general I've become more sympathetic to the position that many/most imports would be better deferred closer to their point of use unless they are required at the top level, are used many, many places in a module, or unless their import cost explicitly is desired to be placed up-front. That's some thing we could discuss another time if there's interest in pursuing. 

#### circular imports through properties

There are many "circular" paths that exist because we go through git giant `bokeh.core.properties` catch-all instead of e.g. through individual `bokeh.core.property.nullable`, etc. I think there has been an interest in dis-agregating these "mega" modules. I do have these changes ready and could submit them separately if desired. These are purely internal changes (we can keep `bokeh.core.properties` for external compat as long as we like) so there's it would not need to wait for 4.0 IMO .

#### circular imports through models

Unlike the happy situation where all the "mega" module `bokeh.core.properties` is on a separate path from all the individual property modules under `bokeh.core.property` the case for modules is more messy. The "mega" module is `bokeh.models` and all the individual model modules are *also* underneath `bokeh.models`. So we can't really clean up any potential cycles without actually moving things. e.g. moving all the individual model modules under `bokeh.model` and using those internally. Seems like 4.0 territory though. 
