### PR TITLE
Fix PasswordInput toggle icon alignment

### DIFF
--- a/bokehjs/src/less/widgets/password_input.less
+++ b/bokehjs/src/less/widgets/password_input.less
@@ -10,13 +10,21 @@
   padding-right: max(var(--padding-horizontal), var(--toggle-width));
 }
 
+.bk-input-container{
+  position: relative;
+}
+
 .bk-toggle {
   position: absolute;
   right: 0;
-  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
   width: var(--toggle-width);
   height: 100%;
-  padding: 0 var(--toggle-padding);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
   background-color: var(--icon-color);
   .mask-image(var(--bokeh-icon-see-off));
   .mask-size(var(--toggle-size) var(--toggle-size));

--- a/bokehjs/src/less/widgets/password_input.less
+++ b/bokehjs/src/less/widgets/password_input.less
@@ -24,7 +24,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  
   background-color: var(--icon-color);
   .mask-image(var(--bokeh-icon-see-off));
   .mask-size(var(--toggle-size) var(--toggle-size));

--- a/bokehjs/src/lib/models/widgets/password_input.ts
+++ b/bokehjs/src/lib/models/widgets/password_input.ts
@@ -26,9 +26,9 @@ export class PasswordInputView extends TextInputView {
       input_el.type = is_visible ? "password" : "text"
     })
     const storage = this.shadow_el.querySelector(".bk-input-container")
-    if (storage != null){
+    if (storage != null) {
       storage.append(this.toggle_el)
-    } else{
+    } else {
       this.shadow_el.append(this.toggle_el)
     }
   }

--- a/bokehjs/src/lib/models/widgets/password_input.ts
+++ b/bokehjs/src/lib/models/widgets/password_input.ts
@@ -25,7 +25,12 @@ export class PasswordInputView extends TextInputView {
       toggle_el.classList.toggle("bk-visible", !is_visible)
       input_el.type = is_visible ? "password" : "text"
     })
-    this.shadow_el.append(this.toggle_el)
+    const storage = this.shadow_el.querySelector(".bk-input-container")
+    if (storage != null){
+      storage.append(this.toggle_el)
+    } else{
+      this.shadow_el.append(this.toggle_el)
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #14739

The PasswordInput visibility toggle icon was incorrectly positioned when a title was set. The toggle element was appended outside the input container, causing alignment issues.

This change:
- Appends the toggle element inside `.bk-input-container`
- Ensures the container is positioned relative
- Vertically centers the toggle icon

### Testing

Tested using a minimal `bokeh serve` reproduction with titled and untitled PasswordInput widgets. The toggle icon now aligns correctly in both cases.

- [x] issues: fixes #14739
- [x] tests added / passed (no new tests required, existing tests pass)
- [ ] release document entry (not required, bug fix only)
<img width="262" height="140" alt="Screenshot 2026-02-16 212245" src="https://github.com/user-attachments/assets/691ac282-60a1-4964-852e-7825627859f3" />

