### PR TITLE
Fix Full CI workflow to skip PR comment when cancelled

### DIFF
--- a/.github/workflows/bokeh-ci-full.yml
+++ b/.github/workflows/bokeh-ci-full.yml
@@ -322,6 +322,18 @@ jobs:
           # Wait for GitHub API to update job statuses
           sleep 10
 
+          # Check if any dependency jobs were cancelled
+          if ! CANCELLED_COUNT=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '[.jobs[] | select(.name != "notify-nightly-failure" and .name != "notify-pr" and .conclusion == "cancelled")] | length'); then
+            echo "Error: Failed to count cancelled jobs"
+            exit 1
+          fi
+
+          if [ "$CANCELLED_COUNT" -gt 0 ]; then
+            # Workflow was cancelled - skip commenting
+            echo "Workflow was cancelled ($CANCELLED_COUNT jobs cancelled) - skipping PR comment"
+            exit 0
+          fi
+
           # Determine overall status with error handling
           if ! FAILED_COUNT=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs --jq '[.jobs[] | select(.name != "notify-nightly-failure" and .name != "notify-pr" and .conclusion == "failure")] | length'); then
             echo "Error: Failed to count failed jobs"


### PR DESCRIPTION
Fixes #14995

Updates notify-pr workflow step to not comment when a workflow run is cancelled. Previously the workflow step commented this scenario as a successful run.

Leaves existing notify-nightly-failure behavior where a cancelled run won't create a github discussion thread (because there's no failed jobs).

