### PR TITLE
Alternative `Server` constructor that uses global settings for configuration

### DIFF
--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -468,7 +468,7 @@ class Server(BaseServer):
     @classmethod
     def from_settings(cls, applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
             io_loop: IOLoop | None = None, http_server_kwargs: dict[str, Any] | None = None, **kwargs: Any) -> Server:
-        ''' Create a ``Server`` instance, applying any relevant ``Server`` settings from the global 
+        ''' Create a ``Server`` instance, applying any relevant ``Server`` settings from the global
         settings module, if they were not explicitly supplied as keyword arguments.
 
         Args:
@@ -491,7 +491,7 @@ class Server(BaseServer):
         Raises:
             ValueError
                 If ``sign_sessions`` is True but no ``secret_key`` is available.
-        
+
         '''
 
         from ..server.auth_provider import AuthModule, NullAuth

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -468,8 +468,23 @@ class Server(BaseServer):
         super().__init__(io_loop, tornado_app, http_server)
 
     @classmethod
-    def init_from_settings(cls, applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
-            io_loop: IOLoop | None = None, http_server_kwargs: dict[str, Any] | None = None, **kwargs: Any) -> Server:
+    def init_from_settings(
+            cls, 
+            applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
+            io_loop: IOLoop | None = None,
+            http_server_kwargs: dict[str, Any] | None = None,
+            *,
+            auth_provider: AuthProvider | None = None,
+            secret_key: bytes | None = None,
+            sign_sessions: bool | None = None,
+            ssl_certfile: str | None = None,
+            ssl_keyfile: str | None = None,
+            ssl_password: str | None = None,
+            cookie_secret: str | None = None,
+            xsrf_cookies: bool | None = None,
+            ico_path: str | None = None,
+            **kwargs: Any
+        ) -> Server:
         ''' Create a ``Server`` instance, applying any relevant ``Server`` settings from the global
         settings module, if they were not explicitly passed as keyword arguments.
 
@@ -483,9 +498,37 @@ class Server(BaseServer):
             http_server_kwargs (dict, optional) :
                 See :class:`~bokeh.server.server.Server`.
 
+            auth_provider (AuthProvider, optional) :
+                An :class:`~bokeh.server.auth_provider.AuthProvider` instance. Defaults to
+                an ``AuthModule`` loaded from the path in ``settings.auth_module()``, or
+                ``NullAuth`` if no module path is configured.
+
+            secret_key (bytes, optional) :
+                Secret key bytes used to sign sessions. Defaults to ``settings.secret_key_bytes()``.
+
+            sign_sessions (bool, optional) :
+                Whether to cryptographically sign session IDs. Defaults to ``settings.sign_sessions()``.
+
+            ssl_certfile (str, optional) :
+                Path to the SSL certificate file. Defaults to ``settings.ssl_certfile()``.
+
+            ssl_keyfile (str, optional) :
+                Path to the SSL key file. Defaults to ``settings.ssl_keyfile()``.
+
+            ssl_password (str, optional) :
+                Password for the SSL key file. Defaults to ``settings.ssl_password()``.
+
+            cookie_secret (str, optional) :
+                Secret used for signing cookies. Defaults to ``settings.cookie_secret()``.
+
+            xsrf_cookies (bool, optional) :
+                Whether to enable XSRF cookie protection. Defaults to ``settings.xsrf_cookies()``.
+
+            ico_path (str, optional) :
+                Path to a custom favicon ``.ico`` file. Defaults to ``settings.ico_path()``.
+
         Any additional keyword arguments are passed directly to
-        :class:`~bokeh.server.server.Server`, and take precedence over
-        values derived from environment variables.
+        :class:`~bokeh.server.server.Server`.
 
         Returns:
             Server
