### PR TITLE
Narrow broad except in convert_datetime_array

### DIFF
--- a/src/bokeh/util/serialization.py
+++ b/src/bokeh/util/serialization.py
@@ -245,7 +245,7 @@ def convert_datetime_array(array: npt.NDArray[Any]) -> npt.NDArray[np.floating[A
     elif array.dtype.kind == "O" and len(array) > 0 and isinstance(array[0], dt.date):
         try:
             return convert(array.astype("datetime64[us]"))
-        except Exception:
+        except (TypeError, ValueError):
             pass
 
     return array


### PR DESCRIPTION
The object-dtype date array conversion path in `convert_datetime_array` catches all exceptions with a bare `except Exception`, silently swallowing errors that are not related to type conversion (e.g. `MemoryError`, internal bugs).

This narrows the catch to `(TypeError, ValueError)`, which are the only expected failure modes when calling `astype("datetime64[us]")` on an object array of `datetime.date` values. All other exceptions now propagate normally.

Fixes #14889