### PR TITLE
Backports for 3.8.2

### DIFF
--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -8,6 +8,9 @@ on:
         description: "Version to deploy a release for (e.g. 3.0.0, 2.4.0.dev8)"
         required: true
 
+permissions:
+  id-token: write  # Required for OIDC and trusted providers for npm publishing
+
 defaults:
   run:
     shell: bash -l {0}
@@ -57,7 +60,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           BOKEH_VERSION: ${{ github.event.inputs.version }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_BUILD_RELEASE_TOKEN }}
         run: python -m release deploy $BOKEH_VERSION

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_stages: [pre-push]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.14.0
     hooks:
       - id: ruff
         stages: [pre-commit]

--- a/conda/environment-build.yml
+++ b/conda/environment-build.yml
@@ -4,11 +4,10 @@ channels:
 dependencies:
   - python=3.10
 
-  - build
-  - conda-build=3.22.0
-  - conda-verify=3.4.2
+  - conda-build 24*    # pre .conda format
+  - conda-verify 3.4*
   - libiconv
   - nodejs 20.*
-  - ripgrep=0.10.0
+  - python-build
   - setuptools
   - yaml

--- a/conda/environment-build.yml
+++ b/conda/environment-build.yml
@@ -7,7 +7,7 @@ dependencies:
   - conda-build 24*    # pre .conda format
   - conda-verify 3.4*
   - libiconv
-  - nodejs 20.*
+  - nodejs 24.*
   - python-build
   - setuptools
   - yaml

--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -6,13 +6,12 @@ dependencies:
 
   # build
   - boto3
-  - build
   - colorama
-  - conda-build=3.22.0
-  - conda-verify=3.4.2
+  - conda-build 24*    # pre .conda format
+  - conda-verify 3.4*
   - libiconv
   - nodejs 20.*
-  - ripgrep=0.10.0
+  - python-build
   - setuptools
   - yaml
 

--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -10,7 +10,7 @@ dependencies:
   - conda-build 24*    # pre .conda format
   - conda-verify 3.4*
   - libiconv
-  - nodejs 20.*
+  - nodejs 24.*
   - python-build
   - setuptools
   - yaml

--- a/conda/environment-release-deploy.yml
+++ b/conda/environment-release-deploy.yml
@@ -8,7 +8,7 @@ dependencies:
   - anaconda-client
   - boto3
   - colorama
-  - nodejs 20.*
+  - nodejs 24.*
   - packaging
   - setuptools
   - twine

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -44,6 +44,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - pytest-timeout
+  - pytest-tornado
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - scipy

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -33,7 +33,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -44,6 +44,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - pytest-timeout
+  - pytest-tornado
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - scipy

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -33,7 +33,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -44,6 +44,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - pytest-timeout
+  - pytest-tornado
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - scipy

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -33,7 +33,7 @@ dependencies:
   - json5
   - nbconvert >=5.4
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -34,7 +34,7 @@ dependencies:
   - json5
   # - nbconvert >=5.4 # Not yet available for Python 3.13
   - networkx
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -45,6 +45,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - pytest-timeout
+  - pytest-tornado
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - scipy

--- a/conda/environment-test-downstream.yml
+++ b/conda/environment-test-downstream.yml
@@ -20,4 +20,4 @@ dependencies:
   - pytest >=7.0
   - pytest-timeout
   - scipy
-  - nodejs 20.*
+  - nodejs 24.*

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -41,6 +41,7 @@ dependencies:
   - pytest-html
   - pytest-xdist
   - pytest-timeout
+  - pytest-tornado
   - requests >=1.2.3,!=2.32.* # see https://github.com/bokeh/bokeh/issues/13910
   - urllib3 <2 # see https://github.com/bokeh/bokeh/issues/13152
   - selenium 4.2

--- a/conda/environment-test-minimal-deps.yml
+++ b/conda/environment-test-minimal-deps.yml
@@ -30,7 +30,7 @@ dependencies:
   - isort 5.8
   - json5
   - nbconvert >=5.4
