### PR TITLE
Don't cache node modules on MacOS in CI

### DIFF
--- a/.github/workflows/composite/test-setup/action.yml
+++ b/.github/workflows/composite/test-setup/action.yml
@@ -62,7 +62,7 @@ runs:
         npm install --location=global npm
 
     - name: Cache node modules
-      if: ${{ inputs.source-tree == 'keep' }}
+      if: ${{ inputs.source-tree == 'keep' && runner.os != 'macOS' }} # TODO remove after https://github.com/actions/runner/issues/449 is fixed
       uses: actions/cache@v4
       with:
         path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS


### PR DESCRIPTION
Workaround for failing CI on MacOS.

fixes #14730