### PR TITLE
Lower the default compression level to 2

### DIFF
--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -643,14 +643,15 @@ class Settings:
     by Snap package manager; see https://snapcraft.io/).
     """)
 
-    compression_level: PrioritizedSetting[int] = PrioritizedSetting("compression_level", "BOKEH_COMPRESSION_LEVEL", default=9, convert=convert_compression, help="""
+    compression_level: PrioritizedSetting[int] = PrioritizedSetting("compression_level", "BOKEH_COMPRESSION_LEVEL", default=2, convert=convert_compression, help="""
     In contexts where array buffers are base64-encoded (e.g. to embed inside
     an HTML file), the buffer will first be compressed to save space.
 
-    Valid values are the standard gzip compression levels 0-9. A setting of 9
-    (the default) will result in the highest compression. A setting of 1 will
-    result in the least compression, but be faster. A setting of 0 will result
-    in no compression.
+    Valid values are the standard gzip compression levels 0-9.
+    Level 9 will result in the highest compression.
+    Level 1 will result in the least compression, but be faster.
+    Level 0 will result in no compression.
+    The default is level 2.
     """)
 
     cookie_secret: PrioritizedSetting[str | None] = PrioritizedSetting("cookie_secret", "BOKEH_COOKIE_SECRET", default=None, help="""

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -647,10 +647,12 @@ class Settings:
     In contexts where array buffers are base64-encoded (e.g. to embed inside
     an HTML file), the buffer will first be compressed to save space.
 
-    Valid values are the standard gzip compression levels 0-9.
-    Level 9 will result in the highest compression.
-    Level 1 will result in the least compression, but be faster.
-    Level 0 will result in no compression.
+    Valid values are the standard gzip compression levels 0-9:
+
+    * Level 9 will result in the highest compression.
+    * Level 1 will result in the least compression, but be faster.
+    * Level 0 will result in no compression.
+
     The default is level 2.
     """)
 

--- a/tests/baselines/cross/regressions/issue_13134.json5
+++ b/tests/baselines/cross/regressions/issue_13134.json5
@@ -76,7 +76,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "H4sIAAEAAAAC/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
+                            data: "H4sIAAEAAAAA/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -91,7 +91,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "H4sIAAEAAAAC/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
+                            data: "H4sIAAEAAAAA/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -118,7 +118,7 @@
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "H4sIAAEAAAAC/2NgYGBgAmIWIAYARVaStgwAAAA=",
+                          data: "H4sIAAEAAAAA/2NgYGBgAmIWIAYARVaStgwAAAA=",
                         },
                         shape: [
                           3,

--- a/tests/baselines/cross/regressions/issue_13660.json5
+++ b/tests/baselines/cross/regressions/issue_13660.json5
@@ -76,7 +76,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "H4sIAAEAAAAC/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
+                            data: "H4sIAAEAAAAA/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -91,7 +91,7 @@
                           type: "ndarray",
                           array: {
                             type: "bytes",
-                            data: "H4sIAAEAAAAC/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
+                            data: "H4sIAAEAAAAA/2NkYGBgAmJmIGYBYlYgBgCQqRgpFAAAAA==",
                           },
                           shape: [
                             5,
@@ -118,7 +118,7 @@
                         type: "ndarray",
                         array: {
                           type: "bytes",
-                          data: "H4sIAAEAAAAC/2NgZGBkAAA5oYVnBQAAAA==",
+                          data: "H4sIAAEAAAAA/2NgZGBkAAA5oYVnBQAAAA==",
                         },
                         shape: [
                           5,

--- a/tests/unit/bokeh/test_settings.py
+++ b/tests/unit/bokeh/test_settings.py
@@ -357,6 +357,9 @@ class TestDefaults:
     def test_chromedriver_path(self):
         assert bs.settings.chromedriver_path.default is None
 
+    def test_compression_level(self):
+        assert bs.settings.compression_level.default == 2
+
     def test_cookie_secret(self):
         assert bs.settings.cookie_secret.default is None
 


### PR DESCRIPTION
This level is a better trade off between compression speed and compressed size.

- [x] issues: fixes #14881 
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
