### PR TITLE
Add WebGPU rendering backend (circle glyph)

### DIFF
--- a/bokehjs/make/tasks/scripts.ts
+++ b/bokehjs/make/tasks/scripts.ts
@@ -62,11 +62,12 @@ task("scripts:glsl", async () => {
   const js_base = paths.build_dir.lib
   const dts_base = paths.build_dir.lib
 
-  for (const glsl_path of scan(lib_base, [".vert", ".frag"])) {
-    const sub_path = relative(lib_base, glsl_path)
+  // Process GLSL shaders (.vert, .frag) and WGSL shaders (.wgsl)
+  for (const shader_path of scan(lib_base, [".vert", ".frag", ".wgsl"])) {
+    const sub_path = relative(lib_base, shader_path)
 
     const js = `\
-const shader = \`\n${read(glsl_path)}\`;
+const shader = \`\n${read(shader_path)}\`;
 export default shader;
 `
     const dts = `\

--- a/bokehjs/package-lock.json
+++ b/bokehjs/package-lock.json
@@ -25,6 +25,7 @@
         "@types/proj4": "^2.5.5",
         "@types/semver": "^7.7.1",
         "@types/sprintf-js": "^1.1.4",
+        "@webgpu/types": "^0.1.67",
         "choices.js": "^10.2.0",
         "dompurify": "^3.3.0",
         "fflate": "^0.8.2",
@@ -1454,6 +1455,12 @@
       "version": "1.2.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.67",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.67.tgz",
+      "integrity": "sha512-uk53+2ECGUkWoDFez/hymwpRfdgdIn6y1ref70fEecGMe5607f4sozNFgBk0oxlr7j2CRGWBEc3IBYMmFdGGTQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",

--- a/bokehjs/package.json
+++ b/bokehjs/package.json
@@ -49,6 +49,7 @@
     "@types/proj4": "^2.5.5",
     "@types/semver": "^7.7.1",
     "@types/sprintf-js": "^1.1.4",
+    "@webgpu/types": "^0.1.67",
     "choices.js": "^10.2.0",
     "dompurify": "^3.3.0",
     "fflate": "^0.8.2",

--- a/bokehjs/src/lib/bokeh.ts
+++ b/bokehjs/src/lib/bokeh.ts
@@ -1,5 +1,6 @@
 export * from "main"
 export * from "models/glyphs/webgl/main"
+export * from "models/glyphs/webgpu/main"
 export * from "api/main"
 export * from "models/widgets/main"
 export * from "models/widgets/tables/main"

--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -136,7 +136,7 @@ export type Orientation = typeof Orientation["__type__"]
 export const OutlineShapeName = Enum("none", "box", "rectangle", "square", "circle", "ellipse", "trapezoid", "parallelogram", "diamond", "triangle")
 export type OutlineShapeName = typeof OutlineShapeName["__type__"]
 
-export const OutputBackend = Enum("canvas", "svg", "webgl")
+export const OutputBackend = Enum("canvas", "svg", "webgl", "webgpu")
 export type OutputBackend = typeof OutputBackend["__type__"]
 
 export const PaddingUnits = Enum("percent", "absolute")

--- a/bokehjs/src/lib/core/util/canvas.ts
+++ b/bokehjs/src/lib/core/util/canvas.ts
@@ -50,6 +50,7 @@ export class CanvasLayer {
 
   constructor(readonly backend: OutputBackend, readonly hidpi: boolean) {
     switch (backend) {
+      case "webgpu":
       case "webgl":
       case "canvas": {
         this._el = this._canvas = canvas({class: "bk-layer"})
@@ -84,7 +85,7 @@ export class CanvasLayer {
   }
 
   get pixel_ratio_changed(): boolean {
-    if (this.hidpi && (this.backend == "canvas" || this.backend == "webgl")) {
+    if (this.hidpi && (this.backend == "canvas" || this.backend == "webgl" || this.backend == "webgpu")) {
       return this.pixel_ratio != devicePixelRatio
     } else {
       return false

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -11,6 +11,7 @@ import type {BBox} from "core/util/bbox"
 import {UIElement, UIElementView} from "../ui/ui_element"
 import type {PlotView} from "../plots/plot"
 import type {ReglWrapper} from "../glyphs/webgl/regl_wrap"
+import type {WebGPUWrapper} from "../glyphs/webgpu/webgpu_wrapper"
 import type {StyleSheetLike} from "core/dom"
 import {InlineStyleSheet} from "core/dom"
 import * as canvas_css from "styles/canvas.css"
@@ -30,6 +31,14 @@ import icons_css from "styles/icons.css"
 export type WebGLState = {
   readonly canvas: HTMLCanvasElement
   readonly regl_wrapper: ReglWrapper
+}
+
+export type WebGPUState = {
+  readonly canvas: HTMLCanvasElement
+  readonly device: GPUDevice
+  readonly context: GPUCanvasContext
+  readonly format: GPUTextureFormat
+  readonly wrapper: WebGPUWrapper
 }
 
 async function init_webgl(): Promise<WebGLState | null> {
@@ -72,10 +81,72 @@ const global_webgl: () => Promise<WebGLState | null> = (() => {
   }
 })()
 
+async function init_webgpu(): Promise<WebGPUState | null> {
+  // Check if WebGPU is available
+  if (typeof navigator === "undefined" || !("gpu" in navigator)) {
+    logger.trace("WebGPU is not supported in this browser")
+    return null
+  }
+
+  try {
+    const adapter = await navigator.gpu.requestAdapter()
+    if (adapter == null) {
+      logger.trace("WebGPU adapter not available")
+      return null
+    }
+
+    const device = await adapter.requestDevice()
+
+    const canvas = document.createElement("canvas")
+    const context = canvas.getContext("webgpu")
+    if (context == null) {
+      logger.trace("WebGPU context not available")
+      return null
+    }
+
+    const format = navigator.gpu.getPreferredCanvasFormat()
+    context.configure({
+      device,
+      format,
+      alphaMode: "premultiplied",
+    })
+
+    // Dynamically load the WebGPU wrapper module (like WebGL)
+    const webgpu = await load_module(import("../glyphs/webgpu"))
+    if (webgpu != null) {
+      const wrapper = webgpu.get_webgpu(device, context, format)
+      if (wrapper.has_webgpu) {
+        logger.info("WebGPU initialized successfully")
+        return {canvas, device, context, format, wrapper}
+      } else {
+        logger.trace("WebGPU is supported, but wrapper initialization failed")
+      }
+    } else {
+      logger.trace("WebGPU is supported, but bokehjs(.min).js bundle is not available")
+    }
+  } catch (err) {
+    logger.warn(`WebGPU initialization failed: ${err}`)
+  }
+
+  return null
+}
+
+const global_webgpu: () => Promise<WebGPUState | null> = (() => {
+  let _global_webgpu: WebGPUState | null | undefined
+  return async () => {
+    if (_global_webgpu !== undefined) {
+      return _global_webgpu
+    } else {
+      return _global_webgpu = await init_webgpu()
+    }
+  }
+})()
+
 export class CanvasView extends UIElementView {
   declare model: Canvas
 
   webgl: WebGLState | null = null
+  webgpu: WebGPUState | null = null
 
   underlays_el: HTMLElement
   primary: CanvasLayer
@@ -118,6 +189,11 @@ export class CanvasView extends UIElementView {
       this.webgl = await global_webgl()
       if (settings.force_webgl && this.webgl == null) {
         throw new Error("webgl is not available")
+      }
+    } else if (this.model.output_backend == "webgpu") {
+      this.webgpu = await global_webgpu()
+      if (this.webgpu == null) {
+        logger.warn("WebGPU is not available, falling back to canvas")
       }
     }
   }
@@ -220,7 +296,6 @@ export class CanvasView extends UIElementView {
       // Blit gl canvas into the 2D canvas. To do 1-on-1 blitting, we need
       // to remove the hidpi transform, then blit, then restore.
       // ctx.globalCompositeOperation = "source-over"  -> OK; is the default
-      logger.debug("Blitting WebGL canvas")
       ctx.restore()
       ctx.drawImage(webgl.canvas, 0, 0)
       // Set back hidpi transform
@@ -240,6 +315,63 @@ export class CanvasView extends UIElementView {
       // Prepare GL for drawing
       const {regl_wrapper, canvas} = webgl
       regl_wrapper.clear(canvas.width, canvas.height)
+    }
+  }
+
+  prepare_webgpu(frame_box: BBox): void {
+    // Prepare WebGPU for a drawing pass
+    const {webgpu} = this
+    if (webgpu != null) {
+      // Sync canvas size
+      const {width, height} = this.bbox
+      const ratio = this.pixel_ratio
+      const new_width = ratio * width
+      const new_height = ratio * height
+
+      // Reconfigure context if canvas size changed
+      if (webgpu.canvas.width !== new_width || webgpu.canvas.height !== new_height) {
+        webgpu.canvas.width = new_width
+        webgpu.canvas.height = new_height
+        // Must reconfigure context after canvas resize
+        webgpu.context.configure({
+          device: webgpu.device,
+          format: webgpu.format,
+          alphaMode: "premultiplied",
+        })
+      }
+
+      const {x: sx, y: sy, width: w, height: h} = frame_box
+      const {xview} = this.bbox
+      const vx = xview.compute(sx)
+      // WebGPU scissor Y is from top (unlike WebGL which is from bottom),
+      // so use sy directly without the yview flip
+      const vy = sy
+
+      // WebGPU requires integer scissor values. Use floor for origin and ceil for size
+      // to ensure we don't accidentally clip pixels that should be visible.
+      webgpu.wrapper.set_scissor(
+        Math.floor(ratio * vx),
+        Math.floor(ratio * vy),
+        Math.ceil(ratio * w),
+        Math.ceil(ratio * h),
+      )
+      webgpu.wrapper.clear()
+    }
+  }
+
+  blit_webgpu(ctx: Context2d): void {
+    // Blit WebGPU canvas into the 2D canvas
+    const {webgpu} = this
+    if (webgpu != null && webgpu.canvas.width * webgpu.canvas.height > 0 && webgpu.wrapper.should_blit) {
+      ctx.restore()
+      ctx.drawImage(webgpu.canvas, 0, 0)
+      // Set back hidpi transform
+      ctx.save()
+      if (this.model.hidpi) {
+        const ratio = this.pixel_ratio
+        ctx.scale(ratio, ratio)
+        ctx.translate(0.5, 0.5)
+      }
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -6,6 +6,8 @@ import {minmax2} from "core/util/arrayable"
 import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
 import type {CircleGL} from "./webgl/circle"
+import type {CircleGPU} from "./webgpu/circle"
+import {LinearScale} from "../scales/linear_scale"
 
 export interface CircleView extends Circle.Data {}
 
@@ -16,9 +18,24 @@ export class CircleView extends RadialGlyphView {
   /** @internal */
   declare glglyph?: CircleGL
 
+  /** @internal */
+  declare gpuglyph?: CircleGPU
+
   override async load_glglyph() {
     const {CircleGL} = await import("./webgl/circle")
     return CircleGL
+  }
+
+  override async load_gpuglyph() {
+    const {CircleGPU} = await import("./webgpu/circle")
+    return CircleGPU
+  }
+
+  protected override _compute_can_use_webgpu(): boolean {
+    // WebGPU implementation only supports linear scales (GPU-side coordinate transform)
+    // Log scales and other non-linear scales require falling back to canvas rendering
+    const {xscale, yscale} = this.renderer
+    return xscale instanceof LinearScale && yscale instanceof LinearScale
   }
 
   protected _paint(ctx: Context2d, indices: number[], data?: Partial<Circle.Data>): void {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -31,6 +31,7 @@ import type {GlyphRendererView} from "../renderers/glyph_renderer"
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import {Decoration} from "../graphics/decoration"
 import type {BaseGLGlyph, BaseGLGlyphConstructor} from "./webgl/base"
+import type {BaseGPUGlyph, BaseGPUGlyphConstructor} from "./webgpu/base"
 
 const {abs, ceil} = Math
 
@@ -53,14 +54,26 @@ export abstract class GlyphView extends DOMComponentView {
   /** @internal */
   glglyph?: BaseGLGlyph
 
+  /** @internal */
+  gpuglyph?: BaseGPUGlyph
+
   async load_glglyph?(): Promise<typeof BaseGLGlyph>
+  async load_gpuglyph?(): Promise<typeof BaseGPUGlyph>
 
   has_webgl(): this is {glglyph: BaseGLGlyph} {
     return this.glglyph != null && this._can_use_webgl
   }
 
+  has_webgpu(): this is {gpuglyph: BaseGPUGlyph} {
+    return this.gpuglyph != null && this._can_use_webgpu
+  }
+
   private _can_use_webgl: boolean = false
+  private _can_use_webgpu: boolean = false
   protected _compute_can_use_webgl(): boolean {
+    return true
+  }
+  protected _compute_can_use_webgpu(): boolean {
     return true
   }
 
@@ -108,8 +121,11 @@ export abstract class GlyphView extends DOMComponentView {
     await super.lazy_initialize()
     await build_views(this.decorations, this.model.decorations, {parent: this.parent})
 
-    const {webgl} = this.canvas
-    if (webgl != null && this.load_glglyph != null) {
+    const {webgl, webgpu} = this.canvas
+    if (webgpu != null && this.load_gpuglyph != null) {
+      const cls = await this.load_gpuglyph() as BaseGPUGlyphConstructor
+      this.gpuglyph = new cls(webgpu.wrapper, this)
+    } else if (webgl != null && this.load_glglyph != null) {
       const cls = await this.load_glglyph() as BaseGLGlyphConstructor
       this.glglyph = new cls(webgl.regl_wrapper, this)
     }
@@ -124,7 +140,10 @@ export abstract class GlyphView extends DOMComponentView {
   }
 
   paint(ctx: Context2d, indices: number[], data?: Partial<Glyph.Data>): void {
-    if (this.has_webgl()) {
+    if (this.has_webgpu()) {
+      logger.debug(`Rendering ${indices.length} ${this.model.type} markers via WebGPU`)
+      this.gpuglyph.render(ctx, indices, this.base ?? this)
+    } else if (this.has_webgl()) {
       this.glglyph.render(ctx, indices, this.base ?? this)
     } else if (this.canvas.webgl != null && settings.force_webgl) {
       throw new Error(`${this} doesn't support webgl rendering`)
@@ -391,7 +410,9 @@ export abstract class GlyphView extends DOMComponentView {
       visual.update()
     }
 
-    if (this.has_webgl()) {
+    if (this.has_webgpu()) {
+      this.gpuglyph.set_visuals_changed()
+    } else if (this.has_webgl()) {
       this.glglyph.set_visuals_changed()
     }
   }
@@ -486,11 +507,16 @@ export abstract class GlyphView extends DOMComponentView {
       decoration.marking.set_data(source, indices)
     }
 
+    if (this.gpuglyph != null) {
+      this._can_use_webgpu = this._compute_can_use_webgpu()
+    }
     if (this.glglyph != null) {
       this._can_use_webgl = this._compute_can_use_webgl()
     }
 
-    if (this.has_webgl()) {
+    if (this.has_webgpu()) {
+      this.gpuglyph.set_data_changed()
+    } else if (this.has_webgl()) {
       this.glglyph.set_data_changed()
     }
 
@@ -559,7 +585,9 @@ export abstract class GlyphView extends DOMComponentView {
     }
 
     this._map_data()
-    if (this.has_webgl()) {
+    if (this.has_webgpu()) {
+      this.gpuglyph.set_data_mapped()
+    } else if (this.has_webgl()) {
       this.glglyph.set_data_mapped()
     }
   }

--- a/bokehjs/src/lib/models/glyphs/webgpu/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgpu/base.ts
@@ -1,0 +1,61 @@
+// Base class for WebGPU glyph implementations
+import type {Context2d} from "core/util/canvas"
+import type {GlyphView} from "../glyph"
+import type {WebGPUWrapper} from "./webgpu_wrapper"
+import type {Transform} from "./types"
+
+export type BaseGPUGlyphConstructor = {
+  new(wrapper: WebGPUWrapper, base_glyph: GlyphView): BaseGPUGlyph
+}
+
+export abstract class BaseGPUGlyph {
+  protected nvertices: number = 0
+  protected size_changed: boolean = false
+  protected data_changed: boolean = false
+  protected data_mapped: boolean = false
+  protected visuals_changed: boolean = false
+
+  constructor(protected readonly webgpu_wrapper: WebGPUWrapper, readonly glyph: GlyphView) {}
+
+  set_data_changed(): void {
+    const {data_size} = this.glyph
+    if (data_size != this.nvertices) {
+      this.nvertices = data_size
+      this.size_changed = true
+    }
+
+    this.data_changed = true
+  }
+
+  set_data_mapped(): void {
+    this.data_mapped = true
+  }
+
+  set_visuals_changed(): void {
+    this.visuals_changed = true
+  }
+
+  render(_ctx: Context2d, indices: number[], mainglyph: GlyphView): void {
+    if (indices.length == 0) {
+      return
+    }
+
+    // Get canvas dimensions from the WebGPU canvas
+    const webgpu = this.glyph.renderer.plot_view.canvas_view.webgpu
+    if (webgpu == null) {
+      return
+    }
+    const {width, height} = webgpu.canvas
+    const {pixel_ratio} = this.glyph.renderer.plot_view.canvas_view
+
+    const trans: Transform = {
+      pixel_ratio,  // Needed to scale antialiasing
+      width: width / pixel_ratio,
+      height: height / pixel_ratio,
+    }
+
+    this.draw(indices, mainglyph, trans)
+  }
+
+  abstract draw(indices: number[], mainglyph: GlyphView, trans: Transform): void
+}

--- a/bokehjs/src/lib/models/glyphs/webgpu/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/webgpu/circle.ts
@@ -1,0 +1,421 @@
+// WebGPU implementation for Circle glyph with GPU-side coordinate transforms
+import type {Transform} from "./types"
+import {BaseGPUGlyph} from "./base"
+import type {WebGPUWrapper} from "./webgpu_wrapper"
+import type {CircleView} from "../circle"
+import type {GlyphView} from "../glyph"
+import type * as visuals from "core/visuals"
+
+export type MarkerVisuals = {
+  readonly line: visuals.LineVector
+  readonly fill: visuals.FillVector
+  readonly hatch: visuals.HatchVector
+}
+
+// Missing data marker value (avoiding NaN/Inf for GPU precision)
+const MISSING_POINT = -10000
+
+// Uniform buffer layout (must match shader):
+// 0-1: canvas_size (vec2f)
+// 2: antialias (f32)
+// 3: size_hint (f32)
+// 4-7: border_radius (vec4f)
+// 8: x_scale (f32)
+// 9: x_offset (f32)
+// 10: y_scale (f32)
+// 11: y_offset (f32)
+// 12: radius_scale (f32)
+// 13-15: padding
+const UNIFORM_FLOATS = 16
+
+export class CircleGPU extends BaseGPUGlyph {
+  private readonly _antialias: number = 1.5
+
+  // GPU buffers - separate for different update frequencies
+  private _position_buffer: GPUBuffer | null = null    // DATA coords - only changes on data change
+  private _size_buffer: GPUBuffer | null = null        // DATA units - only changes on data change
+  private _geometry_buffer: GPUBuffer | null = null    // Only changes on data change
+  private _line_props_buffer: GPUBuffer | null = null  // Changes on visual/selection
+  private _line_color_buffer: GPUBuffer | null = null  // Changes on visual change
+  private _fill_color_buffer: GPUBuffer | null = null  // Changes on visual change
+  private _uniform_buffer: GPUBuffer | null = null
+  private _bind_group: GPUBindGroup | null = null
+
+  // CPU-side arrays - reused to avoid allocations
+  private _position_data: Float32Array | null = null   // 2 floats per marker (DATA coords)
+  private _size_data: Float32Array | null = null       // 2 floats per marker (DATA units)
+  private _geometry_data: Float32Array | null = null   // 2 floats per marker
+  private _line_props_data: Float32Array | null = null // 4 floats per marker
+  private _line_color_data: Float32Array | null = null // 4 floats per marker
+  private _fill_color_data: Float32Array | null = null // 4 floats per marker
+  private _uniform_data: Float32Array = new Float32Array(UNIFORM_FLOATS)
+
+  // Track what needs updating (for CPU-side array rebuild)
+  private _data_dirty: boolean = true  // True when actual data changes
+  private _visuals_dirty: boolean = true
+  private _last_nmarkers: number = 0
+
+  // Track what needs uploading to GPU
+  private _positions_upload_needed: boolean = true
+  private _sizes_upload_needed: boolean = true
+  private _geometry_upload_needed: boolean = true
+  private _line_color_upload_needed: boolean = true
+  private _fill_color_upload_needed: boolean = true
+
+  constructor(wrapper: WebGPUWrapper, override readonly glyph: CircleView) {
+    super(wrapper, glyph)
+  }
+
+  draw(indices: number[], main_glyph: GlyphView, transform: Transform): void {
+    const main_circle = main_glyph as CircleView
+    const main_gpu = main_circle.gpuglyph
+
+    if (main_gpu == null) {
+      return
+    }
+
+    // Only mark data dirty when actual DATA changes, not on pan/zoom
+    // data_changed = true when source data changes
+    // data_mapped = true on pan/zoom (but we handle this via uniforms now)
+    if (main_gpu.data_changed) {
+      main_gpu._data_dirty = true
+      main_gpu.data_changed = false
+    }
+
+    // We still need to clear data_mapped flag, but we don't rebuild buffers
+    if (main_gpu.data_mapped) {
+      main_gpu.data_mapped = false
+      // Transform changes are handled via uniforms - no buffer rebuild needed!
+    }
+
+    // Mark THIS glyph's visuals dirty (not main_gpu's)
+    // Each glyph (main, selection, nonselection) has its own visuals
+    if (this.visuals_changed) {
+      this._visuals_dirty = true
+      this.visuals_changed = false
+    }
+
+    this._draw_markers(indices, transform, main_gpu)
+  }
+
+  private _draw_markers(indices: number[], transform: Transform, main_gpu: CircleGPU): void {
+    const {webgpu_wrapper} = this
+    const device = webgpu_wrapper.device
+
+    const nmarkers = main_gpu.nvertices
+    if (nmarkers === 0) {
+      return
+    }
+
+    // Ensure we have the data we need before proceeding
+    if (main_gpu._position_data == null && !main_gpu._data_dirty) {
+      // Force data update if we don't have position data yet
+      main_gpu._data_dirty = true
+    }
+
+    const size_changed = main_gpu._last_nmarkers !== nmarkers
+    main_gpu._last_nmarkers = nmarkers
+
+    // Track if THIS glyph's marker count changed (for buffer allocation)
+    const this_size_changed = this._last_nmarkers !== nmarkers
+    this._last_nmarkers = nmarkers
+
+    // Update GEOMETRY buffers from main_gpu (shared data)
+    if (main_gpu._data_dirty || size_changed) {
+      main_gpu._update_data_coords(nmarkers)
+      main_gpu._data_dirty = false
+      main_gpu._positions_upload_needed = true
+      main_gpu._sizes_upload_needed = true
+      main_gpu._geometry_upload_needed = true
+    }
+
+    // Update VISUAL buffers from THIS glyph (each glyph has its own visuals)
+    // This is critical for selection - nonselection_glyph has faded alpha
+    if (this._visuals_dirty || this_size_changed) {
+      this._update_visuals(nmarkers)
+      this._visuals_dirty = false
+      this._line_color_upload_needed = true
+      this._fill_color_upload_needed = true
+    }
+
+    // Update show flags based on indices (for selection support)
+    // This needs to happen on every draw call since indices can change
+    this._update_show_flags(indices, nmarkers)
+
+    // Upload GEOMETRY buffers from main_gpu (shared)
+    if (main_gpu._positions_upload_needed) {
+      this._upload_buffer(device, main_gpu._position_data!, main_gpu, "_position_buffer")
+      main_gpu._positions_upload_needed = false
+    }
+    if (main_gpu._sizes_upload_needed) {
+      this._upload_buffer(device, main_gpu._size_data!, main_gpu, "_size_buffer")
+      main_gpu._sizes_upload_needed = false
+    }
+    if (main_gpu._geometry_upload_needed) {
+      this._upload_buffer(device, main_gpu._geometry_data!, main_gpu, "_geometry_buffer")
+      main_gpu._geometry_upload_needed = false
+    }
+
+    // Upload VISUAL buffers from THIS glyph (each has its own visuals)
+    // line_props always needs upload since show flags change every draw
+    this._upload_buffer(device, this._line_props_data!, this, "_line_props_buffer")
+    if (this._line_color_upload_needed) {
+      this._upload_buffer(device, this._line_color_data!, this, "_line_color_buffer")
+      this._line_color_upload_needed = false
+    }
+    if (this._fill_color_upload_needed) {
+      this._upload_buffer(device, this._fill_color_data!, this, "_fill_color_buffer")
+      this._fill_color_upload_needed = false
+    }
+
+    // Update uniform buffer with canvas size and coordinate transform
+    // This is the ONLY thing that changes on pan/zoom!
+    this._update_uniforms(transform)
+
+    if (this._uniform_buffer == null) {
+      this._uniform_buffer = device.createBuffer({
+        size: UNIFORM_FLOATS * 4,  // 16 floats * 4 bytes
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+      })
+      this._bind_group = webgpu_wrapper.create_marker_bind_group(this._uniform_buffer)
+    }
+    device.queue.writeBuffer(this._uniform_buffer, 0, this._uniform_data.buffer, this._uniform_data.byteOffset, this._uniform_data.byteLength)
+
+    // Get render pipeline (cached in wrapper)
+    const pipeline = webgpu_wrapper.get_marker_pipeline("circle", false)
+
+    // Get current texture to render to
+    const texture_view = webgpu_wrapper.context.getCurrentTexture().createView()
+
+    // Create command encoder and render pass
+    const command_encoder = device.createCommandEncoder()
+    const loadOp = webgpu_wrapper.get_load_op()
+
+    const render_pass = command_encoder.beginRenderPass({
+      colorAttachments: [{
+        view: texture_view,
+        clearValue: {r: 0, g: 0, b: 0, a: 0},
+        loadOp,
+        storeOp: "store",
+      }],
+    })
+
+    render_pass.setPipeline(pipeline)
+    render_pass.setBindGroup(0, this._bind_group)
+    render_pass.setVertexBuffer(0, webgpu_wrapper.rect_geometry)
+    // Geometry buffers from main_gpu (shared data)
+    render_pass.setVertexBuffer(1, main_gpu._position_buffer)
+    render_pass.setVertexBuffer(2, main_gpu._size_buffer)
+    render_pass.setVertexBuffer(3, main_gpu._geometry_buffer)
+    // Visual buffers from THIS glyph (selection/nonselection have different visuals)
+    render_pass.setVertexBuffer(4, this._line_props_buffer)
+    render_pass.setVertexBuffer(5, this._line_color_buffer)
+    render_pass.setVertexBuffer(6, this._fill_color_buffer)
+
+    // Apply scissor rect to clip rendering to the plot frame
+    const scissor = webgpu_wrapper.scissor
+    render_pass.setScissorRect(scissor.x, scissor.y, scissor.width, scissor.height)
+
+    render_pass.draw(4, nmarkers, 0, 0)
+    render_pass.end()
+
+    device.queue.submit([command_encoder.finish()])
+
+    // Mark that we've rendered something this frame
+    webgpu_wrapper.mark_rendered()
+  }
+
+  private _update_uniforms(transform: Transform): void {
+    // Get the coordinate transform from the renderer
+    const renderer = this.glyph.renderer
+    const frame = renderer.plot_view.frame
+
+    // Get scales for x and y
+    const x_scale = frame.x_scales.get(renderer.model.x_range_name)
+    const y_scale = frame.y_scales.get(renderer.model.y_range_name)
+
+    if (x_scale == null || y_scale == null) {
+      return
+    }
+
+    // For linear scales: screen = data * factor + offset
+    // We need to extract factor and offset from the scale
+    const x_source = x_scale.source_range
+    const x_target = x_scale.target_range
+    const y_source = y_scale.source_range
+    const y_target = y_scale.target_range
+
+    const x_factor = (x_target.end - x_target.start) / (x_source.end - x_source.start)
+    const x_offset = -(x_factor * x_source.start) + x_target.start
+
+    const y_factor = (y_target.end - y_target.start) / (y_source.end - y_source.start)
+    const y_offset = -(y_factor * y_source.start) + y_target.start
+
+    // For radius, use the x scale factor (could be made configurable)
+    const radius_scale = Math.abs(x_factor)
+
+    // Fill uniform data
+    this._uniform_data[0] = transform.width
+    this._uniform_data[1] = transform.height
+    this._uniform_data[2] = this._antialias / transform.pixel_ratio
+    this._uniform_data[3] = 1.0 // size_hint for circle
+    // border_radius (unused for circle)
+    this._uniform_data[4] = 0
+    this._uniform_data[5] = 0
+    this._uniform_data[6] = 0
+    this._uniform_data[7] = 0
+    // Transform parameters
+    this._uniform_data[8] = x_factor
+    this._uniform_data[9] = x_offset
+    this._uniform_data[10] = y_factor
+    this._uniform_data[11] = y_offset
+    this._uniform_data[12] = radius_scale
+    // Padding
+    this._uniform_data[13] = 0
+    this._uniform_data[14] = 0
+    this._uniform_data[15] = 0
+  }
+
+  private _upload_buffer(
+    device: GPUDevice,
+    data: Float32Array,
+    target: CircleGPU,
+    buffer_name: "_position_buffer" | "_size_buffer" | "_geometry_buffer" | "_line_props_buffer" | "_line_color_buffer" | "_fill_color_buffer",
+  ): void {
+    const byte_size = data.byteLength
+    const existing = target[buffer_name]
+
+    if (existing == null || existing.size < byte_size) {
+      existing?.destroy()
+      target[buffer_name] = device.createBuffer({
+        size: byte_size,
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+      })
+    }
+    device.queue.writeBuffer(target[buffer_name]!, 0, data.buffer, data.byteOffset, data.byteLength)
+  }
+
+  private _ensure_array(current: Float32Array | null, required_length: number): Float32Array {
+    if (current == null || current.length < required_length) {
+      return new Float32Array(required_length)
+    }
+    return current
+  }
+
+  // Store DATA coordinates (x, y) and DATA-unit sizes (radius)
+  // These only change when the actual data source changes, NOT on pan/zoom
+  private _update_data_coords(nmarkers: number): void {
+    this._position_data = this._ensure_array(this._position_data, nmarkers * 2)
+    this._size_data = this._ensure_array(this._size_data, nmarkers * 2)
+    this._geometry_data = this._ensure_array(this._geometry_data, nmarkers * 2)
+
+    const pos_data = this._position_data
+    const size_data = this._size_data
+    const geom_data = this._geometry_data
+
+    // Get DATA coordinates (not screen coordinates)
+    const {x, y, radius} = this.glyph
+
+    for (let i = 0; i < nmarkers; i++) {
+      // Position in DATA coordinates
+      const x_i = x[i]
+      const y_i = y[i]
+      if (!isFinite(x_i) || !isFinite(y_i)) {
+        pos_data[i * 2] = MISSING_POINT
+        pos_data[i * 2 + 1] = MISSING_POINT
+      } else {
+        pos_data[i * 2] = x_i
+        pos_data[i * 2 + 1] = y_i
+      }
+
+      // Size in DATA units (diameter = radius * 2)
+      const r = radius.get(i)
+      const diameter = r * 2
+      size_data[i * 2] = diameter
+      size_data[i * 2 + 1] = diameter
+
+      // Geometry buffer: angle, aux (both 0 for circles)
+      geom_data[i * 2] = 0
+      geom_data[i * 2 + 1] = 0
+    }
+  }
+
+  private _update_visuals(nmarkers: number): void {
+    this._line_props_data = this._ensure_array(this._line_props_data, nmarkers * 4)
+    this._line_color_data = this._ensure_array(this._line_color_data, nmarkers * 4)
+    this._fill_color_data = this._ensure_array(this._fill_color_data, nmarkers * 4)
+
+    const line_props = this._line_props_data
+    const line_color = this._line_color_data
+    const fill_color = this._fill_color_data
+
+    const visuals = this.glyph.visuals
+    const line = visuals.line
+    const fill = visuals.fill
+
+    for (let i = 0; i < nmarkers; i++) {
+      const offset = i * 4
+
+      // Line props: linewidth, unused, unused, show (show set later)
+      line_props[offset] = line.line_width.get(i)
+      line_props[offset + 1] = 0  // unused (cap not needed for circles)
+      line_props[offset + 2] = 0  // unused (join not needed for circles)
+      line_props[offset + 3] = 1.0 // show flag, updated in _update_show_flags
+
+      // Line color - RGBA packed as 32-bit integer with R at bits 24-31, G at 16-23, B at 8-15, A at 0-7
+      const lc = line.line_color.get(i)
+      const lc_a = (lc & 0xff) / 255  // A from color
+      const line_alpha = line.line_alpha.get(i) * lc_a  // Combined alpha
+      line_color[offset] = ((lc >> 24) & 0xff) / 255     // R
+      line_color[offset + 1] = ((lc >> 16) & 0xff) / 255 // G
+      line_color[offset + 2] = ((lc >> 8) & 0xff) / 255  // B
+      line_color[offset + 3] = line_alpha
+
+      // Fill color - RGBA packed as 32-bit integer with R at bits 24-31, G at 16-23, B at 8-15, A at 0-7
+      const fc = fill.fill_color.get(i)
+      const fc_a = (fc & 0xff) / 255  // A from color
+      const fill_alpha = fill.fill_alpha.get(i) * fc_a  // Combined alpha
+      fill_color[offset] = ((fc >> 24) & 0xff) / 255     // R
+      fill_color[offset + 1] = ((fc >> 16) & 0xff) / 255 // G
+      fill_color[offset + 2] = ((fc >> 8) & 0xff) / 255  // B
+      fill_color[offset + 3] = fill_alpha
+    }
+  }
+
+  // Update show flags based on indices (for selection support)
+  // When indices.length < nmarkers, only show markers at specified indices
+  private _update_show_flags(indices: number[], nmarkers: number): void {
+    if (this._line_props_data == null) {
+      return
+    }
+
+    const line_props = this._line_props_data
+
+    if (indices.length < nmarkers) {
+      // Selection case: only show markers at specified indices
+      // First, hide all markers
+      for (let i = 0; i < nmarkers; i++) {
+        line_props[i * 4 + 3] = 0.0
+      }
+      // Then show only the specified indices
+      for (const idx of indices) {
+        line_props[idx * 4 + 3] = 1.0
+      }
+    } else {
+      // Show all markers
+      for (let i = 0; i < nmarkers; i++) {
+        line_props[i * 4 + 3] = 1.0
+      }
+    }
+  }
+
+  destroy(): void {
+    this._position_buffer?.destroy()
+    this._size_buffer?.destroy()
+    this._geometry_buffer?.destroy()
+    this._line_props_buffer?.destroy()
+    this._line_color_buffer?.destroy()
+    this._fill_color_buffer?.destroy()
+    this._uniform_buffer?.destroy()
+  }
+}

--- a/bokehjs/src/lib/models/glyphs/webgpu/index.ts
+++ b/bokehjs/src/lib/models/glyphs/webgpu/index.ts
@@ -1,0 +1,3 @@
+export {get_webgpu} from "./webgpu_wrapper"
+export * from "./base"
+export * from "./circle"

--- a/bokehjs/src/lib/models/glyphs/webgpu/main.ts
+++ b/bokehjs/src/lib/models/glyphs/webgpu/main.ts
@@ -1,0 +1,1 @@
+import "./index"

--- a/bokehjs/src/lib/models/glyphs/webgpu/marker.wgsl
+++ b/bokehjs/src/lib/models/glyphs/webgpu/marker.wgsl
@@ -1,0 +1,237 @@
+// Marker shader for WebGPU rendering
+// Supports circle, rect, and round_rect marker types
+
+// Marker type constants (set via pipeline specialization)
+override MARKER_CIRCLE: bool = false;
+override MARKER_RECT: bool = false;
+override MARKER_ROUND_RECT: bool = false;
+
+// Uniform buffer containing rendering parameters
+struct Uniforms {
+    canvas_size: vec2f,
+    antialias: f32,
+    size_hint: f32,
+    border_radius: vec4f,
+    // Coordinate transform: screen = data * scale + offset
+    // For x: sx = x * x_scale + x_offset
+    // For y: sy = y * y_scale + y_offset
+    x_scale: f32,
+    x_offset: f32,
+    y_scale: f32,
+    y_offset: f32,
+    // Radius transform (for data-unit radius)
+    radius_scale: f32,
+    _pad1: f32,
+    _pad2: f32,
+    _pad3: f32,
+}
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+// Vertex input from quad geometry (per-vertex)
+struct VertexInput {
+    @location(0) position: vec2f,
+}
+
+// Instance data split into separate buffers for efficient partial updates
+// Buffer 1: Position - DATA coordinates (only changes when data changes, NOT on pan/zoom)
+struct PositionInput {
+    @location(1) center: vec2f,  // x, y in data coordinates
+}
+
+// Buffer 2: Size - DATA units (only changes when data changes)
+struct SizeInput {
+    @location(2) size: vec2f,       // width, height (radius * 2 in data units)
+}
+
+// Buffer 3: Geometry (changes on data change)
+struct GeometryInput {
+    @location(3) angle_aux: vec2f,  // angle, aux
+}
+
+// Buffer 4: Line properties (changes on visual/selection change)
+struct LinePropsInput {
+    @location(4) line_props: vec4f, // linewidth, cap, join, show
+}
+
+// Buffer 5: Line color (changes on visual change)
+struct LineColorInput {
+    @location(5) line_color: vec4f,
+}
+
+// Buffer 6: Fill color (changes on visual change)
+struct FillColorInput {
+    @location(6) fill_color: vec4f,
+}
+
+// Data passed from vertex to fragment shader
+struct VertexOutput {
+    @builtin(position) position: vec4f,
+    @location(0) v_coords: vec2f,
+    @location(1) v_size: vec2f,
+    @location(2) v_linewidth: f32,
+    @location(3) v_line_color: vec4f,
+    @location(4) v_fill_color: vec4f,
+}
+
+// Calculate enclosing size for a marker including line width and antialiasing
+fn enclosing_size(size: vec2f, linewidth: f32) -> vec2f {
+    return size + linewidth + uniforms.antialias;
+}
+
+@vertex
+fn vertex_main(
+    vertex: VertexInput,
+    pos_in: PositionInput,
+    size_in: SizeInput,
+    geom_in: GeometryInput,
+    line_props_in: LinePropsInput,
+    line_color_in: LineColorInput,
+    fill_color_in: FillColorInput
+) -> VertexOutput {
+    var output: VertexOutput;
+
+    // Extract line properties
+    let linewidth_raw = line_props_in.line_props.x;
+    let show = line_props_in.line_props.w;
+
+    // Early exit for hidden markers (position off-screen)
+    if (show < 0.5 || size_in.size.x < 0.0 || size_in.size.y < 0.0) {
+        output.position = vec4f(-2.0, -2.0, 0.0, 1.0);
+        return output;
+    }
+
+    // Transform data coordinates to screen coordinates on the GPU
+    // screen = data * scale + offset
+    let screen_center = vec2f(
+        pos_in.center.x * uniforms.x_scale + uniforms.x_offset,
+        pos_in.center.y * uniforms.y_scale + uniforms.y_offset
+    );
+
+    // Transform size from data units to screen units
+    // For circle, size is diameter in data units
+    let screen_size = size_in.size * uniforms.radius_scale;
+
+    // Determine marker size based on type
+    var v_size: vec2f;
+    if (MARKER_CIRCLE) {
+        // Circle uses width for both dimensions (diameter)
+        v_size = vec2f(screen_size.x, screen_size.x);
+    } else {
+        // Rect and round_rect use width and height
+        v_size = screen_size;
+    }
+
+    // Adjust line color alpha for thin lines
+    var v_linewidth = linewidth_raw;
+    var v_line_color = line_color_in.line_color;
+    if (v_linewidth < 1.0) {
+        v_line_color.a *= v_linewidth;
+        v_linewidth = 1.0;
+    }
+
+    // Calculate vertex position in local marker space
+    let v_coords = vertex.position * enclosing_size(v_size, v_linewidth);
+
+    // Apply rotation
+    let angle = geom_in.angle_aux.x;
+    let c = cos(-angle);
+    let s = sin(-angle);
+    let rotation = mat2x2f(c, -s, s, c);
+    var pos = screen_center + rotation * v_coords;
+
+    // Convert to normalized device coordinates
+    // Add 0.5 pixel offset for crisp rendering
+    pos = pos + 0.5;
+    pos = pos / uniforms.canvas_size;
+
+    output.position = vec4f(2.0 * pos.x - 1.0, 1.0 - 2.0 * pos.y, 0.0, 1.0);
+    output.v_coords = v_coords;
+    output.v_size = v_size;
+    output.v_linewidth = v_linewidth;
+    output.v_line_color = v_line_color;
+    output.v_fill_color = fill_color_in.fill_color;
+
+    return output;
+}
+
+// Signed distance function for a circle
+fn circle_sdf(p: vec2f, radius: f32) -> f32 {
+    return length(p) - radius;
+}
+
+// Signed distance function for a rectangle
+fn rect_sdf(p: vec2f, half_size: vec2f) -> f32 {
+    let d = abs(p) - half_size;
+    return length(max(d, vec2f(0.0))) + min(max(d.x, d.y), 0.0);
+}
+
+// Signed distance function for a rounded rectangle
+fn round_rect_sdf(p: vec2f, half_size: vec2f, radius: vec4f) -> f32 {
+    // radius.x = top-right, .y = bottom-right, .z = bottom-left, .w = top-left
+    var r: vec2f;
+    if (p.x > 0.0) {
+        if (p.y > 0.0) {
+            r = vec2f(radius.x, radius.x);
+        } else {
+            r = vec2f(radius.y, radius.y);
+        }
+    } else {
+        if (p.y > 0.0) {
+            r = vec2f(radius.w, radius.w);
+        } else {
+            r = vec2f(radius.z, radius.z);
+        }
+    }
+    let q = abs(p) - half_size + r;
+    return min(max(q.x, q.y), 0.0) + length(max(q, vec2f(0.0))) - r.x;
+}
+
+// Get signed distance based on marker type
+fn marker_sdf(p: vec2f, size: vec2f) -> f32 {
+    if (MARKER_CIRCLE) {
+        return circle_sdf(p, 0.5 * size.x);
+    } else if (MARKER_ROUND_RECT) {
+        return round_rect_sdf(p, size / 2.0, uniforms.border_radius);
+    } else {
+        // Default to rect
+        return rect_sdf(p, size / 2.0);
+    }
+}
+
+// Convert distance to alpha using smoothstep for antialiasing
+fn distance_to_alpha(dist: f32) -> f32 {
+    return 1.0 - smoothstep(-0.5 * uniforms.antialias, 0.5 * uniforms.antialias, dist);
+}
+
+// Apply premultiplied alpha
+fn premultiply_alpha(color: vec4f, alpha: f32) -> vec4f {
+    let a = color.a * alpha;
+    return vec4f(color.rgb * a, a);
+}
+
+// Blend source over destination (premultiplied alpha)
+fn blend_over(src: vec4f, dst: vec4f) -> vec4f {
+    return src + (1.0 - src.a) * dst;
+}
+
+@fragment
+fn fragment_main(input: VertexOutput) -> @location(0) vec4f {
+    // Calculate signed distance from fragment to marker edge
+    let dist = marker_sdf(input.v_coords, input.v_size);
+
+    // Calculate fill contribution
+    let fill_alpha = distance_to_alpha(dist);
+    var color = premultiply_alpha(input.v_fill_color, fill_alpha);
+
+    // Calculate line/stroke contribution
+    let line_dist = abs(dist) - 0.5 * input.v_linewidth;
+    let line_alpha = distance_to_alpha(line_dist);
+
+    if (line_alpha > 0.0) {
+        let line_color = premultiply_alpha(input.v_line_color, line_alpha);
+        color = blend_over(line_color, color);
+    }
+
+    return color;
+}

--- a/bokehjs/src/lib/models/glyphs/webgpu/types.ts
+++ b/bokehjs/src/lib/models/glyphs/webgpu/types.ts
@@ -1,0 +1,19 @@
+import type {MarkerType} from "core/enums"
+
+// Extended marker types supported by WebGPU backend
+export type GPUMarkerType = MarkerType | "rect" | "round_rect"
+
+// Bounding box for scissor/viewport operations
+export type BoundingBox = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+// Transform info passed to draw calls
+export type Transform = {
+  pixel_ratio: number
+  width: number
+  height: number
+}

--- a/bokehjs/src/lib/models/glyphs/webgpu/webgpu_wrapper.ts
+++ b/bokehjs/src/lib/models/glyphs/webgpu/webgpu_wrapper.ts
@@ -1,0 +1,282 @@
+import type {BoundingBox, GPUMarkerType} from "./types"
+import marker_shader from "./marker.wgsl"
+
+// Singleton WebGPU wrapper instance
+let webgpu_wrapper: WebGPUWrapper | null = null
+
+export function get_webgpu(device: GPUDevice, context: GPUCanvasContext, format: GPUTextureFormat): WebGPUWrapper {
+  if (webgpu_wrapper == null) {
+    webgpu_wrapper = new WebGPUWrapper(device, context, format)
+  }
+  return webgpu_wrapper
+}
+
+export class WebGPUWrapper {
+  private _device: GPUDevice
+  private _context: GPUCanvasContext
+  private _format: GPUTextureFormat
+  private _webgpu_available: boolean = true
+
+  // Cached shader modules
+  private _marker_shader_module: GPUShaderModule | null = null
+
+  // Cached render pipelines
+  private _marker_pipeline_cache: Map<string, GPURenderPipeline> = new Map()
+
+  // Static geometry buffers
+  private _rect_geometry: GPUBuffer | null = null
+
+  // Bind group layouts
+  private _marker_bind_group_layout: GPUBindGroupLayout | null = null
+
+  // WebGPU state
+  private _scissor: BoundingBox = {x: 0, y: 0, width: 0, height: 0}
+
+  constructor(device: GPUDevice, context: GPUCanvasContext, format: GPUTextureFormat) {
+    this._device = device
+    this._context = context
+    this._format = format
+
+    this._init_static_buffers()
+  }
+
+  private _init_static_buffers(): void {
+    // Rectangle geometry for instanced rendering (4 vertices for a quad)
+    // Each vertex has position (x, y) in range [-0.5, 0.5]
+    // Order is important for triangle-strip: forms two triangles covering the quad
+    const rect_data = new Float32Array([
+      -0.5, -0.5,  // bottom-left  (vertex 0)
+      0.5, -0.5,   // bottom-right (vertex 1)
+      -0.5, 0.5,   // top-left     (vertex 2)
+      0.5, 0.5,    // top-right    (vertex 3)
+    ])
+
+    this._rect_geometry = this._device.createBuffer({
+      size: rect_data.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+      mappedAtCreation: true,
+    })
+    new Float32Array(this._rect_geometry.getMappedRange()).set(rect_data)
+    this._rect_geometry.unmap()
+  }
+
+  get device(): GPUDevice {
+    return this._device
+  }
+
+  get context(): GPUCanvasContext {
+    return this._context
+  }
+
+  get format(): GPUTextureFormat {
+    return this._format
+  }
+
+  get has_webgpu(): boolean {
+    return this._webgpu_available
+  }
+
+  get scissor(): BoundingBox {
+    return this._scissor
+  }
+
+  set_scissor(x: number, y: number, width: number, height: number): void {
+    this._scissor = {x, y, width, height}
+  }
+
+  private _needs_clear: boolean = true
+  private _has_valid_content: boolean = false
+
+  clear(): void {
+    this._needs_clear = true
+  }
+
+  // Returns the loadOp to use for the next render pass
+  get_load_op(): "clear" | "load" {
+    if (this._needs_clear) {
+      this._needs_clear = false
+      return "clear"
+    }
+    return "load"
+  }
+
+  // Mark that we've rendered something this frame
+  mark_rendered(): void {
+    this._has_valid_content = true
+  }
+
+  // Check if we should blit - either rendered this frame or have valid previous content
+  get should_blit(): boolean {
+    return this._has_valid_content
+  }
+
+  get rect_geometry(): GPUBuffer {
+    return this._rect_geometry!
+  }
+
+  // Get or create the marker shader module
+  get_marker_shader_module(): GPUShaderModule {
+    if (this._marker_shader_module == null) {
+      this._marker_shader_module = this._device.createShaderModule({
+        label: "Marker Shader",
+        code: marker_shader,
+      })
+    }
+    return this._marker_shader_module
+  }
+
+  // Get the bind group layout for marker rendering
+  get_marker_bind_group_layout(): GPUBindGroupLayout {
+    if (this._marker_bind_group_layout == null) {
+      this._marker_bind_group_layout = this._device.createBindGroupLayout({
+        label: "Marker Bind Group Layout",
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: {type: "uniform"},
+          },
+        ],
+      })
+    }
+    return this._marker_bind_group_layout
+  }
+
+  // Get or create render pipeline for a specific marker type
+  get_marker_pipeline(marker_type: GPUMarkerType, hatch: boolean = false): GPURenderPipeline {
+    const key = `${marker_type}_${hatch ? "hatch" : "no_hatch"}`
+    let pipeline = this._marker_pipeline_cache.get(key)
+
+    if (pipeline == null) {
+      const shader_module = this.get_marker_shader_module()
+      const bind_group_layout = this.get_marker_bind_group_layout()
+
+      // Constants for shader specialization
+      const constants: Record<string, number> = {
+        MARKER_CIRCLE: marker_type === "circle" ? 1 : 0,
+        MARKER_RECT: marker_type === "rect" ? 1 : 0,
+        MARKER_ROUND_RECT: marker_type === "round_rect" ? 1 : 0,
+      }
+
+      pipeline = this._device.createRenderPipeline({
+        label: `Marker Pipeline (${key})`,
+        layout: this._device.createPipelineLayout({
+          bindGroupLayouts: [bind_group_layout],
+        }),
+        vertex: {
+          module: shader_module,
+          entryPoint: "vertex_main",
+          constants,
+          buffers: [
+            // Buffer 0: Vertex buffer (quad geometry) - per-vertex
+            {
+              arrayStride: 2 * 4, // 2 floats * 4 bytes
+              stepMode: "vertex",
+              attributes: [
+                {shaderLocation: 0, offset: 0, format: "float32x2"}, // position
+              ],
+            },
+            // Buffer 1: Position (center) - per-instance, changes on pan/zoom
+            {
+              arrayStride: 2 * 4, // 2 floats (cx, cy)
+              stepMode: "instance",
+              attributes: [
+                {shaderLocation: 1, offset: 0, format: "float32x2"}, // center
+              ],
+            },
+            // Buffer 2: Size - per-instance, changes on data change
+            {
+              arrayStride: 2 * 4, // 2 floats (width, height)
+              stepMode: "instance",
+              attributes: [
+                {shaderLocation: 2, offset: 0, format: "float32x2"}, // size
+              ],
+            },
+            // Buffer 3: Geometry - per-instance, changes on data change
+            {
+              arrayStride: 2 * 4, // 2 floats (angle, aux)
+              stepMode: "instance",
+              attributes: [
+                {shaderLocation: 3, offset: 0, format: "float32x2"}, // angle_aux
+              ],
+            },
+            // Buffer 4: Line properties - per-instance, changes on visual/selection
+            {
+              arrayStride: 4 * 4, // 4 floats (linewidth, cap, join, show)
+              stepMode: "instance",
+              attributes: [
+                {shaderLocation: 4, offset: 0, format: "float32x4"}, // line_props
+              ],
+            },
+            // Buffer 5: Line color - per-instance, changes on visual change
+            {
+              arrayStride: 4 * 4, // 4 floats (r, g, b, a)
+              stepMode: "instance",
+              attributes: [
+                {shaderLocation: 5, offset: 0, format: "float32x4"}, // line_color
+              ],
+            },
+            // Buffer 6: Fill color - per-instance, changes on visual change
+            {
+              arrayStride: 4 * 4, // 4 floats (r, g, b, a)
+              stepMode: "instance",
+              attributes: [
+                {shaderLocation: 6, offset: 0, format: "float32x4"}, // fill_color
+              ],
+            },
+          ],
+        },
+        fragment: {
+          module: shader_module,
+          entryPoint: "fragment_main",
+          constants,
+          targets: [
+            {
+              format: this._format,
+              blend: {
+                color: {
+                  srcFactor: "one",
+                  dstFactor: "one-minus-src-alpha",
+                  operation: "add",
+                },
+                alpha: {
+                  srcFactor: "one",
+                  dstFactor: "one-minus-src-alpha",
+                  operation: "add",
+                },
+              },
+            },
+          ],
+        },
+        primitive: {
+          topology: "triangle-strip",
+          stripIndexFormat: "uint32",
+        },
+      })
+
+      this._marker_pipeline_cache.set(key, pipeline)
+    }
+
+    return pipeline
+  }
+
+  // Create a uniform buffer with the given data
+  create_uniform_buffer(data: ArrayBuffer): GPUBuffer {
+    const buffer = this._device.createBuffer({
+      size: data.byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    })
+    this._device.queue.writeBuffer(buffer, 0, data)
+    return buffer
+  }
+
+  // Create a bind group for marker rendering
+  create_marker_bind_group(uniform_buffer: GPUBuffer): GPUBindGroup {
+    return this._device.createBindGroup({
+      layout: this.get_marker_bind_group_layout(),
+      entries: [
+        {binding: 0, resource: {buffer: uniform_buffer}},
+      ],
+    })
+  }
+}

--- a/bokehjs/src/lib/models/glyphs/webgpu/wgsl.d.ts
+++ b/bokehjs/src/lib/models/glyphs/webgpu/wgsl.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wgsl" {
+  declare const shader: string
+  export default shader
+}

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -1288,6 +1288,7 @@ export class PlotView extends LayoutDOMView implements Paintable {
   protected _paint_primary(ctx: Context2d): void {
     const frame_box = this.frame.bbox
     this.canvas_view.prepare_webgl(frame_box)
+    this.canvas_view.prepare_webgpu(frame_box)
 
     this._paint_empty(ctx, frame_box)
     this._paint_outline(ctx, frame_box)
@@ -1325,6 +1326,9 @@ export class PlotView extends LayoutDOMView implements Paintable {
 
       if (renderer_view.has_webgl) {
         this.canvas_view.blit_webgl(ctx)
+      }
+      if (renderer_view.has_webgpu) {
+        this.canvas_view.blit_webgpu(ctx)
       }
     }
   }

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -322,7 +322,7 @@ export class GlyphRendererView extends DataRendererView {
   }
 
   protected _paint(ctx: Context2d): void {
-    const {has_webgl} = this
+    const {has_webgl, has_webgpu} = this
 
     this.map_data()
 
@@ -383,8 +383,8 @@ export class GlyphRendererView extends DataRendererView {
     let nonselection_glyph: GlyphView
     let selection_glyph: GlyphView
     if ((this.model.document != null ? this.model.document.interactive_duration() > 0 : false)
-        && !has_webgl && lod_threshold != null && all_indices.length > lod_threshold) {
-      // Render decimated during interaction if too many elements and not using GL
+        && !has_webgl && !has_webgpu && lod_threshold != null && all_indices.length > lod_threshold) {
+      // Render decimated during interaction if too many elements and not using GPU
       indices = [...this.decimated]
       glyph = this.decimated_glyph
       nonselection_glyph = this.decimated_glyph

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -321,6 +321,10 @@ export class GlyphRendererView extends DataRendererView {
     return this.glyph.has_webgl()
   }
 
+  override get has_webgpu(): boolean {
+    return this.glyph.has_webgpu()
+  }
+
   protected _paint(ctx: Context2d): void {
     const {has_webgl, has_webgpu} = this
 

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -160,6 +160,10 @@ export abstract class RendererView extends StyledElementView implements visuals.
     return false
   }
 
+  get has_webgpu(): boolean {
+    return false
+  }
+
   /*
   get visible(): boolean {
     const {visible, group} = this.model

--- a/bokehjs/src/lib/tsconfig.json
+++ b/bokehjs/src/lib/tsconfig.json
@@ -4,7 +4,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "lib": ["es2022", "dom", "dom.iterable"],
-    "types": ["google.maps"],
+    "types": ["google.maps", "@webgpu/types"],
     "paths": {
       "*": ["./*"]
     },

--- a/bokehjs/test/integration/tsconfig.json
+++ b/bokehjs/test/integration/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["esnext", "dom", "dom.iterable"],
-    "types": [],
+    "types": ["@webgpu/types"],
     "paths": {
       "@bokehjs/*": ["../../build/js/lib/*"],
       "*": ["./*"]

--- a/bokehjs/test/unit/core/enums.ts
+++ b/bokehjs/test/unit/core/enums.ts
@@ -162,7 +162,7 @@ describe("enums module", () => {
   })
 
   it("should have OutputBackend", () => {
-    expect([...enums.OutputBackend]).to.be.equal(["canvas", "svg", "webgl"])
+    expect([...enums.OutputBackend]).to.be.equal(["canvas", "svg", "webgl", "webgpu"])
   })
 
   it("should have PaddingUnits", () => {

--- a/examples/output/webgpu/scatter1m.py
+++ b/examples/output/webgpu/scatter1m.py
@@ -1,0 +1,29 @@
+""" Scatter plot with 1M points comparing WebGL and WebGPU backends.
+
+Note: WebGPU requires browser support. In Chrome, you may need to enable
+WebGPU via chrome://flags/#enable-unsafe-webgpu or use Chrome 113+.
+
+"""
+import numpy as np
+
+from bokeh.io import output_file
+from bokeh.layouts import row
+from bokeh.plotting import figure, show
+
+# Use inline resources to ensure we use the local BokehJS build
+output_file("scatter1m.html", mode="inline")
+
+N = 1_000_000
+
+x = np.random.normal(0, np.pi, N)
+y = np.sin(x) + np.random.normal(0, 0.2, N)
+
+TOOLS = "pan,wheel_zoom,box_zoom,reset,save,box_select"
+
+p_webgl = figure(tools=TOOLS, output_backend="webgl", title="WebGL")
+p_webgl.circle(x, y, radius=0.02, alpha=0.1, nonselection_alpha=0.001)
+
+p_webgpu = figure(tools=TOOLS, output_backend="webgpu", title="WebGPU")
+p_webgpu.circle(x, y, radius=0.02, alpha=0.1, nonselection_alpha=0.001)
+
+show(row(p_webgl, p_webgpu))

--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -511,7 +511,7 @@ OutlineShapeNameType = Literal["none", "box", "rectangle", "square", "circle", "
 OutlineShapeName = enumeration(OutlineShapeNameType)
 
 #: Specify an output backend to render a plot area onto
-OutputBackendType = Literal["canvas", "svg", "webgl"]
+OutputBackendType = Literal["canvas", "svg", "webgl", "webgpu"]
 OutputBackend = enumeration(OutputBackendType)
 
 #: Whether range padding should be interpreted a percentage or and absolute quantity

--- a/tests/unit/bokeh/core/test_enums.py
+++ b/tests/unit/bokeh/core/test_enums.py
@@ -302,7 +302,7 @@ class Test_bce:
         assert tuple(bce.OutlineShapeName) == ("none", "box", "rectangle", "square", "circle", "ellipse", "trapezoid", "parallelogram", "diamond", "triangle")
 
     def test_OutputBackend(self) -> None:
-        assert tuple(bce.OutputBackend) == ("canvas", "svg", "webgl")
+        assert tuple(bce.OutputBackend) == ("canvas", "svg", "webgl", "webgpu")
 
     def test_PaddingUnits(self) -> None:
         assert tuple(bce.PaddingUnits) == ("percent", "absolute")


### PR DESCRIPTION
## Summary

This PR adds experimental WebGPU rendering support for Bokeh, initially implementing the circle glyph as a proof-of-concept for architecture review.

### Key Features

- **GPU-side coordinate transforms**: Data coordinates are stored on the GPU and transformed to screen coordinates via uniforms, eliminating CPU work during pan/zoom operations
- **SDF-based rendering**: Uses Signed Distance Fields for smooth, antialiased circles at any zoom level
- **Instanced rendering**: Efficient batch rendering of millions of markers
- **Separated buffers by update frequency**:
  - Position/size buffers: Only rebuilt on data change
  - Visual buffers: Only rebuilt on style change
  - Uniform buffer: Updated every frame with transform (64 bytes only)

### Changes

- Add `"webgpu"` to `OutputBackend` enum
- Add build system support for WGSL shaders
- Add WebGPU rendering infrastructure (`webgpu/` directory)
- Implement circle glyph with WebGPU acceleration
- Add example script comparing WebGL vs WebGPU with 1M points

### Usage

```python
from bokeh.plotting import figure
p = figure(output_backend="webgpu")
p.circle(x, y, radius=0.02, alpha=0.1)
```

### Browser Support

WebGPU requires Chrome 113+ or other browsers with WebGPU support enabled.

## Test plan

- [x] BokehJS lint passes
- [x] BokehJS unit tests pass
- [x] BokehJS integration tests pass
- [ ] Manual testing with example script

🤖 Generated with [Claude Code](https://claude.ai/code)