### PR TITLE
Fix canvas rendering for Ray glyph using save/restore pattern

### DIFF
--- a/bokehjs/src/lib/models/glyphs/ray.ts
+++ b/bokehjs/src/lib/models/glyphs/ray.ts
@@ -50,6 +50,7 @@ export class RayView extends XYGlyphView {
       if (!isFinite(sx_i + sy_i + angle_i + slength_i))
         continue
 
+      ctx.save()
       ctx.translate(sx_i, sy_i)
       ctx.rotate(angle_i)
 
@@ -59,8 +60,7 @@ export class RayView extends XYGlyphView {
 
       this.visuals.line.apply(ctx, i)
 
-      ctx.rotate(-angle_i)
-      ctx.translate(-sx_i, -sy_i)
+      ctx.restore()
     }
   }
 


### PR DESCRIPTION
## Summary
Refactors the Ray glyph's canvas rendering to use the standard `ctx.save()`/`ctx.restore()` pattern instead of manual transform reversal, bringing it in line with canvas best practices and consistency with other glyphs.

## Changes
- Modified `Ray._render()` to use `ctx.save()`/`ctx.restore()` instead of manual `ctx.rotate(-angle)` and `ctx.translate(-x, -y)` reversal
- This follows the same pattern used by Arc, Segment, and AnnularWedge glyphs (#14950)

## Context
While reviewing #14950 (AnnularWedge canvas rendering fix), I discovered that the Ray glyph had the same manual transform reversal pattern. Unlike AnnularWedge (which had visible fill bugs), Ray only applies line styles, so the old pattern doesn't cause visible rendering issues. However, the new pattern is more correct, maintainable, and consistent with the rest of the codebase.

## Testing
- Existing Ray tests should continue to pass
- No visual changes expected (this is a refactoring for correctness and consistency)

Related to #14950

🤖 Generated with [Claude Code](https://claude.com/claude-code)