### PR TITLE
Moving away from `|` to `tuple` in `isinstance()`

### DIFF
--- a/src/bokeh/core/property/container.py
+++ b/src/bokeh/core/property/container.py
@@ -112,7 +112,7 @@ class Seq(ContainerProperty[T]):
 
     @classmethod
     def _is_seq_like(cls, value: Any) -> bool:
-        return (isinstance(value, Container | Sized | Iterable)
+        return (isinstance(value, (Container, Sized, Iterable))
                 and hasattr(value, "__getitem__") # NOTE: this is what makes it disallow set type
                 and not isinstance(value, Mapping))
 
@@ -291,7 +291,7 @@ class Tuple(ContainerProperty):
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
 
-        if isinstance(value, tuple | list) and len(self.type_params) == len(value):
+        if isinstance(value, (tuple, list)) and len(self.type_params) == len(value):
             if all(type_param.is_valid(item) for type_param, item in zip(self.type_params, value)):
                 return
 

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -480,7 +480,7 @@ class PropertyDescriptor(Generic[T]):
         from types import FunctionType
 
         from .instance import InstanceDefault
-        return isinstance(value, FunctionType | InstanceDefault)
+        return isinstance(value, (FunctionType, InstanceDefault))
 
     def _get(self, obj: HasProps) -> T:
         """ Internal implementation of instance attribute access for the

--- a/src/bokeh/core/property/visual.py
+++ b/src/bokeh/core/property/visual.py
@@ -164,7 +164,7 @@ class Image(Property[str]):
         import numpy as np
         import PIL.Image
 
-        if isinstance(value, str | Path | PIL.Image.Image):
+        if isinstance(value, (str, Path, PIL.Image.Image)):
             return
 
         if isinstance(value, np.ndarray):
@@ -198,7 +198,7 @@ class Image(Property[str]):
             return data_image("svg+xml", "utf8", quote(value.read_text()))
 
         # tempfile doesn't implement IO interface (https://bugs.python.org/issue33762)
-        if isinstance(value, Path | BinaryIO | tempfile._TemporaryFileWrapper):
+        if isinstance(value, (Path, BinaryIO, tempfile._TemporaryFileWrapper)):
             value = PIL.Image.open(value)
 
         if isinstance(value, PIL.Image.Image):

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -589,7 +589,7 @@ class ColumnDataSource(ColumnarDataSource):
         # slightly awkward that we have to call convert_datetime_array here ourselves
         # but the downstream code expects things to already be ms-since-epoch
         for key, values in new_data.items():
-            if pd and isinstance(values, pd.Series | pd.Index):
+            if pd and isinstance(values, (pd.Series, pd.Index)):
                 values = values.values
             old_values = self.data[key]
             # Apply the transformation if the new data contains datetimes

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -223,7 +223,7 @@ def convert_str_seq(value: list[str] | str) -> list[str]:
         list[str]
 
     '''
-    if isinstance(value, list | tuple):
+    if isinstance(value, (list, tuple)):
         return value
 
     try:


### PR DESCRIPTION
This PR attempts to Move away from PEP604

fixes #14633