### PR TITLE
Fix pandas intersphinx URL

### DIFF
--- a/docs/bokeh/source/conf.py
+++ b/docs/bokeh/source/conf.py
@@ -144,7 +144,7 @@ copybutton_prompt_text = ">>> "
 
 intersphinx_mapping = {
     "numpy"       : ("https://numpy.org/doc/stable/", None),
-    "pandas"      : ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "pandas"      : ("https://pandas.pydata.org/docs/", None),
     "python"      : ("https://docs.python.org/3/", None),
     "sphinx"      : ("https://www.sphinx-doc.org/en/master/", None),
     "xyzservices" : ("https://xyzservices.readthedocs.io/en/stable/", None),


### PR DESCRIPTION
Fixes #14938

## Problem

Documentation builds are failing with:
```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://pandas.pydata.org/pandas-docs/stable/objects.inv' not fetchable due to 404 Client Error
```

## Root Cause

Pandas changed their documentation URL structure:
- **Old (404):** https://pandas.pydata.org/pandas-docs/stable/
- **New (works):** https://pandas.pydata.org/docs/

## Solution

Updated `docs/bokeh/source/conf.py` to use the new pandas documentation URL in the `intersphinx_mapping` configuration.

## Impact

This unblocks all PRs that are currently failing the documentation build job.