### PR TITLE
Migrate from NPM tokens to trusted providers for publishing in CI

### DIFF
--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -8,6 +8,9 @@ on:
         description: "Version to deploy a release for (e.g. 3.0.0, 2.4.0.dev8)"
         required: true
 
+permissions:
+  id-token: write  # Required for OIDC and trusted providers for npm publishing
+
 defaults:
   run:
     shell: bash -l {0}
@@ -57,7 +60,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           BOKEH_VERSION: ${{ github.event.inputs.version }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_BUILD_RELEASE_TOKEN }}
         run: python -m release deploy $BOKEH_VERSION

--- a/conda/environment-build.yml
+++ b/conda/environment-build.yml
@@ -7,7 +7,7 @@ dependencies:
   - conda-build 24*    # pre .conda format
   - conda-verify 3.4*
   - libiconv
-  - nodejs 20.*
+  - nodejs 24.*
   - python-build
   - setuptools
   - yaml

--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -10,7 +10,7 @@ dependencies:
   - conda-build 24*    # pre .conda format
   - conda-verify 3.4*
   - libiconv
-  - nodejs 20.*
+  - nodejs 24.*
   - python-build
   - setuptools
   - yaml

--- a/conda/environment-release-deploy.yml
+++ b/conda/environment-release-deploy.yml
@@ -8,7 +8,7 @@ dependencies:
   - anaconda-client
   - boto3
   - colorama
-  - nodejs 20.*
+  - nodejs 24.*
   - packaging
   - setuptools
   - twine

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -33,7 +33,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -33,7 +33,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -33,7 +33,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -33,7 +33,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.14.yml
+++ b/conda/environment-test-3.14.yml
@@ -33,7 +33,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-core.yml
+++ b/conda/environment-test-core.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.13
-  - nodejs 20.*
+  - nodejs 24.*
 
   # required dependencies
   - contourpy >=1.2

--- a/conda/environment-test-downstream.yml
+++ b/conda/environment-test-downstream.yml
@@ -20,4 +20,4 @@ dependencies:
   - pytest >=7.0
   - pytest-timeout
   - scipy
-  - nodejs 20.*
+  - nodejs 24.*

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -30,7 +30,7 @@ dependencies:
   - isort 5.8
   - json5
   - nbconvert >=5.4
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/release/credentials.py
+++ b/release/credentials.py
@@ -81,13 +81,14 @@ def verify_google_credentials(config: Config, system: System, *, token: str) -> 
     pass
 
 
-@collect_credential(token="NPM_TOKEN")
-def verify_npm_credentials(config: Config, system: System, *, token: str) -> None:
-    system.run("npm set registry 'https://registry.npmjs.org'")
-    system.run(f"npm set //registry.npmjs.org/:_authToken {token}")
+def verify_npm_credentials(config: Config, system: System) -> ActionReturn:
+    # NOTE no token, because we use trusted providers to deploy npm packages
+    service = "npm"
     out = system.run("npm whoami")
-    if out.strip() != "bokeh-service":
-        raise RuntimeError(*out.strip().split("\n"))
+    if out.strip() == "bokeh-service":
+        return PASSED(f"Verified {service} credentials")
+    else:
+        return FAILED(f"Could NOT verify {service} credentials")
 
 
 @collect_credential(access_key_id="AWS_ACCESS_KEY_ID", secret_access_key="AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
I set up trusted providers on npmjs.com, so I think this PR should be sufficient to finalize the migration. I think the only real way to test this, is to merge this PR and then publish a 3.9 dev release.

fixes #14757 