@@ -497,35 +540,34 @@ class Server(BaseServer):
         '''
 
         # --- auth_provider ---
-        # settings.auth_module() yields a path string, but Server expects an AuthProvider instance.
-        if 'auth_provider' not in kwargs:
+        if auth_provider is None:
             auth_module_path = settings.auth_module()
+
+            # `settings.auth_module()`` yields a path string, but `Server` expects an AuthProvider instance.
             kwargs['auth_provider'] = AuthModule(auth_module_path) if auth_module_path else NullAuth()
+        else:
+            kwargs['auth_provider'] = auth_provider
 
         # --- session signing ---
-        if 'secret_key' not in kwargs:
-            # Note: setting name doesn't match accessor method name on this one.
-            kwargs['secret_key'] = settings.secret_key_bytes()
+        
+        kwargs['sign_sessions'] = sign_sessions if sign_sessions is not None else settings.sign_sessions()
+        # Note: the setting name doesn't match accessor method name on this one:
+        kwargs['secret_key'] = secret_key if secret_key is not None else settings.secret_key_bytes()
 
-        if 'sign_sessions' not in kwargs:
-            kwargs['sign_sessions'] = settings.sign_sessions()
-
-        if kwargs['sign_sessions'] and not kwargs['secret_key']:
+        if sign_sessions and not secret_key:
             raise ValueError("A 'secret_key' must be set when 'sign_sessions' is enabled.")
 
         # --- SSL ---
-        for key in ('ssl_certfile', 'ssl_keyfile', 'ssl_password'):
-            if key not in kwargs:
-                kwargs[key] = getattr(settings, key)()
+        kwargs['ssl_certfile'] = ssl_certfile if ssl_certfile is not None else settings.ssl_certfile()
+        kwargs['ssl_keyfile'] = ssl_keyfile if ssl_keyfile is not None else settings.ssl_keyfile()
+        kwargs['ssl_password'] = ssl_password if ssl_password is not None else settings.ssl_password()
 
         # --- cookie / XSRF ---
-        for key in ('cookie_secret', 'xsrf_cookies'):
-            if key not in kwargs:
-                kwargs[key] = getattr(settings, key)()
+        kwargs['cookie_secret'] = cookie_secret if cookie_secret is not None else settings.cookie_secret()
+        kwargs['xsrf_cookies'] = xsrf_cookies if xsrf_cookies is not None else settings.xsrf_cookies()
 
         # --- misc ---
-        if 'ico_path' not in kwargs:
-            kwargs['ico_path'] = settings.ico_path()
+        kwargs['ico_path'] = ico_path if ico_path is not None else settings.ico_path()
 
         return cls(applications, io_loop=io_loop, http_server_kwargs=http_server_kwargs, **kwargs)
 

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -53,6 +53,8 @@ from ..core.property.container import List
 from ..core.property.nullable import Nullable
 from ..core.property.primitive import Bool, Int, String
 from ..resources import DEFAULT_SERVER_PORT, server_url
+from ..server.auth_provider import AuthModule, NullAuth
+from ..settings import settings
 from ..util.options import Options
 from .tornado import DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, BokehTornado
 from .util import bind_sockets, create_hosts_allowlist
@@ -494,22 +496,19 @@ class Server(BaseServer):
 
         '''
 
-        from ..server.auth_provider import AuthModule, NullAuth
-        from ..settings import settings as _settings
-
         # --- auth_provider ---
         # `settings.auth_module()`` yields a path string, but `Server` expects an AuthProvider instance.
         if 'auth_provider' not in kwargs:
-            auth_module_path = _settings.auth_module()
+            auth_module_path = settings.auth_module()
             kwargs['auth_provider'] = AuthModule(auth_module_path) if auth_module_path else NullAuth()
 
         # --- session signing ---
         if 'secret_key' not in kwargs:
             # NB: setting name doesn't match accessor method name on this one.
-            kwargs['secret_key'] = _settings.secret_key_bytes()
+            kwargs['secret_key'] = settings.secret_key_bytes()
 
         if 'sign_sessions' not in kwargs:
-            kwargs['sign_sessions'] = _settings.sign_sessions()
+            kwargs['sign_sessions'] = settings.sign_sessions()
 
         if kwargs['sign_sessions'] and not kwargs['secret_key']:
             raise ValueError("A 'secret_key' must be set when 'sign_sessions' is enabled.")
@@ -517,16 +516,16 @@ class Server(BaseServer):
         # --- SSL ---
         for key in ('ssl_certfile', 'ssl_keyfile', 'ssl_password'):
             if key not in kwargs:
-                kwargs[key] = getattr(_settings, key)()
+                kwargs[key] = getattr(settings, key)()
 
         # --- cookie / XSRF ---
         for key in ('cookie_secret', 'xsrf_cookies'):
             if key not in kwargs:
-                kwargs[key] = getattr(_settings, key)()
+                kwargs[key] = getattr(settings, key)()
 
         # --- misc ---
         if 'ico_path' not in kwargs:
