### PR TITLE
Enhance scan performance of linear color mapper

### DIFF
--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -21,7 +21,7 @@ export function minmax(array: Arrayable<number>): [number, number] {
 }
 
 export function min(array: Arrayable<number>): number {
-  const [min,] = minmax(array)
+  const [min] = minmax(array)
   return min
 }
 
@@ -29,6 +29,7 @@ export function max(array: Arrayable<number>): number {
   const [, max] = minmax(array)
   return max
 }
+
 export function is_empty(array: Arrayable): boolean {
   return array.length == 0
 }

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -7,7 +7,7 @@ const {floor} = Math
 export function minmax(array: Arrayable<number>): [number, number] {
   let min = +Infinity
   let max = -Infinity
-  const length = array.length
+  const {length} = array
   for (let i = 0; i < length; i++) {
     const value = array[i]
     if (value < min) {

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -8,7 +8,7 @@ export function minmax(array: Arrayable<number>): [number, number] {
   let min = +Infinity
   let max = -Infinity
   const length = array.length
-  for (let i=0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     const value = array[i]
     if (value < min) {
       min = value

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -21,29 +21,14 @@ export function minmax(array: Arrayable<number>): [number, number] {
 }
 
 export function min(array: Arrayable<number>): number {
-  let min = Infinity
-  const length = array.length
-  for (let i=0; i < length; i++) {
-    const value = array[i]
-    if (value < min) {
-      min = value
-    }
-  }
+  const [min,] = minmax(array)
   return min
 }
 
 export function max(array: Arrayable<number>): number {
-  let max = -Infinity
-  const length = array.length
-  for (let i=0; i < length; i++) {
-    const value = array[i]
-    if (value > max) {
-      max = value
-    }
-  }
+  const [, max] = minmax(array)
   return max
 }
-
 export function is_empty(array: Arrayable): boolean {
   return array.length == 0
 }

--- a/bokehjs/src/lib/core/util/arrayable.ts
+++ b/bokehjs/src/lib/core/util/arrayable.ts
@@ -1,9 +1,48 @@
 import type {Arrayable, ArrayableNew, FloatArray, TypedArray} from "../types"
 import {clamp} from "./math"
 import {assert, assert_debug} from "./assert"
-export {min, max, minmax} from "./iterator"
 
 const {floor} = Math
+
+export function minmax(array: Arrayable<number>): [number, number] {
+  let min = +Infinity
+  let max = -Infinity
+  const length = array.length
+  for (let i=0; i < length; i++) {
+    const value = array[i]
+    if (value < min) {
+      min = value
+    }
+    if (value > max) {
+      max = value
+    }
+  }
+  return [min, max]
+}
+
+export function min(array: Arrayable<number>): number {
+  let min = Infinity
+  const length = array.length
+  for (let i=0; i < length; i++) {
+    const value = array[i]
+    if (value < min) {
+      min = value
+    }
+  }
+  return min
+}
+
+export function max(array: Arrayable<number>): number {
+  let max = -Infinity
+  const length = array.length
+  for (let i=0; i < length; i++) {
+    const value = array[i]
+    if (value > max) {
+      max = value
+    }
+  }
+  return max
+}
 
 export function is_empty(array: Arrayable): boolean {
   return array.length == 0

--- a/bokehjs/src/lib/core/util/iterator.ts
+++ b/bokehjs/src/lib/core/util/iterator.ts
@@ -197,44 +197,28 @@ export function* subsets<T>(seq: T[]): Iterable<T[]> {
   }
 }
 
-export function min(iterable: Iterable<number>): number {
-  let result = Infinity
-
-  for (const value of iterable) {
-    if (!isNaN(value) && value < result) {
-      result = value
-    }
-  }
-
-  return result
-}
-
-export function max(iterable: Iterable<number>): number {
-  let result = -Infinity
-
-  for (const value of iterable) {
-    if (!isNaN(value) && value > result) {
-      result = value
-    }
-  }
-
-  return result
-}
-
 export function minmax(iterable: Iterable<number>): [number, number] {
   let min = +Infinity
   let max = -Infinity
 
   for (const value of iterable) {
-    if (!isNaN(value)) {
-      if (value < min) {
-        min = value
-      }
-      if (value > max) {
-        max = value
-      }
+    if (value < min) {
+      min = value
+    }
+    if (value > max) {
+      max = value
     }
   }
 
   return [min, max]
+}
+
+export function min(iterable: Iterable<number>): number {
+  const [min] = minmax(iterable)
+  return min
+}
+
+export function max(iterable: Iterable<number>): number {
+  const [, max] = minmax(iterable)
+  return max
 }

--- a/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
@@ -1,6 +1,6 @@
 import {ContinuousColorMapper} from "./continuous_color_mapper"
 import type {Arrayable} from "core/types"
-import {min, max} from "core/util/arrayable"
+import {min, max, minmax} from "core/util/arrayable"
 import {clamp} from "core/util/math"
 import type * as p from "core/properties"
 
@@ -27,8 +27,22 @@ export class LinearColorMapper extends ContinuousColorMapper {
   }
 
   protected scan(data: Arrayable<number>, n: number): LinearScanData {
-    const low = this.low != null ? this.low : min(data)
-    const high = this.high != null ? this.high : max(data)
+    /*
+    const [low, high] = (() => {
+      if (this.low == null && this.high == null) {
+        return minmax(data)
+      } else if (this.low == null) {
+        return [min(data), this.high!]
+      } else if (this.high == null) {
+        return [this.low, max(data)]
+      } else {
+        return [this.low, this.high]
+      }
+    })()
+    */
+
+    const [low, high] = (this.low == null && this.high == null)
+      ? minmax(data) : [this.low ?? min(data), this.high ?? max(data)]
 
     const norm_factor = 1 / (high - low)
     const normed_interval = 1 / n

--- a/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
@@ -41,8 +41,13 @@ export class LinearColorMapper extends ContinuousColorMapper {
     })()
     */
 
-    const [low, high] = (this.low == null && this.high == null)
-      ? minmax(data) : [this.low ?? min(data), this.high ?? max(data)]
+    const [low, high] = (() => {
+      if (this.low == null && this.high == null) {
+        return minmax(data)
+      } else {
+        return [this.low ?? min(data), this.high ?? max(data)]
+      }
+    })()
 
     const norm_factor = 1 / (high - low)
     const normed_interval = 1 / n

--- a/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/linear_color_mapper.ts
@@ -27,20 +27,6 @@ export class LinearColorMapper extends ContinuousColorMapper {
   }
 
   protected scan(data: Arrayable<number>, n: number): LinearScanData {
-    /*
-    const [low, high] = (() => {
-      if (this.low == null && this.high == null) {
-        return minmax(data)
-      } else if (this.low == null) {
-        return [min(data), this.high!]
-      } else if (this.high == null) {
-        return [this.low, max(data)]
-      } else {
-        return [this.low, this.high]
-      }
-    })()
-    */
-
     const [low, high] = (() => {
       if (this.low == null && this.high == null) {
         return minmax(data)

--- a/bokehjs/test/unit/core/util/iterator.ts
+++ b/bokehjs/test/unit/core/util/iterator.ts
@@ -2,7 +2,7 @@ import {expect} from "assertions"
 
 import {
   range, reverse, enumerate, take, skip, tail, join, zip,
-  interleave, map, flat_map, no_repeated, every, some, combinations, subsets,
+  interleave, map, flat_map, no_repeated, every, some, combinations, subsets, min, max, minmax,
 } from "@bokehjs/core/util/iterator"
 
 import {AssertionError} from "@bokehjs/core/util/assert"
@@ -150,5 +150,32 @@ describe("core/util/iterator module", () => {
       [1, 2], [1, 3], [2, 3],
       [1, 2, 3],
     ])
+  })
+
+  it("implements min() function", () => {
+    expect(min([])).to.be.equal(Infinity)
+    expect(min([NaN])).to.be.equal(Infinity)
+    expect(min([1, 2, 3])).to.be.equal(1)
+    expect(min([3, 2, 1])).to.be.equal(1)
+    expect(min([1, 2, NaN, 3])).to.be.equal(1)
+    expect(min([3, 2, NaN, 1])).to.be.equal(1)
+  })
+
+  it("implements max() function", () => {
+    expect(max([])).to.be.equal(-Infinity)
+    expect(max([NaN])).to.be.equal(-Infinity)
+    expect(max([1, 2, 3])).to.be.equal(3)
+    expect(max([3, 2, 1])).to.be.equal(3)
+    expect(max([1, 2, NaN, 3])).to.be.equal(3)
+    expect(max([3, 2, NaN, 1])).to.be.equal(3)
+  })
+
+  it("implements minmax() function", () => {
+    expect(minmax([])).to.be.equal([Infinity, -Infinity])
+    expect(minmax([NaN])).to.be.equal([Infinity, -Infinity])
+    expect(minmax([1, 2, 3])).to.be.equal([1, 3])
+    expect(minmax([3, 2, 1])).to.be.equal([1, 3])
+    expect(minmax([1, 2, NaN, 3])).to.be.equal([1, 3])
+    expect(minmax([3, 2, NaN, 1])).to.be.equal([1, 3])
   })
 })


### PR DESCRIPTION
- [x] issues: fixes #14826
- [x] tests added / passed

Performance before:
<img width="275" height="328" alt="performance_before_scan" src="https://github.com/user-attachments/assets/43ffac24-4d2f-4180-a9d2-cc7b9bf34aff" />


Performance after:
<img width="309" height="161" alt="performance_after_scan" src="https://github.com/user-attachments/assets/b7840a82-9f2c-4086-81b7-40af74c3fc6b" />
