### PR TITLE
Convert raw datetime64 arrays at ColumnDataSource init to prevent DTypePromotionError

### DIFF
--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -258,6 +258,14 @@ class ColumnDataSource(ColumnarDataSource):
         super().__init__(**kwargs)
         self.data.update(raw_data)
 
+        # Convert any raw datetime64/timedelta64 arrays to ms-since-epoch so
+        # that later streaming operations (np.append) do not hit NumPy 2.0
+        # DTypePromotionError when mixing datetime64 and float64 arrays.
+        # See https://github.com/bokeh/bokeh/issues/14402.
+        for key, values in list(self.data.items()):
+            if isinstance(values, np.ndarray) and values.dtype.kind in ("M", "m"):
+                self.data[key] = convert_datetime_array(values)
+
     @property
     def column_names(self) -> list[str]:
         ''' A list of the column names in this data source.
@@ -620,9 +628,14 @@ class ColumnDataSource(ColumnarDataSource):
             old_values = self.data[key]
             # Apply the transformation if the new data contains datetimes
             # but the current data has already been transformed
-            if (isinstance(values, np.ndarray) and values.dtype.kind.lower() == 'm' and
-                isinstance(old_values, np.ndarray) and old_values.dtype.kind.lower() != 'm'):
+            if isinstance(values, np.ndarray) and values.dtype.kind in ("M", "m"):
                 new_data[key] = convert_datetime_array(values)
+            elif (isinstance(old_values, np.ndarray) and old_values.dtype.kind in ("M", "m") and
+                  isinstance(values, np.ndarray) and values.dtype.kind not in ("M", "m")):
+                # Old data is raw datetime but hasn't been converted yet;
+                # convert it in place so np.append won't fail.
+                self.data[key] = convert_datetime_array(old_values)
+                new_data[key] = values
             else:
                 new_data[key] = values
 

--- a/tests/unit/bokeh/models/test_sources.py
+++ b/tests/unit/bokeh/models/test_sources.py
@@ -303,6 +303,8 @@ class TestColumnDataSource:
         now = dt.datetime.now()
         dates = np.array([now+dt.timedelta(i) for i in range(1, 10)], dtype='datetime64')
         ds = bms.ColumnDataSource(data=dict(index=dates, b=list(range(1, 10))))
+        # datetime64 arrays should be converted to float ms at init time
+        assert ds.data["index"].dtype.kind == "f"
         ds._document = "doc"
         stuff = {}
         mock_setter = object()
@@ -314,7 +316,9 @@ class TestColumnDataSource:
         # internal implementation of stream
         new_date = np.array([now+dt.timedelta(10)], dtype='datetime64')
         ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
-        assert np.array_equal(stuff['args'][2]['index'], new_date)
+        # new datetime data should also be converted since the existing column is float
+        transformed_date = convert_datetime_array(new_date)
+        assert np.array_equal(stuff['args'][2]['index'], transformed_date)
 
     def test__stream_good_datetime64_data_transformed(self) -> None:
         now = dt.datetime.now()
@@ -334,6 +338,41 @@ class TestColumnDataSource:
         ds._stream(dict(index=new_date, b=[10]), "foo", mock_setter)
         transformed_date = convert_datetime_array(new_date)
         assert np.array_equal(stuff['args'][2]['index'], transformed_date)
+
+    def test_init_converts_datetime64_arrays(self) -> None:
+        """Raw np.datetime64 arrays should be converted at init time."""
+        now = dt.datetime.now()
+        dates = np.array([now + dt.timedelta(i) for i in range(5)], dtype='datetime64')
+        ds = bms.ColumnDataSource(data=dict(dates=dates, values=[1, 2, 3, 4, 5]))
+        # The stored array should be float (ms-since-epoch), not datetime64
+        assert ds.data["dates"].dtype.kind == "f"
+        expected = convert_datetime_array(dates)
+        assert np.array_equal(ds.data["dates"], expected)
+
+    def test_init_converts_timedelta64_arrays(self) -> None:
+        """Raw np.timedelta64 arrays should be converted at init time."""
+        deltas = np.array([1, 2, 3], dtype='timedelta64[s]')
+        ds = bms.ColumnDataSource(data=dict(deltas=deltas))
+        assert ds.data["deltas"].dtype.kind == "f"
+
+    def test_stream_datetime64_to_converted_column_no_error(self) -> None:
+        """Streaming np.datetime64 to a column that was converted at init should work."""
+        now = dt.datetime.now()
+        dates = np.array([now + dt.timedelta(i) for i in range(5)], dtype='datetime64')
+        ds = bms.ColumnDataSource(data=dict(dates=dates, values=list(range(5))))
+
+        # Stream new datetime data -- should not raise DTypePromotionError
+        new_dates = np.array([now + dt.timedelta(10)], dtype='datetime64')
+        ds.stream(dict(dates=new_dates, values=[10]))
+        assert len(ds.data["dates"]) == 6
+        assert ds.data["dates"].dtype.kind == "f"
+
+    def test_stream_datetime64_to_empty_list_no_error(self) -> None:
+        """Streaming np.datetime64 to an initially empty list column should work."""
+        ds = bms.ColumnDataSource(data=dict(dates=[], values=[]))
+        new_dates = np.array([np.datetime64("now")], dtype='datetime64')
+        ds.stream(dict(dates=new_dates, values=[1]))
+        assert len(ds.data["dates"]) == 1
 
     def test_patch_bad_columns(self) -> None:
         ds = bms.ColumnDataSource(data=dict(a=[10, 11], b=[20, 21]))


### PR DESCRIPTION
## Problem

When `ColumnDataSource` receives raw `np.datetime64` arrays (not from a DataFrame), they are stored as-is without conversion. On NumPy 2.0+, subsequent streaming operations (`source.stream(...)`) fail with `DTypePromotionError` because `np.append` can no longer implicitly promote between `datetime64` and `float64` dtypes.

This affects any workflow that initializes a `ColumnDataSource` with datetime arrays and then streams new data to it — including common patterns in Panel/HoloViews streaming applications.

Minimal reproducer:

```python
import numpy as np
from bokeh.models import ColumnDataSource

source = ColumnDataSource(data={"DateTime": np.array([np.datetime64("now")])})
source.stream({"DateTime": np.array([np.datetime64("now")])})
# DTypePromotionError on NumPy 2.0+
```

## Fix

- Convert `datetime64` and `timedelta64` arrays to ms-since-epoch floats at `ColumnDataSource.__init__` time using the existing `convert_datetime_array` utility. This matches the conversion that already happens for DataFrame inputs.
- Simplify the `_stream` datetime conversion logic to always convert incoming datetime arrays, and handle the reverse case where existing data is unconverted datetime but new incoming data is float.

## Tests

- Updated `test__stream_good_datetime64_data` to reflect that init now converts datetime arrays
- Added `test_init_converts_datetime64_arrays` — verifies init conversion
- Added `test_init_converts_timedelta64_arrays` — verifies timedelta conversion
- Added `test_stream_datetime64_to_converted_column_no_error` — verifies streaming works end-to-end without DTypePromotionError
- Added `test_stream_datetime64_to_empty_list_no_error` — covers the empty-list init + datetime stream case

Fixes #14402