### PR TITLE
Use `union` merge strategy for release notes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/bokeh/source/docs/releases/*.rst merge=union


### PR DESCRIPTION
This should resolve endless conflicts in `x.y.z.rst` files.

fixes #14377