### PR TITLE
Avoid bokeh.core.properties internally

### DIFF
--- a/src/bokeh/.ruff.toml
+++ b/src/bokeh/.ruff.toml
@@ -7,4 +7,5 @@ banned-module-level-imports = [
     "PIL",
     "selenium",
     "typing_extensions",
+    "bokeh.core.properties",
 ]

--- a/src/bokeh/core/property_mixins.py
+++ b/src/bokeh/core/property_mixins.py
@@ -90,35 +90,31 @@ from .enums import (
     TextBaseline,
 )
 from .has_props import HasProps
-from .properties import (
-    Alpha,
+from .property.color import Alpha, Color
+from .property.container import Dict
+from .property.dataspec import (
     AlphaSpec,
-    Color,
     ColorSpec,
-    DashPattern,
     DashPatternSpec,
-    Dict,
-    Enum,
-    Float,
     FloatSpec,
-    FontSize,
     FontSizeSpec,
     FontStyleSpec,
     HatchPatternSpec,
-    Instance,
-    Int,
     IntSpec,
     LineCapSpec,
     LineJoinSpec,
-    Nullable,
     NumberSpec,
-    Size,
-    String,
     StringSpec,
     TextAlignSpec,
     TextBaselineSpec,
-    value,
 )
+from .property.enum import Enum
+from .property.instance import Instance
+from .property.nullable import Nullable
+from .property.numeric import Size
+from .property.primitive import Float, Int, String
+from .property.vectorization import value
+from .property.visual import DashPattern, FontSize
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/document/config.py
+++ b/src/bokeh/document/config.py
@@ -22,12 +22,9 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ..core.properties import (
-    Bool,
-    Instance,
-    InstanceDefault,
-    Nullable,
-)
+from ..core.property.instance import Instance, InstanceDefault
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool
 from ..model import Model
 from ..models.ui.notifications import Notifications
 

--- a/src/bokeh/model/model.py
+++ b/src/bokeh/model/model.py
@@ -26,17 +26,12 @@ from typing import TYPE_CHECKING, Any, Iterable
 
 # Bokeh imports
 from ..core.has_props import HasProps, _default_resolver, abstract
-from ..core.properties import (
-    AnyRef,
-    Bool,
-    Dict,
-    Instance,
-    List,
-    Nullable,
-    Set,
-    String,
-)
 from ..core.property._sphinx import type_link
+from ..core.property.any import AnyRef
+from ..core.property.container import Dict, List, Set
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool, String
 from ..core.property.validation import without_property_validation
 from ..core.serialization import ObjectRefRep, Ref, Serializer
 from ..events import Event

--- a/src/bokeh/models/annotations/annotation.py
+++ b/src/bokeh/models/annotations/annotation.py
@@ -25,7 +25,8 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import Instance, InstanceDefault, Override
+from ...core.property.instance import Instance, InstanceDefault
+from ...core.property.override import Override
 from ..renderers.renderer import CompositeRenderer
 from ..sources import ColumnDataSource, DataSource
 

--- a/src/bokeh/models/annotations/arrows.py
+++ b/src/bokeh/models/annotations/arrows.py
@@ -26,16 +26,13 @@ from typing import Any
 # Bokeh imports
 from ...core.enums import CoordinateUnits
 from ...core.has_props import abstract
-from ...core.properties import (
-    Enum,
-    Include,
-    Instance,
-    InstanceDefault,
-    Nullable,
-    NumberSpec,
-    Override,
-    field,
-)
+from ...core.property.dataspec import NumberSpec
+from ...core.property.enum import Enum
+from ...core.property.include import Include
+from ...core.property.instance import Instance, InstanceDefault
+from ...core.property.nullable import Nullable
+from ...core.property.override import Override
+from ...core.property.vectorization import field
 from ...core.property_mixins import FillProps, HatchProps, LineProps
 from ..graphics import Marking
 from .annotation import DataAnnotation

--- a/src/bokeh/models/annotations/dimensional.py
+++ b/src/bokeh/models/annotations/dimensional.py
@@ -26,17 +26,12 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import (
-    Dict,
-    Either,
-    Float,
-    List,
-    Nullable,
-    Override,
-    Required,
-    String,
-    Tuple,
-)
+from ...core.property.container import Dict, List, Tuple
+from ...core.property.either import Either
+from ...core.property.nullable import Nullable
+from ...core.property.override import Override
+from ...core.property.primitive import Float, String
+from ...core.property.required import Required
 from ...model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/annotations/geometry.py
+++ b/src/bokeh/models/annotations/geometry.py
@@ -31,24 +31,18 @@ from ...core.enums import (
     Movable,
     Resizable,
 )
-from ...core.properties import (
-    Bool,
-    CoordinateLike,
-    Enum,
-    Float,
-    Include,
-    Instance,
-    InstanceDefault,
-    NonNegative,
-    Null,
-    Nullable,
-    Override,
-    Positive,
-    Required,
-    Seq,
-    UnitsSpec,
-    field,
-)
+from ...core.property.aliases import CoordinateLike
+from ...core.property.container import Seq
+from ...core.property.dataspec import UnitsSpec
+from ...core.property.enum import Enum
+from ...core.property.include import Include
+from ...core.property.instance import Instance, InstanceDefault
+from ...core.property.nullable import Nullable
+from ...core.property.numeric import NonNegative, Positive
+from ...core.property.override import Override
+from ...core.property.primitive import Bool, Float, Null
+from ...core.property.required import Required
+from ...core.property.vectorization import field
 from ...core.property_aliases import BorderRadius
 from ...core.property_mixins import (
     LineProps,

--- a/src/bokeh/models/annotations/html/labels.py
+++ b/src/bokeh/models/annotations/html/labels.py
@@ -31,23 +31,17 @@ from ....core.enums import (
     TextAlign,
     VerticalAlign,
 )
-from ....core.properties import (
-    Alpha,
-    Angle,
-    AngleSpec,
-    Color,
-    CoordinateLike,
-    Enum,
-    Float,
-    Include,
-    Nullable,
-    NullStringSpec,
-    NumberSpec,
-    Override,
-    Required,
-    String,
-    field,
-)
+from ....core.property.aliases import CoordinateLike
+from ....core.property.color import Alpha, Color
+from ....core.property.dataspec import AngleSpec, NullStringSpec, NumberSpec
+from ....core.property.enum import Enum
+from ....core.property.include import Include
+from ....core.property.nullable import Nullable
+from ....core.property.numeric import Angle
+from ....core.property.override import Override
+from ....core.property.primitive import Float, String
+from ....core.property.required import Required
+from ....core.property.vectorization import field
 from ....core.property_aliases import BorderRadius, Padding
 from ....core.property_mixins import (
     FillProps,

--- a/src/bokeh/models/annotations/html/toolbars.py
+++ b/src/bokeh/models/annotations/html/toolbars.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ....core.properties import Instance
+from ....core.property.instance import Instance
 from .html_annotation import HTMLAnnotation
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/annotations/labels.py
+++ b/src/bokeh/models/annotations/labels.py
@@ -32,20 +32,15 @@ from ...core.enums import (
     VerticalAlign,
 )
 from ...core.has_props import abstract
-from ...core.properties import (
-    Angle,
-    AngleSpec,
-    Bool,
-    Enum,
-    Float,
-    Include,
-    NullStringSpec,
-    NumberSpec,
-    Override,
-    Required,
-    TextLike,
-    field,
-)
+from ...core.property.dataspec import AngleSpec, NullStringSpec, NumberSpec
+from ...core.property.enum import Enum
+from ...core.property.include import Include
+from ...core.property.numeric import Angle
+from ...core.property.override import Override
+from ...core.property.primitive import Bool, Float
+from ...core.property.required import Required
+from ...core.property.text_like import TextLike
+from ...core.property.vectorization import field
 from ...core.property_aliases import BorderRadius, Padding, TextAnchor
 from ...core.property_mixins import (
     FillProps,

--- a/src/bokeh/models/annotations/legends.py
+++ b/src/bokeh/models/annotations/legends.py
@@ -36,31 +36,25 @@ from ...core.enums import (
     VAlign,
 )
 from ...core.has_props import abstract
-from ...core.properties import (
-    Auto,
-    Bool,
-    CoordinateLike,
+from ...core.property.aliases import CoordinateLike
+from ...core.property.auto import Auto
+from ...core.property.container import (
     Dict,
-    Either,
-    Enum,
-    Float,
-    Include,
-    Instance,
-    InstanceDefault,
-    Int,
     List,
-    NonNegative,
-    Nullable,
-    NullStringSpec,
-    Override,
-    Positive,
     Seq,
-    String,
-    TextLike,
     Tuple,
-    value,
 )
-from ...core.property.vectorization import Field
+from ...core.property.dataspec import NullStringSpec
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.include import Include
+from ...core.property.instance import Instance, InstanceDefault
+from ...core.property.nullable import Nullable
+from ...core.property.numeric import Int, NonNegative, Positive
+from ...core.property.override import Override
+from ...core.property.primitive import Bool, Float, String
+from ...core.property.text_like import TextLike
+from ...core.property.vectorization import Field, value
 from ...core.property_aliases import AutoAnchor, BorderRadius, Padding
 from ...core.property_mixins import (
     FillProps,

--- a/src/bokeh/models/axes.py
+++ b/src/bokeh/models/axes.py
@@ -27,26 +27,23 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import Align, AxisLabelStandoffMode, LabelOrientation
 from ..core.has_props import abstract
-from ..core.properties import (
-    Auto,
-    Datetime,
-    Dict,
-    Either,
-    Enum,
-    Factor,
+from ..core.property.auto import Auto
+from ..core.property.container import Dict, Seq, Tuple
+from ..core.property.datetime import Datetime
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.factors import Factor
+from ..core.property.include import Include
+from ..core.property.instance import Instance, InstanceDefault
+from ..core.property.nullable import Nullable
+from ..core.property.override import Override
+from ..core.property.primitive import (
     Float,
-    Include,
-    Instance,
-    InstanceDefault,
     Int,
     Null,
-    Nullable,
-    Override,
-    Seq,
     String,
-    TextLike,
-    Tuple,
 )
+from ..core.property.text_like import TextLike
 from ..core.property_mixins import (
     ScalarFillProps,
     ScalarHatchProps,

--- a/src/bokeh/models/callbacks.py
+++ b/src/bokeh/models/callbacks.py
@@ -26,17 +26,14 @@ from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
 from ..core.has_props import HasProps, abstract
-from ..core.properties import (
-    AnyRef,
-    Auto,
-    Bool,
-    Dict,
-    Either,
-    Instance,
-    Required,
-    String,
-)
+from ..core.property.any import AnyRef
+from ..core.property.auto import Auto
 from ..core.property.bases import Init
+from ..core.property.container import Dict
+from ..core.property.either import Either
+from ..core.property.instance import Instance
+from ..core.property.primitive import Bool, String
+from ..core.property.required import Required
 from ..core.property.singletons import Intrinsic
 from ..core.validation import error
 from ..core.validation.errors import INVALID_PROPERTY_VALUE, NOT_A_PROPERTY_OF

--- a/src/bokeh/models/canvas.py
+++ b/src/bokeh/models/canvas.py
@@ -22,7 +22,8 @@ from typing import Any
 
 # Bokeh imports
 from ..core.enums import OutputBackend
-from ..core.properties import Bool, Enum
+from ..core.property.enum import Enum
+from ..core.property.primitive import Bool
 from .ui import UIElement
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/common/properties.py
+++ b/src/bokeh/models/common/properties.py
@@ -21,12 +21,10 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Bokeh imports
-from ...core.properties import (
-    CoordinateLike,
-    Either,
-    Instance,
-    TypeOfAttr,
-)
+from ...core.property.aliases import CoordinateLike
+from ...core.property.constraints import TypeOfAttr
+from ...core.property.either import Either
+from ...core.property.instance import Instance
 from ...model import Model
 from ..glyph import Glyph
 from ..nodes import Node

--- a/src/bokeh/models/comparisons.py
+++ b/src/bokeh/models/comparisons.py
@@ -27,12 +27,9 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import (
-    AnyRef,
-    Bool,
-    Dict,
-    String,
-)
+from ..core.property.any import AnyRef
+from ..core.property.container import Dict
+from ..core.property.primitive import Bool, String
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/coordinates.py
+++ b/src/bokeh/models/coordinates.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ..core.properties import Instance, InstanceDefault
+from ..core.property.instance import Instance, InstanceDefault
 from ..model import Model
 from .ranges import DataRange1d, Range
 from .scales import LinearScale, Scale

--- a/src/bokeh/models/css.py
+++ b/src/bokeh/models/css.py
@@ -25,7 +25,9 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import Nullable, Required, String
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import String
+from ..core.property.required import Required
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/dom.py
+++ b/src/bokeh/models/dom.py
@@ -26,18 +26,14 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import BuiltinFormatter
 from ..core.has_props import HasProps, abstract
-from ..core.properties import (
-    Bool,
-    Dict,
-    Either,
-    Enum,
-    Instance,
-    List,
-    Nullable,
-    Required,
-    String,
-)
 from ..core.property.bases import Init
+from ..core.property.container import Dict, List
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool, String
+from ..core.property.required import Required
 from ..core.property.singletons import Intrinsic
 from ..core.validation import error
 from ..core.validation.errors import NOT_A_PROPERTY_OF

--- a/src/bokeh/models/expressions.py
+++ b/src/bokeh/models/expressions.py
@@ -47,21 +47,15 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import Direction
 from ..core.has_props import abstract
-from ..core.properties import (
-    AngleSpec,
-    AnyRef,
-    Bool,
-    Dict,
-    Enum,
-    Float,
-    Instance,
-    Nullable,
-    NumberSpec,
-    Required,
-    Seq,
-    String,
-    field,
-)
+from ..core.property.any import AnyRef
+from ..core.property.container import Dict, Seq
+from ..core.property.dataspec import AngleSpec, NumberSpec
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool, Float, String
+from ..core.property.required import Required
+from ..core.property.vectorization import field
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/filters.py
+++ b/src/bokeh/models/filters.py
@@ -22,18 +22,12 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import (
-    AnyRef,
-    Bool,
-    Instance,
-    Int,
-    NonEmpty,
-    Nullable,
-    Required,
-    RestrictedDict,
-    Seq,
-    String,
-)
+from ..core.property.any import AnyRef
+from ..core.property.container import NonEmpty, RestrictedDict, Seq
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool, Int, String
+from ..core.property.required import Required
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -35,19 +35,14 @@ from ..core.enums import (
     TimedeltaResolutionType,
 )
 from ..core.has_props import abstract
-from ..core.properties import (
-    AnyRef,
-    Auto,
-    Bool,
-    Dict,
-    Either,
-    Enum,
-    Instance,
-    Int,
-    Nullable,
-    Seq,
-    String,
-)
+from ..core.property.any import AnyRef
+from ..core.property.auto import Auto
+from ..core.property.container import Dict, Seq
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool, Int, String
 from ..core.validation import error
 from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model

--- a/src/bokeh/models/glyph.py
+++ b/src/bokeh/models/glyph.py
@@ -32,7 +32,8 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import HasProps, abstract
-from ..core.properties import Instance, List
+from ..core.property.container import List
+from ..core.property.instance import Instance
 from ..model import Model
 from .graphics import Decoration
 

--- a/src/bokeh/models/glyphs.py
+++ b/src/bokeh/models/glyphs.py
@@ -48,33 +48,32 @@ from ..core.enums import (
     StepMode,
 )
 from ..core.has_props import abstract
-from ..core.properties import (
+from ..core.property.container import Dict, Tuple
+from ..core.property.dataspec import (
     AngleSpec,
-    Bool,
     DataSpec,
-    Dict,
     DistanceSpec,
-    Either,
-    Enum,
-    Float,
     FloatSpec,
-    Include,
-    Instance,
-    InstanceDefault,
-    Int,
     MarkerSpec,
     NullDistanceSpec,
     NumberSpec,
-    Override,
-    Regex,
-    Size,
     SizeSpec,
-    String,
     StringSpec,
-    Tuple,
-    field,
-    value,
 )
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.include import Include
+from ..core.property.instance import Instance, InstanceDefault
+from ..core.property.numeric import Size
+from ..core.property.override import Override
+from ..core.property.primitive import (
+    Bool,
+    Float,
+    Int,
+    String,
+)
+from ..core.property.string import Regex
+from ..core.property.vectorization import field, value
 from ..core.property_aliases import (
     Anchor,
     BorderRadius,

--- a/src/bokeh/models/graphics.py
+++ b/src/bokeh/models/graphics.py
@@ -23,7 +23,9 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import Enum, Instance, Required
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance
+from ..core.property.required import Required
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/graphs.py
+++ b/src/bokeh/models/graphs.py
@@ -22,16 +22,10 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import (
-    Dict,
-    Either,
-    Float,
-    Instance,
-    Int,
-    Len,
-    Seq,
-    String,
-)
+from ..core.property.container import Dict, Len, Seq
+from ..core.property.either import Either
+from ..core.property.instance import Instance
+from ..core.property.primitive import Float, Int, String
 from ..model import Model
 from .expressions import CoordinateTransform
 

--- a/src/bokeh/models/grids.py
+++ b/src/bokeh/models/grids.py
@@ -24,18 +24,14 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ..core.properties import (
-    Auto,
-    Either,
-    Float,
-    Include,
-    Instance,
-    Int,
-    Nullable,
-    Override,
-    Seq,
-    Tuple,
-)
+from ..core.property.auto import Auto
+from ..core.property.container import Seq, Tuple
+from ..core.property.either import Either
+from ..core.property.include import Include
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.override import Override
+from ..core.property.primitive import Float, Int
 from ..core.property_mixins import ScalarFillProps, ScalarHatchProps, ScalarLineProps
 from .axes import Axis
 from .renderers import GuideRenderer

--- a/src/bokeh/models/labeling.py
+++ b/src/bokeh/models/labeling.py
@@ -23,12 +23,9 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import (
-    AnyRef,
-    Dict,
-    Int,
-    String,
-)
+from ..core.property.any import AnyRef
+from ..core.property.container import Dict
+from ..core.property.primitive import Int, String
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/layouts.py
+++ b/src/bokeh/models/layouts.py
@@ -35,23 +35,21 @@ from ..core.enums import (
     SizingPolicy,
 )
 from ..core.has_props import HasProps, abstract
-from ..core.properties import (
-    Auto,
+from ..core.property.auto import Auto
+from ..core.property.container import List, Tuple
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.numeric import NonNegative
+from ..core.property.primitive import (
     Bool,
-    Either,
-    Enum,
     Float,
-    Instance,
     Int,
-    List,
-    NonNegative,
     Null,
-    Nullable,
     String,
-    Struct,
-    Tuple,
 )
-from ..core.property.struct import Optional
+from ..core.property.struct import Optional, Struct
 from ..core.property_aliases import GridSpacing, Pixels, TracksSizing
 from ..core.validation import error, warning
 from ..core.validation.errors import (

--- a/src/bokeh/models/map_plots.py
+++ b/src/bokeh/models/map_plots.py
@@ -26,20 +26,19 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import MapType
 from ..core.has_props import abstract
-from ..core.properties import (
-    JSON,
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance, InstanceDefault
+from ..core.property.json import JSON
+from ..core.property.nullable import Nullable
+from ..core.property.override import Override
+from ..core.property.primitive import (
     Bool,
     Bytes,
-    Enum,
     Float,
-    Instance,
-    InstanceDefault,
     Int,
-    Nullable,
-    Override,
-    Required,
     String,
 )
+from ..core.property.required import Required
 from ..core.validation import error, warning
 from ..core.validation.errors import (
     INCOMPATIBLE_MAP_RANGE_TYPE,

--- a/src/bokeh/models/mappers.py
+++ b/src/bokeh/models/mappers.py
@@ -29,23 +29,20 @@ from typing import Any
 from .. import palettes
 from ..core.enums import Palette
 from ..core.has_props import abstract
-from ..core.properties import (
+from ..core.property.color import Color
+from ..core.property.container import List, Seq, Tuple
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.factors import FactorSeq
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import (
     Bool,
-    Color,
-    Either,
-    Enum,
-    FactorSeq,
     Float,
-    HatchPatternType,
-    Instance,
     Int,
-    List,
-    MarkerType,
-    Nullable,
-    Seq,
     String,
-    Tuple,
 )
+from ..core.property.visual import HatchPatternType, MarkerType
 from ..core.validation import error, warning
 from ..core.validation.errors import WEIGHTED_STACK_COLOR_MAPPER_LABEL_LENGTH_MISMATCH
 from ..core.validation.warnings import PALETTE_LENGTH_FACTORS_MISMATCH

--- a/src/bokeh/models/misc/group_by.py
+++ b/src/bokeh/models/misc/group_by.py
@@ -23,7 +23,9 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import Instance, List, Required
+from ...core.property.container import List
+from ...core.property.instance import Instance
+from ...core.property.required import Required
 from ...model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/nodes.py
+++ b/src/bokeh/models/nodes.py
@@ -23,15 +23,12 @@ from typing import Any, ClassVar
 # Bokeh imports
 from ..core.enums import ImplicitTarget, ImplicitTargetType
 from ..core.has_props import abstract
-from ..core.properties import (
-    Either,
-    Enum,
-    Instance,
-    Int,
-    Required,
-    String,
-)
 from ..core.property.aliases import CoordinateLike
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance
+from ..core.property.primitive import Int, String
+from ..core.property.required import Required
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/plots.py
+++ b/src/bokeh/models/plots.py
@@ -41,26 +41,22 @@ from ..core.enums import (
     ResetPolicy,
     WindowAxis,
 )
-from ..core.properties import (
+from ..core.property.container import Dict, List, Tuple
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.include import Include
+from ..core.property.instance import Instance, InstanceDefault
+from ..core.property.nullable import Nullable
+from ..core.property.override import Override
+from ..core.property.primitive import (
     Bool,
-    Dict,
-    Either,
-    Enum,
     Float,
-    Include,
-    Instance,
-    InstanceDefault,
     Int,
-    List,
     Null,
-    Nullable,
-    Override,
-    Readonly,
     String,
-    Struct,
-    Tuple,
 )
-from ..core.property.struct import Optional
+from ..core.property.readonly import Readonly
+from ..core.property.struct import Optional, Struct
 from ..core.property_mixins import ScalarFillProps, ScalarHatchProps, ScalarLineProps
 from ..core.query import find
 from ..core.validation import error, warning

--- a/src/bokeh/models/ranges.py
+++ b/src/bokeh/models/ranges.py
@@ -30,24 +30,19 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import PaddingUnits, StartEnd
 from ..core.has_props import abstract
-from ..core.properties import (
-    Auto,
-    Bool,
-    Datetime,
-    Either,
-    Enum,
-    FactorSeq,
-    Float,
-    Instance,
-    List,
-    MinMaxBounds,
-    Null,
-    Nullable,
-    Override,
-    Readonly,
-    Required,
-    TimeDelta,
-)
+from ..core.property.auto import Auto
+from ..core.property.container import List
+from ..core.property.datetime import Datetime, TimeDelta
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.factors import FactorSeq
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.override import Override
+from ..core.property.primitive import Bool, Float, Null
+from ..core.property.readonly import Readonly
+from ..core.property.required import Required
+from ..core.property.visual import MinMaxBounds
 from ..core.validation import error
 from ..core.validation.errors import DUPLICATE_FACTORS
 from ..model import Model

--- a/src/bokeh/models/renderers/contour_renderer.py
+++ b/src/bokeh/models/renderers/contour_renderer.py
@@ -23,7 +23,9 @@ log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Any
 
 # Bokeh imports
-from ...core.properties import Float, Instance, Seq
+from ...core.property.container import Seq
+from ...core.property.instance import Instance
+from ...core.property.numeric import Float
 from .glyph_renderer import GlyphRenderer
 from .renderer import DataRenderer
 

--- a/src/bokeh/models/renderers/glyph_renderer.py
+++ b/src/bokeh/models/renderers/glyph_renderer.py
@@ -27,15 +27,12 @@ from typing import TYPE_CHECKING, Any, Literal
 from bokeh.core.property.vectorization import Field
 
 # Bokeh imports
-from ...core.properties import (
-    Auto,
-    Bool,
-    Either,
-    Instance,
-    InstanceDefault,
-    Nullable,
-    Required,
-)
+from ...core.property.auto import Auto
+from ...core.property.either import Either
+from ...core.property.instance import Instance, InstanceDefault
+from ...core.property.nullable import Nullable
+from ...core.property.primitive import Bool
+from ...core.property.required import Required
 from ...core.validation import error
 from ...core.validation.errors import BAD_COLUMN_NAME, CDSVIEW_FILTERS_WITH_CONNECTED
 from ..filters import AllIndices

--- a/src/bokeh/models/renderers/graph_renderer.py
+++ b/src/bokeh/models/renderers/graph_renderer.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ...core.properties import Instance, InstanceDefault
+from ...core.property.instance import Instance, InstanceDefault
 from ...core.validation import error
 from ...core.validation.errors import MALFORMED_GRAPH_SOURCE
 from ..glyphs import MultiLine, Scatter

--- a/src/bokeh/models/renderers/renderer.py
+++ b/src/bokeh/models/renderers/renderer.py
@@ -25,16 +25,13 @@ from typing import Any
 # Bokeh imports
 from ...core.enums import RenderLevel
 from ...core.has_props import abstract
-from ...core.properties import (
-    Bool,
-    Either,
-    Enum,
-    Instance,
-    List,
-    Nullable,
-    Override,
-    String,
-)
+from ...core.property.container import List
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
+from ...core.property.override import Override
+from ...core.property.primitive import Bool, String
 from ...model import Model
 from ..coordinates import CoordinateMapping
 from ..ui.ui_element import StyledElement

--- a/src/bokeh/models/renderers/tile_renderer.py
+++ b/src/bokeh/models/renderers/tile_renderer.py
@@ -23,13 +23,9 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ...core.properties import (
-    Bool,
-    Float,
-    Instance,
-    InstanceDefault,
-    Override,
-)
+from ...core.property.instance import Instance, InstanceDefault
+from ...core.property.override import Override
+from ...core.property.primitive import Bool, Float
 from ..tiles import TileSource, WMTSTileSource
 from .renderer import Renderer
 

--- a/src/bokeh/models/scales.py
+++ b/src/bokeh/models/scales.py
@@ -25,7 +25,8 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import Instance, Required
+from ..core.property.instance import Instance
+from ..core.property.required import Required
 from .transforms import Transform
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/selections.py
+++ b/src/bokeh/models/selections.py
@@ -22,13 +22,9 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import (
-    Dict,
-    Int,
-    List,
-    Seq,
-    Struct,
-)
+from ..core.property.container import Dict, List, Seq
+from ..core.property.primitive import Int
+from ..core.property.struct import Struct
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/selectors.py
+++ b/src/bokeh/models/selectors.py
@@ -25,8 +25,9 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import Required, String
 from ..core.property.bases import Init
+from ..core.property.primitive import String
+from ..core.property.required import Required
 from ..core.property.singletons import Intrinsic
 from ..model import Model
 

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -31,24 +31,16 @@ import numpy as np
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import (
-    JSON,
-    Any as AnyVal,
-    AnyRef,
-    Bool,
-    ColumnData,
-    Dict,
-    Enum,
-    Instance,
-    InstanceDefault,
-    Int,
-    Nullable,
-    Readonly,
-    Required,
-    Seq,
-    String,
-)
+from ..core.property.any import Any as AnyVal, AnyRef
+from ..core.property.container import ColumnData, Dict, Seq
 from ..core.property.data_frame import EagerDataFrame, PandasGroupBy
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance, InstanceDefault
+from ..core.property.json import JSON
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool, Int, String
+from ..core.property.readonly import Readonly
+from ..core.property.required import Required
 from ..model import Model
 from ..util.serialization import convert_datetime_array
 from .callbacks import CustomJS

--- a/src/bokeh/models/text.py
+++ b/src/bokeh/models/text.py
@@ -24,15 +24,10 @@ from typing import Any
 
 # Bokeh imports
 from ..core.has_props import abstract
-from ..core.properties import (
-    Bool,
-    Dict,
-    Either,
-    Int,
-    Required,
-    String,
-    Tuple,
-)
+from ..core.property.container import Dict, Tuple
+from ..core.property.either import Either
+from ..core.property.primitive import Bool, Int, String
+from ..core.property.required import Required
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/textures.py
+++ b/src/bokeh/models/textures.py
@@ -26,12 +26,10 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import TextureRepetition
 from ..core.has_props import abstract
-from ..core.properties import (
-    Enum,
-    Image,
-    Required,
-    String,
-)
+from ..core.property.enum import Enum
+from ..core.property.primitive import String
+from ..core.property.required import Required
+from ..core.property.visual import Image
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/tickers.py
+++ b/src/bokeh/models/tickers.py
@@ -27,22 +27,16 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import LatLon
 from ..core.has_props import abstract
-from ..core.properties import (
-    AnyRef,
-    Auto,
-    Dict,
-    Either,
-    Enum,
-    Float,
-    Instance,
-    Int,
-    NonEmpty,
-    Nullable,
-    Override,
-    Required,
-    Seq,
-    String,
-)
+from ..core.property.any import AnyRef
+from ..core.property.auto import Auto
+from ..core.property.container import Dict, NonEmpty, Seq
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.override import Override
+from ..core.property.primitive import Float, Int, String
+from ..core.property.required import Required
 from ..core.validation import error
 from ..core.validation.errors import MISSING_MERCATOR_DIMENSION
 from ..model import Model

--- a/src/bokeh/models/tiles.py
+++ b/src/bokeh/models/tiles.py
@@ -24,17 +24,17 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ..core.properties import (
-    AnyRef,
+from ..core.property.any import AnyRef
+from ..core.property.container import Dict
+from ..core.property.nullable import Nullable
+from ..core.property.override import Override
+from ..core.property.primitive import (
     Bool,
-    Dict,
     Float,
     Int,
-    Nullable,
-    Override,
-    Required,
     String,
 )
+from ..core.property.required import Required
 from ..model import Model
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -59,36 +59,32 @@ from ..core.enums import (
     TooltipFieldFormatter,
 )
 from ..core.has_props import abstract
-from ..core.properties import (
-    Alpha,
-    AnyRef,
-    Auto,
-    Bool,
-    Color,
-    Date,
-    Datetime,
-    DeprecatedAlias,
+from ..core.property.alias import DeprecatedAlias
+from ..core.property.any import AnyRef
+from ..core.property.auto import Auto
+from ..core.property.color import Alpha, Color
+from ..core.property.container import (
     Dict,
-    Either,
-    Enum,
-    Float,
-    Instance,
-    InstanceDefault,
-    Int,
     List,
-    NonNegative,
-    Null,
-    Nullable,
-    Override,
-    Percent,
-    Positive,
-    Required,
     Seq,
-    String,
-    Struct,
     Tuple,
 )
-from ..core.property.struct import Optional
+from ..core.property.datetime import Date, Datetime
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance, InstanceDefault
+from ..core.property.nullable import Nullable
+from ..core.property.numeric import NonNegative, Percent, Positive
+from ..core.property.override import Override
+from ..core.property.primitive import (
+    Bool,
+    Float,
+    Int,
+    Null,
+    String,
+)
+from ..core.property.required import Required
+from ..core.property.struct import Optional, Struct
 from ..core.property_aliases import IconLike
 from ..core.validation import error
 from ..core.validation.errors import NO_RANGE_TOOL_RANGES

--- a/src/bokeh/models/transforms.py
+++ b/src/bokeh/models/transforms.py
@@ -26,19 +26,14 @@ from typing import Any
 # Bokeh imports
 from ..core.enums import JitterRandomDistribution, StepMode
 from ..core.has_props import abstract
-from ..core.properties import (
-    AnyRef,
-    Bool,
-    Dict,
-    Either,
-    Enum,
-    Float,
-    Instance,
-    Nullable,
-    Required,
-    Seq,
-    String,
-)
+from ..core.property.any import AnyRef
+from ..core.property.container import Dict, Seq
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool, Float, String
+from ..core.property.required import Required
 from ..model import Model
 from .sources import ColumnarDataSource
 

--- a/src/bokeh/models/ui/dialogs.py
+++ b/src/bokeh/models/ui/dialogs.py
@@ -23,15 +23,12 @@ from typing import Any
 
 # Bokeh imports
 from ...core.enums import Movable, Resizable
-from ...core.properties import (
-    Bool,
-    Either,
-    Enum,
-    Instance,
-    Nullable,
-    Required,
-    String,
-)
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
+from ...core.property.primitive import Bool, String
+from ...core.property.required import Required
 from ..dom import DOMNode
 from ..nodes import Node
 from .ui_element import UIElement

--- a/src/bokeh/models/ui/examiner.py
+++ b/src/bokeh/models/ui/examiner.py
@@ -25,7 +25,8 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import HasProps
-from ...core.properties import Instance, Nullable
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
 from .ui_element import UIElement
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/ui/floating.py
+++ b/src/bokeh/models/ui/floating.py
@@ -23,14 +23,11 @@ from typing import Any
 
 # Bokeh imports
 from ...core.enums import Location
-from ...core.properties import (
-    Bool,
-    CSSLength,
-    Either,
-    Enum,
-    Float,
-    Required,
-)
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.primitive import Bool, Float
+from ...core.property.required import Required
+from ...core.property.visual import CSSLength
 from .panes import Pane
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/ui/icons.py
+++ b/src/bokeh/models/ui/icons.py
@@ -27,17 +27,14 @@ from typing import Any
 # Bokeh imports
 from ...core.enums import ToolIcon
 from ...core.has_props import abstract
-from ...core.properties import (
-    Color,
-    Either,
-    Enum,
-    FontSize,
-    Int,
-    Required,
-    String,
-)
 from ...core.property.bases import Init
+from ...core.property.color import Color
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.primitive import Int, String
+from ...core.property.required import Required
 from ...core.property.singletons import Intrinsic
+from ...core.property.visual import FontSize
 from .ui_element import UIElement
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/ui/menus.py
+++ b/src/bokeh/models/ui/menus.py
@@ -22,16 +22,12 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ...core.properties import (
-    Bool,
-    Either,
-    Instance,
-    List,
-    Null,
-    Nullable,
-    Required,
-    String,
-)
+from ...core.property.container import List
+from ...core.property.either import Either
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
+from ...core.property.primitive import Bool, Null, String
+from ...core.property.required import Required
 from ...core.property_aliases import IconLike
 from ...model import Model
 from ..callbacks import Callback

--- a/src/bokeh/models/ui/panels.py
+++ b/src/bokeh/models/ui/panels.py
@@ -22,13 +22,11 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ...core.properties import (
-    Auto,
-    Either,
-    Instance,
-    Int,
-    Required,
-)
+from ...core.property.auto import Auto
+from ...core.property.either import Either
+from ...core.property.instance import Instance
+from ...core.property.primitive import Int
+from ...core.property.required import Required
 from ...core.property_aliases import Anchor
 from ..nodes import Coordinate, Node
 from .panes import Pane

--- a/src/bokeh/models/ui/panes.py
+++ b/src/bokeh/models/ui/panes.py
@@ -22,7 +22,9 @@ log = logging.getLogger(__name__)
 from typing import Any
 
 # Bokeh imports
-from ...core.properties import Either, Instance, List
+from ...core.property.container import List
+from ...core.property.either import Either
+from ...core.property.instance import Instance
 from ..dom import DOMNode
 from .ui_element import UIElement
 

--- a/src/bokeh/models/ui/tooltips.py
+++ b/src/bokeh/models/ui/tooltips.py
@@ -25,19 +25,15 @@ from typing import Any
 
 # Bokeh imports
 from ...core.enums import Anchor, TooltipAttachment
-from ...core.properties import (
-    Auto,
-    Bool,
-    Either,
-    Enum,
-    Float,
-    Instance,
-    Nullable,
-    Override,
-    Required,
-    String,
-    Tuple,
-)
+from ...core.property.auto import Auto
+from ...core.property.container import Tuple
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
+from ...core.property.override import Override
+from ...core.property.primitive import Bool, Float, String
+from ...core.property.required import Required
 from ..dom import DOMNode
 from ..nodes import Coordinate
 from ..selectors import Selector

--- a/src/bokeh/models/ui/ui_element.py
+++ b/src/bokeh/models/ui/ui_element.py
@@ -25,17 +25,12 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import (
-    Bool,
-    Dict,
-    Either,
-    Enum,
-    Instance,
-    List,
-    Nullable,
-    Seq,
-    String,
-)
+from ...core.property.container import Dict, List, Seq
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
+from ...core.property.primitive import Bool, String
 from ...model import Model
 from ..css import Styles, StyleSheet
 from ..nodes import Node

--- a/src/bokeh/models/util/structure.py
+++ b/src/bokeh/models/util/structure.py
@@ -39,7 +39,7 @@ from itertools import permutations
 from typing import TYPE_CHECKING
 
 # Bokeh imports
-from bokeh.core.properties import UnsetValueError
+from bokeh.core.property.descriptors import UnsetValueError
 from bokeh.layouts import column
 from bokeh.models import (
     BoxZoomTool,

--- a/src/bokeh/models/widgets/buttons.py
+++ b/src/bokeh/models/widgets/buttons.py
@@ -26,18 +26,14 @@ from typing import TYPE_CHECKING, Any, Callable
 # Bokeh imports
 from ...core.enums import ButtonType
 from ...core.has_props import HasProps, abstract
-from ...core.properties import (
-    Bool,
-    Either,
-    Enum,
-    Instance,
-    List,
-    Nullable,
-    Override,
-    Required,
-    String,
-    Tuple,
-)
+from ...core.property.container import List, Tuple
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
+from ...core.property.override import Override
+from ...core.property.primitive import Bool, String
+from ...core.property.required import Required
 from ...events import ButtonClick, MenuItemClick
 from ..callbacks import Callback
 from ..dom import DOMNode

--- a/src/bokeh/models/widgets/groups.py
+++ b/src/bokeh/models/widgets/groups.py
@@ -25,14 +25,10 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import (
-    Bool,
-    Enum,
-    Int,
-    List,
-    Nullable,
-    String,
-)
+from ...core.property.container import List
+from ...core.property.enum import Enum
+from ...core.property.nullable import Nullable
+from ...core.property.primitive import Bool, Int, String
 from .buttons import ButtonLike
 from .widget import Widget
 

--- a/src/bokeh/models/widgets/indicators.py
+++ b/src/bokeh/models/widgets/indicators.py
@@ -26,13 +26,9 @@ from typing import Any
 # Bokeh imports
 from ...core.enums import Orientation
 from ...core.has_props import abstract
-from ...core.properties import (
-    Bool,
-    Enum,
-    Int,
-    Nullable,
-    String,
-)
+from ...core.property.enum import Enum
+from ...core.property.nullable import Nullable
+from ...core.property.primitive import Bool, Int, String
 from .widget import Widget
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/widgets/inputs.py
+++ b/src/bokeh/models/widgets/inputs.py
@@ -26,31 +26,30 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import (
-    AnyRef,
-    Auto,
-    Bool,
-    Color,
-    ColorHex,
+from ...core.property.any import AnyRef
+from ...core.property.auto import Auto
+from ...core.property.color import Color, ColorHex
+from ...core.property.container import (
     Dict,
-    Either,
-    Enum,
-    Float,
-    Instance,
-    Int,
-    Interval,
     List,
-    NonNegative,
-    Null,
-    Nullable,
-    Override,
-    Positive,
-    Readonly,
-    Required,
     Seq,
-    String,
     Tuple,
 )
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
+from ...core.property.numeric import Interval, NonNegative, Positive
+from ...core.property.override import Override
+from ...core.property.primitive import (
+    Bool,
+    Float,
+    Int,
+    Null,
+    String,
+)
+from ...core.property.readonly import Readonly
+from ...core.property.required import Required
 from ...core.property_aliases import IconLike
 from ...events import ModelEvent
 from ..dom import HTML

--- a/src/bokeh/models/widgets/markups.py
+++ b/src/bokeh/models/widgets/markups.py
@@ -31,7 +31,7 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import Bool, String
+from ...core.property.primitive import Bool, String
 from .widget import Widget
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/widgets/pickers.py
+++ b/src/bokeh/models/widgets/pickers.py
@@ -26,21 +26,14 @@ from typing import Any
 # Bokeh imports
 from ...core.enums import CalendarPosition
 from ...core.has_props import HasProps, abstract
-from ...core.properties import (
-    Bool,
-    Date,
-    Datetime,
-    Either,
-    Enum,
-    Int,
-    List,
-    Nullable,
-    Override,
-    Positive,
-    String,
-    Time,
-    Tuple,
-)
+from ...core.property.container import List, Tuple
+from ...core.property.datetime import Date, Datetime, Time
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.nullable import Nullable
+from ...core.property.numeric import Positive
+from ...core.property.override import Override
+from ...core.property.primitive import Bool, Int, String
 from .inputs import InputWidget
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/widgets/sliders.py
+++ b/src/bokeh/models/widgets/sliders.py
@@ -27,24 +27,23 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import (
-    Bool,
-    Color,
-    Datetime,
-    Either,
-    Enum,
-    Float,
-    Instance,
-    Int,
-    Nullable,
-    Override,
-    Readonly,
-    Required,
-    Seq,
-    String,
-    Tuple,
-)
+from ...core.property.color import Color
+from ...core.property.container import Seq, Tuple
+from ...core.property.datetime import Datetime
 from ...core.property.descriptors import UnsetValueError
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.instance import Instance
+from ...core.property.nullable import Nullable
+from ...core.property.override import Override
+from ...core.property.primitive import (
+    Bool,
+    Float,
+    Int,
+    String,
+)
+from ...core.property.readonly import Readonly
+from ...core.property.required import Required
 from ...core.property.singletons import Undefined
 from ...core.validation import error
 from ...core.validation.errors import EQUAL_SLIDER_START_END

--- a/src/bokeh/models/widgets/tables.py
+++ b/src/bokeh/models/widgets/tables.py
@@ -31,23 +31,20 @@ from ...core.enums import (
     RoundingFunction,
 )
 from ...core.has_props import abstract
-from ...core.properties import (
+from ...core.property.container import List
+from ...core.property.dataspec import ColorSpec, FontStyleSpec, TextAlignSpec
+from ...core.property.either import Either
+from ...core.property.enum import Enum
+from ...core.property.instance import Instance, InstanceDefault
+from ...core.property.nullable import Nullable
+from ...core.property.override import Override
+from ...core.property.primitive import (
     Bool,
-    ColorSpec,
-    Either,
-    Enum,
     Float,
-    FontStyleSpec,
-    Instance,
-    InstanceDefault,
     Int,
-    List,
-    Nullable,
-    Override,
-    Required,
     String,
-    TextAlignSpec,
 )
+from ...core.property.required import Required
 from ...core.property.singletons import Intrinsic
 from ...model import Model
 from ..comparisons import Comparison

--- a/src/bokeh/models/widgets/widget.py
+++ b/src/bokeh/models/widgets/widget.py
@@ -30,7 +30,7 @@ from typing import Any
 
 # Bokeh imports
 from ...core.has_props import abstract
-from ...core.properties import Override
+from ...core.property.override import Override
 from ..layouts import LayoutDOM
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -26,24 +26,16 @@ import numpy as np
 
 # Bokeh imports
 from ..core.enums import HorizontalLocation, MarkerType, VerticalLocation
-from ..core.properties import (
-    Auto,
-    Datetime,
-    Either,
-    Enum,
-    Float,
-    Instance,
-    InstanceDefault,
-    Int,
-    List,
-    Nullable,
-    Seq,
-    String,
-    TextLike,
-    TimeDelta,
-    Tuple,
-)
+from ..core.property.auto import Auto
+from ..core.property.container import List, Seq, Tuple
 from ..core.property.data_frame import EagerSeries, PandasGroupBy
+from ..core.property.datetime import Datetime, TimeDelta
+from ..core.property.either import Either
+from ..core.property.enum import Enum
+from ..core.property.instance import Instance, InstanceDefault
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Float, Int, String
+from ..core.property.text_like import TextLike
 from ..models import (
     ColumnDataSource,
     CoordinateMapping,

--- a/src/bokeh/plotting/_graph.py
+++ b/src/bokeh/plotting/_graph.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 import sys
 
 # Bokeh imports
-from ..core.properties import field
+from ..core.property.vectorization import field
 from ..models import (
     Circle,
     ColumnarDataSource,

--- a/src/bokeh/plotting/_legends.py
+++ b/src/bokeh/plotting/_legends.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 # Bokeh imports
-from ..core.properties import field, value
+from ..core.property.vectorization import field, value
 from ..models import Legend, LegendItem
 
 if TYPE_CHECKING:

--- a/src/bokeh/plotting/_plot.py
+++ b/src/bokeh/plotting/_plot.py
@@ -30,7 +30,7 @@ from typing import (
 import numpy as np
 
 # Bokeh imports
-from ..core.properties import Datetime
+from ..core.property.datetime import Datetime
 from ..core.property.singletons import Intrinsic
 from ..models import (
     Axis,

--- a/src/bokeh/plotting/_renderer.py
+++ b/src/bokeh/plotting/_renderer.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 import numpy as np
 
 # Bokeh imports
-from ..core.properties import ColorSpec
+from ..core.property.dataspec import ColorSpec
 from ..models import ColumnarDataSource, ColumnDataSource, GlyphRenderer
 from ._legends import pop_legend_kwarg, update_legend
 

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -48,13 +48,9 @@ from tornado.ioloop import IOLoop
 
 # Bokeh imports
 from .. import __version__
-from ..core.properties import (
-    Bool,
-    Int,
-    List,
-    Nullable,
-    String,
-)
+from ..core.property.container import List
+from ..core.property.nullable import Nullable
+from ..core.property.primitive import Bool, Int, String
 from ..resources import DEFAULT_SERVER_PORT, server_url
 from ..util.options import Options
 from .tornado import DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, BokehTornado


### PR DESCRIPTION
As a follow-up to #14632 this PR updates library code to avoid importing from the "mega" consolidation module `bokeh.core.properties` and instead only import from individual `bokeh.core.property.foo` modules. 

I left tests and examples using `bokeh.core.properties` — we do want to make sure importing from there outside library code still works as expected.

closes #14642 