### PR TITLE
Simplify `CustomJS` construction with template strings

### DIFF
--- a/.github/workflows/bokeh-ci-full.yml
+++ b/.github/workflows/bokeh-ci-full.yml
@@ -260,7 +260,9 @@ jobs:
       matrix:
         # Comprehensive: All platforms
         os: [ubuntu-24.04, macos-latest, windows-latest]
-        python-version: ['3.11']
+        # Build only on the most recent version of Python, so that documentation
+        # and included examples can utilize newest available syntax and standard APIs.
+        python-version: ['3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -235,12 +235,15 @@ jobs:
 
   documentation:
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         # Documentation: Linux only
+        os: [ubuntu-24.04]
+        # Build only on the most recent version of Python, so that documentation
+        # and included examples can utilize newest available syntax and standard APIs.
         python-version: ['3.14']
 
     steps:

--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -4702,7 +4702,10 @@ describe("Bug", () => {
   })
 
   describe("in issue #14549", () => {
-    it("doesn't prevent hover action upon bbox change", async () => {
+    // TODO This test can produce to marginally different states, that cause
+    // tests to fail at random. Re-enable this when vDOM migration and layout
+    // redesign are completed.
+    it.skip("doesn't prevent hover action upon bbox change", async () => {
       const n = 1000
       const x = linspace(0, 20, n)
       const y = x

--- a/docs/bokeh/source/docs/releases/3.10.0.rst
+++ b/docs/bokeh/source/docs/releases/3.10.0.rst
@@ -15,3 +15,4 @@ Bokeh version ``3.10.0`` (May 2026) is a minor milestone of Bokeh project.
 * Support ``LightDark`` component auto/system option and add tri-state handling to toggle like components (:bokeh-pull:`14915`)
 * Make it easier to theme ``Tooltip`` component and migrate it to vDOM (:bokeh-pull:`14955`)
 * Fix broken inverted color mapping when using LogColorMapper (:bokeh-pull:`15035`)
+* Simplified ``CustomJS`` construction with template strings (Python 3.14+) (:bokeh-pull:`14977`)

--- a/docs/bokeh/source/docs/releases/3.10.0.rst
+++ b/docs/bokeh/source/docs/releases/3.10.0.rst
@@ -11,3 +11,4 @@ Bokeh version ``3.10.0`` (May 2026) is a minor milestone of Bokeh project.
 * Dropped support for Python 3.10 (:bokeh-pull:`14865`)
 * Added ``perform_error_diagnostics`` settings flag (:bokeh-pull:`14947`)
 * Redesigned BokehJS' build system to use TypeScript native (tsgo) compiler (:bokeh-pull:`14812`)
+* Simplified ``CustomJS`` construction with template strings (Python 3.14+) (:bokeh-pull:`14977`)

--- a/examples/interaction/widgets/slider_template_string.py
+++ b/examples/interaction/widgets/slider_template_string.py
@@ -6,7 +6,7 @@ from bokeh.models.widgets import Div
 output = Div(text="Slide to reveal the value")
 slider = Slider(start=0, end=10, value=1, step=0.1, title=None)
 
-callback = CustomJS.from_string(t"""
+callback = CustomJS.from_template(t"""
     {output}.text = `Slider was updated to <b>${{ {slider}.value }}</b> value`
 """)
 slider.js_on_change("value", callback)

--- a/examples/interaction/widgets/slider_template_string.py
+++ b/examples/interaction/widgets/slider_template_string.py
@@ -6,12 +6,9 @@ from bokeh.models.widgets import Div
 output = Div(text="Slide to reveal the value")
 slider = Slider(start=0, end=10, value=1, step=0.1, title=None)
 
-callback = CustomJS(
-    args=dict(slider=slider, output=output),
-    code="""
-        output.text = `Slider was updated to <b>${{ slider.value }}</b> value`
-    """,
-)
+callback = CustomJS.from_string(t"""
+    {output}.text = `Slider was updated to <b>${{ {slider}.value }}</b> value`
+""")
 slider.js_on_change("value", callback)
 
 show(row([slider, output]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,9 @@ lint.ignore = [
 ]
 line-length = 165
 
+[tool.ruff.per-file-target-version]
+"examples/interaction/widgets/slider_template_string.py" = "py314"
+
 # For now enable each typed module individually.
 [[tool.mypy.overrides]]
 module = [

--- a/src/bokeh/models/callbacks.py
+++ b/src/bokeh/models/callbacks.py
@@ -203,7 +203,7 @@ class CustomJS(CustomCode):
 
         return CustomJS(code=code, args=args, module=module)
 
-    if sys.version_info >= (3, 14):
+    if sys.version_info[:2] >= (3, 14):
         if TYPE_CHECKING:
             from string.templatelib import Template  # novermin
 

--- a/src/bokeh/models/callbacks.py
+++ b/src/bokeh/models/callbacks.py
@@ -22,7 +22,11 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import pathlib
+import sys
 from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from string.templatelib import Template
 
 # Bokeh imports
 from ..core.has_props import HasProps, abstract
@@ -201,6 +205,46 @@ class CustomJS(CustomCode):
             code = file.read()
 
         return CustomJS(code=code, args=args, module=module)
+
+    @classmethod
+    def from_string(cls, template: str | Template) -> CustomJS:
+        """
+        Construct a ``CustomJS`` instance from an interpolated string.
+
+        This allows to fill ``CustomJS.args`` by simply referring to Bokeh models
+        and other values from within interpolations.
+
+        .. code-block: python
+
+            from bokeh.models import CustomJS, Slider
+            slider = Slider(start=0, end=10)
+            CustomJS.from_string(t"console.log('Slider value: ' + {slider}.value)")
+
+        .. note::
+
+            This requires Python 3.14 and above to work.
+
+        """
+        if isinstance(template, str):
+            return CustomJS(code=template)
+
+        if sys.version_info < (3, 14):
+            raise RuntimeError("template literals are supported only by Python 3.14 and above")
+
+        from string.templatelib import Interpolation
+
+        args: dict[str, Any] = {}
+        code = ""
+
+        for item in template:
+            if isinstance(item, Interpolation):
+                name = item.expression
+                args[name] = item.value
+                code += name
+            else:
+                code += item
+
+        return CustomJS(args=args, code=code)
 
 class SetValue(Callback):
     """ Allows to update a property of an object. """

--- a/src/bokeh/models/callbacks.py
+++ b/src/bokeh/models/callbacks.py
@@ -205,7 +205,7 @@ class CustomJS(CustomCode):
 
     if sys.version_info >= (3, 14):
         if TYPE_CHECKING:
-            from string.templatelib import Template
+            from string.templatelib import Template  # novermin
 
         @classmethod
         def from_string(cls, template: str | Template) -> CustomJS:
@@ -229,7 +229,7 @@ class CustomJS(CustomCode):
             if isinstance(template, str):
                 return CustomJS(code=template)
 
-            from string.templatelib import Interpolation
+            from string.templatelib import Interpolation  # novermin
 
             args: dict[str, Any] = {}
             code = ""

--- a/src/bokeh/models/callbacks.py
+++ b/src/bokeh/models/callbacks.py
@@ -208,7 +208,7 @@ class CustomJS(CustomCode):
             from string.templatelib import Template  # novermin
 
         @classmethod
-        def from_string(cls, template: str | Template) -> CustomJS:
+        def from_template(cls, template: Template) -> CustomJS:
             """
             Construct a ``CustomJS`` instance from an interpolated string.
 
@@ -219,16 +219,13 @@ class CustomJS(CustomCode):
 
                 from bokeh.models import CustomJS, Slider
                 slider = Slider(start=0, end=10)
-                CustomJS.from_string(t"console.log('Slider value: ' + {slider}.value)")
+                CustomJS.from_template(t"console.log('Slider value: ' + {slider}.value)")
 
             .. note::
 
                 This requires Python 3.14 and above to work.
 
             """
-            if isinstance(template, str):
-                return CustomJS(code=template)
-
             from string.templatelib import Interpolation  # novermin
 
             args: dict[str, Any] = {}

--- a/src/bokeh/models/callbacks.py
+++ b/src/bokeh/models/callbacks.py
@@ -25,9 +25,6 @@ import pathlib
 import sys
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from string.templatelib import Template
-
 # Bokeh imports
 from ..core.has_props import HasProps, abstract
 from ..core.property.any import AnyRef
@@ -206,45 +203,46 @@ class CustomJS(CustomCode):
 
         return CustomJS(code=code, args=args, module=module)
 
-    @classmethod
-    def from_string(cls, template: str | Template) -> CustomJS:
-        """
-        Construct a ``CustomJS`` instance from an interpolated string.
+    if sys.version_info >= (3, 14):
+        if TYPE_CHECKING:
+            from string.templatelib import Template
 
-        This allows to fill ``CustomJS.args`` by simply referring to Bokeh models
-        and other values from within interpolations.
+        @classmethod
+        def from_string(cls, template: str | Template) -> CustomJS:
+            """
+            Construct a ``CustomJS`` instance from an interpolated string.
 
-        .. code-block: python
+            This allows to fill ``CustomJS.args`` by simply referring to Bokeh models
+            and other values from within interpolations.
 
-            from bokeh.models import CustomJS, Slider
-            slider = Slider(start=0, end=10)
-            CustomJS.from_string(t"console.log('Slider value: ' + {slider}.value)")
+            .. code-block: python
 
-        .. note::
+                from bokeh.models import CustomJS, Slider
+                slider = Slider(start=0, end=10)
+                CustomJS.from_string(t"console.log('Slider value: ' + {slider}.value)")
 
-            This requires Python 3.14 and above to work.
+            .. note::
 
-        """
-        if isinstance(template, str):
-            return CustomJS(code=template)
+                This requires Python 3.14 and above to work.
 
-        if sys.version_info < (3, 14):
-            raise RuntimeError("template literals are supported only by Python 3.14 and above")
+            """
+            if isinstance(template, str):
+                return CustomJS(code=template)
 
-        from string.templatelib import Interpolation
+            from string.templatelib import Interpolation
 
-        args: dict[str, Any] = {}
-        code = ""
+            args: dict[str, Any] = {}
+            code = ""
 
-        for item in template:
-            if isinstance(item, Interpolation):
-                name = item.expression
-                args[name] = item.value
-                code += name
-            else:
-                code += item
+            for item in template:
+                if isinstance(item, Interpolation):
+                    name = item.expression
+                    args[name] = item.value
+                    code += name
+                else:
+                    code += item
 
-        return CustomJS(args=args, code=code)
+            return CustomJS(args=args, code=code)
 
 class SetValue(Callback):
     """ Allows to update a property of an object. """

--- a/src/bokeh/models/callbacks.py
+++ b/src/bokeh/models/callbacks.py
@@ -25,7 +25,7 @@ import pathlib
 import sys
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
+if TYPE_CHECKING and sys.version_info >= (3, 14):
     from string.templatelib import Template
 
 # Bokeh imports
@@ -206,45 +206,43 @@ class CustomJS(CustomCode):
 
         return CustomJS(code=code, args=args, module=module)
 
-    @classmethod
-    def from_string(cls, template: str | Template) -> CustomJS:
-        """
-        Construct a ``CustomJS`` instance from an interpolated string.
+    if sys.version_info >= (3, 14):
+        @classmethod
+        def from_string(cls, template: str | Template) -> CustomJS:
+            """
+            Construct a ``CustomJS`` instance from an interpolated string.
 
-        This allows to fill ``CustomJS.args`` by simply referring to Bokeh models
-        and other values from within interpolations.
+            This allows to fill ``CustomJS.args`` by simply referring to Bokeh models
+            and other values from within interpolations.
 
-        .. code-block: python
+            .. code-block: python
 
-            from bokeh.models import CustomJS, Slider
-            slider = Slider(start=0, end=10)
-            CustomJS.from_string(t"console.log('Slider value: ' + {slider}.value)")
+                from bokeh.models import CustomJS, Slider
+                slider = Slider(start=0, end=10)
+                CustomJS.from_string(t"console.log('Slider value: ' + {slider}.value)")
 
-        .. note::
+            .. note::
 
-            This requires Python 3.14 and above to work.
+                This requires Python 3.14 and above to work.
 
-        """
-        if isinstance(template, str):
-            return CustomJS(code=template)
+            """
+            if isinstance(template, str):
+                return CustomJS(code=template)
 
-        if sys.version_info < (3, 14):
-            raise RuntimeError("template literals are supported only by Python 3.14 and above")
+            from string.templatelib import Interpolation
 
-        from string.templatelib import Interpolation
+            args: dict[str, Any] = {}
+            code = ""
 
-        args: dict[str, Any] = {}
-        code = ""
+            for item in template:
+                if isinstance(item, Interpolation):
+                    name = item.expression
+                    args[name] = item.value
+                    code += name
+                else:
+                    code += item
 
-        for item in template:
-            if isinstance(item, Interpolation):
-                name = item.expression
-                args[name] = item.value
-                code += name
-            else:
-                code += item
-
-        return CustomJS(args=args, code=code)
+            return CustomJS(args=args, code=code)
 
 class SetValue(Callback):
     """ Allows to update a property of an object. """

--- a/src/bokeh/models/callbacks.pyi
+++ b/src/bokeh/models/callbacks.pyi
@@ -10,7 +10,7 @@ import sys
 from abc import abstractmethod
 from typing import Any, Unpack
 
-if sys.version_info >= (3, 14):
+if sys.version_info[:2] >= (3, 14):
     from string.templatelib import Template
 
 # Bokeh imports
@@ -59,7 +59,7 @@ class CustomJS(CustomCode):
     @classmethod
     def from_file(cls, path: PathLike, **args: Any) -> CustomJS: ...
 
-    if sys.version_info >= (3, 14):
+    if sys.version_info[:2] >= (3, 14):
         @classmethod
         def from_template(cls, template: Template) -> CustomJS: ...
 

--- a/src/bokeh/models/callbacks.pyi
+++ b/src/bokeh/models/callbacks.pyi
@@ -8,8 +8,10 @@
 # Standard library imports
 import sys
 from abc import abstractmethod
-from string.templatelib import Template
 from typing import Any, Unpack
+
+if sys.version_info >= (3, 14):
+    from string.templatelib import Template
 
 # Bokeh imports
 from ..core.enums import AutoType as Auto

--- a/src/bokeh/models/callbacks.pyi
+++ b/src/bokeh/models/callbacks.pyi
@@ -7,6 +7,7 @@
 
 # Standard library imports
 from abc import abstractmethod
+from string.templatelib import Template
 from typing import Any, Unpack
 
 # Bokeh imports
@@ -54,6 +55,9 @@ class CustomJS(CustomCode):
 
     @classmethod
     def from_file(cls, path: PathLike, **args: Any) -> CustomJS: ...
+
+    @classmethod
+    def from_string(cls, template: str | Template) -> CustomJS: ...
 
 class _SetValueInit(_CallbackInit, total=False):
     obj: HasProps

--- a/src/bokeh/models/callbacks.pyi
+++ b/src/bokeh/models/callbacks.pyi
@@ -6,6 +6,7 @@
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import sys
 from abc import abstractmethod
 from string.templatelib import Template
 from typing import Any, Unpack
@@ -56,8 +57,9 @@ class CustomJS(CustomCode):
     @classmethod
     def from_file(cls, path: PathLike, **args: Any) -> CustomJS: ...
 
-    @classmethod
-    def from_string(cls, template: str | Template) -> CustomJS: ...
+    if sys.version_info >= (3, 14):
+        @classmethod
+        def from_string(cls, template: str | Template) -> CustomJS: ...
 
 class _SetValueInit(_CallbackInit, total=False):
     obj: HasProps

--- a/src/bokeh/models/callbacks.pyi
+++ b/src/bokeh/models/callbacks.pyi
@@ -61,7 +61,7 @@ class CustomJS(CustomCode):
 
     if sys.version_info >= (3, 14):
         @classmethod
-        def from_string(cls, template: str | Template) -> CustomJS: ...
+        def from_template(cls, template: Template) -> CustomJS: ...
 
 class _SetValueInit(_CallbackInit, total=False):
     obj: HasProps

--- a/src/bokeh/models/formatters.py
+++ b/src/bokeh/models/formatters.py
@@ -924,7 +924,7 @@ def create_format_table(fields: tuple[str, ...], primary: TickFormatter) -> str:
         c2_fmt = add_row_item(tertiary, field, lens[3])
         rows.append(extended_join("|", [scale, p_fmt, c1_fmt, c2_fmt]))
         rows.append(separator)
-    n = 0 if sys.version_info >= (3, 12) else 4 # remove when Python 3.11 is dropped
+    n = 0 if sys.version_info[:2] >= (3, 12) else 4 # remove when Python 3.11 is dropped
     indent = " "*n
     return f"\n{indent}".join(rows)
 

--- a/tests/examples.yaml
+++ b/tests/examples.yaml
@@ -8,7 +8,7 @@
 - path: "examples/integration/**"
 
 - path: "examples/interaction/**"
-  skip: ["doc_js_events.py"]
+  skip: ["doc_js_events.py", "slider_template_string.py:min_python=3.14"]
 
 - path: "examples/models/*"
   no_js: ["maps_cities.py", "maps.py", "trail.py"]

--- a/tests/examples.yaml
+++ b/tests/examples.yaml
@@ -35,3 +35,6 @@
 - path: "examples/topics/**"
   slow: ["geo/choropleth.py"]
   no_js: ["geo/gmap.py"]
+
+- path: "examples/interaction/widgets/slider_template_string.py"
+  min_python: "3.14"

--- a/tests/support/util/examples.py
+++ b/tests/support/util/examples.py
@@ -71,7 +71,7 @@ class Flags:
 
 
 class Example:
-    def __init__(self, path: str, flags: int, examples_dir: str, extensions: list[str] = []) -> None:
+    def __init__(self, path: str, flags: int, examples_dir: str, extensions: list[str] = [], min_python: str | None = None) -> None:
         self.path = normpath(path)
         self.flags = flags
         self.examples_dir = examples_dir
@@ -79,6 +79,7 @@ class Example:
         self._diff_ref = None
         self.pixels = 0
         self._has_ref = None
+        self.min_python = tuple(int(n) for n in min_python.split(".")) if min_python is not None else None
 
     def __str__(self) -> str:
         flags = [
@@ -148,17 +149,27 @@ class Example:
 
 All = Literal["all"]
 
-def add_examples(list_of_examples: list[Example], path: str, examples_dir: str, example_type: int | None = None,
-        slow: list[str] | All | None = None, skip: list[str] | All | None = None,
-        xfail: list[str] | All | None = None, no_js: list[str] | All | None = None) -> None:
-
+def add_examples(
+    list_of_examples: list[Example],
+    path: str,
+    examples_dir: str,
+    *,
+    example_type: int | None = None,
+    slow: list[str] | All | None = None,
+    skip: list[str] | All | None = None,
+    xfail: list[str] | All | None = None,
+    no_js: list[str] | All | None = None,
+) -> None:
     example_pattern = normpath(join(examples_dir, path))
     example_path = normpath(example_pattern.strip("*"))
 
     for path in sorted(iglob(example_pattern, recursive=True)):
         flags = 0
         extensions: list[str] = []
-        orig_name = name = str(Path(path).relative_to(example_path))
+        if path != example_path:
+            orig_name = name = str(Path(path).relative_to(example_path))
+        else:
+            orig_name = name = path # this is a bit of a hack
 
         if name.startswith(('_', '.')):
             continue
@@ -187,6 +198,18 @@ def add_examples(list_of_examples: list[Example], path: str, examples_dir: str, 
         else:
             continue
 
+        min_python: str | None = None
+
+        if skip is not None:
+            for skip_name in skip:
+                if ":" in skip_name:
+                    skip_name, opts = skip_name.split(":")
+                    if basename(orig_name) == skip_name:
+                        for opt in opts.split(","):
+                            key, val = opt.split("=")
+                            if key == "min_python":
+                                min_python = val
+
         if slow is not None and orig_name in slow:
             flags |= Flags.slow
 
@@ -199,7 +222,7 @@ def add_examples(list_of_examples: list[Example], path: str, examples_dir: str, 
         if no_js is not None and (no_js == 'all' or basename(orig_name) in no_js):
             flags |= Flags.no_js
 
-        list_of_examples.append(Example(join(example_path, name), flags, examples_dir, extensions))
+        list_of_examples.append(Example(join(example_path, name), flags, examples_dir, extensions, min_python))
 
 
 def collect_examples(config_path: str) -> list[Example]:

--- a/tests/support/util/examples.py
+++ b/tests/support/util/examples.py
@@ -71,7 +71,7 @@ class Flags:
 
 
 class Example:
-    def __init__(self, path: str, flags: int, examples_dir: str, extensions: list[str] = []) -> None:
+    def __init__(self, path: str, flags: int, examples_dir: str, extensions: list[str] = [], min_python: str | None = None) -> None:
         self.path = normpath(path)
         self.flags = flags
         self.examples_dir = examples_dir
@@ -79,6 +79,7 @@ class Example:
         self._diff_ref = None
         self.pixels = 0
         self._has_ref = None
+        self.min_python = tuple(int(n) for n in min_python.split(".")) if min_python is not None else None
 
     def __str__(self) -> str:
         flags = [
@@ -148,17 +149,28 @@ class Example:
 
 All = Literal["all"]
 
-def add_examples(list_of_examples: list[Example], path: str, examples_dir: str, example_type: int | None = None,
-        slow: list[str] | All | None = None, skip: list[str] | All | None = None,
-        xfail: list[str] | All | None = None, no_js: list[str] | All | None = None) -> None:
-
+def add_examples(
+    list_of_examples: list[Example],
+    path: str,
+    examples_dir: str,
+    *,
+    example_type: int | None = None,
+    slow: list[str] | All | None = None,
+    skip: list[str] | All | None = None,
+    xfail: list[str] | All | None = None,
+    no_js: list[str] | All | None = None,
+    min_python: str | None = None,
+) -> None:
     example_pattern = normpath(join(examples_dir, path))
     example_path = normpath(example_pattern.strip("*"))
 
     for path in sorted(iglob(example_pattern, recursive=True)):
         flags = 0
         extensions: list[str] = []
-        orig_name = name = str(Path(path).relative_to(example_path))
+        if path != example_path:
+            orig_name = name = str(Path(path).relative_to(example_path))
+        else:
+            orig_name = name = path # this is a bit of a hack
 
         if name.startswith(('_', '.')):
             continue
@@ -199,7 +211,7 @@ def add_examples(list_of_examples: list[Example], path: str, examples_dir: str, 
         if no_js is not None and (no_js == 'all' or basename(orig_name) in no_js):
             flags |= Flags.no_js
 
-        list_of_examples.append(Example(join(example_path, name), flags, examples_dir, extensions))
+        list_of_examples.append(Example(join(example_path, name), flags, examples_dir, extensions, min_python))
 
 
 def collect_examples(config_path: str) -> list[Example]:
@@ -220,9 +232,10 @@ def collect_examples(config_path: str) -> list[Example]:
         skip_status = example.get("skip")
         xfail_status = example.get("xfail")
         no_js_status = example.get("no_js")
+        min_python = example.get("min_python")
 
         add_examples(list_of_examples, path, examples_dir,
-            example_type=example_type, slow=slow_status, skip=skip_status, xfail=xfail_status, no_js=no_js_status)
+            example_type=example_type, slow=slow_status, skip=skip_status, xfail=xfail_status, no_js=no_js_status, min_python=min_python)
 
     return list_of_examples
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -96,7 +96,7 @@ def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
             if example.min_python is not None:
                 result.append(
                     pytest.mark.skipif(
-                        sys.version_info < example.min_python,
+                        sys.version_info[:2] < example.min_python,
                         reason=f"skipping {example.relpath}; requires Python {example.min_python} or above",
                     ),
                 )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -90,9 +90,16 @@ def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
         examples = get_all_examples(config)
 
         def marks(example: Example) -> list[_pytest.mark.MarkDecorator]:
-            result = []
+            result: list[_pytest.mark.MarkDecorator] = []
             if example.is_skip:
                 result.append(pytest.mark.skip(reason=f"skipping {example.relpath}"))
+            if example.min_python is not None:
+                result.append(
+                    pytest.mark.skipif(
+                        sys.version_info < example.min_python,
+                        reason=f"skipping {example.relpath}; requires Python {example.min_python} or above",
+                    ),
+                )
             if example.is_xfail and not example.no_js:
                 result.append(pytest.mark.xfail(reason=f"xfail {example.relpath}", strict=True))
             return result

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -90,9 +90,13 @@ def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
         examples = get_all_examples(config)
 
         def marks(example: Example) -> list[_pytest.mark.MarkDecorator]:
-            result = []
+            result: list[_pytest.mark.MarkDecorator] = []
             if example.is_skip:
                 result.append(pytest.mark.skip(reason=f"skipping {example.relpath}"))
+            if example.min_python is not None:
+                if sys.version_info < example.min_python:
+                    print(f"SKIPPING because {example.min_python} {example.relpath}")
+                    result.append(pytest.mark.skip(reason=f"skipping {example.relpath}; requires Python {example.min_python} or above"))
             if example.is_xfail and not example.no_js:
                 result.append(pytest.mark.xfail(reason=f"xfail {example.relpath}", strict=True))
             return result

--- a/tests/unit/bokeh/core/test_serialization.py
+++ b/tests/unit/bokeh/core/test_serialization.py
@@ -270,7 +270,7 @@ class TestSerializer:
         with pytest.raises(SerializationError, match="circular reference"):
             encoder.encode(val)
 
-    @pytest.mark.skipif(sys.platform == "win32" and sys.version_info < (3, 11), reason="stack overflow instead of RecursionError")
+    @pytest.mark.skipif(sys.platform == "win32" and sys.version_info[:2] < (3, 11), reason="stack overflow instead of RecursionError")
     def test_list_circular_without_checking(self) -> None:
         val: Sequence[Any] = [1, 2, 3]
         val.append(val)
@@ -313,7 +313,7 @@ class TestSerializer:
         with pytest.raises(SerializationError, match="circular reference"):
             encoder.encode(val)
 
-    @pytest.mark.skipif(sys.platform == "win32" and sys.version_info < (3, 11), reason="stack overflow instead of RecursionError")
+    @pytest.mark.skipif(sys.platform == "win32" and sys.version_info[:2] < (3, 11), reason="stack overflow instead of RecursionError")
     def test_dict_circular_without_checking(self) -> None:
         val: dict[Any, Any] = {nan: [1, 2]}
         val[inf] = val

--- a/tests/unit/bokeh/models/test_callbacks__models.py
+++ b/tests/unit/bokeh/models/test_callbacks__models.py
@@ -72,7 +72,7 @@ def test_CustomJS_from_code_bad_file_type() -> None:
     with pytest.raises(RuntimeError):
         CustomJS.from_file(Path("some/module.css"))
 
-@pytest.mark.skipif(sys.version_info < (3, 14), reason="needs support for template literals")
+@pytest.mark.skipif(sys.version_info[:2] < (3, 14), reason="needs support for template literals")
 def test_CustomJS_from_template() -> None:
     # TODO can't implement this directly, because it will cause SyntaxError earlier Pythons
     slider = Slider()

--- a/tests/unit/bokeh/models/test_callbacks__models.py
+++ b/tests/unit/bokeh/models/test_callbacks__models.py
@@ -73,20 +73,27 @@ def test_CustomJS_from_code_bad_file_type() -> None:
         CustomJS.from_file(Path("some/module.css"))
 
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="needs support for template literals")
-def test_CustomJS_from_string_with_template() -> None:
+def test_CustomJS_from_template() -> None:
+    # TODO can't implement this directly, because it will cause SyntaxError earlier Pythons
     slider = Slider()
 
-    cb0 = CustomJS.from_string("export default () => console.log('foo')")
+    code0 = """CustomJS.from_template(t"export default () => console.log('foo')")"""
+    cb0: CustomJS = eval(compile(code0, "<test>", "eval"))
     assert cb0.module == "auto"
     assert cb0.code == "export default () => console.log('foo')"
     assert cb0.args == dict()
 
-    # TODO can't implement this directly, because it will cause SyntaxError earlier Pythons
-    code = """CustomJS.from_string(t"export default () => console.log('foo: ' + {slider}.value)")"""
-    cb1: CustomJS = eval(compile(code, "<test>", "eval"))
+    code1 = """CustomJS.from_template(t"export default () => console.log('foo: ' + {slider}.value)")"""
+    cb1: CustomJS = eval(compile(code1, "<test>", "eval"))
     assert cb1.module == "auto"
     assert cb1.code == "export default () => console.log('foo: ' + slider.value)"
     assert cb1.args == dict(slider=slider)
+
+    code2 = """CustomJS.from_template(t"export default () => console.log(`foo: ${{ {slider}.value }}`)")"""
+    cb2: CustomJS = eval(compile(code2, "<test>", "eval"))
+    assert cb2.module == "auto"
+    assert cb2.code == "export default () => console.log(`foo: ${ slider.value }`)"
+    assert cb2.args == dict(slider=slider)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/models/test_callbacks__models.py
+++ b/tests/unit/bokeh/models/test_callbacks__models.py
@@ -17,6 +17,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import sys
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
@@ -70,6 +71,22 @@ def test_CustomJS_from_code_js() -> None:
 def test_CustomJS_from_code_bad_file_type() -> None:
     with pytest.raises(RuntimeError):
         CustomJS.from_file(Path("some/module.css"))
+
+def test_CustomJS_from_string_with_str() -> None:
+    cb = CustomJS.from_string("export default () => console.log('foo')")
+    assert cb.module == "auto"
+    assert cb.code == "export default () => console.log('foo')"
+    assert cb.args == dict()
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="needs support for template literals")
+def test_CustomJS_from_string_with_template() -> None:
+    slider = Slider()
+    # TODO can't implement this directly, because it will cause SyntaxError earlier Pythons
+    code = """CustomJS.from_string(t"export default () => console.log('foo: ' + {slider}.value)")"""
+    cb: CustomJS = eval(compile(code, "<test>", "eval"))
+    assert cb.module == "auto"
+    assert cb.code == "export default () => console.log('foo: ' + slider.value)"
+    assert cb.args == dict(slider=slider)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/models/test_callbacks__models.py
+++ b/tests/unit/bokeh/models/test_callbacks__models.py
@@ -72,21 +72,21 @@ def test_CustomJS_from_code_bad_file_type() -> None:
     with pytest.raises(RuntimeError):
         CustomJS.from_file(Path("some/module.css"))
 
-def test_CustomJS_from_string_with_str() -> None:
-    cb = CustomJS.from_string("export default () => console.log('foo')")
-    assert cb.module == "auto"
-    assert cb.code == "export default () => console.log('foo')"
-    assert cb.args == dict()
-
 @pytest.mark.skipif(sys.version_info < (3, 14), reason="needs support for template literals")
 def test_CustomJS_from_string_with_template() -> None:
     slider = Slider()
+
+    cb0 = CustomJS.from_string("export default () => console.log('foo')")
+    assert cb0.module == "auto"
+    assert cb0.code == "export default () => console.log('foo')"
+    assert cb0.args == dict()
+
     # TODO can't implement this directly, because it will cause SyntaxError earlier Pythons
     code = """CustomJS.from_string(t"export default () => console.log('foo: ' + {slider}.value)")"""
-    cb: CustomJS = eval(compile(code, "<test>", "eval"))
-    assert cb.module == "auto"
-    assert cb.code == "export default () => console.log('foo: ' + slider.value)"
-    assert cb.args == dict(slider=slider)
+    cb1: CustomJS = eval(compile(code, "<test>", "eval"))
+    assert cb1.module == "auto"
+    assert cb1.code == "export default () => console.log('foo: ' + slider.value)"
+    assert cb1.args == dict(slider=slider)
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
No need to fill in `CustomJS.args` manually anymore:

```py
from bokeh.models import CustomJS, Slider
slider = Slider(start=0, end=10)
CustomJS.from_string(t"console.log('Slider value: ' + {slider}.value)")
```

Requires Python 3.14+ to work.

fixes #14649