### PR TITLE
Update `switcher.json` for 3.9 release

### DIFF
--- a/docs/bokeh/switcher.json
+++ b/docs/bokeh/switcher.json
@@ -1,9 +1,13 @@
 [
   {
-    "name": "3.8.0 (latest)",
-    "version": "3.8.0",
+    "name": "3.9.0 (latest)",
+    "version": "3.9.0",
     "url": "https://docs.bokeh.org/en/latest/",
     "preferred": true
+  },
+  {
+    "version": "3.8.2",
+    "url": "https://docs.bokeh.org/en/3.8.2/"
   },
   {
     "version": "3.7.3",


### PR DESCRIPTION
This is a release blocker.

fixes #14919 