### PR TITLE
Add rudimentary editing support to `Examiner`

### DIFF
--- a/bokehjs/src/less/examiner.less
+++ b/bokehjs/src/less/examiner.less
@@ -221,7 +221,7 @@
 }
 
 .prop-value {
-  gap: 1em;
+  gap: 0.5em;
 }
 
 .underline {
@@ -258,17 +258,34 @@
   }
 }
 
+.btn-edit {
+  .icon-mask(var(--bokeh-icon-pencil));
+}
+
+.btn-accept {
+  .icon-mask(var(--bokeh-icon-check));
+}
+
+.btn-cancel {
+  .icon-mask(var(--bokeh-icon-x));
+}
+
 .btn-delete {
   .icon-mask(var(--bokeh-icon-trash));
 }
 
-.btn-edit {
-  .icon-mask(var(--bokeh-icon-pencil));
-  visibility: hidden;
-}
-
-.prop-value:hover {
+.prop-value {
   .btn-edit {
-    visibility: visible;
+    visibility: hidden;
+  }
+
+  &:hover {
+    .btn-edit {
+      visibility: visible;
+    }
+  }
+
+  .btn-accept:hover {
+    background-color: green;
   }
 }

--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -94,9 +94,9 @@ export class Document implements Equatable {
 
   readonly event_manager: EventManager
   readonly idle: Signal0<this>
+  readonly resolver: ModelResolver
 
   protected readonly _init_timestamp: number
-  protected readonly _resolver: ModelResolver
   protected _title: string
   protected _roots: HasProps[]
   protected _all_models: Map<ID, HasProps>
@@ -123,7 +123,7 @@ export class Document implements Equatable {
   constructor(options: DocumentOptions = {}) {
     documents.push(this)
     this._init_timestamp = Date.now()
-    this._resolver = options.resolver ?? new ModelResolver(default_resolver)
+    this.resolver = options.resolver ?? new ModelResolver(default_resolver)
     this._title = DEFAULT_TITLE
     this._roots = []
     this._all_models = new Map()
@@ -649,7 +649,7 @@ export class Document implements Equatable {
       this._new_models.add(obj)
       this._all_models.set(obj.id, obj)
     }
-    const deserializer = new Deserializer(this._resolver, this._all_models, finalize)
+    const deserializer = new Deserializer(this.resolver, this._all_models, finalize)
     const events = deserializer.decode(patch.events, buffers) as Decoded.DocumentChanged[]
 
     for (const event of events) {

--- a/bokehjs/src/lib/models/ui/examiner.tsx
+++ b/bokehjs/src/lib/models/ui/examiner.tsx
@@ -1,11 +1,13 @@
 import {UIElement, UIElementView} from "./ui_element"
 import * as p from "core/properties"
 import {HasProps} from "core/has_props"
-import type {StyleSheetLike} from "core/dom"
+import type {StyleSheetLike, Keys} from "core/dom"
 import {isArray} from "core/util/types"
 import {keys} from "core/util/object"
+import {map} from "core/util/iterator"
 import {receivers_for_sender} from "core/signaling"
 import {diagnostics} from "core/diagnostics"
+import {assert} from "core/util/assert"
 import {ValuePrinter, KindPrinter, OpaqueKindPrinter} from "./printers"
 
 import examiner_css from "styles/examiner.css"
@@ -13,11 +15,11 @@ import pretty_css from "styles/pretty.css"
 import icons_css from "styles/icons.css"
 
 import {render, Component} from "preact"
-import type {VNode} from "preact"
+import type {VNode, TargetedEvent} from "preact"
 import {signal, computed} from "@preact/signals"
 
-import type {Kind} from "core/kinds"
-import {Kinds} from "core/kinds"
+import {Serializer} from "core/serialization/serializer"
+import {Deserializer} from "core/serialization/deserializer"
 
 function highlight(el: Element): void {
   for (const animation of el.getAnimations()) {
@@ -230,49 +232,89 @@ export class ExaminerView extends UIElementView {
       }
     }
 
-    type PropEditorProps = {prop: p.Property}
+    type PropEditorProps = {prop: p.Property, close: () => void}
     class PropEditor extends Component<PropEditorProps> {
       constructor(props: PropEditorProps) {
         super(props)
       }
 
-      editors(kind: Kind<unknown>): VNode<HTMLElement> {
-        if (kind instanceof Kinds.Int) {
-          return <input type="number" step="1"></input>
-        } else if (kind instanceof Kinds.Float) {
-          return <input type="number"></input>
-        } else if (kind instanceof Kinds.Str) {
-          return <input type="text"></input>
-        } else if (kind instanceof Kinds.Enum) {
-          return <select>
-            {[...kind.values].map((value) => <option>{value}</option>)}
-          </select>
-        } else if (kind instanceof Kinds.Nullable) {
-          return (
-            <div class="col">
-              {this.editors(kind.base_type)}
-              <label><input type="radio"></input>null</label>
-            </div>
-          )
-        } else {
-          return <div>Not supported</div>
-        }
+      get serializer(): Serializer {
+        const doc = this.props.prop.obj.document
+        assert(doc != null)
+        const all_refs = new Map(map(doc.all_models, (model) => [model, model.ref()]))
+        return new Serializer({binary: false, include_defaults: false, references: all_refs})
       }
 
-      protected _editor_el: HTMLElement | null = null
+      get deserializer(): Deserializer {
+        const doc = this.props.prop.obj.document
+        assert(doc != null)
+        const all_models = new Map(map(doc.all_models, (model) => [model.id, model]))
+        return new Deserializer(doc.resolver, all_models, (obj) => obj.attach_document(doc))
+      }
+
+      commit(value: string): void {
+        const parsed = JSON.parse(value)
+        const decoded = this.deserializer.decode(parsed)
+        const {prop} = this.props
+        prop.obj.setv({[prop.attr]: decoded})
+      }
+
+      protected input_el: HTMLInputElement | null = null
 
       render(): VNode<HTMLElement> {
         const {prop} = this.props
+        const value = this.serializer.encode(prop.get_value())
         return (
-          <div popover ref={(el) =>{ this._editor_el = el }} onToggle={() => console.log("XXX")}>
-            <div>Editing {to_html(prop)}</div>
-            {this.editors(prop.kind)}
-          </div>
+          <>
+            <input
+              type="text"
+              ref={(el) => { this.input_el = el }}
+              onKeyUp={(event) => this.on_key_up(event)}
+              value={JSON.stringify(value)}></input>
+            <div class="btn btn-accept" onClick={() => this.accept_edit()}></div>
+            <div class="btn btn-cancel" onClick={() => this.cancel_edit()}></div>
+            <div class="btn btn-delete" onClick={() => this.delete_value()}></div>
+          </>
         )
       }
 
+      accept_edit() {
+        assert(this.input_el != null)
+        this.commit(this.input_el.value)
+        this.finalize()
+      }
+
+      cancel_edit() {
+        this.finalize()
+      }
+
+      delete_value() {
+        const {prop} = this.props
+        const value = prop.default_value(prop.obj)
+        prop.obj.setv({[prop.attr]: value})
+        this.finalize()
+      }
+
+      finalize(): void {
+        this.props.close()
+      }
+
+      on_key_up(event: TargetedEvent<HTMLInputElement, KeyboardEvent>): void {
+        switch (event.key as Keys) {
+          case "Enter": {
+            this.commit(event.currentTarget.value)
+            break
+          }
+          case "Escape": {
+            this.cancel_edit()
+            break
+          }
+          default:
+        }
+      }
+
       override componentDidMount(): void {
-        this._editor_el?.showPopover()
+        this.input_el?.focus()
       }
     }
 
@@ -314,15 +356,14 @@ export class ExaminerView extends UIElementView {
 
     type PropItemProps = {prop: p.Property}
     class PropItem extends Component<PropItemProps, {editing: boolean}> {
-      protected _editor_el: VNode<HTMLElement> | null = null
-
       constructor(props: PropItemProps) {
         super(props)
         this.state = {editing: false}
       }
 
-      edit_value(): void {
-        this.setState({editing: true})
+      toggle_edit(): void {
+        const {editing} = this.state
+        this.setState({editing: !editing})
       }
 
       render(): VNode<HTMLElement> {
@@ -348,6 +389,7 @@ export class ExaminerView extends UIElementView {
 
         const kind_printer = opaque_types.value ? new OpaqueKindPrinter() : new KindPrinter()
 
+        const {editing} = this.state
         return (
           <div class={cls("prop", dirty, internal, hidden)}>
             <div class="prop-attr" tabIndex={0}>
@@ -361,10 +403,14 @@ export class ExaminerView extends UIElementView {
             <div class="prop-kind">
               {kind_printer.to_html(prop.kind)}
             </div>
-            <div class="prop-value">
-              <PropValue prop={prop}></PropValue>
-              <div class="btn btn-edit" onClick={() => this.edit_value()}></div>
-              {this.state.editing ? <PropEditor prop={prop}></PropEditor> : null}
+            <div class={cls("prop-value", editing ? "editing" : null)}>
+              {!editing ?
+                <>
+                  <PropValue prop={prop}></PropValue>
+                  <div class="btn btn-edit" onClick={() => this.toggle_edit()}></div>
+                </>
+                :
+                <PropEditor prop={prop} close={() => this.toggle_edit()}></PropEditor>}
             </div>
           </div>
         )


### PR DESCRIPTION
Adding this just for the sake of completeness. Currently it's just a simple text input and the editor parses the text as JSON, deserializes it and sets property value.

[Screencast from 2026-02-19 15-55-54.webm](https://github.com/user-attachments/assets/c606527b-e645-480d-95b9-3b4a3cb126ad)

fixes #14772