### PR TITLE
Backports for 3.8.1

### DIFF
--- a/bokehjs/src/lib/core/util/templating.ts
+++ b/bokehjs/src/lib/core/util/templating.ts
@@ -303,9 +303,6 @@ export function replace_placeholders(content: string | {html: string}, data_sour
     has_html = true
   }
 
-  // this handles the special case @$name, replacing it with an @var corresponding to special_vars.name
-  str = str.replace(/@\$name/g, (_match) => `@{${special_vars.name}}`)
-
   str = process_placeholders(str, (type, name, format, _, spec) => {
     const value = get_value(type, name, data_source, i, special_vars)
 
@@ -352,15 +349,15 @@ export function replace_placeholders(content: string | {html: string}, data_sour
  * - full names: @{one two} (@{anything except curly brackets}
  * - optional formatting: $x{format}, ${x}{format}, @x{format}, @{one two}{format}
  */
-const regex = /((?:[$@][\p{Letter}\p{Number}_]+)|(?:[$@]\{(?:[^{}]+)\}))(?:\{([^{}]+)\})?/gu
+const regex = /(@\$|@|\$)((?:[\p{Letter}\p{Number}_]+)|(?:\{(?:[^{}]+)\}))(?:\{([^{}]+)\})?/gu
 
 export type PlaceholderReplacer = (type: PlaceholderType, name: string, format: string | undefined, i: number, spec: string) => string | null | undefined
 
 export function process_placeholders(text: string, fn: PlaceholderReplacer): string {
   let i = 0 // this var is used for testing purposes
-  return text.replace(regex, (_match, spec: string, format: string | undefined) => {
-    const type = spec[0] as "@" | "$"
-    const name = spec.substring(1).replace(/^{/, "").replace(/}$/, "").trim()
+  return text.replace(regex, (_match: string, type: PlaceholderType, content: string, format: string | undefined) => {
+    const name = content.replace(/^{/, "").replace(/}$/, "").trim()
+    const spec = `${type}${content}`
     return fn(type, name, format, i++, spec) ?? MISSING
   })
 }

--- a/bokehjs/test/unit/core/util/templating.ts
+++ b/bokehjs/test/unit/core/util/templating.ts
@@ -376,5 +376,21 @@ describe("templating module", () => {
         ["@", "x", ":"],
       ])
     })
+
+    it("should handle special @$name case", () => {
+      const found: [string, string, string?][] = []
+      /* eslint-disable no-template-curly-in-string */ // using `@\${name}` results in a different lint error
+      const result = tmpl.process_placeholders("stuff @$name @${name} @${name}{format}", (type, name, format, i) => {
+        found.push([type, name, format])
+        return `${i}`
+      })
+      /* eslint-enable no-template-curly-in-string */
+      expect(result).to.be.equal("stuff 0 1 2")
+      expect(found).to.be.equal([
+        ["@$", "name", undefined],
+        ["@$", "name", undefined],
+        ["@$", "name", "format"],
+      ])
+    })
   })
 })

--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -42,4 +42,4 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -74,7 +74,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - pandas-stubs >=2.2
     - ruff ==0.12.3

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -74,7 +74,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - pandas-stubs >=2.2
     - ruff ==0.12.3

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -74,7 +74,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - pandas-stubs >=2.2
     - ruff ==0.12.3

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -75,7 +75,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - pandas-stubs >=2.2
     - ruff ==0.12.3

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -62,7 +62,7 @@ dependencies:
     - sphinx-copybutton
     - sphinx-design
     - sphinx-favicon
-    - sphinxext-opengraph
+    - sphinxext-opengraph >= 0.11.0
     # tests
     - ruff ==0.11.6
     - types-boto3

--- a/docs/bokeh/Makefile
+++ b/docs/bokeh/Makefile
@@ -17,7 +17,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 	-rm -rf source/docs/gallery/*
 	-rm -rf source/docs/examples/*
-	-rm -rf source/_images/icons/*
+	-rm -rf source/_images/icons/*.svg
 
 html:
 	@start=$$(date +%s) \

--- a/docs/bokeh/make.bat
+++ b/docs/bokeh/make.bat
@@ -30,6 +30,7 @@ if "%1" == "clean" (
 	rmdir %BUILDDIR% /s /q
 	del /q /s source\docs\gallery\*
 	del /q /s source\docs\examples\*
+	del /q /s source\_images\icons\*.svg
 	goto end
 )
 
@@ -38,6 +39,7 @@ if "%1" == "all" (
 )
 
 if "%1" == "html" (
+	xcopy ..\..\bokehjs\src\less\icons\* source\_images\icons\ /y
 	%SPHINXBUILD% -W -b html %ALLSPHINXOPTS% %BUILDDIR%\html
 	xcopy ..\bokeh\server\static %BUILDDIR%\html\static\ /s /e /h /y
 	if errorlevel 1 exit /b 1

--- a/docs/bokeh/source/docs/releases/3.8.1.rst
+++ b/docs/bokeh/source/docs/releases/3.8.1.rst
@@ -1,0 +1,13 @@
+.. _release-3-8-1:
+
+3.8.1
+=====
+
+Bokeh version ``3.8.1`` (November 2025) is a patch release that fixes a number of
+minor bugs/regressions and documentation issues.
+
+Changes
+-------
+
+* Restored support for ``@$name`` and improved ``replace_placeholders()`` (:bokeh-pull:`14652`)
+* Regression fixes to documentation build, especially on Windows (:bokeh-pull:`14627`, :bokeh-pull:`14625`)

--- a/docs/bokeh/switcher.json
+++ b/docs/bokeh/switcher.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "3.8.0 (latest)",
-    "version": "3.8.0",
+    "name": "3.8.1 (latest)",
+    "version": "3.8.1",
     "url": "https://docs.bokeh.org/en/latest/",
     "preferred": true
   },


### PR DESCRIPTION
This PR collects bug-fixes and tasks for a 3.8.1 release:

- [x] #14652
- [x] #14627
- [x] #14625
- [x] 3.8.1 release notes
- [x] updated `switcher.json`

Release checklist:

- [x] do **not** squash merge
- [x] update milestone to `3.8.1` of relevant issues and PRs
- [x] remove `NEEDS BACKPORT` label