### PR TITLE
PasswordInput toggle icon aligned when title defined

### DIFF
--- a/bokehjs/src/less/widgets/password_input.less
+++ b/bokehjs/src/less/widgets/password_input.less
@@ -10,7 +10,6 @@
   padding-right: max(var(--padding-horizontal), var(--toggle-width));
 }
 
-// Ensure the input group is positioned relatively for both titled and non-titled cases
 .bk-input-group {
   position: relative;
   display: flex;
@@ -20,10 +19,8 @@
 .bk-toggle {
   position: absolute;
   right: 0;
-  // Position relative to the input element, not the container
   bottom: 0;
   width: var(--toggle-width);
-  // Match the input height
   height: var(--input-height, 31px);
   padding: 0 var(--toggle-padding);
   display: flex;

--- a/bokehjs/src/less/widgets/password_input.less
+++ b/bokehjs/src/less/widgets/password_input.less
@@ -29,7 +29,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  
   &::before {
     content: "";
     display: block;
@@ -41,8 +40,8 @@
     .mask-position(center center);
     .mask-repeat(no-repeat);
   }
-  
-  cursor: pointer;
+
+ cursor: pointer;
 }
 
 .bk-toggle.bk-visible::before {

--- a/bokehjs/src/less/widgets/password_input.less
+++ b/bokehjs/src/less/widgets/password_input.less
@@ -10,21 +10,41 @@
   padding-right: max(var(--padding-horizontal), var(--toggle-width));
 }
 
+// Ensure the input group is positioned relatively for both titled and non-titled cases
+.bk-input-group {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
 .bk-toggle {
   position: absolute;
   right: 0;
-  top: 0;
+  // Position relative to the input element, not the container
+  bottom: 0;
   width: var(--toggle-width);
-  height: 100%;
+  // Match the input height
+  height: var(--input-height, 31px);
   padding: 0 var(--toggle-padding);
-  background-color: var(--icon-color);
-  .mask-image(var(--bokeh-icon-see-off));
-  .mask-size(var(--toggle-size) var(--toggle-size));
-  .mask-position(center center);
-  .mask-repeat(no-repeat);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
+  &::before {
+    content: "";
+    display: block;
+    width: var(--toggle-size);
+    height: var(--toggle-size);
+    background-color: var(--icon-color);
+    .mask-image(var(--bokeh-icon-see-off));
+    .mask-size(var(--toggle-size) var(--toggle-size));
+    .mask-position(center center);
+    .mask-repeat(no-repeat);
+  }
+  
   cursor: pointer;
 }
 
-.bk-toggle.bk-visible {
+.bk-toggle.bk-visible::before {
   .mask-image(var(--bokeh-icon-see-on));
 }

--- a/bokehjs/src/lib/models/widgets/password_input.ts
+++ b/bokehjs/src/lib/models/widgets/password_input.ts
@@ -26,6 +26,7 @@ export class PasswordInputView extends TextInputView {
       input_el.type = is_visible ? "password" : "text"
     })
     this.shadow_el.append(this.toggle_el)
+    //testing commits
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/password_input.ts
+++ b/bokehjs/src/lib/models/widgets/password_input.ts
@@ -9,7 +9,6 @@ export class PasswordInputView extends TextInputView {
   declare model: PasswordInput
 
   toggle_el: HTMLElement
-  version_label: HTMLElement
 
   override stylesheets(): StyleSheetLike[] {
     return [...super.stylesheets(), password_input_css, icons_css]

--- a/bokehjs/src/lib/models/widgets/password_input.ts
+++ b/bokehjs/src/lib/models/widgets/password_input.ts
@@ -18,18 +18,6 @@ export class PasswordInputView extends TextInputView {
   override render(): void {
     super.render()
     this.input_el.type = "password"
-    
-    // Add visible version label
-    // this.version_label = div({
-    //   style: {
-    //     color: "red",
-    //     fontSize: "12px",
-    //     fontWeight: "bold",
-    //     marginBottom: "5px"
-    //   }
-    // }, "🔴 USING LOCAL VERSION v5")
-    // this.shadow_el.prepend(this.version_label)
-
     this.toggle_el = div({class: "bk-toggle"})
     this.toggle_el.addEventListener("click", () => {
       const {input_el, toggle_el} = this
@@ -37,7 +25,7 @@ export class PasswordInputView extends TextInputView {
       toggle_el.classList.toggle("bk-visible", !is_visible)
       input_el.type = is_visible ? "password" : "text"
     })
-    
+
     this.input_el.parentElement?.append(this.toggle_el)
   }
 }

--- a/bokehjs/src/lib/models/widgets/password_input.ts
+++ b/bokehjs/src/lib/models/widgets/password_input.ts
@@ -9,6 +9,7 @@ export class PasswordInputView extends TextInputView {
   declare model: PasswordInput
 
   toggle_el: HTMLElement
+  version_label: HTMLElement
 
   override stylesheets(): StyleSheetLike[] {
     return [...super.stylesheets(), password_input_css, icons_css]
@@ -17,6 +18,17 @@ export class PasswordInputView extends TextInputView {
   override render(): void {
     super.render()
     this.input_el.type = "password"
+    
+    // Add visible version label
+    // this.version_label = div({
+    //   style: {
+    //     color: "red",
+    //     fontSize: "12px",
+    //     fontWeight: "bold",
+    //     marginBottom: "5px"
+    //   }
+    // }, "🔴 USING LOCAL VERSION v5")
+    // this.shadow_el.prepend(this.version_label)
 
     this.toggle_el = div({class: "bk-toggle"})
     this.toggle_el.addEventListener("click", () => {
@@ -25,8 +37,8 @@ export class PasswordInputView extends TextInputView {
       toggle_el.classList.toggle("bk-visible", !is_visible)
       input_el.type = is_visible ? "password" : "text"
     })
-    this.shadow_el.append(this.toggle_el)
-    //testing commits
+    
+    this.input_el.parentElement?.append(this.toggle_el)
   }
 }
 


### PR DESCRIPTION

- [x] issues: fixes #14739 


This is a styling/DOM alignment fix only. No functional API changes were made, so no new tests were added.

Current output: (alignment of toggle icon is ok when title is defined)
<img width="532" height="241" alt="image" src="https://github.com/user-attachments/assets/3063b03f-3964-45bb-9fb2-f701102db696" />
