### PR TITLE
Fix mutable default argument for argv in application handlers

### DIFF
--- a/src/bokeh/application/handlers/code.py
+++ b/src/bokeh/application/handlers/code.py
@@ -87,7 +87,7 @@ class CodeHandler(Handler):
 
     _origin: ClassVar[str]
 
-    def __init__(self, *, source: str, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, source: str, filename: PathLike, argv: list[str] | None = None, package: ModuleType | None = None) -> None:
         '''
 
         Args:
@@ -100,6 +100,8 @@ class CodeHandler(Handler):
 
         '''
         super().__init__()
+        if argv is None:
+            argv = []
 
         self._runner = CodeRunner(source, filename, argv, package=package)
 

--- a/src/bokeh/application/handlers/directory.py
+++ b/src/bokeh/application/handlers/directory.py
@@ -108,7 +108,7 @@ class DirectoryHandler(Handler):
     _static: str | None
     _template: Template | None
 
-    def __init__(self, *, filename: PathLike, argv: list[str] = []) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] | None = None) -> None:
         '''
         Keywords:
             filename (str) : a path to an application directory with either "main.py" or "main.ipynb"
@@ -116,6 +116,8 @@ class DirectoryHandler(Handler):
             argv (list[str], optional) : a list of string arguments to make available as sys.argv to main.py
         '''
         super().__init__()
+        if argv is None:
+            argv = []
 
         src_path = filename
 

--- a/src/bokeh/application/handlers/notebook.py
+++ b/src/bokeh/application/handlers/notebook.py
@@ -67,7 +67,7 @@ class NotebookHandler(CodeHandler):
 
     _origin = "Notebook"
 
-    def __init__(self, *, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] | None = None, package: ModuleType | None = None) -> None:
         '''
 
         Keywords:
@@ -110,6 +110,8 @@ class NotebookHandler(CodeHandler):
                 self._cell_counter = 0
                 return self.preprocess(nb,resources)
 
+        if argv is None:
+            argv = []
         preprocessors = [StripMagicsProcessor()]
 
         with open(filename, encoding="utf-8") as f:

--- a/src/bokeh/application/handlers/script.py
+++ b/src/bokeh/application/handlers/script.py
@@ -81,13 +81,15 @@ class ScriptHandler(CodeHandler):
 
     _origin = "Script"
 
-    def __init__(self, *, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] | None = None, package: ModuleType | None = None) -> None:
         '''
 
         Keywords:
             filename (str) : a path to a Python source (".py") file
 
         '''
+        if argv is None:
+            argv = []
         with open(filename, encoding='utf-8') as f:
             source = f.read()
 

--- a/src/bokeh/application/handlers/server_lifecycle.py
+++ b/src/bokeh/application/handlers/server_lifecycle.py
@@ -56,7 +56,7 @@ class ServerLifecycleHandler(LifecycleHandler):
 
     '''
 
-    def __init__(self, *, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] | None = None, package: ModuleType | None = None) -> None:
         '''
 
         Keyword Args:
@@ -67,6 +67,8 @@ class ServerLifecycleHandler(LifecycleHandler):
 
         '''
         super().__init__()
+        if argv is None:
+            argv = []
 
         with open(filename, encoding='utf-8') as f:
             source = f.read()

--- a/src/bokeh/application/handlers/server_request_handler.py
+++ b/src/bokeh/application/handlers/server_request_handler.py
@@ -58,7 +58,7 @@ class ServerRequestHandler(RequestHandler):
 
     _module: ModuleType
 
-    def __init__(self, *, filename: PathLike, argv: list[str] = [], package: ModuleType | None = None) -> None:
+    def __init__(self, *, filename: PathLike, argv: list[str] | None = None, package: ModuleType | None = None) -> None:
         '''
 
         Keyword Args:
@@ -69,6 +69,8 @@ class ServerRequestHandler(RequestHandler):
 
         '''
         super().__init__()
+        if argv is None:
+            argv = []
 
         with open(filename, encoding='utf-8') as f:
             source = f.read()


### PR DESCRIPTION
All six application handler `__init__` methods use `argv: list[str] = []` as a default argument. Since the list literal is created once at class definition time, any mutation of the default object would be shared across all instances that don't pass an explicit `argv`. The same pattern repeats across `CodeHandler`, `DirectoryHandler`, `NotebookHandler`, `ScriptHandler`, `ServerLifecycleHandler`, and `ServerRequestHandler`.

Fixed by replacing `= []` with `= None` and initializing to a fresh list at the top of each `__init__`.