### PR TITLE
Add PR comment notifications for Full CI workflow

### DIFF
--- a/.github/workflows/bokeh-ci-full.yml
+++ b/.github/workflows/bokeh-ci-full.yml
@@ -256,7 +256,7 @@ jobs:
           name: docs-html-${{ matrix.os }}-${{ matrix.python-version }}
           path: docs/bokeh/docs-html.tgz
 
-  notify-failure:
+  notify-nightly-failure:
     needs: [build, codebase, examples, unit-test, minimal-deps, core-deps, documentation]
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
@@ -297,3 +297,63 @@ jobs:
 
           ---
           *Automated notification from [Bokeh-CI-Full](${{ github.server_url }}/${{ github.repository }}/actions/workflows/bokeh-ci-full.yml)*"
+
+  notify-pr:
+    needs: [build, codebase, examples, unit-test, minimal-deps, core-deps, documentation]
+    if: always() && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Find associated PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --head "${{ github.ref_name }}" --state open --json number --jq '.[0].number // empty')
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.number }}"
+
+          # Wait for GitHub API to update job statuses
+          sleep 10
+
+          # Get job results with error handling
+          if ! RESULTS=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '
+            .jobs[] |
+            select(.name != "notify-nightly-failure" and .name != "notify-pr") |
+            "- [\(.conclusion | if . == "success" then "✅" elif . == "failure" then "❌" elif . == "cancelled" then "⏭️" elif . == "skipped" then "⏭️" else "⚠️" end)] **\(.name)** ([job #\(.id)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/\(.id)))"
+          '); then
+            echo "Error: Failed to fetch job results from GitHub API"
+            exit 1
+          fi
+
+          # Determine overall status with error handling
+          if ! FAILED_COUNT=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '[.jobs[] | select(.name != "notify-nightly-failure" and .name != "notify-pr" and .conclusion == "failure")] | length'); then
+            echo "Error: Failed to count failed jobs"
+            exit 1
+          fi
+
+          if [ "$FAILED_COUNT" -eq 0 ]; then
+            OVERALL="✅ **All tests passed!**"
+          else
+            OVERALL="❌ **${FAILED_COUNT} job(s) failed**"
+          fi
+
+          # Post comment
+          gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "## Full CI Results
+
+          ${OVERALL}
+
+          ${RESULTS}
+
+          **Triggered:** ${{ github.event.inputs.reason || 'Manual run' }} at $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+          [View full workflow run →](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          ---
+          *Automated comment from [Bokeh-CI-Full](${{ github.server_url }}/${{ github.repository }}/actions/workflows/bokeh-ci-full.yml)*"

--- a/.github/workflows/bokeh-ci-full.yml
+++ b/.github/workflows/bokeh-ci-full.yml
@@ -322,16 +322,6 @@ jobs:
           # Wait for GitHub API to update job statuses
           sleep 10
 
-          # Get job results with error handling
-          if ! RESULTS=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '
-            .jobs[] |
-            select(.name != "notify-nightly-failure" and .name != "notify-pr") |
-            "- [\(.conclusion | if . == "success" then "✅" elif . == "failure" then "❌" elif . == "cancelled" then "⏭️" elif . == "skipped" then "⏭️" else "⚠️" end)] **\(.name)** ([job #\(.id)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/\(.id)))"
-          '); then
-            echo "Error: Failed to fetch job results from GitHub API"
-            exit 1
-          fi
-
           # Determine overall status with error handling
           if ! FAILED_COUNT=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '[.jobs[] | select(.name != "notify-nightly-failure" and .name != "notify-pr" and .conclusion == "failure")] | length'); then
             echo "Error: Failed to count failed jobs"
@@ -339,17 +329,10 @@ jobs:
           fi
 
           if [ "$FAILED_COUNT" -eq 0 ]; then
-            OVERALL="✅ **All tests passed!**"
-          else
-            OVERALL="❌ **${FAILED_COUNT} job(s) failed**"
-          fi
+            # All jobs succeeded - simple message
+            gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "## Full CI Results
 
-          # Post comment
-          gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "## Full CI Results
-
-          ${OVERALL}
-
-          ${RESULTS}
+          ✅ **All jobs succeeded**
 
           **Triggered:** ${{ github.event.inputs.reason || 'Manual run' }} at $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
@@ -357,3 +340,27 @@ jobs:
 
           ---
           *Automated comment from [Bokeh-CI-Full](${{ github.server_url }}/${{ github.repository }}/actions/workflows/bokeh-ci-full.yml)*"
+          else
+            # Some jobs failed - list only the failures
+            if ! FAILED_JOBS=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '
+              .jobs[] |
+              select(.name != "notify-nightly-failure" and .name != "notify-pr" and .conclusion == "failure") |
+              "- ❌ **\(.name)** ([job #\(.id)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/\(.id)))"
+            '); then
+              echo "Error: Failed to fetch failed job results from GitHub API"
+              exit 1
+            fi
+
+            gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} --body "## Full CI Results
+
+          ❌ **${FAILED_COUNT} job(s) failed**
+
+          ${FAILED_JOBS}
+
+          **Triggered:** ${{ github.event.inputs.reason || 'Manual run' }} at $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+          [View full workflow run →](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          ---
+          *Automated comment from [Bokeh-CI-Full](${{ github.server_url }}/${{ github.repository }}/actions/workflows/bokeh-ci-full.yml)*"
+          fi


### PR DESCRIPTION
Adds automatic PR commenting when the Full CI workflow is manually triggered for a branch associated with an open PR.

**Features:**
- Automatically detects if workflow is running on a PR branch
- Posts comment with overall pass/fail status and individual job results
- Each job name is a clickable link to its specific run
- Includes timestamp and trigger reason
- Gracefully skips if no PR found for the branch

**Implementation:**
- New `notify-pr` job queries GitHub API to find PR by branch name
- Renamed `notify-failure` → `notify-nightly-failure` for clarity
- Error handling for API calls with 10-second delay for consistency

See [example below](https://github.com/bokeh/bokeh/pull/14983#issuecomment-4149241889)

Fixes #14981

Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>