### PR TITLE
Perform inplace byte swap for big endian conversion

### DIFF
--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -700,9 +700,9 @@ export class ColorSpec extends DataSpec<types.Color | null> {
   override v_materialize(colors: Arrayable<types.Color | null> | NDArray): ColorArray {
     if (is_NDArray(colors)) {
       if (colors.dtype == "uint32" && colors.dimension == 1) {
-        const c_array = colors.slice()
-        to_big_endian(c_array)
-        return c_array
+        const colors_copy = colors.slice()
+        to_big_endian(colors_copy)
+        return colors_copy
       } else if (colors.dtype == "uint8" && colors.dimension == 1) {
         const [n] = colors.shape
         const array = new RGBAArray(4*n)

--- a/bokehjs/src/lib/core/properties.ts
+++ b/bokehjs/src/lib/core/properties.ts
@@ -700,7 +700,9 @@ export class ColorSpec extends DataSpec<types.Color | null> {
   override v_materialize(colors: Arrayable<types.Color | null> | NDArray): ColorArray {
     if (is_NDArray(colors)) {
       if (colors.dtype == "uint32" && colors.dimension == 1) {
-        return to_big_endian(colors)
+        const c_array = colors.slice()
+        to_big_endian(c_array)
+        return c_array
       } else if (colors.dtype == "uint8" && colors.dimension == 1) {
         const [n] = colors.shape
         const array = new RGBAArray(4*n)

--- a/bokehjs/src/lib/core/util/platform.ts
+++ b/bokehjs/src/lib/core/util/platform.ts
@@ -21,14 +21,17 @@ export const BYTE_ORDER: ByteOrder = is_little_endian ? "little" : "big"
 
 export function to_big_endian(values: Uint32Array): Uint32Array {
   if (is_little_endian) {
-    const result = new Uint32Array(values.length)
-    const view = new DataView(result.buffer)
-    let j = 0
-    for (const color of values) {
-      view.setUint32(j, color)
-      j += 4
+    const bytes = new Uint8Array(values.buffer)
+    const n_bytes = bytes.length
+    for (let i = 0; i < n_bytes; i+=4) {
+      let temp_byte = bytes[i]
+      bytes[i] = bytes[i+3]
+      bytes[i+3] = temp_byte
+      temp_byte = bytes[i+1]
+      bytes[i+1] = bytes[i+2]
+      bytes[i+2] = temp_byte
     }
-    return result
+    return new Uint32Array(bytes.buffer)
   } else {
     return values
   }

--- a/bokehjs/src/lib/core/util/platform.ts
+++ b/bokehjs/src/lib/core/util/platform.ts
@@ -19,7 +19,7 @@ export const is_little_endian = (() => {
 
 export const BYTE_ORDER: ByteOrder = is_little_endian ? "little" : "big"
 
-export function to_big_endian(values: Uint32Array): Uint32Array {
+export function to_big_endian(values: Uint32Array): void {
   if (is_little_endian) {
     const bytes = new Uint8Array(values.buffer)
     const n_bytes = bytes.length
@@ -31,8 +31,5 @@ export function to_big_endian(values: Uint32Array): Uint32Array {
       bytes[i+1] = bytes[i+2]
       bytes[i+2] = temp_byte
     }
-    return new Uint32Array(bytes.buffer)
-  } else {
-    return values
   }
 }

--- a/bokehjs/src/lib/models/mappers/color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/color_mapper.ts
@@ -72,7 +72,8 @@ export abstract class ColorMapper extends Mapper<Color> {
         const length_divisor = is_NDArray(xs) && xs.dimension == 3 ? xs.shape[2] : 1
         const values = new ColorArray(xs.length / length_divisor)
         self._v_compute(xs, values, palette, colors)
-        return new Uint8ClampedArray(to_big_endian(values).buffer)
+        to_big_endian(values)
+        return new Uint8ClampedArray(values.buffer)
       },
     }
   }


### PR DESCRIPTION
- [x] issues: fixes #14824
- [x] tests added / passed

Performance gain is roughly 2x on function level. However as this operation is usually not the bottleneck the overall contribution is still minor. 
Edit: for Chrome it seems to be more like in the 5x range.
