### PR TITLE
avoid iterating over typed array within _value_record_references

### DIFF
--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -12,7 +12,7 @@ import type {Property} from "./properties"
 import {assert} from "./util/assert"
 import {unique_id} from "./util/string"
 import {keys, values, entries, extend, is_empty, dict} from "./util/object"
-import {isObject, isIterable, isPlainObject, isArray, isFunction, isPrimitive, isTypedArray} from "./util/types"
+import {isObject, isIterable, isPlainObject, isArray, isFunction, isPrimitive} from "./util/types"
 import type {Serializable, Serializer, ObjectRefRep, AnyVal} from "./serialization"
 import {serialize} from "./serialization"
 import type {Document} from "../document/document"
@@ -599,10 +599,6 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
         }
       }
     } else if (isIterable(value)) {
-      if (isTypedArray(value)) {
-        return
-      }
-
       for (const elem of value) {
         HasProps._value_record_references(elem, refs, {recursive})
       }

--- a/bokehjs/src/lib/core/has_props.ts
+++ b/bokehjs/src/lib/core/has_props.ts
@@ -12,7 +12,7 @@ import type {Property} from "./properties"
 import {assert} from "./util/assert"
 import {unique_id} from "./util/string"
 import {keys, values, entries, extend, is_empty, dict} from "./util/object"
-import {isObject, isIterable, isPlainObject, isArray, isFunction, isPrimitive} from "./util/types"
+import {isObject, isIterable, isPlainObject, isArray, isFunction, isPrimitive, isTypedArray} from "./util/types"
 import type {Serializable, Serializer, ObjectRefRep, AnyVal} from "./serialization"
 import {serialize} from "./serialization"
 import type {Document} from "../document/document"
@@ -599,6 +599,10 @@ export abstract class HasProps extends Signalable() implements Equatable, Printa
         }
       }
     } else if (isIterable(value)) {
+      if (isTypedArray(value)) {
+        return
+      }
+
       for (const elem of value) {
         HasProps._value_record_references(elem, refs, {recursive})
       }

--- a/bokehjs/src/lib/core/util/refs.ts
+++ b/bokehjs/src/lib/core/util/refs.ts
@@ -1,5 +1,5 @@
 import type {Attrs} from "../types"
-import {isPlainObject, isObject} from "./types"
+import {isPlainObject, isObject, isTypedArray} from "./types"
 
 export type Struct = {
   id: string
@@ -36,6 +36,9 @@ export function may_have_refs(obj: object): boolean {
   const type = obj.constructor
   if (is_HasRefs(type)) {
     return type[has_refs]
+  }
+  if (isTypedArray(obj)) {
+    return false
   }
   return true
 }

--- a/bokehjs/test/unit/core/util/refs.ts
+++ b/bokehjs/test/unit/core/util/refs.ts
@@ -8,4 +8,9 @@ describe("refs module", () => {
     expect(refs.is_ref({id: 10})).to.be.true
     expect(refs.is_ref({id: 10, type: "some"})).to.be.false
   })
+
+  it("should may_have_refs()", () => {
+    expect(refs.may_have_refs(new Uint8Array(3))).to.be.false
+    expect(refs.may_have_refs(new Float64Array(3))).to.be.false
+  })
 })

--- a/bokehjs/test/unit/core/util/refs.ts
+++ b/bokehjs/test/unit/core/util/refs.ts
@@ -12,5 +12,7 @@ describe("refs module", () => {
   it("should may_have_refs()", () => {
     expect(refs.may_have_refs(new Uint8Array(3))).to.be.false
     expect(refs.may_have_refs(new Float64Array(3))).to.be.false
+    expect(refs.may_have_refs(new Float64Array(0))).to.be.false
+    expect(refs.may_have_refs([])).to.be.true
   })
 })


### PR DESCRIPTION
- [x] issues: fixes #14802
- [x] tests added / passed

Speed up >100x (in Firefox the function no longer shows up in the profiler)

Performance before:
<img width="466" height="371" alt="performance_before" src="https://github.com/user-attachments/assets/7879a33e-2ec4-4513-9298-a1277db124c4" />


Performance after:

<img width="478" height="206" alt="performance_after" src="https://github.com/user-attachments/assets/4b0821d0-94f2-4f90-bfac-54d30ff07381" />

