### PR TITLE
handle missing npm in "bokeh info"

### DIFF
--- a/src/bokeh/util/compiler.py
+++ b/src/bokeh/util/compiler.py
@@ -448,7 +448,7 @@ def _run_npmjs(argv: list[str], input: dict[str, Any] | None = None) -> str:
 def _version(run_app: Callable[[list[str], dict[str, Any] | None], str]) -> str | None:
     try:
         version = run_app(["--version"], None)  # explicit None to make mypy happy
-    except RuntimeError:
+    except (RuntimeError, FileNotFoundError):
         return None
     else:
         return version.strip()

--- a/tests/unit/bokeh/util/test_compiler.py
+++ b/tests/unit/bokeh/util/test_compiler.py
@@ -175,6 +175,24 @@ def test_inline_extension() -> None:
     p.xaxis.formatter = TestFormatter()
     save(p)
 
+@patch("bokeh.util.compiler._run")
+def test_npmjs_version(mock_run) -> None:
+    mock_run.side_effect = [FileNotFoundError, "11.6.3\n"]
+    # assume npm is not installed, no file can be found and None is returned
+    assert buc.npmjs_version() is None
+    # assume npm is installed, a version is returned and stripped
+    assert buc.npmjs_version() == "11.6.3"
+
+@patch("bokeh.util.compiler._run")
+@patch("bokeh.util.compiler._nodejs_path")
+def test_nodejs_version(mock_path, mock_run) -> None:
+    mock_path.side_effect = [RuntimeError, "node"]
+    mock_run.return_value = "v20.19.5\n"
+    # assume node is not installed, then `_detect_nodejs()` raises a RuntimeError
+    assert buc.nodejs_version() is None
+    # assume node is installed, a version is returned and stripped
+    assert buc.nodejs_version() == "v20.19.5"
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/util/test_compiler.py
+++ b/tests/unit/bokeh/util/test_compiler.py
@@ -176,7 +176,7 @@ def test_inline_extension() -> None:
     save(p)
 
 @patch("bokeh.util.compiler._run")
-def test_npmjs_version(mock_run) -> None:
+def test_npmjs_version(mock_run: MagicMock) -> None:
     mock_run.side_effect = [FileNotFoundError, "11.6.3\n"]
     # assume npm is not installed, no file can be found and None is returned
     assert buc.npmjs_version() is None
@@ -185,7 +185,7 @@ def test_npmjs_version(mock_run) -> None:
 
 @patch("bokeh.util.compiler._run")
 @patch("bokeh.util.compiler._nodejs_path")
-def test_nodejs_version(mock_path, mock_run) -> None:
+def test_nodejs_version(mock_path: MagicMock, mock_run: MagicMock) -> None:
     mock_path.side_effect = [RuntimeError, "node"]
     mock_run.return_value = "v20.19.5\n"
     # assume node is not installed, then `_detect_nodejs()` raises a RuntimeError


### PR DESCRIPTION
It is sufficient to check for a `FileNotFoundError`, because this is what `Popen([package, "--version"], stdout=PIPE, stderr=PIPE, stdin=PIPE)` raises if a package is not installed.

- [x] issues: fixes #14404
- [x] tests added / passed