### PR TITLE
Refactor: replace multiple | PEP604 instances with tuple

### DIFF
--- a/src/bokeh/client/connection.py
+++ b/src/bokeh/client/connection.py
@@ -154,7 +154,7 @@ class ClientConnection:
         def connected_or_closed() -> bool:
             # we should be looking at the same state here as the 'connected' property above, so connected
             # means both connected and that we did our initial message exchange
-            return isinstance(self._state, (CONNECTED_AFTER_ACK, DISCONNECTED))
+            return isinstance(self._state, CONNECTED_AFTER_ACK | DISCONNECTED)
         self._loop_until(connected_or_closed)
 
     def close(self, why: str = "closed") -> None:

--- a/src/bokeh/client/connection.py
+++ b/src/bokeh/client/connection.py
@@ -154,7 +154,7 @@ class ClientConnection:
         def connected_or_closed() -> bool:
             # we should be looking at the same state here as the 'connected' property above, so connected
             # means both connected and that we did our initial message exchange
-            return isinstance(self._state, CONNECTED_AFTER_ACK | DISCONNECTED)
+            return isinstance(self._state, (CONNECTED_AFTER_ACK, DISCONNECTED))
         self._loop_until(connected_or_closed)
 
     def close(self, why: str = "closed") -> None:

--- a/src/bokeh/core/property/container.py
+++ b/src/bokeh/core/property/container.py
@@ -112,7 +112,7 @@ class Seq(ContainerProperty[T]):
 
     @classmethod
     def _is_seq_like(cls, value: Any) -> bool:
-        return (isinstance(value, Container | Sized | Iterable)
+        return (isinstance(value, (Container, Sized, Iterable))
                 and hasattr(value, "__getitem__") # NOTE: this is what makes it disallow set type
                 and not isinstance(value, Mapping))
 
@@ -291,7 +291,7 @@ class Tuple(ContainerProperty):
     def validate(self, value: Any, detail: bool = True) -> None:
         super().validate(value, detail)
 
-        if isinstance(value, tuple | list) and len(self.type_params) == len(value):
+        if isinstance(value, (tuple , list)) and len(self.type_params) == len(value):
             if all(type_param.is_valid(item) for type_param, item in zip(self.type_params, value)):
                 return
 

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -480,7 +480,7 @@ class PropertyDescriptor(Generic[T]):
         from types import FunctionType
 
         from .instance import InstanceDefault
-        return isinstance(value, FunctionType | InstanceDefault)
+        return isinstance(value, (FunctionType , InstanceDefault))
 
     def _get(self, obj: HasProps) -> T:
         """ Internal implementation of instance attribute access for the

--- a/src/bokeh/core/property/enum.py
+++ b/src/bokeh/core/property/enum.py
@@ -65,7 +65,7 @@ class Enum(Either):
     def __init__(self, enum: int, *values: int, default: Init[int] = ..., help: str | None = ...) -> None: ...
 
     def __init__(self, enum: str | int | enums.Enumeration, *values: str | int, default: Init[str | int] = Intrinsic, help: str | None = None) -> None:
-        if isinstance(enum, str | int):
+        if isinstance(enum, (str, int)):
             self._enum = enums.enumeration(enum, *values)
         elif values:
             raise ValueError("unexpected enum values")

--- a/src/bokeh/core/property/visual.py
+++ b/src/bokeh/core/property/visual.py
@@ -164,7 +164,7 @@ class Image(Property[str]):
         import numpy as np
         import PIL.Image
 
-        if isinstance(value, str | Path | PIL.Image.Image):
+        if isinstance(value, (str, Path, PIL.Image.Image)):
             return
 
         if isinstance(value, np.ndarray):
@@ -198,7 +198,7 @@ class Image(Property[str]):
             return data_image("svg+xml", "utf8", quote(value.read_text()))
 
         # tempfile doesn't implement IO interface (https://bugs.python.org/issue33762)
-        if isinstance(value, Path | BinaryIO | tempfile._TemporaryFileWrapper):
+        if isinstance(value, (Path, BinaryIO, tempfile._TemporaryFileWrapper)):
             value = PIL.Image.open(value)
 
         if isinstance(value, PIL.Image.Image):

--- a/src/bokeh/core/property/wrappers.py
+++ b/src/bokeh/core/property/wrappers.py
@@ -543,7 +543,7 @@ class PropertyValueColumnData(PropertyValueDict[Sequence[Any]]):
 
         for name, patch in patches.items():
             for ind, value in patch:
-                if isinstance(ind, int | slice):
+                if isinstance(ind, (int, slice)):
                     self[name][ind] = value
                 else:
                     shape = self[name][ind[0]][tuple(ind[1:])].shape

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -470,7 +470,7 @@ class Serializer:
         # avoid importing pandas here unless it is actually in use
         if uses_pandas(obj):
             import pandas as pd
-            if isinstance(obj, pd.Series | pd.Index | pd.api.extensions.ExtensionArray):
+            if isinstance(obj, (pd.Series, pd.Index, pd.api.extensions.ExtensionArray)):
                 return self._encode_ndarray(transform_series(obj))
             elif obj is pd.NA:
                 return None

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -196,7 +196,7 @@ class Document:
 
     @template.setter
     def template(self, template: Template) -> None:
-        if not isinstance(template, Template | str):
+        if not isinstance(template, (Template, str)):
             raise ValueError("document template must be Jinja2 template or a string")
         self._template = template
 

--- a/src/bokeh/embed/standalone.py
+++ b/src/bokeh/embed/standalone.py
@@ -457,12 +457,12 @@ def _check_models_or_docs(models: ModelLike | ModelLikeCollection) -> ModelLikeC
         models = [models]
 
     # Check for sequence
-    if isinstance(models, Sequence) and all(isinstance(x, Model | Document) for x in models):
+    if isinstance(models, Sequence) and all(isinstance(x, (Model, Document)) for x in models):
         input_type_valid = True
 
     if isinstance(models, dict) and \
         all(isinstance(x, str) for x in models.keys()) and \
-        all(isinstance(x, Model | Document) for x in models.values()):
+        all(isinstance(x, (Model, Document)) for x in models.values()):
         input_type_valid = True
 
     if not input_type_valid:


### PR DESCRIPTION
### Description
This PR replaces uses of the PEP 604 `|` operator in `isinstance` and `issubclass`
checks with tuple syntax (e.g., `(A, B)`), improving compatibility and readability.

### Motivation
See issue #14645 — the project aims to remove `|` usage in these contexts for
Python version compatibility and consistent style.

### Changes
- Replaced `isinstance(..., A | B)` → `isinstance(..., (A, B))`
- Verified unit tests pass and code style checks via pre-commit hooks.

### Checklist
- [x] Code changes only
- [x] Pre-commit hooks pass locally
- [x] Related issue linked