### PR TITLE
Fix Windows unit test failures in CI-Full workflow

### DIFF
--- a/.github/workflows/bokeh-ci-full.yml
+++ b/.github/workflows/bokeh-ci-full.yml
@@ -51,6 +51,7 @@ jobs:
         os: [ubuntu-24.04, macos-latest, windows-latest]
 
     steps:
+      # Required for codebase tests that check file formatting (line endings, whitespace, etc).
       - name: Configure line endings in git
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
@@ -145,10 +146,6 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - name: Configure line endings in git
-        if: runner.os == 'Windows'
-        run: git config --global core.autocrlf false
-
       - uses: actions/checkout@v6
 
       - name: Prepare Environment
@@ -179,10 +176,6 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
-      - name: Configure line endings in git
-        if: runner.os == 'Windows'
-        run: git config --global core.autocrlf false
-
       - uses: actions/checkout@v6
 
       - name: Prepare Environment
@@ -212,10 +205,6 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
-      - name: Configure line endings in git
-        if: runner.os == 'Windows'
-        run: git config --global core.autocrlf false
-
       - uses: actions/checkout@v6
 
       - name: Prepare Environment
@@ -244,10 +233,6 @@ jobs:
         python-version: ['3.11']
 
     steps:
-      - name: Configure line endings in git
-        if: runner.os == 'Windows'
-        run: git config --global core.autocrlf false
-
       - uses: actions/checkout@v6
 
       - name: Prepare Environment

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -45,6 +45,7 @@ jobs:
         os: [ubuntu-24.04, macos-latest, windows-latest]
 
     steps:
+      # Required for codebase tests that check file formatting (line endings, whitespace, etc).
       - name: Configure line endings in git
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -45,6 +45,11 @@ jobs:
         os: [ubuntu-24.04, macos-latest, windows-latest]
 
     steps:
+      # Required for codebase tests that check file formatting (line endings, whitespace, etc).
+      - name: Configure line endings in git
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@v6
 
       - name: Prepare Environment

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -45,11 +45,6 @@ jobs:
         os: [ubuntu-24.04, macos-latest, windows-latest]
 
     steps:
-      # Required for codebase tests that check file formatting (line endings, whitespace, etc).
-      - name: Configure line endings in git
-        if: runner.os == 'Windows'
-        run: git config --global core.autocrlf false
-
       - uses: actions/checkout@v6
 
       - name: Prepare Environment


### PR DESCRIPTION
Fixes #14973

See #14974 

Remove the `git config --global core.autocrlf false` configuration from the `unit-test` job in `bokeh-ci-full.yml` to resolve `test_defaults.py` failures.

This aligns `bokeh-ci-full.yml` with `bokeh-ci.yml`

Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>