### PR TITLE
Fix conda channel configuration in CI test setup

### DIFF
--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -48,10 +48,10 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          miniconda-version: 'latest'
+          miniforge-version: latest
+          mamba-version: "*"
           activate-environment: bk-release-build
           environment-file: conda/environment-release-build.yml
-          conda-remove-defaults: true
 
       - name: List installed software
         run: |

--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -46,10 +46,10 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          miniconda-version: 'latest'
+          miniforge-version: latest
+          mamba-version: "*"
           activate-environment: bk-release-deploy
           environment-file: conda/environment-release-deploy.yml
-          conda-remove-defaults: true
 
       - name: Deploy Release Tarball
         env:

--- a/.github/workflows/composite/build/action.yml
+++ b/.github/workflows/composite/build/action.yml
@@ -7,21 +7,11 @@ runs:
   steps:
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniconda-version: 'latest'
+        miniforge-version: latest
+        mamba-version: "*"
         activate-environment: bk-test
-        conda-remove-defaults: true
+        environment-file: conda/environment-build.yml
         run-post: ${{ runner.os != 'Windows' }}
-
-    - name: Install libmamba solver
-      shell: bash -l {0}
-      run: |
-        conda install -q -n base conda-libmamba-solver
-        conda config --set solver libmamba
-
-    - name: Update bk-test environment
-      shell: bash -l {0}
-      run: |
-        conda env update -q -n bk-test -f conda/environment-build.yml
 
     - name: Install node modules
       shell: bash -l {0}

--- a/.github/workflows/composite/test-setup/action.yml
+++ b/.github/workflows/composite/test-setup/action.yml
@@ -18,21 +18,11 @@ runs:
   steps:
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniconda-version: 'latest'
+        miniforge-version: latest
+        mamba-version: "*"
         activate-environment: bk-test
-        conda-remove-defaults: true
+        environment-file: conda/environment-test-${{ inputs.test-env }}.yml
         run-post: ${{ runner.os != 'Windows' }}
-
-    - name: Install libmamba solver
-      shell: bash -l {0}
-      run: |
-        conda install -q -n base conda-libmamba-solver
-        conda config --set solver libmamba
-
-    - name: Update bk-test environment
-      shell: bash -l {0}
-      run: |
-        conda env update -q -n bk-test -f conda/environment-test-${{ inputs.test-env }}.yml
 
     - name: Download wheel package
       id: download


### PR DESCRIPTION
Fixes https://github.com/bokeh/bokeh/issues/14894

## Summary

Fixes the `NoChannelsConfiguredError` causing CI failures and prevents the same issue in release workflows.

## Problem

PR #14309 added `conda-remove-defaults: true` to exclude the defaults conda channel. However, when used with `miniconda-version: latest`, this removes **ALL** channels, causing:

```
NoChannelsConfiguredError: No channels are configured. Conda requires at least one channel to search for packages.
```

This broke:
- ❌ Build job (all platforms)  
- ❌ Windows Python 3.10 and 3.14 unit tests
- ❌ Would break release workflows when run

## Solution

Switch from **Miniconda** to **Miniforge** and use **mamba** for faster dependency solving across all conda-based workflows.

**Changes to all four affected files:**
- `.github/workflows/composite/build/action.yml`
- `.github/workflows/composite/test-setup/action.yml`
- `.github/workflows/bokeh-release-build.yml`
- `.github/workflows/bokeh-release-deploy.yml`

**Example diff:**

```diff
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniconda-version: 'latest'
+        miniforge-version: latest
+        mamba-version: "*"
         activate-environment: bk-{test,release-build,release-deploy}
         environment-file: conda/environment-{build,test-X,release-build,release-deploy}.yml
-        conda-remove-defaults: true
```

## Why This Works

**Miniforge**:
- Pre-configured with conda-forge as the default (and only) channel
- Doesn't include the defaults channel
- Purpose-built for conda-forge environments

**Mamba**:
- Faster dependency solver than conda
- Installed via `mamba-version: "*"` parameter
- No separate installation step needed

**environment-file parameter**:
- Already used in release workflows
- Added to composite actions (cleaner than separate `conda env update` step)

This achieves the original intent of PR #14309 (use only conda-forge, exclude defaults) in a simpler, more efficient way.

## Testing

The fix will be validated by CI - we should see:
- ✅ Build job passes on all platforms
- ✅ Windows Python 3.10 and 3.14 unit tests pass
- ✅ All other jobs continue to pass
- ✅ Release workflows will work when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)