### PR TITLE
Use `UInt8Array.{to,from}Base64()` if available

### DIFF
--- a/bokehjs/src/lib/core/util/buffer.ts
+++ b/bokehjs/src/lib/core/util/buffer.ts
@@ -2,20 +2,32 @@ import type {NDDataType} from "../types"
 
 import {gunzipSync, gzipSync} from "fflate"
 
-export function b64encode(data: Uint8Array): string {
-  const chars = Array.from(data).map((b) => String.fromCharCode(b))
-  return btoa(chars.join(""))
-}
-
-export function b64decode(data: string): Uint8Array<ArrayBuffer> {
-  const binary_string = atob(data)
-  const len = binary_string.length
-  const bytes = new Uint8Array(len)
-  for (let i = 0, end = len; i < end; i++) {
-    bytes[i] = binary_string.charCodeAt(i)
+export const b64encode: (data: Uint8Array) => string = (() => {
+  if (typeof Uint8Array.prototype.toBase64 !== "undefined") {
+    return (data) => data.toBase64()
+  } else {
+    return (data) => {
+      const chars = Array.from(data).map((b) => String.fromCharCode(b))
+      return btoa(chars.join(""))
+    }
   }
-  return bytes
-}
+})()
+
+export const b64decode: (data: string) => Uint8Array<ArrayBuffer> = (() => {
+  if (typeof Uint8Array.fromBase64 !== "undefined") {
+    return (data) => Uint8Array.fromBase64(data)
+  } else {
+    return (data) => {
+      const binary_string = atob(data)
+      const len = binary_string.length
+      const bytes = new Uint8Array(len)
+      for (let i = 0, end = len; i < end; i++) {
+        bytes[i] = binary_string.charCodeAt(i)
+      }
+      return bytes
+    }
+  }
+})()
 
 export function buffer_to_base64(buffer: ArrayBufferLike): string {
   const bytes = new Uint8Array(buffer)

--- a/bokehjs/src/lib/es.d.ts
+++ b/bokehjs/src/lib/es.d.ts
@@ -39,3 +39,37 @@ interface Float64Array {
 interface Element {
   webkitRequestFullscreen(options?: FullscreenOptions): Promise<void>
 }
+
+// from lib.esnext.d.ts (needs TS 6/7)
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
+  /**
+   * Converts the `Uint8Array` to a base64-encoded string.
+   * @param options If provided, sets the alphabet and padding behavior used.
+   * @returns A base64-encoded string.
+   */
+  toBase64(
+    options?: {
+      alphabet?: "base64" | "base64url" | undefined
+      omitPadding?: boolean | undefined
+    },
+  ): string
+}
+
+// from lib.esnext.d.ts (needs TS 6/7)
+interface Uint8ArrayConstructor {
+  /**
+   * Creates a new `Uint8Array` from a base64-encoded string.
+   * @param string The base64-encoded string.
+   * @param options If provided, specifies the alphabet and handling of the last chunk.
+   * @returns A new `Uint8Array` instance.
+   * @throws {SyntaxError} If the input string contains characters outside the specified alphabet, or if the last
+   * chunk is inconsistent with the `lastChunkHandling` option.
+   */
+  fromBase64(
+    string: string,
+    options?: {
+      alphabet?: "base64" | "base64url" | undefined
+      lastChunkHandling?: "loose" | "strict" | "stop-before-partial" | undefined
+    },
+  ): Uint8Array<ArrayBuffer>
+}

--- a/bokehjs/src/server/tsconfig.json
+++ b/bokehjs/src/server/tsconfig.json
@@ -7,6 +7,6 @@
     }
   },
   "extends": "../../tsconfig.base",
-  "include": ["./**/*.ts"],
+  "include": ["./**/*.ts", "../lib/es.d.ts"],
   "exclude": ["./_build"]
 }


### PR DESCRIPTION
May improve performance for large binary buffers.

fixes #14810 