### PR TITLE
Remove default type="text/javascript" from script tag wrapper

### DIFF
--- a/src/bokeh/core/_templates/script_tag.html.jinja
+++ b/src/bokeh/core/_templates/script_tag.html.jinja
@@ -6,7 +6,7 @@ Renders a ``<script>`` tag for raw JavaScript code.
 
 #}
 
-<script type="{{ type }}"{% if id %} id="{{ id }}"{% endif %}>
+<script{% if type %} type="{{ type }}"{% endif %}{% if id %} id="{{ id }}"{% endif %}>
 {# Already indented in wrappers.py #}
 {{ js_code }}
 </script>

--- a/src/bokeh/embed/wrappers.py
+++ b/src/bokeh/embed/wrappers.py
@@ -54,7 +54,7 @@ def wrap_in_safely(code: str) -> str:
     '''
     return _SAFELY % dict(code=indent(code, 2))
 
-def wrap_in_script_tag(js: str, type: str="text/javascript", id: str | None = None) -> str:
+def wrap_in_script_tag(js: str, type: str="", id: str | None = None) -> str:
     '''
 
     '''


### PR DESCRIPTION
## Summary

Removes the default `type="text/javascript"` attribute from script tag wrapper to follow HTML5 best practices.

## Problem

In HTML5, the `type="text/javascript"` attribute is unnecessary since JavaScript is the default scripting language. Including it adds extra bytes to the HTML output without providing any benefit.

## Changes

- `src/bokeh/embed/wrappers.py`: Changed default `type` parameter from `"text/javascript"` to empty string
- `src/bokeh/core/_templates/script_tag.html.jinja`: Updated template to only render the `type` attribute when it is non-empty

## Benefits

- Smaller HTML payload size
- Follows modern HTML5 best practices
- Cleaner output
- Backward compatible - users can still explicitly specify type if needed
