### PR TITLE
Add concurrency control to CI workflows

### DIFF
--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -7,6 +7,10 @@ on:
       - branch-*
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 defaults:
   run:
     shell: bash -l {0}

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -7,6 +7,10 @@ on:
       - branch-*
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CHROME_VER: "141.0.7390.54"
   CHROME_REV: "chromium_3265"


### PR DESCRIPTION
## Summary
Automatically cancels outdated workflow runs when new commits are pushed to pull requests. This eliminates wasted runner time on superseded commits while allowing main/branch pushes to complete normally for full test coverage. I (unfortunately) push commits to PRs to quickly, so I create a backlog of runs.

## Related Issues
Partially addresses #12931

## Changes
- Adds `concurrency` configuration to both `bokeh-ci.yml` and `bokehjs-ci.yml`
- Cancels in-progress runs only for pull requests (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`)
- Main and branch pushes continue to run all jobs to completion

## Impact
- **Massive reduction** in wasted CI runner time on PRs with multiple commits
- Faster feedback loop for PR authors (latest commit gets resources immediately)
- Helps with GitHub Actions concurrency limits mentioned in #12849

## Testing
- This change takes effect immediately upon merge
- Observable when pushing multiple commits rapidly to a PR