### PR TITLE
[DISCUSSION PR][NOT FOR REVIEW] Add WebGL2 rendering backend with GPU-side coordinate transforms

### DIFF
--- a/bokehjs/src/compiler/linker.ts
+++ b/bokehjs/src/compiler/linker.ts
@@ -327,7 +327,7 @@ export class Linker {
     const [entries] = this.resolve(this.entries)
     const [main, ...plugins] = entries
 
-    const dirnames = plugins.map((plugin) => dirname(plugin.file))
+    const dirnames = plugins.map((plugin) => dirname(plugin.file) + sep)
     const is_excluded = (module: ModuleInfo) => {
       return dirnames.find((e) => module.file.startsWith(e)) != null
     }

--- a/bokehjs/src/lib/core/enums.ts
+++ b/bokehjs/src/lib/core/enums.ts
@@ -136,7 +136,7 @@ export type Orientation = typeof Orientation["__type__"]
 export const OutlineShapeName = Enum("none", "box", "rectangle", "square", "circle", "ellipse", "trapezoid", "parallelogram", "diamond", "triangle")
 export type OutlineShapeName = typeof OutlineShapeName["__type__"]
 
-export const OutputBackend = Enum("canvas", "svg", "webgl")
+export const OutputBackend = Enum("canvas", "svg", "webgl", "webgl2")
 export type OutputBackend = typeof OutputBackend["__type__"]
 
 export const PaddingUnits = Enum("percent", "absolute")

--- a/bokehjs/src/lib/core/util/canvas.ts
+++ b/bokehjs/src/lib/core/util/canvas.ts
@@ -50,6 +50,7 @@ export class CanvasLayer {
 
   constructor(readonly backend: OutputBackend, readonly hidpi: boolean) {
     switch (backend) {
+      case "webgl2":
       case "webgl":
       case "canvas": {
         this._el = this._canvas = canvas({class: "bk-layer"})

--- a/bokehjs/src/lib/models/canvas/canvas.ts
+++ b/bokehjs/src/lib/models/canvas/canvas.ts
@@ -11,6 +11,7 @@ import type {BBox} from "core/util/bbox"
 import {UIElement, UIElementView} from "../ui/ui_element"
 import type {PlotView} from "../plots/plot"
 import type {ReglWrapper} from "../glyphs/webgl/regl_wrap"
+import type {WebGL2Wrapper} from "../glyphs/webgl2/webgl2_wrapper"
 import type {StyleSheetLike} from "core/dom"
 import {InlineStyleSheet} from "core/dom"
 import * as canvas_css from "styles/canvas.css"
@@ -30,6 +31,12 @@ import icons_css from "styles/icons.css"
 export type WebGLState = {
   readonly canvas: HTMLCanvasElement
   readonly regl_wrapper: ReglWrapper
+}
+
+export type WebGL2State = {
+  readonly canvas: HTMLCanvasElement
+  readonly gl: WebGL2RenderingContext
+  readonly wrapper: WebGL2Wrapper
 }
 
 async function init_webgl(): Promise<WebGLState | null> {
@@ -72,10 +79,51 @@ const global_webgl: () => Promise<WebGLState | null> = (() => {
   }
 })()
 
+async function init_webgl2(): Promise<WebGL2State | null> {
+  const canvas = document.createElement("canvas")
+  const gl = canvas.getContext("webgl2", {
+    alpha: true,
+    antialias: false,
+    depth: false,
+    premultipliedAlpha: true,
+  })
+
+  if (gl != null) {
+    const webgl2 = await load_module(import("../glyphs/webgl2"))
+    if (webgl2 != null) {
+      const wrapper = webgl2.get_webgl2(gl)
+      if (wrapper.has_webgl2) {
+        logger.info("WebGL2 initialized successfully")
+        return {canvas, gl, wrapper}
+      } else {
+        logger.trace("WebGL2 is supported, but wrapper initialization failed")
+      }
+    } else {
+      logger.trace("WebGL2 is supported, but bokehjs(.min).js bundle is not available")
+    }
+  } else {
+    logger.trace("WebGL2 is not supported")
+  }
+
+  return null
+}
+
+const global_webgl2: () => Promise<WebGL2State | null> = (() => {
+  let _global_webgl2: WebGL2State | null | undefined
+  return async () => {
+    if (_global_webgl2 !== undefined) {
+      return _global_webgl2
+    } else {
+      return _global_webgl2 = await init_webgl2()
+    }
+  }
+})()
+
 export class CanvasView extends UIElementView {
   declare model: Canvas
 
   webgl: WebGLState | null = null
+  webgl2: WebGL2State | null = null
 
   underlays_el: HTMLElement
   primary: CanvasLayer
@@ -118,6 +166,11 @@ export class CanvasView extends UIElementView {
       this.webgl = await global_webgl()
       if (settings.force_webgl && this.webgl == null) {
         throw new Error("webgl is not available")
+      }
+    } else if (this.model.output_backend == "webgl2") {
+      this.webgl2 = await global_webgl2()
+      if (this.webgl2 == null) {
+        logger.warn("WebGL2 is not available, falling back to canvas")
       }
     }
   }
@@ -240,6 +293,44 @@ export class CanvasView extends UIElementView {
       // Prepare GL for drawing
       const {regl_wrapper, canvas} = webgl
       regl_wrapper.clear(canvas.width, canvas.height)
+    }
+  }
+
+  prepare_webgl2(frame_box: BBox): void {
+    const {webgl2} = this
+    if (webgl2 != null) {
+      const {width, height} = this.bbox
+      const ratio = this.pixel_ratio
+      webgl2.canvas.width = ratio * width
+      webgl2.canvas.height = ratio * height
+
+      const {x: sx, y: sy, width: w, height: h} = frame_box
+      const {xview} = this.bbox
+      const vx = xview.compute(sx)
+      // WebGL2 scissor Y is from bottom, so flip
+      const vy = sy
+
+      webgl2.wrapper.set_scissor(
+        Math.floor(ratio * vx),
+        Math.floor(ratio * vy),
+        Math.ceil(ratio * w),
+        Math.ceil(ratio * h),
+      )
+      webgl2.wrapper.clear()
+    }
+  }
+
+  blit_webgl2(ctx: Context2d): void {
+    const {webgl2} = this
+    if (webgl2 != null && webgl2.canvas.width * webgl2.canvas.height > 0 && webgl2.wrapper.should_blit) {
+      ctx.restore()
+      ctx.drawImage(webgl2.canvas, 0, 0)
+      ctx.save()
+      if (this.model.hidpi) {
+        const ratio = this.pixel_ratio
+        ctx.scale(ratio, ratio)
+        ctx.translate(0.5, 0.5)
+      }
     }
   }
 

--- a/bokehjs/src/lib/models/glyphs/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/circle.ts
@@ -5,7 +5,9 @@ import type * as p from "core/properties"
 import {minmax2} from "core/util/arrayable"
 import type {Context2d} from "core/util/canvas"
 import {Selection} from "../selections/selection"
+import {LinearScale} from "../scales/linear_scale"
 import type {CircleGL} from "./webgl/circle"
+import type {CircleGL2} from "./webgl2/circle"
 
 export interface CircleView extends Circle.Data {}
 
@@ -16,9 +18,22 @@ export class CircleView extends RadialGlyphView {
   /** @internal */
   declare glglyph?: CircleGL
 
+  /** @internal */
+  declare gl2glyph?: CircleGL2
+
   override async load_glglyph() {
     const {CircleGL} = await import("./webgl/circle")
     return CircleGL
+  }
+
+  override async load_gl2glyph() {
+    const {CircleGL2} = await import("./webgl2/circle")
+    return CircleGL2
+  }
+
+  protected override _compute_can_use_webgl2(): boolean {
+    const {xscale, yscale} = this.renderer
+    return xscale instanceof LinearScale && yscale instanceof LinearScale
   }
 
   protected _paint(ctx: Context2d, indices: number[], data?: Partial<Circle.Data>): void {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -31,6 +31,7 @@ import type {GlyphRendererView} from "../renderers/glyph_renderer"
 import type {ColumnarDataSource} from "../sources/columnar_data_source"
 import {Decoration} from "../graphics/decoration"
 import type {BaseGLGlyph, BaseGLGlyphConstructor} from "./webgl/base"
+import type {BaseGL2Glyph, BaseGL2GlyphConstructor} from "./webgl2/base"
 
 const {abs, ceil} = Math
 
@@ -53,14 +54,26 @@ export abstract class GlyphView extends DOMComponentView {
   /** @internal */
   glglyph?: BaseGLGlyph
 
+  /** @internal */
+  gl2glyph?: BaseGL2Glyph
+
   async load_glglyph?(): Promise<typeof BaseGLGlyph>
+  async load_gl2glyph?(): Promise<typeof BaseGL2Glyph>
 
   has_webgl(): this is {glglyph: BaseGLGlyph} {
     return this.glglyph != null && this._can_use_webgl
   }
 
+  has_webgl2(): this is {gl2glyph: BaseGL2Glyph} {
+    return this.gl2glyph != null && this._can_use_webgl2
+  }
+
   private _can_use_webgl: boolean = false
+  private _can_use_webgl2: boolean = false
   protected _compute_can_use_webgl(): boolean {
+    return true
+  }
+  protected _compute_can_use_webgl2(): boolean {
     return true
   }
 
@@ -108,8 +121,11 @@ export abstract class GlyphView extends DOMComponentView {
     await super.lazy_initialize()
     await build_views(this.decorations, this.model.decorations, {parent: this.parent})
 
-    const {webgl} = this.canvas
-    if (webgl != null && this.load_glglyph != null) {
+    const {webgl, webgl2} = this.canvas
+    if (webgl2 != null && this.load_gl2glyph != null) {
+      const cls = await this.load_gl2glyph() as BaseGL2GlyphConstructor
+      this.gl2glyph = new cls(webgl2.wrapper, this)
+    } else if (webgl != null && this.load_glglyph != null) {
       const cls = await this.load_glglyph() as BaseGLGlyphConstructor
       this.glglyph = new cls(webgl.regl_wrapper, this)
     }
@@ -124,7 +140,10 @@ export abstract class GlyphView extends DOMComponentView {
   }
 
   paint(ctx: Context2d, indices: number[], data?: Partial<Glyph.Data>): void {
-    if (this.has_webgl()) {
+    if (this.has_webgl2()) {
+      logger.debug(`Rendering ${indices.length} ${this.model.type} markers via WebGL2`)
+      this.gl2glyph.render(ctx, indices, this.base ?? this)
+    } else if (this.has_webgl()) {
       this.glglyph.render(ctx, indices, this.base ?? this)
     } else if (this.canvas.webgl != null && settings.force_webgl) {
       throw new Error(`${this} doesn't support webgl rendering`)
@@ -391,7 +410,9 @@ export abstract class GlyphView extends DOMComponentView {
       visual.update()
     }
 
-    if (this.has_webgl()) {
+    if (this.has_webgl2()) {
+      this.gl2glyph.set_visuals_changed()
+    } else if (this.has_webgl()) {
       this.glglyph.set_visuals_changed()
     }
   }
@@ -486,11 +507,16 @@ export abstract class GlyphView extends DOMComponentView {
       decoration.marking.set_data(source, indices)
     }
 
+    if (this.gl2glyph != null) {
+      this._can_use_webgl2 = this._compute_can_use_webgl2()
+    }
     if (this.glglyph != null) {
       this._can_use_webgl = this._compute_can_use_webgl()
     }
 
-    if (this.has_webgl()) {
+    if (this.has_webgl2()) {
+      this.gl2glyph.set_data_changed()
+    } else if (this.has_webgl()) {
       this.glglyph.set_data_changed()
     }
 
@@ -559,7 +585,9 @@ export abstract class GlyphView extends DOMComponentView {
     }
 
     this._map_data()
-    if (this.has_webgl()) {
+    if (this.has_webgl2()) {
+      this.gl2glyph.set_data_mapped()
+    } else if (this.has_webgl()) {
       this.glglyph.set_data_mapped()
     }
   }

--- a/bokehjs/src/lib/models/glyphs/webgl2/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl2/base.ts
@@ -17,6 +17,10 @@ export abstract class BaseGL2Glyph {
 
   constructor(protected readonly webgl2_wrapper: WebGL2Wrapper, readonly glyph: GlyphView) {}
 
+  get gpu_transform(): boolean {
+    return true
+  }
+
   set_data_changed(): void {
     const {data_size} = this.glyph
     if (data_size != this.nvertices) {

--- a/bokehjs/src/lib/models/glyphs/webgl2/base.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl2/base.ts
@@ -1,0 +1,61 @@
+// Base class for WebGL2 glyph implementations
+import type {Context2d} from "core/util/canvas"
+import type {GlyphView} from "../glyph"
+import type {WebGL2Wrapper} from "./webgl2_wrapper"
+import type {Transform} from "./types"
+
+export type BaseGL2GlyphConstructor = {
+  new(wrapper: WebGL2Wrapper, base_glyph: GlyphView): BaseGL2Glyph
+}
+
+export abstract class BaseGL2Glyph {
+  protected nvertices: number = 0
+  protected size_changed: boolean = false
+  protected data_changed: boolean = false
+  protected data_mapped: boolean = false
+  protected visuals_changed: boolean = false
+
+  constructor(protected readonly webgl2_wrapper: WebGL2Wrapper, readonly glyph: GlyphView) {}
+
+  set_data_changed(): void {
+    const {data_size} = this.glyph
+    if (data_size != this.nvertices) {
+      this.nvertices = data_size
+      this.size_changed = true
+    }
+
+    this.data_changed = true
+  }
+
+  set_data_mapped(): void {
+    this.data_mapped = true
+  }
+
+  set_visuals_changed(): void {
+    this.visuals_changed = true
+  }
+
+  render(_ctx: Context2d, indices: number[], mainglyph: GlyphView): void {
+    if (indices.length == 0) {
+      return
+    }
+
+    // Get canvas dimensions from the WebGL2 canvas
+    const webgl2 = this.glyph.renderer.plot_view.canvas_view.webgl2
+    if (webgl2 == null) {
+      return
+    }
+    const {width, height} = webgl2.canvas
+    const {pixel_ratio} = this.glyph.renderer.plot_view.canvas_view
+
+    const trans: Transform = {
+      pixel_ratio,  // Needed to scale antialiasing
+      width: width / pixel_ratio,
+      height: height / pixel_ratio,
+    }
+
+    this.draw(indices, mainglyph, trans)
+  }
+
+  abstract draw(indices: number[], mainglyph: GlyphView, trans: Transform): void
+}

--- a/bokehjs/src/lib/models/glyphs/webgl2/circle.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl2/circle.ts
@@ -1,0 +1,496 @@
+// WebGL2 implementation for Circle glyph with GPU-side coordinate transforms
+import type {Transform} from "./types"
+import {BaseGL2Glyph} from "./base"
+import type {WebGL2Wrapper} from "./webgl2_wrapper"
+import type {CircleView} from "../circle"
+import type {GlyphView} from "../glyph"
+
+// Missing data marker value (avoiding NaN/Inf for GPU precision)
+const MISSING_POINT = -10000
+
+// Uniform buffer layout (must match shader UBO):
+// 0-1: canvas_size (vec2)
+// 2: antialias (f32)
+// 3: size_hint (f32)
+// 4-7: border_radius (vec4)
+// 8: x_scale (f32)
+// 9: x_offset (f32)
+// 10: y_scale (f32)
+// 11: y_offset (f32)
+// 12: radius_scale (f32)
+// 13-15: padding
+const UNIFORM_FLOATS = 16
+
+// Attribute locations (must match shader layout)
+const LOC_POSITION = 0    // a_position (quad vertex)
+const LOC_CENTER = 1      // a_center
+const LOC_SIZE = 2        // a_size
+const LOC_ANGLE_AUX = 3   // a_angle_aux
+const LOC_LINE_PROPS = 4  // a_line_props
+const LOC_LINE_COLOR = 5  // a_line_color
+const LOC_FILL_COLOR = 6  // a_fill_color
+
+export class CircleGL2 extends BaseGL2Glyph {
+  private readonly _antialias: number = 1.5
+
+  // GPU buffers - separate for different update frequencies
+  private _position_buffer: WebGLBuffer | null = null    // DATA coords - only changes on data change
+  private _size_buffer: WebGLBuffer | null = null        // DATA units - only changes on data change
+  private _geometry_buffer: WebGLBuffer | null = null    // Only changes on data change
+  private _line_props_buffer: WebGLBuffer | null = null  // Changes on visual/selection
+  private _line_color_buffer: WebGLBuffer | null = null  // Changes on visual change
+  private _fill_color_buffer: WebGLBuffer | null = null  // Changes on visual change
+  private _uniform_buffer: WebGLBuffer | null = null
+
+  // VAO for this glyph instance
+  private _vao: WebGLVertexArrayObject | null = null
+  private _vao_needs_setup: boolean = true
+
+  // CPU-side arrays - reused to avoid allocations
+  private _position_data: Float32Array | null = null   // 2 floats per marker (DATA coords)
+  private _size_data: Float32Array | null = null       // 2 floats per marker (DATA units)
+  private _geometry_data: Float32Array | null = null   // 2 floats per marker
+  private _line_props_data: Float32Array | null = null // 4 floats per marker
+  private _line_color_data: Float32Array | null = null // 4 floats per marker
+  private _fill_color_data: Float32Array | null = null // 4 floats per marker
+  private _uniform_data: Float32Array = new Float32Array(UNIFORM_FLOATS)
+
+  // Track what needs updating (for CPU-side array rebuild)
+  private _data_dirty: boolean = true  // True when actual data changes
+  private _visuals_dirty: boolean = true
+  private _last_nmarkers: number = 0
+
+  // Track what needs uploading to GPU
+  private _positions_upload_needed: boolean = true
+  private _sizes_upload_needed: boolean = true
+  private _geometry_upload_needed: boolean = true
+  private _line_color_upload_needed: boolean = true
+  private _fill_color_upload_needed: boolean = true
+
+  constructor(wrapper: WebGL2Wrapper, override readonly glyph: CircleView) {
+    super(wrapper, glyph)
+  }
+
+  draw(indices: number[], main_glyph: GlyphView, transform: Transform): void {
+    const main_circle = main_glyph as CircleView
+    const main_gl2 = main_circle.gl2glyph
+
+    if (main_gl2 == null) {
+      return
+    }
+
+    // Only mark data dirty when actual DATA changes, not on pan/zoom
+    if (main_gl2.data_changed) {
+      main_gl2._data_dirty = true
+      main_gl2.data_changed = false
+    }
+
+    // Clear data_mapped flag - transform changes handled via uniforms
+    if (main_gl2.data_mapped) {
+      main_gl2.data_mapped = false
+    }
+
+    // Mark THIS glyph's visuals dirty
+    if (this.visuals_changed) {
+      this._visuals_dirty = true
+      this.visuals_changed = false
+    }
+
+    this._draw_markers(indices, transform, main_gl2)
+  }
+
+  private _draw_markers(indices: number[], transform: Transform, main_gl2: CircleGL2): void {
+    const {webgl2_wrapper} = this
+    const gl = webgl2_wrapper.gl
+
+    const nmarkers = main_gl2.nvertices
+    if (nmarkers === 0) {
+      return
+    }
+
+    // Ensure we have the data we need before proceeding
+    if (main_gl2._position_data == null && !main_gl2._data_dirty) {
+      main_gl2._data_dirty = true
+    }
+
+    const size_changed = main_gl2._last_nmarkers !== nmarkers
+    main_gl2._last_nmarkers = nmarkers
+
+    const this_size_changed = this._last_nmarkers !== nmarkers
+    this._last_nmarkers = nmarkers
+
+    // Update GEOMETRY buffers from main_gl2 (shared data)
+    if (main_gl2._data_dirty || size_changed) {
+      main_gl2._update_data_coords(nmarkers)
+      main_gl2._data_dirty = false
+      main_gl2._positions_upload_needed = true
+      main_gl2._sizes_upload_needed = true
+      main_gl2._geometry_upload_needed = true
+    }
+
+    // Update VISUAL buffers from THIS glyph
+    if (this._visuals_dirty || this_size_changed) {
+      this._update_visuals(nmarkers)
+      this._visuals_dirty = false
+      this._line_color_upload_needed = true
+      this._fill_color_upload_needed = true
+    }
+
+    // Update show flags based on indices (for selection support)
+    this._update_show_flags(indices, nmarkers)
+
+    // Upload GEOMETRY buffers from main_gl2 (shared)
+    if (main_gl2._positions_upload_needed) {
+      main_gl2._position_buffer = this._upload_buffer(gl, main_gl2._position_data!, main_gl2._position_buffer)
+      main_gl2._positions_upload_needed = false
+      this._vao_needs_setup = true
+    }
+    if (main_gl2._sizes_upload_needed) {
+      main_gl2._size_buffer = this._upload_buffer(gl, main_gl2._size_data!, main_gl2._size_buffer)
+      main_gl2._sizes_upload_needed = false
+      this._vao_needs_setup = true
+    }
+    if (main_gl2._geometry_upload_needed) {
+      main_gl2._geometry_buffer = this._upload_buffer(gl, main_gl2._geometry_data!, main_gl2._geometry_buffer)
+      main_gl2._geometry_upload_needed = false
+      this._vao_needs_setup = true
+    }
+
+    // Upload VISUAL buffers from THIS glyph
+    // line_props always needs upload since show flags change every draw
+    this._line_props_buffer = this._upload_buffer(gl, this._line_props_data!, this._line_props_buffer)
+    if (this._line_color_upload_needed) {
+      this._line_color_buffer = this._upload_buffer(gl, this._line_color_data!, this._line_color_buffer)
+      this._line_color_upload_needed = false
+      this._vao_needs_setup = true
+    }
+    if (this._fill_color_upload_needed) {
+      this._fill_color_buffer = this._upload_buffer(gl, this._fill_color_data!, this._fill_color_buffer)
+      this._fill_color_upload_needed = false
+      this._vao_needs_setup = true
+    }
+
+    // Update uniform buffer with canvas size and coordinate transform
+    this._update_uniforms(transform)
+
+    if (this._uniform_buffer == null) {
+      this._uniform_buffer = webgl2_wrapper.create_uniform_buffer(this._uniform_data.buffer as ArrayBuffer)
+    } else {
+      webgl2_wrapper.update_uniform_buffer(this._uniform_buffer, this._uniform_data.buffer as ArrayBuffer)
+    }
+
+    // Get program
+    const program = webgl2_wrapper.get_marker_program("circle")
+    if (program == null) {
+      return
+    }
+
+    // Setup VAO if needed
+    if (this._vao == null) {
+      this._vao = gl.createVertexArray()
+      this._vao_needs_setup = true
+    }
+
+    if (this._vao_needs_setup) {
+      this._setup_vao(gl, main_gl2)
+      this._vao_needs_setup = false
+    }
+
+    // Begin rendering
+    gl.useProgram(program)
+
+    // Set viewport to match canvas size (in device pixels)
+    gl.viewport(0, 0, gl.canvas.width, gl.canvas.height)
+
+    // Handle clear
+    if (webgl2_wrapper.needs_clear) {
+      gl.clearColor(0, 0, 0, 0)
+      gl.clear(gl.COLOR_BUFFER_BIT)
+      webgl2_wrapper.consume_clear()
+    }
+
+    // Set up blending (premultiplied alpha: One + OneMinusSrcAlpha)
+    gl.enable(gl.BLEND)
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
+
+    // Apply scissor
+    const scissor = webgl2_wrapper.scissor
+    gl.enable(gl.SCISSOR_TEST)
+    // WebGL2 scissor Y is from bottom-left, need to flip
+    const canvas_height = gl.canvas.height
+    gl.scissor(
+      scissor.x,
+      canvas_height - scissor.y - scissor.height,
+      scissor.width,
+      scissor.height,
+    )
+
+    // Bind UBO
+    webgl2_wrapper.bind_uniform_buffer(this._uniform_buffer)
+
+    // Bind VAO and draw
+    gl.bindVertexArray(this._vao)
+    gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, nmarkers)
+    gl.bindVertexArray(null)
+
+    // Cleanup state
+    gl.disable(gl.SCISSOR_TEST)
+    gl.disable(gl.BLEND)
+    gl.useProgram(null)
+
+    // Mark that we've rendered something this frame
+    webgl2_wrapper.mark_rendered()
+  }
+
+  private _setup_vao(gl: WebGL2RenderingContext, main_gl2: CircleGL2): void {
+    gl.bindVertexArray(this._vao)
+
+    // Buffer 0: Quad geometry (per-vertex)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.webgl2_wrapper.rect_geometry)
+    gl.enableVertexAttribArray(LOC_POSITION)
+    gl.vertexAttribPointer(LOC_POSITION, 2, gl.FLOAT, false, 0, 0)
+    // Per-vertex (divisor = 0, default)
+
+    // Buffer 1: Position/center (per-instance)
+    gl.bindBuffer(gl.ARRAY_BUFFER, main_gl2._position_buffer)
+    gl.enableVertexAttribArray(LOC_CENTER)
+    gl.vertexAttribPointer(LOC_CENTER, 2, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(LOC_CENTER, 1)
+
+    // Buffer 2: Size (per-instance)
+    gl.bindBuffer(gl.ARRAY_BUFFER, main_gl2._size_buffer)
+    gl.enableVertexAttribArray(LOC_SIZE)
+    gl.vertexAttribPointer(LOC_SIZE, 2, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(LOC_SIZE, 1)
+
+    // Buffer 3: Geometry (per-instance)
+    gl.bindBuffer(gl.ARRAY_BUFFER, main_gl2._geometry_buffer)
+    gl.enableVertexAttribArray(LOC_ANGLE_AUX)
+    gl.vertexAttribPointer(LOC_ANGLE_AUX, 2, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(LOC_ANGLE_AUX, 1)
+
+    // Buffer 4: Line properties (per-instance)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this._line_props_buffer)
+    gl.enableVertexAttribArray(LOC_LINE_PROPS)
+    gl.vertexAttribPointer(LOC_LINE_PROPS, 4, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(LOC_LINE_PROPS, 1)
+
+    // Buffer 5: Line color (per-instance)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this._line_color_buffer)
+    gl.enableVertexAttribArray(LOC_LINE_COLOR)
+    gl.vertexAttribPointer(LOC_LINE_COLOR, 4, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(LOC_LINE_COLOR, 1)
+
+    // Buffer 6: Fill color (per-instance)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this._fill_color_buffer)
+    gl.enableVertexAttribArray(LOC_FILL_COLOR)
+    gl.vertexAttribPointer(LOC_FILL_COLOR, 4, gl.FLOAT, false, 0, 0)
+    gl.vertexAttribDivisor(LOC_FILL_COLOR, 1)
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, null)
+    gl.bindVertexArray(null)
+  }
+
+  private _update_uniforms(transform: Transform): void {
+    const renderer = this.glyph.renderer
+    const frame = renderer.plot_view.frame
+
+    const x_scale = frame.x_scales.get(renderer.model.x_range_name)
+    const y_scale = frame.y_scales.get(renderer.model.y_range_name)
+
+    if (x_scale == null || y_scale == null) {
+      return
+    }
+
+    const x_source = x_scale.source_range
+    const x_target = x_scale.target_range
+    const y_source = y_scale.source_range
+    const y_target = y_scale.target_range
+
+    const x_factor = (x_target.end - x_target.start) / (x_source.end - x_source.start)
+    const x_offset = -(x_factor * x_source.start) + x_target.start
+
+    const y_factor = (y_target.end - y_target.start) / (y_source.end - y_source.start)
+    const y_offset = -(y_factor * y_source.start) + y_target.start
+
+    const radius_scale = Math.abs(x_factor)
+
+    this._uniform_data[0] = transform.width
+    this._uniform_data[1] = transform.height
+    this._uniform_data[2] = this._antialias / transform.pixel_ratio
+    this._uniform_data[3] = 1.0 // size_hint for circle
+    // border_radius (unused for circle)
+    this._uniform_data[4] = 0
+    this._uniform_data[5] = 0
+    this._uniform_data[6] = 0
+    this._uniform_data[7] = 0
+    // Transform parameters
+    this._uniform_data[8] = x_factor
+    this._uniform_data[9] = x_offset
+    this._uniform_data[10] = y_factor
+    this._uniform_data[11] = y_offset
+    this._uniform_data[12] = radius_scale
+    // Padding
+    this._uniform_data[13] = 0
+    this._uniform_data[14] = 0
+    this._uniform_data[15] = 0
+  }
+
+  private _upload_buffer(
+    gl: WebGL2RenderingContext,
+    data: Float32Array,
+    existing: WebGLBuffer | null,
+  ): WebGLBuffer {
+    const byte_size = data.byteLength
+
+    if (existing == null) {
+      const buffer = gl.createBuffer()
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer)
+      gl.bufferData(gl.ARRAY_BUFFER, data, gl.DYNAMIC_DRAW)
+      gl.bindBuffer(gl.ARRAY_BUFFER, null)
+      return buffer
+    }
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, existing)
+    // Check if buffer is large enough
+    const current_size = gl.getBufferParameter(gl.ARRAY_BUFFER, gl.BUFFER_SIZE)
+    if (current_size < byte_size) {
+      gl.bufferData(gl.ARRAY_BUFFER, data, gl.DYNAMIC_DRAW)
+      this._vao_needs_setup = true
+    } else {
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, data)
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, null)
+    return existing
+  }
+
+  private _ensure_array(current: Float32Array | null, required_length: number): Float32Array {
+    if (current == null || current.length < required_length) {
+      return new Float32Array(required_length)
+    }
+    return current
+  }
+
+  // Store DATA coordinates (x, y) and DATA-unit sizes (radius)
+  private _update_data_coords(nmarkers: number): void {
+    this._position_data = this._ensure_array(this._position_data, nmarkers * 2)
+    this._size_data = this._ensure_array(this._size_data, nmarkers * 2)
+    this._geometry_data = this._ensure_array(this._geometry_data, nmarkers * 2)
+
+    const pos_data = this._position_data
+    const size_data = this._size_data
+    const geom_data = this._geometry_data
+
+    const {x, y, radius} = this.glyph
+
+    for (let i = 0; i < nmarkers; i++) {
+      const x_i = x[i]
+      const y_i = y[i]
+      if (!isFinite(x_i) || !isFinite(y_i)) {
+        pos_data[i * 2] = MISSING_POINT
+        pos_data[i * 2 + 1] = MISSING_POINT
+      } else {
+        pos_data[i * 2] = x_i
+        pos_data[i * 2 + 1] = y_i
+      }
+
+      const r = radius.get(i)
+      const diameter = r * 2
+      size_data[i * 2] = diameter
+      size_data[i * 2 + 1] = diameter
+
+      geom_data[i * 2] = 0
+      geom_data[i * 2 + 1] = 0
+    }
+  }
+
+  private _update_visuals(nmarkers: number): void {
+    this._line_props_data = this._ensure_array(this._line_props_data, nmarkers * 4)
+    this._line_color_data = this._ensure_array(this._line_color_data, nmarkers * 4)
+    this._fill_color_data = this._ensure_array(this._fill_color_data, nmarkers * 4)
+
+    const line_props = this._line_props_data
+    const line_color = this._line_color_data
+    const fill_color = this._fill_color_data
+
+    const visuals = this.glyph.visuals
+    const line = visuals.line
+    const fill = visuals.fill
+
+    for (let i = 0; i < nmarkers; i++) {
+      const offset = i * 4
+
+      line_props[offset] = line.line_width.get(i)
+      line_props[offset + 1] = 0  // unused (cap not needed for circles)
+      line_props[offset + 2] = 0  // unused (join not needed for circles)
+      line_props[offset + 3] = 1.0 // show flag, updated in _update_show_flags
+
+      // Line color - RGBA packed as 32-bit integer
+      const lc = line.line_color.get(i)
+      const lc_a = (lc & 0xff) / 255
+      const line_alpha = line.line_alpha.get(i) * lc_a
+      line_color[offset] = ((lc >> 24) & 0xff) / 255     // R
+      line_color[offset + 1] = ((lc >> 16) & 0xff) / 255 // G
+      line_color[offset + 2] = ((lc >> 8) & 0xff) / 255  // B
+      line_color[offset + 3] = line_alpha
+
+      // Fill color - RGBA packed as 32-bit integer
+      const fc = fill.fill_color.get(i)
+      const fc_a = (fc & 0xff) / 255
+      const fill_alpha = fill.fill_alpha.get(i) * fc_a
+      fill_color[offset] = ((fc >> 24) & 0xff) / 255     // R
+      fill_color[offset + 1] = ((fc >> 16) & 0xff) / 255 // G
+      fill_color[offset + 2] = ((fc >> 8) & 0xff) / 255  // B
+      fill_color[offset + 3] = fill_alpha
+    }
+  }
+
+  private _update_show_flags(indices: number[], nmarkers: number): void {
+    if (this._line_props_data == null) {
+      return
+    }
+
+    const line_props = this._line_props_data
+
+    if (indices.length < nmarkers) {
+      for (let i = 0; i < nmarkers; i++) {
+        line_props[i * 4 + 3] = 0.0
+      }
+      for (const idx of indices) {
+        line_props[idx * 4 + 3] = 1.0
+      }
+    } else {
+      for (let i = 0; i < nmarkers; i++) {
+        line_props[i * 4 + 3] = 1.0
+      }
+    }
+  }
+
+  destroy(): void {
+    const gl = this.webgl2_wrapper.gl
+    if (this._position_buffer != null) {
+      gl.deleteBuffer(this._position_buffer)
+    }
+    if (this._size_buffer != null) {
+      gl.deleteBuffer(this._size_buffer)
+    }
+    if (this._geometry_buffer != null) {
+      gl.deleteBuffer(this._geometry_buffer)
+    }
+    if (this._line_props_buffer != null) {
+      gl.deleteBuffer(this._line_props_buffer)
+    }
+    if (this._line_color_buffer != null) {
+      gl.deleteBuffer(this._line_color_buffer)
+    }
+    if (this._fill_color_buffer != null) {
+      gl.deleteBuffer(this._fill_color_buffer)
+    }
+    if (this._uniform_buffer != null) {
+      gl.deleteBuffer(this._uniform_buffer)
+    }
+    if (this._vao != null) {
+      gl.deleteVertexArray(this._vao)
+    }
+  }
+}

--- a/bokehjs/src/lib/models/glyphs/webgl2/index.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl2/index.ts
@@ -1,0 +1,3 @@
+export {get_webgl2} from "./webgl2_wrapper"
+export * from "./base"
+export * from "./circle"

--- a/bokehjs/src/lib/models/glyphs/webgl2/marker.frag
+++ b/bokehjs/src/lib/models/glyphs/webgl2/marker.frag
@@ -1,0 +1,102 @@
+#version 300 es
+precision highp float;
+
+// Marker type defines (set via preprocessor)
+// #define MARKER_CIRCLE
+// #define MARKER_RECT
+// #define MARKER_ROUND_RECT
+
+in vec2 v_coords;
+in vec2 v_size;
+in float v_linewidth;
+in vec4 v_line_color;
+in vec4 v_fill_color;
+
+out vec4 fragColor;
+
+// Transform uniforms (UBO) - shared with vertex shader
+uniform TransformBlock {
+    vec2 u_canvas_size;
+    float u_antialias;
+    float u_size_hint;
+    vec4 u_border_radius;
+    float u_x_scale;
+    float u_x_offset;
+    float u_y_scale;
+    float u_y_offset;
+    float u_radius_scale;
+    float _pad1;
+    float _pad2;
+    float _pad3;
+};
+
+float circle_sdf(vec2 p, float radius) {
+    return length(p) - radius;
+}
+
+float rect_sdf(vec2 p, vec2 half_size) {
+    vec2 d = abs(p) - half_size;
+    return length(max(d, vec2(0.0))) + min(max(d.x, d.y), 0.0);
+}
+
+float round_rect_sdf(vec2 p, vec2 half_size, vec4 radius) {
+    vec2 r;
+    if (p.x > 0.0) {
+        if (p.y > 0.0) {
+            r = vec2(radius.x);
+        } else {
+            r = vec2(radius.y);
+        }
+    } else {
+        if (p.y > 0.0) {
+            r = vec2(radius.w);
+        } else {
+            r = vec2(radius.z);
+        }
+    }
+    vec2 q = abs(p) - half_size + r;
+    return min(max(q.x, q.y), 0.0) + length(max(q, vec2(0.0))) - r.x;
+}
+
+float marker_sdf(vec2 p, vec2 size) {
+#ifdef MARKER_CIRCLE
+    return circle_sdf(p, 0.5 * size.x);
+#elif defined(MARKER_ROUND_RECT)
+    return round_rect_sdf(p, size / 2.0, u_border_radius);
+#else
+    // Default to rect
+    return rect_sdf(p, size / 2.0);
+#endif
+}
+
+float distance_to_alpha(float dist) {
+    return 1.0 - smoothstep(-0.5 * u_antialias, 0.5 * u_antialias, dist);
+}
+
+vec4 premultiply_alpha(vec4 color, float alpha) {
+    float a = color.a * alpha;
+    return vec4(color.rgb * a, a);
+}
+
+vec4 blend_over(vec4 src, vec4 dst) {
+    return src + (1.0 - src.a) * dst;
+}
+
+void main() {
+    float dist = marker_sdf(v_coords, v_size);
+
+    // Calculate fill contribution
+    float fill_alpha = distance_to_alpha(dist);
+    vec4 color = premultiply_alpha(v_fill_color, fill_alpha);
+
+    // Calculate line/stroke contribution
+    float line_dist = abs(dist) - 0.5 * v_linewidth;
+    float line_alpha = distance_to_alpha(line_dist);
+
+    if (line_alpha > 0.0) {
+        vec4 line_color = premultiply_alpha(v_line_color, line_alpha);
+        color = blend_over(line_color, color);
+    }
+
+    fragColor = color;
+}

--- a/bokehjs/src/lib/models/glyphs/webgl2/marker.vert
+++ b/bokehjs/src/lib/models/glyphs/webgl2/marker.vert
@@ -1,0 +1,99 @@
+#version 300 es
+precision highp float;
+
+// Per-vertex quad geometry (instanced)
+layout(location = 0) in vec2 a_position;  // [-0.5, -0.5] to [0.5, 0.5]
+
+// Per-instance attributes
+layout(location = 1) in vec2 a_center;      // data coordinates
+layout(location = 2) in vec2 a_size;        // width, height (diameter in data units)
+layout(location = 3) in vec2 a_angle_aux;   // angle, aux
+layout(location = 4) in vec4 a_line_props;  // linewidth, cap, join, show
+layout(location = 5) in vec4 a_line_color;
+layout(location = 6) in vec4 a_fill_color;
+
+// Transform uniforms (UBO)
+uniform TransformBlock {
+    vec2 u_canvas_size;
+    float u_antialias;
+    float u_size_hint;
+    vec4 u_border_radius;
+    float u_x_scale;
+    float u_x_offset;
+    float u_y_scale;
+    float u_y_offset;
+    float u_radius_scale;
+    float _pad1;
+    float _pad2;
+    float _pad3;
+};
+
+out vec2 v_coords;
+out vec2 v_size;
+out float v_linewidth;
+out vec4 v_line_color;
+out vec4 v_fill_color;
+
+vec2 enclosing_size(vec2 size, float linewidth) {
+    return size + linewidth + u_antialias;
+}
+
+void main() {
+    float linewidth_raw = a_line_props.x;
+    float show = a_line_props.w;
+
+    // Early exit for hidden markers
+    if (show < 0.5 || a_size.x < 0.0 || a_size.y < 0.0) {
+        gl_Position = vec4(-2.0, -2.0, 0.0, 1.0);
+        return;
+    }
+
+    // Transform data coordinates to screen coordinates on the GPU
+    vec2 screen_center = vec2(
+        a_center.x * u_x_scale + u_x_offset,
+        a_center.y * u_y_scale + u_y_offset
+    );
+
+    // Transform size from data units to screen units
+    vec2 screen_size = a_size * u_radius_scale;
+
+    // Determine marker size based on type
+    vec2 v_sz;
+#ifdef MARKER_CIRCLE
+    v_sz = vec2(screen_size.x, screen_size.x);
+#else
+    v_sz = screen_size;
+#endif
+
+    // Adjust line color alpha for thin lines
+    float lw = linewidth_raw;
+    vec4 lc = a_line_color;
+    if (lw < 1.0) {
+        lc.a *= lw;
+        lw = 1.0;
+    }
+
+    // Calculate vertex position in local marker space
+    vec2 coords = a_position * enclosing_size(v_sz, lw);
+
+    // Apply rotation
+    float angle = a_angle_aux.x;
+    float c = cos(-angle);
+    float s = sin(-angle);
+    mat2 rotation = mat2(c, -s, s, c);
+    vec2 pos = screen_center + rotation * coords;
+
+    // Convert to normalized device coordinates
+    // Add 0.5 pixel offset for crisp rendering
+    pos = pos + 0.5;
+    pos = pos / u_canvas_size;
+
+    gl_Position = vec4(2.0 * pos.x - 1.0, 1.0 - 2.0 * pos.y, 0.0, 1.0);
+
+    // Pass to fragment shader
+    v_coords = coords;
+    v_size = v_sz;
+    v_linewidth = lw;
+    v_line_color = lc;
+    v_fill_color = a_fill_color;
+}

--- a/bokehjs/src/lib/models/glyphs/webgl2/types.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl2/types.ts
@@ -1,0 +1,19 @@
+import type {MarkerType} from "core/enums"
+
+// Extended marker types supported by WebGL2 backend
+export type GL2MarkerType = MarkerType | "rect" | "round_rect"
+
+// Bounding box for scissor/viewport operations
+export type BoundingBox = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+// Transform info passed to draw calls
+export type Transform = {
+  pixel_ratio: number
+  width: number
+  height: number
+}

--- a/bokehjs/src/lib/models/glyphs/webgl2/webgl2_wrapper.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl2/webgl2_wrapper.ts
@@ -41,9 +41,9 @@ export class WebGL2Wrapper {
     // Rectangle geometry for instanced rendering (4 vertices for a quad)
     const rect_data = new Float32Array([
       -0.5, -0.5,  // bottom-left  (vertex 0)
-       0.5, -0.5,  // bottom-right (vertex 1)
-      -0.5,  0.5,  // top-left     (vertex 2)
-       0.5,  0.5,  // top-right    (vertex 3)
+      0.5, -0.5,   // bottom-right (vertex 1)
+      -0.5, 0.5,   // top-left     (vertex 2)
+      0.5, 0.5,    // top-right    (vertex 3)
     ])
 
     this._rect_geometry = gl.createBuffer()
@@ -144,7 +144,7 @@ export class WebGL2Wrapper {
     const inject_defines = (source: string): string => {
       const trimmed = source.trimStart()
       const version_line_end = trimmed.indexOf("\n") + 1
-      return trimmed.slice(0, version_line_end) + define_block + "\n" + trimmed.slice(version_line_end)
+      return `${trimmed.slice(0, version_line_end)}${define_block}\n${trimmed.slice(version_line_end)}`
     }
 
     const vert_shader = this._compile_shader(gl.VERTEX_SHADER, inject_defines(marker_vert))
@@ -183,7 +183,7 @@ export class WebGL2Wrapper {
   // Create a UBO buffer
   create_uniform_buffer(data: ArrayBuffer): WebGLBuffer {
     const gl = this._gl
-    const buffer = gl.createBuffer()!
+    const buffer = gl.createBuffer()
     gl.bindBuffer(gl.UNIFORM_BUFFER, buffer)
     gl.bufferData(gl.UNIFORM_BUFFER, data, gl.DYNAMIC_DRAW)
     gl.bindBuffer(gl.UNIFORM_BUFFER, null)

--- a/bokehjs/src/lib/models/glyphs/webgl2/webgl2_wrapper.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl2/webgl2_wrapper.ts
@@ -1,0 +1,216 @@
+import type {BoundingBox, GL2MarkerType} from "./types"
+import marker_vert from "./marker.vert"
+import marker_frag from "./marker.frag"
+
+// Singleton WebGL2 wrapper instance
+let webgl2_wrapper: WebGL2Wrapper | null = null
+
+export function get_webgl2(gl: WebGL2RenderingContext): WebGL2Wrapper {
+  if (webgl2_wrapper == null) {
+    webgl2_wrapper = new WebGL2Wrapper(gl)
+  }
+  return webgl2_wrapper
+}
+
+// UBO binding point for the transform block
+const TRANSFORM_UBO_BINDING = 0
+
+export class WebGL2Wrapper {
+  private _gl: WebGL2RenderingContext
+  private _webgl2_available: boolean = true
+
+  // Cached shader programs
+  private _program_cache: Map<string, WebGLProgram> = new Map()
+
+  // Static geometry buffers
+  private _rect_geometry: WebGLBuffer | null = null
+  private _rect_vao_cache: Map<string, WebGLVertexArrayObject> = new Map()
+
+  // WebGL2 state
+  private _scissor: BoundingBox = {x: 0, y: 0, width: 0, height: 0}
+  private _needs_clear: boolean = true
+  private _has_valid_content: boolean = false
+
+  constructor(gl: WebGL2RenderingContext) {
+    this._gl = gl
+    this._init_static_buffers()
+  }
+
+  private _init_static_buffers(): void {
+    const gl = this._gl
+    // Rectangle geometry for instanced rendering (4 vertices for a quad)
+    const rect_data = new Float32Array([
+      -0.5, -0.5,  // bottom-left  (vertex 0)
+       0.5, -0.5,  // bottom-right (vertex 1)
+      -0.5,  0.5,  // top-left     (vertex 2)
+       0.5,  0.5,  // top-right    (vertex 3)
+    ])
+
+    this._rect_geometry = gl.createBuffer()
+    gl.bindBuffer(gl.ARRAY_BUFFER, this._rect_geometry)
+    gl.bufferData(gl.ARRAY_BUFFER, rect_data, gl.STATIC_DRAW)
+    gl.bindBuffer(gl.ARRAY_BUFFER, null)
+  }
+
+  get gl(): WebGL2RenderingContext {
+    return this._gl
+  }
+
+  get has_webgl2(): boolean {
+    return this._webgl2_available
+  }
+
+  get scissor(): BoundingBox {
+    return this._scissor
+  }
+
+  set_scissor(x: number, y: number, width: number, height: number): void {
+    this._scissor = {x, y, width, height}
+  }
+
+  clear(): void {
+    this._needs_clear = true
+  }
+
+  get needs_clear(): boolean {
+    return this._needs_clear
+  }
+
+  consume_clear(): void {
+    this._needs_clear = false
+  }
+
+  mark_rendered(): void {
+    this._has_valid_content = true
+  }
+
+  get should_blit(): boolean {
+    return this._has_valid_content
+  }
+
+  get rect_geometry(): WebGLBuffer {
+    return this._rect_geometry!
+  }
+
+  // Compile a shader with error reporting
+  private _compile_shader(type: number, source: string): WebGLShader | null {
+    const gl = this._gl
+    const shader = gl.createShader(type)
+    if (shader == null) {
+      return null
+    }
+    gl.shaderSource(shader, source)
+    gl.compileShader(shader)
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      const info = gl.getShaderInfoLog(shader)
+      console.error(`Shader compilation error: ${info}`)
+      gl.deleteShader(shader)
+      return null
+    }
+    return shader
+  }
+
+  // Get or create a cached program for a specific marker type
+  get_marker_program(marker_type: GL2MarkerType): WebGLProgram | null {
+    const key = marker_type
+    let program = this._program_cache.get(key)
+
+    if (program != null) {
+      return program
+    }
+
+    const gl = this._gl
+
+    // Build preprocessor defines based on marker type
+    const defines: string[] = []
+    switch (marker_type) {
+      case "circle":
+        defines.push("#define MARKER_CIRCLE")
+        break
+      case "rect":
+        defines.push("#define MARKER_RECT")
+        break
+      case "round_rect":
+        defines.push("#define MARKER_ROUND_RECT")
+        break
+      default:
+        defines.push("#define MARKER_CIRCLE")
+        break
+    }
+    const define_block = defines.join("\n")
+
+    // Inject defines after #version directive
+    const inject_defines = (source: string): string => {
+      const trimmed = source.trimStart()
+      const version_line_end = trimmed.indexOf("\n") + 1
+      return trimmed.slice(0, version_line_end) + define_block + "\n" + trimmed.slice(version_line_end)
+    }
+
+    const vert_shader = this._compile_shader(gl.VERTEX_SHADER, inject_defines(marker_vert))
+    const frag_shader = this._compile_shader(gl.FRAGMENT_SHADER, inject_defines(marker_frag))
+
+    if (vert_shader == null || frag_shader == null) {
+      return null
+    }
+
+    program = gl.createProgram()!
+    gl.attachShader(program, vert_shader)
+    gl.attachShader(program, frag_shader)
+    gl.linkProgram(program)
+
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      const info = gl.getProgramInfoLog(program)
+      console.error(`Program link error: ${info}`)
+      gl.deleteProgram(program)
+      gl.deleteShader(vert_shader)
+      gl.deleteShader(frag_shader)
+      return null
+    }
+
+    // Bind the UBO to the known binding point
+    const ubo_index = gl.getUniformBlockIndex(program, "TransformBlock")
+    gl.uniformBlockBinding(program, ubo_index, TRANSFORM_UBO_BINDING)
+
+    // Clean up shaders (they're linked into the program now)
+    gl.deleteShader(vert_shader)
+    gl.deleteShader(frag_shader)
+
+    this._program_cache.set(key, program)
+    return program
+  }
+
+  // Create a UBO buffer
+  create_uniform_buffer(data: ArrayBuffer): WebGLBuffer {
+    const gl = this._gl
+    const buffer = gl.createBuffer()!
+    gl.bindBuffer(gl.UNIFORM_BUFFER, buffer)
+    gl.bufferData(gl.UNIFORM_BUFFER, data, gl.DYNAMIC_DRAW)
+    gl.bindBuffer(gl.UNIFORM_BUFFER, null)
+    return buffer
+  }
+
+  // Update an existing UBO buffer
+  update_uniform_buffer(buffer: WebGLBuffer, data: ArrayBuffer): void {
+    const gl = this._gl
+    gl.bindBuffer(gl.UNIFORM_BUFFER, buffer)
+    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, data)
+    gl.bindBuffer(gl.UNIFORM_BUFFER, null)
+  }
+
+  // Bind UBO to the transform binding point
+  bind_uniform_buffer(buffer: WebGLBuffer): void {
+    this._gl.bindBufferBase(this._gl.UNIFORM_BUFFER, TRANSFORM_UBO_BINDING, buffer)
+  }
+
+  // Get or create a VAO for a marker type
+  // We cache VAOs per marker type since attribute layout is the same
+  get_or_create_vao(key: string): WebGLVertexArrayObject {
+    let vao = this._rect_vao_cache.get(key)
+    if (vao == null) {
+      vao = this._gl.createVertexArray()!
+      this._rect_vao_cache.set(key, vao)
+    }
+    return vao
+  }
+}

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -1288,6 +1288,7 @@ export class PlotView extends LayoutDOMView implements Paintable {
   protected _paint_primary(ctx: Context2d): void {
     const frame_box = this.frame.bbox
     this.canvas_view.prepare_webgl(frame_box)
+    this.canvas_view.prepare_webgl2(frame_box)
 
     this._paint_empty(ctx, frame_box)
     this._paint_outline(ctx, frame_box)
@@ -1325,6 +1326,9 @@ export class PlotView extends LayoutDOMView implements Paintable {
 
       if (renderer_view.has_webgl) {
         this.canvas_view.blit_webgl(ctx)
+      }
+      if (renderer_view.has_webgl2) {
+        this.canvas_view.blit_webgl2(ctx)
       }
     }
   }

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -77,6 +77,7 @@ export class GlyphRendererView extends DataRendererView {
 
   protected all_indices: Indices
   protected decimated: Indices
+  private _gpu_fast_indices: number[] | null = null
 
   protected last_dtrender: number
 
@@ -321,9 +322,32 @@ export class GlyphRendererView extends DataRendererView {
     return this.glyph.has_webgl()
   }
 
-  protected _paint(ctx: Context2d): void {
-    const {has_webgl} = this
+  override get has_webgl2(): boolean {
+    return this.glyph.has_webgl2()
+  }
 
+  protected _paint(ctx: Context2d): void {
+    const {has_webgl, has_webgl2} = this
+
+    // Fast path: when the GPU glyph uses GPU-side coordinate transforms,
+    // skip map_data() and all CPU index management and draw all markers directly.
+    // The GPU handles viewport culling via clip space.
+    if (has_webgl2 && this.glyph.gl2glyph!.gpu_transform) {
+      const {selected, inspected} = this.model.data_source
+      if (selected.is_empty() && inspected.is_empty()) {
+        ctx.save()
+        const glyph = this.model.muted ? this.muted_glyph : this.glyph
+        const n = this.all_indices.count
+        if (this._gpu_fast_indices == null || this._gpu_fast_indices.length != n) {
+          this._gpu_fast_indices = new Array(n)
+        }
+        glyph.paint(ctx, this._gpu_fast_indices)
+        ctx.restore()
+        return
+      }
+    }
+
+    // Normal path: compute screen coordinates for canvas 2d rendering
     this.map_data()
 
     // all_indices is in full data space, indices is converted to subset space by mask_data (that may use the spatial index)
@@ -383,8 +407,8 @@ export class GlyphRendererView extends DataRendererView {
     let nonselection_glyph: GlyphView
     let selection_glyph: GlyphView
     if ((this.model.document != null ? this.model.document.interactive_duration() > 0 : false)
-        && !has_webgl && lod_threshold != null && all_indices.length > lod_threshold) {
-      // Render decimated during interaction if too many elements and not using GL
+        && !has_webgl && !has_webgl2 && lod_threshold != null && all_indices.length > lod_threshold) {
+      // Render decimated during interaction if too many elements and not using GPU
       indices = [...this.decimated]
       glyph = this.decimated_glyph
       nonselection_glyph = this.decimated_glyph
@@ -510,6 +534,14 @@ export class GlyphRendererView extends DataRendererView {
   hit_test(geometry: Geometry): HitTestResult {
     if (!this.model.visible) {
       return null
+    }
+
+    // When using the GPU fast path, map_data() is skipped during rendering,
+    // so sx/sy may be stale. Recompute them for accurate hit testing.
+    // This only runs once per selection action, not every frame.
+    const {has_webgl2} = this
+    if (has_webgl2 && this.glyph.gl2glyph!.gpu_transform) {
+      this.glyph.map_data()
     }
 
     const hit_test_result = this.glyph.hit_test(geometry)

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -160,6 +160,10 @@ export abstract class RendererView extends StyledElementView implements visuals.
     return false
   }
 
+  get has_webgl2(): boolean {
+    return false
+  }
+
   /*
   get visible(): boolean {
     const {visible, group} = this.model

--- a/examples/output/webgl2/scatter1m.py
+++ b/examples/output/webgl2/scatter1m.py
@@ -1,0 +1,26 @@
+""" Scatter plot with 1M points comparing WebGL and WebGL2 backends.
+
+"""
+import numpy as np
+
+from bokeh.io import output_file
+from bokeh.layouts import row
+from bokeh.plotting import figure, show
+
+# Use inline resources to ensure we use the local BokehJS build
+output_file("scatter1m.html", mode="inline")
+
+N = 1_000_000
+
+x = np.random.normal(0, np.pi, N)
+y = np.sin(x) + np.random.normal(0, 0.2, N)
+
+TOOLS = "pan,wheel_zoom,box_zoom,reset,save,box_select"
+
+p_webgl = figure(tools=TOOLS, output_backend="webgl", title="WebGL")
+p_webgl.circle(x, y, radius=0.02, alpha=0.1, nonselection_alpha=0.001)
+
+p_webgl2 = figure(tools=TOOLS, output_backend="webgl2", title="WebGL2")
+p_webgl2.circle(x, y, radius=0.02, alpha=0.1, nonselection_alpha=0.001)
+
+show(row(p_webgl, p_webgl2))

--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -511,7 +511,7 @@ OutlineShapeNameType = Literal["none", "box", "rectangle", "square", "circle", "
 OutlineShapeName = enumeration(OutlineShapeNameType)
 
 #: Specify an output backend to render a plot area onto
-OutputBackendType = Literal["canvas", "svg", "webgl"]
+OutputBackendType = Literal["canvas", "svg", "webgl", "webgl2"]
 OutputBackend = enumeration(OutputBackendType)
 
 #: Whether range padding should be interpreted a percentage or and absolute quantity

--- a/tests/unit/bokeh/core/test_enums.py
+++ b/tests/unit/bokeh/core/test_enums.py
@@ -302,7 +302,7 @@ class Test_bce:
         assert tuple(bce.OutlineShapeName) == ("none", "box", "rectangle", "square", "circle", "ellipse", "trapezoid", "parallelogram", "diamond", "triangle")
 
     def test_OutputBackend(self) -> None:
-        assert tuple(bce.OutputBackend) == ("canvas", "svg", "webgl")
+        assert tuple(bce.OutputBackend) == ("canvas", "svg", "webgl", "webgl2")
 
     def test_PaddingUnits(self) -> None:
         assert tuple(bce.PaddingUnits) == ("percent", "absolute")


### PR DESCRIPTION
[DISCUSSION PR][NOT FOR REVIEW]

## Summary
- Add `webgl2` as a new `output_backend` option alongside `canvas`, `svg`, and `webgl`
- Implement a WebGL2 circle glyph that uploads data-space coordinates once and computes the data-to-screen transform in the vertex shader using uniforms, making pan/zoom O(1) instead of O(n)
- Wire up the full rendering pipeline: canvas initialization, prepare/blit lifecycle, glyph dispatch, selection/nonselection support with per-instance show flags
- Fix linker path prefix matching bug where `webgl2/` was incorrectly matched as being inside `webgl/` plugin directory

## Test plan
- [ ] Run `examples/output/webgl2/scatter1m.py` and verify 1M circles render correctly in both WebGL and WebGL2 panels
- [ ] Pan and zoom on both panels — WebGL2 should feel noticeably smoother
- [ ] Use box select tool — selected markers should highlight and non-selected markers should fade in both panels
- [ ] Test with non-linear scales (e.g., log) to verify WebGL2 falls back to canvas rendering gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ref: https://github.com/bokeh/bokeh/issues/14843