### PR TITLE
Add support for optional package dependencies

### DIFF
--- a/docs/bokeh/source/docs/first_steps/installation.rst
+++ b/docs/bokeh/source/docs/first_steps/installation.rst
@@ -33,6 +33,20 @@ Bokeh can be installed using either the Python package installer ``pip``, or
 
             pip install bokeh
 
+        This installs only the required dependencies. To unlock other features
+        or improve performance, additional packages are needed and can be
+        installed as follows:
+
+        .. code-block:: sh
+
+            pip install bokeh[all]
+
+        Available options are:
+        * ``all`` - this includes ``extra``, ``export`` and ``sampledata``
+        * ``extra`` - installs ``pandas``, etc.
+        * ``export`` - install ``selenium``, etc.
+        * ``sampledata`` - installs ``bokeh_sampledata`` package (see :ref:`install_sampledata`)
+
     .. grid-item-card::
 
         Installing with ``conda``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,12 @@ description = "Interactive plots and applications in the browser from Python"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "Jinja2 >=2.9",
-    "contourpy >=1.2",
+    "jinja2 >=2.9",
     "narwhals>=1.13",
     "numpy >=1.16",
     "packaging >=16.8",
     "pillow >=7.1.0",
-    "PyYAML >=3.10",
+    "pyyaml >=3.10",
     "tornado >=6.2; sys_platform != 'emscripten'",
     "xyzservices >=2021.09.1",
 ]
@@ -53,6 +52,21 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Utilities",
+]
+
+[project.optional-dependencies]
+sampledata = [
+    "bokeh_sampledata >=2025.0",
+]
+extra = [
+    "contourpy >=1.2",
+    "pandas >=2.0",
+]
+export = [
+    "selenium ~=4.2",
+]
+all = [
+    "bokeh[sampledata,extra,export]",
 ]
 
 [project.urls]


### PR DESCRIPTION
This allows `pip install bokeh[all]` to install `pandas`, `bokeh_sampledata`, etc. I also moved `contourpy` to optional dependencies, because it's already treated like one in the implementation.

fixes #14923 