-  - nodejs 20.*
+  - nodejs 24.*
   - pre-commit
   - psutil
   - pygments

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - python
     - python-dateutil
     - pyyaml
-    - ripgrep
     - setuptools >=62.3.3
     - yaml
 

--- a/docs/bokeh/source/docs/releases/3.8.2.rst
+++ b/docs/bokeh/source/docs/releases/3.8.2.rst
@@ -1,0 +1,12 @@
+.. _release-3-8-2:
+
+3.8.2
+=====
+
+Bokeh version ``3.8.2`` (January 2026) is a patch release that fixes a security
+issue with the Bokeh server.
+
+Changes
+-------
+
+* Addressed a security issue with Incomplete Origin Validation for WebSockets in Bokeh server applications

--- a/docs/bokeh/switcher.json
+++ b/docs/bokeh/switcher.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "3.8.1 (latest)",
-    "version": "3.8.1",
+    "name": "3.8.2 (latest)",
+    "version": "3.8.2",
     "url": "https://docs.bokeh.org/en/latest/",
     "preferred": true
   },

--- a/release/credentials.py
+++ b/release/credentials.py
@@ -81,13 +81,14 @@ def verify_google_credentials(config: Config, system: System, *, token: str) -> 
     pass
 
 
-@collect_credential(token="NPM_TOKEN")
-def verify_npm_credentials(config: Config, system: System, *, token: str) -> None:
-    system.run("npm set registry 'https://registry.npmjs.org'")
-    system.run(f"npm set //registry.npmjs.org/:_authToken {token}")
+def verify_npm_credentials(config: Config, system: System) -> ActionReturn:
+    # NOTE no token, because we use trusted providers to deploy npm packages
+    service = "npm"
     out = system.run("npm whoami")
-    if out.strip() != "bokeh-service":
-        raise RuntimeError(*out.strip().split("\n"))
+    if out.strip() == "bokeh-service":
+        return PASSED(f"Verified {service} credentials")
+    else:
+        return FAILED(f"Could NOT verify {service} credentials")
 
 
 @collect_credential(access_key_id="AWS_ACCESS_KEY_ID", secret_access_key="AWS_SECRET_ACCESS_KEY")

--- a/release/credentials.py
+++ b/release/credentials.py
@@ -82,13 +82,16 @@ def verify_google_credentials(config: Config, system: System, *, token: str) -> 
 
 
 def verify_npm_credentials(config: Config, system: System) -> ActionReturn:
-    # NOTE no token, because we use trusted providers to deploy npm packages
     service = "npm"
-    out = system.run("npm whoami")
-    if out.strip() == "bokeh-service":
-        return PASSED(f"Verified {service} credentials")
-    else:
-        return FAILED(f"Could NOT verify {service} credentials")
+    return PASSED(f"Verification of {service} credentials is not currently supported")
+
+    # NOTE no token, because we use trusted providers to deploy npm packages
+    # TODO restore this when OICD support is added to npm whoami
+    # out = system.run("npm whoami")
+    # if out.strip() == "bokeh-service":
+    #     return PASSED(f"Verified {service} credentials")
+    # else:
+    #     return FAILED(f"Could NOT verify {service} credentials")
 
 
 @collect_credential(access_key_id="AWS_ACCESS_KEY_ID", secret_access_key="AWS_SECRET_ACCESS_KEY")

--- a/src/bokeh/server/util.py
+++ b/src/bokeh/server/util.py
@@ -175,8 +175,10 @@ def match_host(host: str, pattern: str) -> bool:
             wildcards for ip address octets or ports.
 
     This function will return ``True`` if the hostname matches the pattern,
-    including any wildcards. If the pattern contains a port, the host string
-    must also contain a matching port.
+    including any wildcards. If the pattern does not include any wildcards,
+    then the length the host parts and pattern parts must match identically.
+    If the pattern contains a port, the host string must also contain a
+    matching port.
 
     Returns:
         bool
