### PR TITLE
Add conda environment pkg to CI workflows

### DIFF
--- a/.github/workflows/composite/build/action.yml
+++ b/.github/workflows/composite/build/action.yml
@@ -5,18 +5,43 @@ description: 'Build Bokeh and Bokeh.js for testing'
 runs:
   using: "composite"
   steps:
+    # Build conda cache key (24-hour expiration via date)
+    # To manually reset cache, increment the version number (v1, v2, etc.)
+    # We cache the package directory (pkgs/) instead of individual environments
+    # to allow sharing packages across different Python versions on the same OS.
+    # This dramatically reduces cache size (3-6 GB total vs 10+ GB with per-env caching).
+    - name: Build conda cache key
+      id: conda-cache-key
+      shell: bash
+      run: |
+        TODAY=$(date -u '+%Y%m%d')
+        CACHE_KEY="conda-pkgs-v1-${{ runner.os }}-${{ runner.arch }}-${TODAY}"
+        echo "key=${CACHE_KEY}" >> $GITHUB_OUTPUT
+
+    # Cache conda packages (shared across all environments on this OS)
+    - name: Cache conda packages
+      uses: actions/cache@v4
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ steps.conda-cache-key.outputs.key }}
+      id: cache
+
     # Remove nodejs from conda environment to avoid duplicate installation
     # We'll install Node.js via setup-node instead for better npm caching
     - name: Filter nodejs from environment file
       shell: bash
       run: grep -v '^\s*-\s*nodejs\b' conda/environment-build.yml > conda/environment-build-no-nodejs.yml
 
-    - uses: conda-incubator/setup-miniconda@v3
+    # Setup Miniforge and create environment from filtered file
+    # This creates and activates the bk-test environment with all packages
+    - name: Setup Miniforge
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
         mamba-version: "*"
         activate-environment: bk-test
         environment-file: conda/environment-build-no-nodejs.yml
+        conda-remove-defaults: true
         run-post: ${{ runner.os != 'Windows' }}
 
     - name: Install Node.js

--- a/.github/workflows/composite/test-setup/action.yml
+++ b/.github/workflows/composite/test-setup/action.yml
@@ -16,6 +16,27 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Build conda cache key (24-hour expiration via date)
+    # To manually reset cache, increment the version number (v1, v2, etc.)
+    # We cache the package directory (pkgs/) instead of individual environments
+    # to allow sharing packages across different Python versions on the same OS.
+    # This dramatically reduces cache size (3-6 GB total vs 10+ GB with per-env caching).
+    - name: Build conda cache key
+      id: conda-cache-key
+      shell: bash
+      run: |
+        TODAY=$(date -u '+%Y%m%d')
+        CACHE_KEY="conda-pkgs-v1-${{ runner.os }}-${{ runner.arch }}-${TODAY}"
+        echo "key=${CACHE_KEY}" >> $GITHUB_OUTPUT
+
+    # Cache conda packages (shared across all environments on this OS)
+    - name: Cache conda packages
+      uses: actions/cache@v4
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ steps.conda-cache-key.outputs.key }}
+      id: cache
+
     # Remove nodejs from conda environment to avoid duplicate installation
     # We'll install Node.js via setup-node instead for better npm caching
     - name: Filter nodejs from environment file
@@ -24,13 +45,16 @@ runs:
         LOC="conda/environment-test-${{ inputs.test-env }}"
         grep -v '^\s*-\s*nodejs\b' $LOC.yml > $LOC-no-nodejs.yml
 
-    - name: Setup conda environment
+    # Setup Miniforge and create environment from filtered file
+    # This creates and activates the bk-test environment with all packages
+    - name: Setup Miniforge
       uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
         mamba-version: "*"
         activate-environment: bk-test
         environment-file: conda/environment-test-${{ inputs.test-env }}-no-nodejs.yml
+        conda-remove-defaults: true
         run-post: ${{ runner.os != 'Windows' }}
 
     - name: Install Node.js


### PR DESCRIPTION
Partially addresses https://github.com/bokeh/bokeh/issues/12931

## Results
I'm inclined to close this PR as not worthwhile.

I sought to improve CI performance by adding conda caching to reduce environment setup time. It "works" and saves ~60-90 secs per workflow but with multiple Python versions (3.11, 3.12, 3.13, 3.14) and job types (build, minimal-deps, core-deps, etc.) per OS, the
resulting cache size is larger than the free 10GB Github action cache limit.

The current PR implementation caches the conda packages per OS (as the different python versions generally use the same dependencies on the same OS). This addresses the cache size issue (3 OS × 1 shared cache = **3 caches → 3-6GB total**), but only results in a ~10 second time saving per workflow as the conda/mamba dependency resolution step is the slow part of bulding a conda environment (~50 seconds).

As a result, I'm not sure the added complexity of the conda packaging caching is worth the small ~10 second improvement.

-------------------

## Details:

### Conda package caching
- Cache the shared package directory (`~/conda_pkgs_dir`) configured by setup-miniconda
- Use `actions/cache@v4` to cache packages shared across all Python versions on the same OS
- Cache key: `conda-pkgs-v1-{OS}-{arch}-{date}`
  - Manual version prefix (`conda-pkgs-v1`) for manual cache invalidation
  - OS and architecture (`runner.os`, `runner.arch`) for platform-specific caching
  - Current date (24-hour automatic expiration)
- Environment creation uses `environment-file` parameter in `setup-miniconda@v3`
- Applied to both build and test-setup composite actions

Conda uses hardlinks/symlinks from `pkgs/` to `envs/`, so all environments on the same OS share the same packages. Caching the package directory allows:
- ✅ All Python versions share the same cache (dramatic size reduction)
- ✅ Environment creation is still fast (just creates hardlinks)
- ✅ Follows official setup-miniconda example pattern
- ✅ Avoids Windows path issues with cached environments
- ✅ Stays well under GitHub's 10GB cache limit

## Benefits
- **Faster CI runs**: Cached conda packages reduce setup time
- **Efficient cache usage**: 3-6GB total vs 10GB+ with environment caching
- **Flexible cache management**: 
  - Automatic daily refresh (24-hour expiration) prevents stale caches
  - Manual reset capability via version prefix (change `v1` to `v2`)
  - Mamba automatically downloads new packages when environment files change
- **No functional changes**: CI behavior remains identical, only performance improves

## Cache Testing Note

**⚠️ Cache verification limited in fork PRs:** Due to GitHub Actions security restrictions, caches created in pull requests from forks (like this one) have limited scope and may not be accessible across workflow runs. This is by design for security ([GitHub docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)).

However, **fork PRs can access caches from the base branch** once this is merged. This means:
- ✅ First run after merge: Creates caches on `branch-3.10`
- ✅ Subsequent runs on `branch-3.10`: Cache hits
- ✅ Future fork PRs: Can restore caches from `branch-3.10`

The caching implementation follows official GitHub Actions and setup-miniconda patterns and will work correctly once merged to the main repository.

## Notes
- To manually reset conda cache: change `conda-pkgs-v1` to `conda-pkgs-v2` in the cache key
- Based on official setup-miniconda caching guide: https://github.com/conda-incubator/setup-miniconda#caching-environments
- Complements npm caching from #14903 for maximum CI speedup
- Uses `~/conda_pkgs_dir` which works cross-platform (recommended by actions/cache for Windows compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)