### PR TITLE
Fix: Accept numpy arrays and Index in vline_stack/hline_stack

### DIFF
--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -532,7 +532,7 @@ class figure(Plot, GlyphAPI):
                 p.line(x=stack('2016', '2017'), y='y', color='red',  source=source, name='2017')
 
         '''
-        return self._line_stack(x=stackers, **kw)
+        return self._line_stack(x=list(stackers), **kw)
 
     def varea_stack(self, stackers, **kw):
         ''' Generate multiple ``VArea`` renderers for levels stacked bottom
@@ -655,7 +655,7 @@ class figure(Plot, GlyphAPI):
                 p.line(y=stack('2016', '2017'), x='x', color='red',  source=source, name='2017')
 
         '''
-        return self._line_stack(y=stackers, **kw)
+        return self._line_stack(y=list(stackers), **kw)
 
     def graph(self, node_source: ColumnDataSource, edge_source: ColumnDataSource, layout_provider: LayoutProvider, **kwargs):
         ''' Creates a network graph using the given node, edge and layout provider.


### PR DESCRIPTION
varea_stack accepted list, np.ndarray, and pandas Index as stackers, while vline_stack and hline_stack only accepted list/tuple because _line_stack uses isinstance checks for list and tuple.

Wrap stackers with list() before passing to _line_stack to normalize all sequence types, matching varea_stack behavior.

Fixes #10067