@@ -199,7 +201,9 @@ def match_host(host: str, pattern: str) -> bool:
         True
         >>> match_host('alice', 'bob')
         False
-        >>> match_host('foo.example.com', 'foo.example.com.net')
+        >>> match_host('example.com', 'example.com.net')
+        False
+        >>> match_host('example.com.bad.com', 'example.com')
         False
         >>> match_host('alice', '*')
         True
@@ -213,6 +217,9 @@ def match_host(host: str, pattern: str) -> bool:
         False
 
     '''
+    if pattern == "*":
+        return True
+
     host_port: str | None = None
     if ':' in host:
         host, host_port = host.rsplit(':', 1)
@@ -229,7 +236,10 @@ def match_host(host: str, pattern: str) -> bool:
     host_parts = host.split('.')
     pattern_parts = pattern.split('.')
 
-    if len(pattern_parts) > len(host_parts):
+    # since the pattern is not '*', we must enforce that the host and
+    # pattern have the same number of parts, to avoid matching subdomains
+    # unintentionally.
+    if len(pattern_parts) != len(host_parts):
         return False
 
     for h, p in zip(host_parts, pattern_parts):

--- a/src/bokeh/server/util.py
+++ b/src/bokeh/server/util.py
@@ -217,6 +217,7 @@ def match_host(host: str, pattern: str) -> bool:
         False
 
     '''
+    # This is for a wildcard match without any port restriction
     if pattern == "*":
         return True
 
@@ -232,6 +233,10 @@ def match_host(host: str, pattern: str) -> bool:
 
     if pattern_port is not None and host_port != pattern_port:
         return False
+
+    # This is for a wildcard match including any port restriction
+    if pattern == "*":
+        return True
 
     host_parts = host.split('.')
     pattern_parts = pattern.split('.')

--- a/src/bokeh/server/views/ws.py
+++ b/src/bokeh/server/views/ws.py
@@ -112,14 +112,14 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
         if settings.allowed_ws_origin():
             allowed_hosts = set(settings.allowed_ws_origin())
 
-        allowed = check_allowlist(origin_host, allowed_hosts)
-        if allowed:
+
+        if check_allowlist(origin_host, allowed_hosts):
             return True
-        else:
-            log.error("Refusing websocket connection from Origin '%s'; \
-                      use --allow-websocket-origin=%s or set BOKEH_ALLOW_WS_ORIGIN=%s to permit this; currently we allow origins %r",
-                      origin, origin_host, origin_host, allowed_hosts)
-            return False
+
+        log.error("Refusing websocket connection from Origin '%s'; \
+                    use --allow-websocket-origin=%s or set BOKEH_ALLOW_WS_ORIGIN=%s to permit this; currently we allow origins %r",
+                    origin, origin_host, origin_host, allowed_hosts)
+        return False
 
     @web.authenticated
     def open(self) -> None:

--- a/src/bokeh/sphinxext/_internal/bokeh_directive.py
+++ b/src/bokeh/sphinxext/_internal/bokeh_directive.py
@@ -34,13 +34,13 @@ from sphinx.util.nodes import nested_parse_with_titles
 # Globals and constants
 # -----------------------------------------------------------------------------
 
