### PR TITLE
Optimize serializing numpy string arrays

### DIFF
--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -434,7 +434,7 @@ class Serializer:
         data: ArrayRepLike | BytesRep
         dtype: NDDataType
         if array.dtype.kind == 'U':
-            data = self._encode_ndarray_str(array)
+            data = obj.flatten().tolist()
             dtype = "object"
         elif array_encoding_disabled(array):
             data = self._encode_list(array.flatten().tolist())
@@ -450,9 +450,6 @@ class Serializer:
             dtype=dtype,
             order=sys.byteorder,
         )
-
-    def _encode_ndarray_str(self, obj: npt.NDArray[np.str_]) -> list[str]:
-        return obj.flatten().tolist()
 
     def _encode_other(self, obj: Any) -> AnyRep:
         # date/time values that get serialized as milliseconds

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -451,7 +451,7 @@ class Serializer:
             order=sys.byteorder,
         )
 
-    def _encode_ndarray_str(self, obj: npt.NDArray[str]) -> list[str]:
+    def _encode_ndarray_str(self, obj: npt.NDArray[np.str_]) -> list[str]:
         return obj.flatten().tolist()
 
     def _encode_other(self, obj: Any) -> AnyRep:

--- a/src/bokeh/core/serialization.py
+++ b/src/bokeh/core/serialization.py
@@ -433,7 +433,10 @@ class Serializer:
 
         data: ArrayRepLike | BytesRep
         dtype: NDDataType
-        if array_encoding_disabled(array):
+        if array.dtype.kind == 'U':
+            data = self._encode_ndarray_str(array)
+            dtype = "object"
+        elif array_encoding_disabled(array):
             data = self._encode_list(array.flatten().tolist())
             dtype = "object"
         else:
@@ -447,6 +450,9 @@ class Serializer:
             dtype=dtype,
             order=sys.byteorder,
         )
+
+    def _encode_ndarray_str(self, obj: npt.NDArray[str]) -> list[str]:
+        return obj.flatten().tolist()
 
     def _encode_other(self, obj: Any) -> AnyRep:
         # date/time values that get serialized as milliseconds

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -583,6 +583,21 @@ class TestSerializer:
             dtype="float64",
         )
 
+    def test_ndarray_str(self) -> None:
+        encoder = Serializer()
+        val = np.array(["a", "bb", "ccc"])
+        rep = encoder.encode(val)
+
+        assert len(encoder.buffers) == 0
+
+        assert rep == NDArrayRep(
+            type="ndarray",
+            array=["a", "bb", "ccc"],
+            order=sys.byteorder,
+            shape=[3],
+            dtype="object",
+        )
+
     def test_ndarray_object(self) -> None:
         @dataclass
         class X:


### PR DESCRIPTION
- [x] issues: fixes #14851 
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

Avoids the overhead of encoding each item in a string array individually.
Benchmark results when serializing `np.array(["a", "be", "cat"] * 100)`

- prev: 219 μs ± 46.8 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
- curr: 10.2 μs ± 121 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
