### PR TITLE
Documentation updated with references to `Server.from_settings`.

### DIFF
--- a/docs/bokeh/source/docs/user_guide/server/deploy.rst
+++ b/docs/bokeh/source/docs/user_guide/server/deploy.rst
@@ -740,6 +740,21 @@ templates:
 
 For full details, see the Tornado documentation on `XSRF Cookies`_.
 
+Programmatic server with global settings
+----------------------------------------
+
+When embedding a Bokeh server in another application (see
+:ref:`ug_server_library`), you may want your programmatic ``Server`` to honor
+the same environment variables and configuration files that ``bokeh serve``
+uses — such as ``BOKEH_AUTH_MODULE``, ``BOKEH_SSL_CERTFILE``, or
+``BOKEH_SIGN_SESSIONS``.
+
+The :meth:`~bokeh.server.server.Server.from_settings` factory method creates
+a ``Server`` instance that automatically reads these values from the Bokeh
+global settings system (see :ref:`bokeh.settings <bokeh.settings>`). Any
+values you pass explicitly as keyword arguments will take precedence over the
+settings.
+
 Scaling the server
 ------------------
 

--- a/docs/bokeh/source/docs/user_guide/server/library.rst
+++ b/docs/bokeh/source/docs/user_guide/server/library.rst
@@ -20,6 +20,23 @@ basis for integration of Bokeh in such a scenario:
    # start timers and services and immediately return
    server.start()
 
+If your server should honor the same environment variables and configuration
+files used by ``bokeh serve`` (for example, ``BOKEH_AUTH_MODULE``,
+``BOKEH_SSL_CERTFILE``, ``BOKEH_SIGN_SESSIONS``), use the
+:meth:`~bokeh.server.server.Server.from_settings` factory method instead:
+
+.. code-block:: python
+
+   from bokeh.server.server import Server
+
+   server = Server.from_settings(
+       bokeh_applications,  # list of Bokeh applications
+       io_loop=loop,        # Tornado IOLoop
+       **server_kwargs
+   )
+
+   server.start()
+
 You can also create and control an ``IOLoop`` directly. This can be useful when
 creating standalone "normal" Python scripts that serve Bokeh apps or embedding
 a Bokeh application in a framework like Flask or Django without having to run a

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -18,6 +18,12 @@ There are two public classes in this module:
     :class:`~bokeh.application.application.Application` instances, and will
     automatically create and coordinate the lower level Tornado components.
 
+    The ``Server`` class also provides a :meth:`~Server.from_settings` factory
+    method that automatically applies configuration values from the Bokeh global
+    settings system for parameters such as authentication, SSL, session signing,
+    and cookies. This is useful for programmatic server creation that should
+    honor the same environment variable conventions used by ``bokeh serve``.
+
 See :ref:`ug_server_introduction` for general information on the Bokeh server.
 
 '''

--- a/src/bokeh/settings.py
+++ b/src/bokeh/settings.py
@@ -94,6 +94,21 @@ global defaults
 If no value is obtained after searching all of these locations, then a
 RuntimeError will be raised.
 
+Usage with ``Server``
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``bokeh serve`` command applies relevant settings from this module
+automatically. When creating a :class:`~bokeh.server.server.Server`
+programmatically, use the :meth:`~bokeh.server.server.Server.from_settings`
+factory method to similarly relay relevant settings to the Server instance, as
+the primary ``Server`` constructor does not read from this module by default.
+
+Any values explicitly passed as keyword arguments to ``from_settings()`` will
+take precedence over settings values from environment variables or direct
+interaction with this module.
+
+See :ref:`ug_server_library` for details.
+
 API
 ~~~
 


### PR DESCRIPTION
This PR adds some minor doc references for a merged PR I made back in February: https://github.com/bokeh/bokeh/pull/14874

No code changes. Happy to tweak verbiage as requested!

- [X] issues: fixes #14850
- [X] tests added / passed - Docs built and reviewed locally; no issues caught by linter.