-# taken from Sphinx autodoc
+# taken from Sphinx autodoc, all we use is the "thing name", e.g. model name
 py_sig_re = re.compile(
-    r"""^ ([\w.]*\.)?            # class name(s)
-          (\w+)  \s*             # thing name
-          (?: \((.*)\)           # optional: arguments
-           (?:\s* -> \s* (.*))?  # return annotation
-          )? $                   # and nothing more
+    r"""^ (?:[\w.]*\.)?            # class name(s)
+          (\w+)  \s*               # thing name
+          (?: \((?:.*)\)           # optional: arguments
+           (?:\s* -> \s* (?:.*))?  # return annotation
+          )? $                     # and nothing more
           """,
     re.VERBOSE,
 )

--- a/src/bokeh/sphinxext/_internal/bokeh_model.py
+++ b/src/bokeh/sphinxext/_internal/bokeh_model.py
@@ -90,7 +90,7 @@ class BokehModelDirective(BokehDirective):
         m = py_sig_re.match(sig)
         if m is None:
             raise SphinxError(f"Unable to parse signature for bokeh-model: {sig!r}")
-        name_prefix, model_name, arglist, retann = m.groups()
+        model_name = m.group(1)
 
         if getenv("BOKEH_SPHINX_QUICK") == "1":
             return self.parse(f"{model_name}\n{'-'*len(model_name)}\n", f"<bokeh-model: {model_name}>")

--- a/src/bokeh/sphinxext/_internal/bokeh_options.py
+++ b/src/bokeh/sphinxext/_internal/bokeh_options.py
@@ -79,7 +79,7 @@ class BokehOptionsDirective(BokehDirective):
         m = py_sig_re.match(sig)
         if m is None:
             raise SphinxError(f"Unable to parse signature for bokeh-options: {sig!r}")
-        name_prefix, options_name, arglist, retann = m.groups()
+        options_name = m.group(1)
 
         module_name = self.options["module"]
 

--- a/src/bokeh/sphinxext/_internal/bokeh_settings.py
+++ b/src/bokeh/sphinxext/_internal/bokeh_settings.py
@@ -78,7 +78,7 @@ class BokehSettingsDirective(BokehDirective):
         m = py_sig_re.match(sig)
         if m is None:
             raise SphinxError(f"Unable to parse signature for bokeh-model: {sig!r}")
-        name_prefix, obj_name, arglist, retann = m.groups()
+        obj_name = m.group(1)
 
         module_name = self.options["module"]
 

--- a/src/bokeh/sphinxext/bokeh_plot.py
+++ b/src/bokeh/sphinxext/bokeh_plot.py
@@ -249,7 +249,7 @@ class BokehPlotDirective(BokehDirective):
         if not hasattr(self.env, 'solved_sampledata'):
             self.env.solved_sampledata = []
 
-        file, lineno =  self.get_source_info()
+        file, _ = self.get_source_info()
         # collect links to all standalone examples
 
         if '/docs/examples/' in file and file not in self.env.solved_sampledata:

--- a/tests/unit/bokeh/command/test_bootstrap.py
+++ b/tests/unit/bokeh/command/test_bootstrap.py
@@ -70,7 +70,7 @@ def test_error(capsys: Capture) -> None:
     Info.invoke = err
     with pytest.raises(SystemExit):
         main(["bokeh", "info"])
-    out, err = capsys.readouterr()
+    _, err = capsys.readouterr()
     assert err == 'ERROR: foo\n'
     Info.invoke = old_invoke
 

--- a/tests/unit/bokeh/core/property/test_bases.py
+++ b/tests/unit/bokeh/core/property/test_bases.py
@@ -121,7 +121,7 @@ class TestProperty:
         for x in [1, 1.2, "a", np.arange(4), None, False, True, {}, []]:
                 assert p.matches(x, x) is True
                 assert p.matches(x, "junk") is False
-        out, err = capsys.readouterr()
+        _, err = capsys.readouterr()
         assert err == ""
 
     def test_matches_compatible_arrays(self, capsys: Capture) -> None:
@@ -133,7 +133,7 @@ class TestProperty:
         for x in [1, 1.2, "a", np.arange(4), None, False]:
                 assert p.matches(a, x) is False
                 assert p.matches(x, b) is False
-        out, err = capsys.readouterr()
+        _, err = capsys.readouterr()
         assert err == ""
 
     def test_matches_incompatible_arrays(self, capsys: Capture) -> None:
@@ -141,9 +141,9 @@ class TestProperty:
         a = np.arange(5)
         b = np.arange(5).astype(str)
         assert p.matches(a, b) is False
-        out, err = capsys.readouterr()
+        _, _err = capsys.readouterr()
         # no way to suppress FutureWarning in this case
-        # assert err == ""
+        # assert _err == ""
 
     def test_matches_dicts_with_array_values(self, capsys: Capture) -> None:
         p = bcpb.Property()
@@ -159,7 +159,7 @@ class TestProperty:
         assert p.matches(d1, dict(foo=np.arange(11))) is False
         assert p.matches(d1, dict(bar=np.arange(10))) is False
         assert p.matches(d1, dict(bar=10)) is False
-        out, err = capsys.readouterr()
+        _, err = capsys.readouterr()
         assert err == ""
 
     def test_matches_non_dict_containers_with_array_false(self, capsys: Capture) -> None:
@@ -174,7 +174,7 @@ class TestProperty:
         assert p.matches(t1, t1) is True  # because object identity
         assert p.matches(t1, t2) is False
 
-        out, err = capsys.readouterr()
+        _, err = capsys.readouterr()
         assert err == ""
 
     def test_matches_dicts_with_series_values(self, capsys: Capture) -> None:
@@ -191,7 +191,7 @@ class TestProperty:
         assert p.matches(d1.foo, np.arange(11)) is False
         assert p.matches(d1.foo, np.arange(10)+1) is False
         assert p.matches(d1.foo, 10) is False
-        out, err = capsys.readouterr()
+        _, err = capsys.readouterr()
         assert err == ""
 
     def test_matches_dicts_with_index_values(self, capsys: Capture) -> None:
@@ -208,7 +208,7 @@ class TestProperty:
         assert p.matches(d1.index, np.arange(11)) is False
         assert p.matches(d1.index, np.arange(10)+1) is False
         assert p.matches(d1.index, 10) is False
-        out, err = capsys.readouterr()
+        _, err = capsys.readouterr()
         assert err == ""
 
     def test_validation_on(self) -> None:

--- a/tests/unit/bokeh/core/test_properties.py
+++ b/tests/unit/bokeh/core/test_properties.py
@@ -396,15 +396,15 @@ class TestBasic:
         assert o.z == 'xyz'
 
         obj0 = ReadonlyModel(x=20)
-        with pytest.raises(RuntimeError, match="ReadonlyModel.x is a readonly property"):
+        with pytest.raises(RuntimeError, match=r"ReadonlyModel.x is a readonly property"):
             obj0.x = 30
 
         obj1 = ReadonlyModel(y=30)
-        with pytest.raises(RuntimeError, match="ReadonlyModel.y is a readonly property"):
+        with pytest.raises(RuntimeError, match=r"ReadonlyModel.y is a readonly property"):
             obj1.y = 40
 
         obj2 = ReadonlyModel(x=20, y=30)
-        with pytest.raises(RuntimeError, match="ReadonlyModel.x is a readonly property"):
+        with pytest.raises(RuntimeError, match=r"ReadonlyModel.x is a readonly property"):
             obj2.update(x=30, y=40)
 
     def test_include_defaults(self) -> None:
@@ -576,9 +576,9 @@ def test_HasProps_clone() -> None:
     assert obj1.p3.p0 == 30
     assert obj0.p3.p0 == 30
 
-    with pytest.raises(RuntimeError, match="CloneModel.p3 is a readonly property"):
+    with pytest.raises(RuntimeError, match=r"CloneModel.p3 is a readonly property"):
         obj0.p3 = None
-    with pytest.raises(RuntimeError, match="CloneModel.p3 is a readonly property"):
+    with pytest.raises(RuntimeError, match=r"CloneModel.p3 is a readonly property"):
         obj1.p3 = None
 
 def test_Model_clone() -> None:

--- a/tests/unit/bokeh/server/test_util.py
+++ b/tests/unit/bokeh/server/test_util.py
@@ -129,6 +129,8 @@ def test_match_host() -> None:
         assert util.match_host('alice:80', '*') is True
         assert util.match_host('alice:80', '*:80') is True
         assert util.match_host('alice:8080', '*:80') is False
+        assert util.match_host("192.168.0.1:80", '*:80') is True
+        assert util.match_host("192.168.0.1:8080", '*:80') is False
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/server/test_util.py
+++ b/tests/unit/bokeh/server/test_util.py
@@ -73,6 +73,11 @@ def test_check_allowlist_accepts_all_on_star() -> None:
     assert util.check_allowlist("foobarbaz:5006", ['*:*']) is True
     assert util.check_allowlist("foobarbaz:5006", ['*:5006']) is True
 
+def test_check_allowlist_rejects_subdomain_matches() -> None:
+    assert util.check_allowlist("example.com.bad.com", ["example.com"]) is False
+    assert util.check_allowlist("example.com.bad.com:80", ["example.com:80"]) is False
+    assert util.check_allowlist("example.com.bad.com:80", ["example.com:*"]) is False
+
 def test_create_hosts_allowlist_no_host() -> None:
     hosts = util.create_hosts_allowlist(None, 1000)
     assert hosts == ["localhost:1000"]
@@ -118,6 +123,7 @@ def test_match_host() -> None:
         assert util.match_host('alice:80', 'alice') is True
         assert util.match_host('alice', 'bob') is False
         assert util.match_host('foo.example.com', 'foo.example.com.net') is False
+        assert util.match_host('example.com.bad.com', 'example.com') is False
         assert util.match_host('alice', '*') is True
         assert util.match_host('alice', '*:*') is True
         assert util.match_host('alice:80', '*') is True

--- a/tests/unit/bokeh/server/views/test_ws.py
+++ b/tests/unit/bokeh/server/views/test_ws.py
@@ -22,14 +22,14 @@ from collections.abc import Callable
 from typing import Generator
 
 # External imports
-from tornado.httpclient import HTTPRequest, HTTPClientError
+from tornado.httpclient import HTTPClientError, HTTPRequest
 from tornado.httpserver import HTTPServer
 from tornado.websocket import WebSocketClosedError, websocket_connect
 
 # Bokeh imports
 from bokeh.application import Application
-from bokeh.server.views.auth_request_handler import AuthRequestHandler
 from bokeh.server.tornado import BokehTornado
+from bokeh.server.views.auth_request_handler import AuthRequestHandler
 from bokeh.util.logconfig import basicConfig
 from bokeh.util.token import generate_jwt_token, generate_session_id
 

--- a/tests/unit/bokeh/server/views/test_ws.py
+++ b/tests/unit/bokeh/server/views/test_ws.py
@@ -18,13 +18,20 @@ import pytest ; pytest
 
 # Standard library imports
 import logging
+from collections.abc import Callable
+from typing import Generator
 
 # External imports
-from tornado.websocket import WebSocketClosedError
+from tornado.httpclient import HTTPRequest, HTTPClientError
+from tornado.httpserver import HTTPServer
+from tornado.websocket import WebSocketClosedError, websocket_connect
 
 # Bokeh imports
+from bokeh.application import Application
 from bokeh.server.views.auth_request_handler import AuthRequestHandler
+from bokeh.server.tornado import BokehTornado
 from bokeh.util.logconfig import basicConfig
+from bokeh.util.token import generate_jwt_token, generate_session_id
 
 # Module under test
 from bokeh.server.views.ws import WSHandler # isort:skip
@@ -35,6 +42,11 @@ from bokeh.server.views.ws import WSHandler # isort:skip
 
 # needed for caplog tests to function
 basicConfig()
+
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:pytest-asyncio detected an unclosed event loop:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:clear_current is deprecated:DeprecationWarning"),
+]
 
 #-----------------------------------------------------------------------------
 # General API
@@ -55,16 +67,99 @@ async def test_send_message_raises(caplog: pytest.LogCaptureFixture) -> None:
         # resulting in varying number of messages, depending on the tests run and their order
         assert len([msg for msg in caplog.messages if "Failed sending message as connection was closed" in msg]) == 1
 
+
 def test_uses_auth_request_handler() -> None:
     assert issubclass(WSHandler, AuthRequestHandler)
+
+
+GOOD_ORIGIN_CASES = (
+    pytest.param(["*"],                "http://example.com",      id="global wildcard"),
+    pytest.param(["example.*"],        "http://example.com",      id="partial wildcard"),
+    pytest.param(["example.com:*"],    "http://example.com",      id="port wildcard"),
+    pytest.param(["example.com:80"],   "http://example.com",      id="implicit port 80"),
+    pytest.param(["example.com:8080"], "http://example.com:8080", id="explicit port"),
+    pytest.param(["example.com"],      "http://example.com",      id="exact match"),
+)
+
+
+@pytest.mark.gen_test
+@pytest.mark.parametrize(("allowed_origins", "request_origin"), GOOD_ORIGIN_CASES)
+async def test_ws_handler_accepts_allowed_origins(
+    websocket_url_factory: Callable[[list[str]], str],
+    allowed_origins: list[str],
+    request_origin: str,
+) -> None:
+    ws_url = websocket_url_factory(allowed_origins)
+    request = build_ws_request(ws_url, request_origin)
+    connection = await websocket_connect(request)
+    connection.close()
+
+
+BAD_ORIGIN_CASES = (
+    pytest.param(["example.com"],    "http://example.com.bad.com", id="subdomain rejection"),
+    pytest.param(["example.com"],    "http://foo.com",             id="exact name mismatch"),
+    pytest.param(["example.com.*"],  "http://example.com",         id="pattern mismatch"),
+    pytest.param(["example.com:80"], "http://example.com:8080",    id="port mismatch"),
+)
+
+
+@pytest.mark.gen_test
+@pytest.mark.parametrize(("allowed_origins", "request_origin"), BAD_ORIGIN_CASES)
+async def test_ws_handler_rejects_disallowed_origins(
+    websocket_url_factory: Callable[[list[str]], str],
+    allowed_origins: list[str],
+    request_origin: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ws_url = websocket_url_factory(allowed_origins)
+    request = build_ws_request(ws_url, request_origin)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(HTTPClientError) as e:
+            await websocket_connect(request)
+
+    assert e.value.code == 403
+    assert f"Refusing websocket connection from Origin {request_origin!r}" in caplog.text
+    assert f"currently we allow origins {set(allowed_origins)!r}" in caplog.text
+
 
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
 
+@pytest.fixture
+def websocket_url_factory(unused_tcp_port_factory) -> Generator[Callable[[list[str]], str], None, None]:
+    servers: list[HTTPServer] = []
+
+    def start(allowed_origins: list[str]) -> str:
+        port = unused_tcp_port_factory()
+        app = Application
+        tornado_app = BokehTornado({"/": app}, extra_websocket_origins=allowed_origins)
+        server = HTTPServer(tornado_app)
+        server.listen(port, address="localhost")
+        servers.append(server)
+        return f"ws://localhost:{port}/ws"
+
+    yield start
+
+    for server in servers:
+        server.stop()
+
+def build_ws_request(url: str, origin: str) -> HTTPRequest:
+    session_id = generate_session_id()
+    token = generate_jwt_token(session_id)
+    return HTTPRequest(
+        url=url,
+        headers={
+            "Origin": origin,
+            "Sec-WebSocket-Protocol": f"bokeh, {token}",
+        },
+    )
+
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
 
 #-----------------------------------------------------------------------------
 # Code

--- a/tests/unit/bokeh/server/views/test_ws.py
+++ b/tests/unit/bokeh/server/views/test_ws.py
@@ -76,6 +76,7 @@ GOOD_ORIGIN_CASES = (
     pytest.param(["*"],                "http://example.com",      id="global wildcard"),
     pytest.param(["example.*"],        "http://example.com",      id="partial wildcard"),
     pytest.param(["example.com:*"],    "http://example.com",      id="port wildcard"),
+    pytest.param(["*:81"],             "http://example.com:81",   id="host wildcard"),
     pytest.param(["example.com:80"],   "http://example.com",      id="implicit port 80"),
     pytest.param(["example.com:8080"], "http://example.com:8080", id="explicit port"),
     pytest.param(["example.com"],      "http://example.com",      id="exact match"),
@@ -97,9 +98,11 @@ async def test_ws_handler_accepts_allowed_origins(
 
 BAD_ORIGIN_CASES = (
     pytest.param(["example.com"],    "http://example.com.bad.com", id="subdomain rejection"),
-    pytest.param(["example.com"],    "http://foo.com",             id="exact name mismatch"),
+    pytest.param(["example.com"],    "http://foo.com",             id="exact host mismatch"),
+    pytest.param(["example.com:80"], "http://foo.com:80",          id="exact host mismatch with port"),
     pytest.param(["example.com.*"],  "http://example.com",         id="pattern mismatch"),
-    pytest.param(["example.com:80"], "http://example.com:8080",    id="port mismatch"),
+    pytest.param(["example.com:80"], "http://example.com:8080",    id="port mismatch with exact host"),
+    pytest.param(["*:81"],           "http://example.com:8080",    id="port mismatch with wildcard host"),
 )
 
 

--- a/tests/unit/bokeh/test___init__.py
+++ b/tests/unit/bokeh/test___init__.py
@@ -84,7 +84,7 @@ def test___version___defined() -> None:
 
 def test_license(capsys: Capture) -> None:
     b.license()
-    out, err = capsys.readouterr()
+    out, _ = capsys.readouterr()
     assert out == _LICENSE
 
 class TestWarnings:

--- a/tests/unit/bokeh/util/test_token.py
+++ b/tests/unit/bokeh/util/test_token.py
@@ -209,13 +209,13 @@ class Test__get_sysrandom:
             expected = True
         except NotImplementedError:
             expected = False
-        _random, using_sysrandom = _get_sysrandom()
+        _, using_sysrandom = _get_sysrandom()
         assert using_sysrandom == expected
 
     @patch('random.SystemRandom', new_callable=_nie)
     def test_missing_sysrandom_no_secret_key(self, _mock_sysrandom: MagicMock) -> None:
         with pytest.warns(UserWarning) as warns:
-            random, using_sysrandom = _get_sysrandom()
+            _, using_sysrandom = _get_sysrandom()
             assert not using_sysrandom
             assert len(warns) == 2
             assert warns[0].message.args[0] == _MERSENNE_MSG
@@ -230,7 +230,7 @@ class Test__get_sysrandom:
     def test_missing_sysrandom_with_secret_key(self, _mock_sysrandom: MagicMock) -> None:
         with envset(BOKEH_SECRET_KEY="foo"):
             with pytest.warns(UserWarning) as warns:
-                random, using_sysrandom = _get_sysrandom()
+                _, using_sysrandom = _get_sysrandom()
                 assert not using_sysrandom
                 assert len(warns) == 1
                 assert warns[0].message.args[0] == _MERSENNE_MSG


### PR DESCRIPTION
This PR backports the fix for the Bokeh server CSWSH advisory. Also had to cherry-pick an incidental commit for linting.

This PR collects bug-fixes and tasks for a 3.8.2 release:

- [x] https://github.com/bokeh/bokeh/pull/14661
- [x] https://github.com/bokeh/bokeh/pull/14758
- [x] https://github.com/bokeh/bokeh/pull/14766
- [x] https://github.com/bokeh/bokeh/pull/14769
- [x] 3.8.2 release notes
- [x] updated `switcher.json`

Release checklist:

- [x] do **not** squash merge
- [x] update milestone to 3.8.2 of relevant issues and PRs
- [x] remove `NEEDS BACKPORT` label