-            kwargs['ico_path'] = _settings.ico_path()
+            kwargs['ico_path'] = settings.ico_path()
 
         return cls(applications, io_loop=io_loop, http_server_kwargs=http_server_kwargs, **kwargs)
 

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -468,7 +468,7 @@ class Server(BaseServer):
         super().__init__(io_loop, tornado_app, http_server)
 
     @classmethod
-    def init_from_settings(
+    def from_settings(
             cls,
             applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
             io_loop: IOLoop | None = None,

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -504,8 +504,8 @@ class Server(BaseServer):
             kwargs['auth_provider'] = AuthModule(auth_module_path) if auth_module_path else NullAuth()
 
         # --- session signing ---
-        # secret_key is handled explicitly because the accessor name differs from setting name.
         if 'secret_key' not in kwargs:
+            # NB: setting name doesn't match accessor method name on this one.
             kwargs['secret_key'] = _settings.secret_key_bytes()
 
         if 'sign_sessions' not in kwargs:

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -471,7 +471,7 @@ class Server(BaseServer):
     def from_settings(cls, applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
             io_loop: IOLoop | None = None, http_server_kwargs: dict[str, Any] | None = None, **kwargs: Any) -> Server:
         ''' Create a ``Server`` instance, applying any relevant ``Server`` settings from the global
-        settings module, if they were not explicitly supplied as keyword arguments.
+        settings module, if they were not explicitly passed as keyword arguments.
 
         Args:
             applications (dict[str, Application] or Application or callable) :
@@ -497,14 +497,14 @@ class Server(BaseServer):
         '''
 
         # --- auth_provider ---
-        # `settings.auth_module()`` yields a path string, but `Server` expects an AuthProvider instance.
+        # settings.auth_module() yields a path string, but Server expects an AuthProvider instance.
         if 'auth_provider' not in kwargs:
             auth_module_path = settings.auth_module()
             kwargs['auth_provider'] = AuthModule(auth_module_path) if auth_module_path else NullAuth()
 
         # --- session signing ---
         if 'secret_key' not in kwargs:
-            # NB: setting name doesn't match accessor method name on this one.
+            # Note: setting name doesn't match accessor method name on this one.
             kwargs['secret_key'] = settings.secret_key_bytes()
 
         if 'sign_sessions' not in kwargs:

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -468,7 +468,7 @@ class Server(BaseServer):
         super().__init__(io_loop, tornado_app, http_server)
 
     @classmethod
-    def from_settings(cls, applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
+    def init_from_settings(cls, applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
             io_loop: IOLoop | None = None, http_server_kwargs: dict[str, Any] | None = None, **kwargs: Any) -> Server:
         ''' Create a ``Server`` instance, applying any relevant ``Server`` settings from the global
         settings module, if they were not explicitly passed as keyword arguments.

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -53,7 +53,7 @@ from ..core.property.container import List
 from ..core.property.nullable import Nullable
 from ..core.property.primitive import Bool, Int, String
 from ..resources import DEFAULT_SERVER_PORT, server_url
-from ..server.auth_provider import AuthModule, NullAuth
+from ..server.auth_provider import AuthModule, AuthProvider, NullAuth
 from ..settings import settings
 from ..util.options import Options
 from .tornado import DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, BokehTornado
@@ -469,7 +469,7 @@ class Server(BaseServer):
 
     @classmethod
     def init_from_settings(
-            cls, 
+            cls,
             applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
             io_loop: IOLoop | None = None,
             http_server_kwargs: dict[str, Any] | None = None,
@@ -483,7 +483,7 @@ class Server(BaseServer):
             cookie_secret: str | None = None,
             xsrf_cookies: bool | None = None,
             ico_path: str | None = None,
-            **kwargs: Any
+            **kwargs: Any,
         ) -> Server:
         ''' Create a ``Server`` instance, applying any relevant ``Server`` settings from the global
         settings module, if they were not explicitly passed as keyword arguments.
@@ -549,7 +549,7 @@ class Server(BaseServer):
             kwargs['auth_provider'] = auth_provider
 
         # --- session signing ---
-        
+
         kwargs['sign_sessions'] = sign_sessions if sign_sessions is not None else settings.sign_sessions()
         # Note: the setting name doesn't match accessor method name on this one:
         kwargs['secret_key'] = secret_key if secret_key is not None else settings.secret_key_bytes()

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -465,6 +465,71 @@ class Server(BaseServer):
 
         super().__init__(io_loop, tornado_app, http_server)
 
+    @classmethod
+    def from_settings(cls, applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
+            io_loop: IOLoop | None = None, http_server_kwargs: dict[str, Any] | None = None, **kwargs: Any) -> Server:
+        ''' Create a ``Server`` instance, applying any relevant ``Server`` settings from the global 
+        settings module, if they were not explicitly supplied as keyword arguments.
+
+        Args:
+            applications (dict[str, Application] or Application or callable) :
+                See :class:`~bokeh.server.server.Server`.
+
+            io_loop (IOLoop, optional) :
+                See :class:`~bokeh.server.server.Server`.
+
+            http_server_kwargs (dict, optional) :
+                See :class:`~bokeh.server.server.Server`.
+
+        Any additional keyword arguments are passed directly to
+        :class:`~bokeh.server.server.Server`, and take precedence over
+        values derived from environment variables.
+
+        Returns:
+            Server
+
+        Raises:
+            ValueError
+                If ``sign_sessions`` is True but no ``secret_key`` is available.
+        
+        '''
+
+        from ..server.auth_provider import AuthModule, NullAuth
+        from ..settings import settings as _settings
+
+        # --- auth_provider ---
+        # `settings.auth_module()`` yields a path string, but `Server` expects an AuthProvider instance.
+        if 'auth_provider' not in kwargs:
+            auth_module_path = _settings.auth_module()
+            kwargs['auth_provider'] = AuthModule(auth_module_path) if auth_module_path else NullAuth()
+
+        # --- session signing ---
+        # secret_key is handled explicitly because the accessor name differs from setting name.
+        if 'secret_key' not in kwargs:
+            kwargs['secret_key'] = _settings.secret_key_bytes()
+
+        if 'sign_sessions' not in kwargs:
+            kwargs['sign_sessions'] = _settings.sign_sessions()
+
+        if kwargs['sign_sessions'] and not kwargs['secret_key']:
+            raise ValueError("A 'secret_key' must be set when 'sign_sessions' is enabled.")
+
+        # --- SSL ---
+        for key in ('ssl_certfile', 'ssl_keyfile', 'ssl_password'):
+            if key not in kwargs:
+                kwargs[key] = getattr(_settings, key)()
+
+        # --- cookie / XSRF ---
+        for key in ('cookie_secret', 'xsrf_cookies'):
+            if key not in kwargs:
+                kwargs[key] = getattr(_settings, key)()
+
+        # --- misc ---
+        if 'ico_path' not in kwargs:
+            kwargs['ico_path'] = _settings.ico_path()
+
+        return cls(applications, io_loop=io_loop, http_server_kwargs=http_server_kwargs, **kwargs)
+
     @property
     def port(self) -> int | None:
         ''' The configured port number that the server listens on for HTTP

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -373,7 +373,7 @@ def test__from_settings_uses_envvars() -> None:
             mock_settings.xsrf_cookies.return_value = True
             mock_settings.ico_path.return_value = None
             with mock.patch.object(Server, '__init__', return_value=None) as init:
-                Server.from_settings(Application())
+                Server.init_from_settings(Application())
                 _, kwargs = init.call_args
     finally:
         os.unlink(auth_path)
@@ -400,7 +400,7 @@ def test__from_settings_kwarg_overrides_envvar() -> None:
         mock_settings.xsrf_cookies.return_value = False
         mock_settings.ico_path.return_value = None
         with mock.patch.object(Server, '__init__', return_value=None) as init:
-            Server.from_settings(Application(), auth_provider=null_auth)
+            Server.init_from_settings(Application(), auth_provider=null_auth)
             _, kwargs = init.call_args
     assert kwargs['auth_provider'] is null_auth
 

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -56,7 +56,6 @@ from bokeh.util.token import (
     get_token_payload,
 )
 from tests.support.plugins.managed_server_loop import MSL
-from tests.support.util.env import envset
 
 # Module under test
 import bokeh.server.server as server # isort:skip
@@ -360,16 +359,16 @@ async def test__exclude_cookies(ManagedServerLoop: MSL) -> None:
 
 def test__from_settings_uses_envvars() -> None:
     with tempfile.NamedTemporaryFile(suffix='.py') as f:
-        with envset(
-            BOKEH_AUTH_MODULE=f.name,
-            BOKEH_SIGN_SESSIONS='yes',
-            BOKEH_SECRET_KEY='0' * 32,
-            BOKEH_SSL_CERTFILE='/path/to/cert.pem',
-            BOKEH_SSL_KEYFILE='/path/to/key.pem',
-            BOKEH_SSL_PASSWORD='hunter2',
-            BOKEH_COOKIE_SECRET='verysecret',
-            BOKEH_XSRF_COOKIES='yes',
-        ):
+        with mock.patch('bokeh.server.server.settings') as mock_settings:
+            mock_settings.auth_module.return_value = f.name
+            mock_settings.sign_sessions.return_value = True
+            mock_settings.secret_key_bytes.return_value = b'0' * 32
+            mock_settings.ssl_certfile.return_value = '/path/to/cert.pem'
+            mock_settings.ssl_keyfile.return_value = '/path/to/key.pem'
+            mock_settings.ssl_password.return_value = 'hunter2'
+            mock_settings.cookie_secret.return_value = 'verysecret'
+            mock_settings.xsrf_cookies.return_value = True
+            mock_settings.ico_path.return_value = None
             with mock.patch.object(Server, '__init__', return_value=None) as init:
                 Server.from_settings(Application())
                 _, kwargs = init.call_args
@@ -385,7 +384,16 @@ def test__from_settings_uses_envvars() -> None:
 def test__from_settings_kwarg_overrides_envvar() -> None:
     """Ensure that a kwarg to Server.from_settings overrides the equivalent envvar setting, if present."""
     null_auth = NullAuth()
-    with envset(BOKEH_AUTH_MODULE='/some/auth.py'):
+    with mock.patch('bokeh.server.server.settings') as mock_settings:
+        mock_settings.auth_module.return_value = '/some/auth.py'
+        mock_settings.sign_sessions.return_value = False
+        mock_settings.secret_key_bytes.return_value = None
+        mock_settings.ssl_certfile.return_value = None
+        mock_settings.ssl_keyfile.return_value = None
+        mock_settings.ssl_password.return_value = None
+        mock_settings.cookie_secret.return_value = None
+        mock_settings.xsrf_cookies.return_value = False
+        mock_settings.ico_path.return_value = None
         with mock.patch.object(Server, '__init__', return_value=None) as init:
             Server.from_settings(Application(), auth_provider=null_auth)
             _, kwargs = init.call_args

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -373,7 +373,7 @@ def test__from_settings_uses_envvars() -> None:
             mock_settings.xsrf_cookies.return_value = True
             mock_settings.ico_path.return_value = None
             with mock.patch.object(Server, '__init__', return_value=None) as init:
-                Server.init_from_settings(Application())
+                Server.from_settings(Application())
                 _, kwargs = init.call_args
     finally:
         os.unlink(auth_path)
@@ -400,7 +400,7 @@ def test__from_settings_kwarg_overrides_envvar() -> None:
         mock_settings.xsrf_cookies.return_value = False
         mock_settings.ico_path.return_value = None
         with mock.patch.object(Server, '__init__', return_value=None) as init:
-            Server.init_from_settings(Application(), auth_provider=null_auth)
+            Server.from_settings(Application(), auth_provider=null_auth)
             _, kwargs = init.call_args
     assert kwargs['auth_provider'] is null_auth
 

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -22,6 +22,7 @@ import logging
 import re
 import ssl
 import sys
+import tempfile
 import time
 from datetime import timedelta
 from unittest import mock
@@ -45,6 +46,7 @@ from bokeh.client import pull_session
 from bokeh.core.properties import List, String
 from bokeh.core.types import ID
 from bokeh.model import Model
+from bokeh.server.auth_provider import AuthModule, NullAuth
 from bokeh.server.server import BaseServer, Server
 from bokeh.server.tornado import BokehTornado
 from bokeh.util.token import (
@@ -54,6 +56,7 @@ from bokeh.util.token import (
     get_token_payload,
 )
 from tests.support.plugins.managed_server_loop import MSL
+from tests.support.util.env import envset
 
 # Module under test
 import bokeh.server.server as server # isort:skip
@@ -354,6 +357,39 @@ async def test__exclude_cookies(ManagedServerLoop: MSL) -> None:
         payload = get_token_payload(token)
         assert 'cookies' in payload
         assert payload['cookies'] == {'custom2': 'test2'}
+
+def test__from_settings_uses_envvars() -> None:
+    with tempfile.NamedTemporaryFile(suffix='.py') as f:
+        with envset(
+            BOKEH_AUTH_MODULE=f.name,
+            BOKEH_SIGN_SESSIONS='yes',
+            BOKEH_SECRET_KEY='0' * 32,
+            BOKEH_SSL_CERTFILE='/path/to/cert.pem',
+            BOKEH_SSL_KEYFILE='/path/to/key.pem',
+            BOKEH_SSL_PASSWORD='hunter2',
+            BOKEH_COOKIE_SECRET='verysecret',
+            BOKEH_XSRF_COOKIES='yes',
+        ):
+            with mock.patch.object(Server, '__init__', return_value=None) as init:
+                Server.from_settings(Application())
+                _, kwargs = init.call_args
+    assert isinstance(kwargs['auth_provider'], AuthModule)
+    assert kwargs['sign_sessions'] == True
+    assert kwargs['secret_key'] is not None
+    assert kwargs['ssl_certfile'] == '/path/to/cert.pem'
+    assert kwargs['ssl_keyfile'] == '/path/to/key.pem'
+    assert kwargs['ssl_password'] == 'hunter2'
+    assert kwargs['cookie_secret'] == 'verysecret'
+    assert kwargs['xsrf_cookies'] == True
+
+def test__from_settings_kwarg_overrides_envvar() -> None:
+    """Ensure that a kwarg to Server.from_settings overrides the equivalent envvar setting, if present."""
+    null_auth = NullAuth()
+    with envset(BOKEH_AUTH_MODULE='/some/auth.py'):
+        with mock.patch.object(Server, '__init__', return_value=None) as init:
+            Server.from_settings(Application(), auth_provider=null_auth)
+            _, kwargs = init.call_args
+    assert kwargs['auth_provider'] is null_auth
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -19,6 +19,7 @@ import pytest ; pytest
 # Standard library imports
 import asyncio
 import logging
+import os
 import re
 import ssl
 import sys
@@ -358,9 +359,11 @@ async def test__exclude_cookies(ManagedServerLoop: MSL) -> None:
         assert payload['cookies'] == {'custom2': 'test2'}
 
 def test__from_settings_uses_envvars() -> None:
-    with tempfile.NamedTemporaryFile(suffix='.py') as f:
+    with tempfile.NamedTemporaryFile(suffix='.py', delete=False) as f:
+        auth_path = f.name
+    try:
         with mock.patch('bokeh.server.server.settings') as mock_settings:
-            mock_settings.auth_module.return_value = f.name
+            mock_settings.auth_module.return_value = auth_path
             mock_settings.sign_sessions.return_value = True
             mock_settings.secret_key_bytes.return_value = b'0' * 32
             mock_settings.ssl_certfile.return_value = '/path/to/cert.pem'
@@ -372,6 +375,8 @@ def test__from_settings_uses_envvars() -> None:
             with mock.patch.object(Server, '__init__', return_value=None) as init:
                 Server.from_settings(Application())
                 _, kwargs = init.call_args
+    finally:
+        os.unlink(auth_path)
     assert isinstance(kwargs['auth_provider'], AuthModule)
     assert kwargs['sign_sessions']
     assert kwargs['secret_key'] is not None

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -374,13 +374,13 @@ def test__from_settings_uses_envvars() -> None:
                 Server.from_settings(Application())
                 _, kwargs = init.call_args
     assert isinstance(kwargs['auth_provider'], AuthModule)
-    assert kwargs['sign_sessions'] == True
+    assert kwargs['sign_sessions']
     assert kwargs['secret_key'] is not None
     assert kwargs['ssl_certfile'] == '/path/to/cert.pem'
     assert kwargs['ssl_keyfile'] == '/path/to/key.pem'
     assert kwargs['ssl_password'] == 'hunter2'
     assert kwargs['cookie_secret'] == 'verysecret'
-    assert kwargs['xsrf_cookies'] == True
+    assert kwargs['xsrf_cookies']
 
 def test__from_settings_kwarg_overrides_envvar() -> None:
     """Ensure that a kwarg to Server.from_settings overrides the equivalent envvar setting, if present."""


### PR DESCRIPTION
This PR adds a factory method to Bokeh's main `Server` class, which automatically passes relevant config variables from the Bokeh's `settings` module to the main `Server` constructor. The alternative-constructor approach was chosen because it preserves the existing default behavior in-place, while adding a more convenient interface for users who would prefer it.

I have not included documentation updates in this PR, but am happy to address that pending initial review.

- [X] issues: fixes #14850
- [X] tests added / passed
- [?] release document entry (if new feature or API change)
