### PR TITLE
Use asyncio's `add_signal_handler()` for handling SIGTERM

### DIFF
--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -35,6 +35,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
 import atexit
 import signal
 import socket
@@ -57,8 +58,6 @@ from .tornado import DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, BokehTornado
 from .util import bind_sockets, create_hosts_allowlist
 
 if TYPE_CHECKING:
-    from types import FrameType
-
     from ..application.application import Application
     from ..application.handlers.function import ModifyDoc
     from ..core.types import ID
@@ -193,9 +192,14 @@ class BaseServer:
         '''
         if not self._started:
             self.start()
+
         # Install shutdown hooks
         atexit.register(self._atexit)
-        signal.signal(signal.SIGTERM, self._sigterm)
+
+        if sys.platform != "win32":
+            io_loop = asyncio.get_event_loop()
+            io_loop.add_signal_handler(signal.SIGTERM, self._sigterm)
+
         try:
             self._loop.start()
         except KeyboardInterrupt:
@@ -286,10 +290,10 @@ class BaseServer:
         if not self._stopped:
             self.stop(wait=False)
 
-    def _sigterm(self, signum: int, frame: FrameType | None) -> None:
-        print(f"Received signal {signum}, shutting down")
+    def _sigterm(self) -> None:
+        print("Received signal SIGTERM, shutting down")
         # Tell self._loop.start() to return.
-        self._loop.add_callback_from_signal(self._loop.stop)
+        self._loop.stop()
 
     @property
     def port(self) -> int | None:

--- a/tests/unit/bokeh/command/subcommands/test_serve.py
+++ b/tests/unit/bokeh/command/subcommands/test_serve.py
@@ -29,6 +29,7 @@ from os.path import join, split
 from pathlib import Path
 from queue import Empty, Queue
 from threading import Thread
+from typing import IO
 
 # Bokeh imports
 from bokeh.command.subcommand import Argument
@@ -49,20 +50,21 @@ PORT_PAT = re.compile(r'Bokeh app running at: http://localhost:(\d+)')
 
 # http://eyalarubas.com/python-subproc-nonblock.html
 class NBSR:
-    def __init__(self, stream) -> None:
+    _s: IO[bytes]
+    _q: Queue[bytes]
+
+    def __init__(self, stream: IO[bytes]) -> None:
         '''
         stream: the stream to read from.
                 Usually a process' stdout or stderr.
         '''
-
         self._s = stream
         self._q = Queue()
 
-        def _populateQueue(stream, queue):
+        def _populateQueue(stream: IO[bytes], queue: Queue[bytes]) -> None:
             '''
             Collect lines from 'stream' and put them in 'queue'.
             '''
-
             while True:
                 line = stream.readline()
                 if line:
@@ -70,15 +72,13 @@ class NBSR:
                 else:
                     break
 
-        self._t = Thread(target = _populateQueue,
-                args = (self._s, self._q))
+        self._t = Thread(target=_populateQueue, args=(self._s, self._q))
         self._t.daemon = True
-        self._t.start() #start collecting lines from the stream
+        self._t.start() # start collecting lines from the stream
 
-    def readline(self, timeout = None):
+    def readline(self, timeout: float | None = None) -> bytes | None:
         try:
-            return self._q.get(block = timeout is not None,
-                    timeout = timeout)
+            return self._q.get(block=timeout is not None, timeout=timeout)
         except Empty:
             return None
 
@@ -421,7 +421,7 @@ def test_args() -> None:
     )
 
 @contextlib.contextmanager
-def run_bokeh_serve(args):
+def run_bokeh_serve(args: list[str]):
     cmd = [sys.executable, '-m', 'bokeh', 'serve', *args]
     with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False) as p:
         nbsr = NBSR(p.stdout)
@@ -442,32 +442,28 @@ def run_bokeh_serve(args):
             p.terminate()
             p.wait()
 
-def assert_pattern(nbsr, pat):
-    m = None
-    for i in range(20):
+def find_pattern(nbsr: NBSR, pat: re.Pattern[str]) -> re.Match[str] | None:
+    for _ in range(20):
         o = nbsr.readline(0.5)
         if not o:
             continue
         m = pat.search(o.decode())
         if m is not None:
-            break
+            return m
+    return None
+
+def assert_pattern(nbsr: NBSR, pat: re.Pattern[str]):
+    m = find_pattern(nbsr, pat)
     if m is None:
         pytest.fail("Did not find pattern in process output")
 
-def check_port(nbsr):
-    m = None
-    for i in range(20):
-        o = nbsr.readline(0.5)
-        if not o:
-            continue
-        m = PORT_PAT.search(o.decode())
-        if m is not None:
-            break
+def check_port(nbsr: NBSR):
+    m = find_pattern(nbsr, PORT_PAT)
     if m is None:
         pytest.fail("Did not find port in process output")
     return int(m.group(1))
 
-def check_error(args):
+def check_error(args: list[str]):
     cmd = [sys.executable, '-m', 'bokeh', 'serve', *args]
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)

--- a/tests/unit/bokeh/command/subcommands/test_serve.py
+++ b/tests/unit/bokeh/command/subcommands/test_serve.py
@@ -21,6 +21,7 @@ import argparse
 import contextlib
 import os.path
 import re
+import signal
 import socket
 import subprocess
 import sys
@@ -447,7 +448,8 @@ def find_pattern(nbsr: NBSR, pat: re.Pattern[str]) -> re.Match[str] | None:
         o = nbsr.readline(0.5)
         if not o:
             continue
-        m = pat.search(o.decode())
+        s = o.decode()
+        m = pat.search(s)
         if m is not None:
             return m
     return None
@@ -646,7 +648,21 @@ class TestIco:
                 r = requests.get(f"http://localhost:{port}/favicon.ico")
                 assert r.status_code == 404
 
+@pytest.mark.skipif(sys.platform == "win32", reason="`ioloop.add_signal_handler()` is not available on Windows")
+def test_handling_SIGTERM() -> None:
+    pat_pid = re.compile(r"Starting Bokeh server with process id: (\d+)")
+    pat_term = re.compile(r"Received signal SIGTERM, shutting down")
 
+    with run_bokeh_serve([]) as (_, nbsr):
+        time.sleep(1) # otherwise won't work; can be replaced with breakpoint()
+        match = find_pattern(nbsr, pat_pid)
+        if match is None:
+            pytest.fail("Did not find server PID in process output")
+        pid = int(match.group(1))
+        os.kill(pid, signal.SIGTERM)
+        match = find_pattern(nbsr, pat_term)
+        if match is None:
+            pytest.fail("Did not find SIGTERM confirmation in process output")
 
 #-----------------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
This works as expected, e.g. by using `kill -s TERM 809791` we get:
```
2026-02-09 11:53:24,372 Bokeh app running at: http://localhost:5006/duffing_oscillator
2026-02-09 11:53:24,372 Starting Bokeh server with process id: 809791
Received signal SIGTERM, shutting down
2026-02-09 11:53:35,360 Shutdown: cleaning up
```
~~I need to figure out a test for this~~.

fixes #14835
