### PR TITLE
fix bad formatted code block directives

### DIFF
--- a/docs/bokeh/source/docs/user_guide/server/deploy.rst
+++ b/docs/bokeh/source/docs/user_guide/server/deploy.rst
@@ -480,7 +480,7 @@ modules.
 
 Add balancers for both http and websocket protocols:
 
-.. code-block :: apache
+.. code-block:: apache
 
     <Proxy "balancer://myapp_http">
         BalancerMember "http://127.0.0.1:5100/myapp"

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -842,10 +842,9 @@ Serializer.register(MetaHasProps, _HasProps_to_serializable)
 #-----------------------------------------------------------------------------
 
 _ABSTRACT_ADMONITION = '''
-    .. note::
-        This is an abstract base class used to help organize the hierarchy of Bokeh
-        model types. **It is not useful to instantiate on its own.**
-
+.. note::
+    This is an abstract base class used to help organize the hierarchy of Bokeh
+    model types. **It is not useful to instantiate on its own.**
 '''
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/models/expressions.py
+++ b/src/bokeh/models/expressions.py
@@ -81,10 +81,10 @@ class Expression(Model):
 
     JavaScripts implementations should implement the following methods:
 
-    .. code-block
+    .. code-block:: typescript
 
         v_compute(source: ColumnarDataSource): Arrayable {
-            # compute and return array of values
+            // compute and return array of values
         }
 
     .. note::

--- a/src/bokeh/models/graphs.py
+++ b/src/bokeh/models/graphs.py
@@ -100,7 +100,7 @@ class StaticLayoutProvider(LayoutProvider):
 @abstract
 class GraphCoordinates(CoordinateTransform):
     '''
-    Abstract class for coordinate transform expression obtained from ``LayoutProvider``
+    Abstract class for coordinate transform expression obtained from ``LayoutProvider``.
 
     '''
 
@@ -112,7 +112,7 @@ class GraphCoordinates(CoordinateTransform):
 
 class NodeCoordinates(GraphCoordinates):
     '''
-    Node coordinate expression obtained from ``LayoutProvider``
+    Node coordinate expression obtained from ``LayoutProvider``.
 
     '''
 

--- a/src/bokeh/models/scales.py
+++ b/src/bokeh/models/scales.py
@@ -52,22 +52,22 @@ class Scale(Transform):
 
     JavaScript implementations should implement the following methods:
 
-    .. code-block
+    .. code-block:: typescript
 
         compute(x: number): number {
-            # compute and return the transform of a single value
+            // compute and return the transform of a single value
         }
 
         v_compute(xs: Arrayable<number>): Arrayable<number> {
-            # compute and return the transform of an array of values
+            // compute and return the transform of an array of values
         }
 
         invert(sx: number): number {
-            # compute and return the inverse transform of a single value
+            // compute and return the inverse transform of a single value
         }
 
         v_invert(sxs: Arrayable<number>): Arrayable<number> {
-            # compute and return the inverse transform of an array of values
+            // compute and return the inverse transform of an array of values
         }
 
     '''

--- a/src/bokeh/models/transforms.py
+++ b/src/bokeh/models/transforms.py
@@ -62,14 +62,14 @@ class Transform(Model):
 
     JavaScript implementations should implement the following methods:
 
-    .. code-block
+    .. code-block:: typescript
 
         compute(x: number): number {
-            # compute and return the transform of a single value
+            // compute and return the transform of a single value
         }
 
         v_compute(xs: Arrayable<number>): Arrayable<number> {
-            # compute and return the transform of an array of values
+            // compute and return the transform of an array of values
         }
 
     '''


### PR DESCRIPTION
This PR fixes some code blocks in the documentation.

- [x] issues: fixes #15022

Documentation on local machine:

- [Expression](https://docs.bokeh.org/en/latest/docs/reference/models/expressions.html#bokeh.models.Expression)

<img width="916" height="652" alt="grafik" src="https://github.com/user-attachments/assets/ad9b97a7-007f-4875-806f-ae7fd617cf5f" />

- [Scale](https://docs.bokeh.org/en/latest/docs/reference/models/scales.html#bokeh.models.Scale)

<img width="918" height="728" alt="grafik" src="https://github.com/user-attachments/assets/52450f49-a0bf-494a-81a6-b9320cbfef9a" />

- [Transform](https://docs.bokeh.org/en/latest/docs/reference/models/transforms.html#bokeh.models.Transform)

<img width="915" height="562" alt="grafik" src="https://github.com/user-attachments/assets/6d250020-2568-4ae5-aeda-2b27a6485a36" />
