### PR TITLE
Pin gmpy2 to version 2.2* due to bad `__version__`

### DIFF
--- a/conda/environment-release-build.yml
+++ b/conda/environment-release-build.yml
@@ -30,6 +30,7 @@ dependencies:
   - scipy
   - squarify
   - sympy
+  - gmpy2 ==2.2.* # for sympy, see https://github.com/bokeh/bokeh/issues/14916
   - toml
 
   # pip dependencies

--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -63,6 +63,7 @@ dependencies:
   - scikit-learn
   - squarify
   - sympy
+  - gmpy2 ==2.2.* # for sympy, see https://github.com/bokeh/bokeh/issues/14916
 
   # pip dependencies
   - pip

--- a/conda/environment-test-3.11.yml
+++ b/conda/environment-test-3.11.yml
@@ -63,6 +63,7 @@ dependencies:
   - scikit-learn
   - squarify
   - sympy
+  - gmpy2 ==2.2.* # for sympy, see https://github.com/bokeh/bokeh/issues/14916
 
   # pip dependencies
   - pip

--- a/conda/environment-test-3.12.yml
+++ b/conda/environment-test-3.12.yml
@@ -63,6 +63,7 @@ dependencies:
   - scikit-learn
   #- squarify
   - sympy
+  - gmpy2 ==2.2.* # for sympy, see https://github.com/bokeh/bokeh/issues/14916
 
   # pip dependencies
   - pip

--- a/conda/environment-test-3.13.yml
+++ b/conda/environment-test-3.13.yml
@@ -63,6 +63,7 @@ dependencies:
   - scikit-learn
   - squarify
   - sympy
+  - gmpy2 ==2.2.* # for sympy, see https://github.com/bokeh/bokeh/issues/14916
 
   # pip dependencies
   - pip

--- a/conda/environment-test-3.14.yml
+++ b/conda/environment-test-3.14.yml
@@ -63,6 +63,7 @@ dependencies:
   - scikit-learn
   - squarify
   - sympy
+  - gmpy2 ==2.2.* # for sympy, see https://github.com/bokeh/bokeh/issues/14916
 
   # pip dependencies
   - pip


### PR DESCRIPTION
fixes #14916 