### PR TITLE
Increase pixel allowance in #11339 regression test

### DIFF
--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -2102,7 +2102,7 @@ describe("Bug", () => {
   })
 
   describe("in issue #11339", () => {
-    it.allowing(2*8)("collapses layout after toggling visibility", async () => {
+    it.allowing(20)("collapses layout after toggling visibility", async () => {
       const toggle = new Toggle({label: "Click", active: true})
       const select1 = new Select({title: "Select 1:", options: ["1", "2"], value: "1"})
       const select2 = new Select({title: "Select 2:", options: ["1", "2"], value: "1"})


### PR DESCRIPTION
For some reason Chromium is unable to consistently render round corners and shadows.

fixes #14700 