### PR TITLE
fix: Replace deprecated add_callback_from_signal with add_callback

### DIFF
--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -289,7 +289,9 @@ class BaseServer:
     def _sigterm(self, signum: int, frame: FrameType | None) -> None:
         print(f"Received signal {signum}, shutting down")
         # Tell self._loop.start() to return.
-        self._loop.add_callback_from_signal(self._loop.stop)
+        # Use add_callback instead of deprecated add_callback_from_signal
+        # (deprecated in Tornado 6.4, to be removed in 7.0)
+        self._loop.add_callback(self._loop.stop)
 
     @property
     def port(self) -> int | None:


### PR DESCRIPTION
Fixes #14835

Tornado's add_callback_from_signal has been deprecated since Tornado 6.4
and will be removed in 7.0. This method was previously needed because
signal handlers could run in a different thread context, but with modern
asyncio integration, this is no longer necessary.

## Changes
- Replaced self._loop.add_callback_from_signal() with self._loop.add_callback()
in the SIGTERM handler in src/bokeh/server/server.py

This ensures compatibility with Tornado 7.0+ while maintaining the same
functionality for graceful shutdown on SIGTERM.