### PR TITLE
Add GitHub CLI examples for triggering full CI workflow

### DIFF
--- a/docs/bokeh/source/docs/dev_guide/testing.rst
+++ b/docs/bokeh/source/docs/dev_guide/testing.rst
@@ -215,6 +215,21 @@ Run all available tests
 
         pytest
 
+.. _contributor_guide_testing_local_python_parallel:
+
+Run unit tests in parallel
+    To speed up the Python unit test suite, use the ``-n`` option to distribute tests
+    across multiple CPU cores. Some examples are given below:
+
+    .. code-block:: sh
+
+        pytest tests/unit -n auto     # All physically available CPU cores
+        pytest tests/unit -n logical  # All logical CPU cores
+        pytest tests/unit -n 4        # 4 CPU cores
+
+    .. seealso::
+        Parallel test execution is provided by `pytest-xdist`_.
+
 .. _contributor_guide_testing_local_python_select:
 
 Select specific tests

--- a/docs/bokeh/source/docs/dev_guide/testing.rst
+++ b/docs/bokeh/source/docs/dev_guide/testing.rst
@@ -517,11 +517,27 @@ Bokeh uses multiple CI workflows to balance speed and coverage:
 
     **To manually trigger the full workflow:**
 
+    Via GitHub Web UI:
+
     1. Go to the `Actions tab <https://github.com/bokeh/bokeh/actions>`_
     2. Select "Bokeh-CI-Full" from the workflow list
     3. Click "Run workflow" (top right)
-    4. Optionally provide a reason for the manual run
-    5. Click "Run workflow" to start
+    4. Select the branch to test
+    5. Optionally provide a reason for the manual run
+    6. Click "Run workflow" to start
+
+    Via GitHub CLI:
+
+    .. code-block:: sh
+
+        # Trigger on a specific branch
+        gh workflow run bokeh-ci-full.yml --ref branch-name
+
+        # Trigger on a PR's branch
+        gh workflow run bokeh-ci-full.yml --ref $(gh pr view PR_NUMBER --json headRefName --jq .headRefName)
+
+        # With a custom reason
+        gh workflow run bokeh-ci-full.yml --ref branch-name -f reason="Testing before release"
 
     Manual triggers are useful before major releases, after dependency updates,
     or when investigating platform-specific bugs.


### PR DESCRIPTION
Fixes #14930

(I messed up a rebase and lost these docs changes from #14934)

- Revert removal of running unit tests in parallel
- Add GitHub CLI examples for triggering the full CI workflow alongside the existing web UI instructions.