### PR TITLE
Fix index rounding to display proper tooltips in CategoricalSlider

### DIFF
--- a/bokehjs/src/lib/models/widgets/sliders/categorical_slider.ts
+++ b/bokehjs/src/lib/models/widgets/sliders/categorical_slider.ts
@@ -25,7 +25,7 @@ export class CategoricalSliderView extends AbstractSliderView<string> {
       start: [this.model.value],
       step: 1,
       format: {
-        to: (value: number) => categories[value],
+        to: (value: number) => categories[Math.round(value)], // value may not be an integer due to noUiSlider's FP math
         from: (value: string) => categories.indexOf(value),
       },
     }
@@ -33,11 +33,12 @@ export class CategoricalSliderView extends AbstractSliderView<string> {
 
   protected _calc_from([value]: number[]): string {
     const {categories} = this.model
-    return categories[value | 0] // value may not be an integer due to noUiSlider's FP math
+    return categories[Math.round(value)] // value may not be an integer due to noUiSlider's FP math
   }
 
   pretty(value: number | string): string {
-    return isNumber(value) ? this.model.categories[value] : value
+    // value may not be an integer due to noUiSlider's FP math
+    return isNumber(value) ? this.model.categories[Math.round(value)] : value
   }
 }
 

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -1778,8 +1778,8 @@ describe("Bug", () => {
       expect_not_null(el)
       expect(slider.value).to.be.equal("0")
 
-      // The expectation is that no errors accumulate during sliding
-      for (let c of categories.slice(1)) {
+      // The expectation is that no errors accumulate during sliding.
+      for (const c of categories.slice(1)) {
         el.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowRight"}))
         await view.ready
         // After an event the tooltip and the slider value should be updated.

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -1768,7 +1768,7 @@ describe("Bug", () => {
     })
   })
 
-  describe("in issue #13965", () => {
+  describe("in issue #13965 and #14645", () => {
     it("doesn't allow to correctly index categories in CategoricalSlider", async () => {
       const categories = range(0, 20).map((i) => `${i}`)
       const slider = new CategoricalSlider({categories, value: "0"})
@@ -1776,11 +1776,16 @@ describe("Bug", () => {
 
       const el = view.shadow_el.querySelector(".noUi-handle")
       expect_not_null(el)
+      expect(slider.value).to.be.equal("0")
 
-      // The expectation is that no errors accumulate during sliding.
-      for (const _ of categories) {
+      // The expectation is that no errors accumulate during sliding
+      for (let c of categories.slice(1)) {
         el.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowRight"}))
         await view.ready
+        // After an event the tooltip and the slider value should be updated.
+        // The displayed string shouldn't be "undefiend".
+        expect(el.ariaValueText).to.be.equal(c)
+        expect(slider.value).to.be.equal(c)
       }
     })
   })

--- a/docs/bokeh/source/docs/releases/3.9.0.rst
+++ b/docs/bokeh/source/docs/releases/3.9.0.rst
@@ -11,3 +11,4 @@ Bokeh version ``3.9.0`` (November 2025) is a minor milestone of Bokeh project.
 * Added ``text_outline_width`` to ``Text`` to support user defined width of outline borders (:bokeh-pull:`14733`, :bokeh-pull:`14746`)
 * Removed ``pandas`` as a required dependency (:bokeh-pull:`14686`)
 * Fixed issue where ``Block`` glyph did not render correctly with reversed axes (:bokeh-pull:`14750`)
+* Fixed issue where ``CategoricalSlider`` displayed "undefined" in the tooltip (:bokeh-pull:`14774`)


### PR DESCRIPTION
- [x] issues: fixes #14645
- [x] tests adapted/ passed




https://github.com/user-attachments/assets/833b6d6d-69c2-44d1-8526-a1f1a5802099

Code of the example to reproduce.

```python
from bokeh.plotting import show, output_notebook
from bokeh.models import CategoricalSlider
output_notebook()


categories = list(map(str, range(1, 11)))
slider = CategoricalSlider(value="1", categories=categories)

show(slider)
```
