### PR TITLE
add logic for inverted color mapping using LogColorMapper

### DIFF
--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -27,14 +27,20 @@ export class LogColorMapper extends ContinuousColorMapper {
 
   protected scan(data: Arrayable<number>, n: number): LogScanData {
     const low = this.low != null ? this.low : min(data)
+    if (low <= 0) {
+      console.log(`LogColorMapper detects invalid value "${low}" for parameter "low".`)
+    }
     const high = this.high != null ? this.high : max(data)
+    if (high <= 0) {
+      console.log(`LogColorMapper detects invalid value "${high}" for parameter "high".`)
+    }
     const scale = n / Math.log(high / low)  // subtract the low offset
     return {max: high, min: low, scale}
   }
 
   override index_to_value(index: number): number {
     const scan_data = this._scan_data as LogScanData
-    return scan_data.min * Math.exp(index / scan_data.scale)
+    return scan_data.min * Math.exp(index / Math.abs(scan_data.scale))
   }
 
   override value_to_index(value: number, palette_length: number): number {
@@ -42,16 +48,31 @@ export class LogColorMapper extends ContinuousColorMapper {
 
     // This handles the edge case where value == high, since the code below maps
     // values exactly equal to high to palette.length when it should be one less.
-    if (value == scan_data.max) {
-      return palette_length - 1
-    } else if (value > scan_data.max) {
-      return palette_length
-    } else if (value < scan_data.min) {
-      return -1
-    }
+    if (0 < scan_data.scale) {
+      if (value == scan_data.max) {
+        return palette_length - 1
+      } else if (value > scan_data.max) {
+        return palette_length
+      } else if (value < scan_data.min) {
+        return -1
+      }
 
-    const log = Math.log(value / scan_data.min)
-    const index = Math.floor(log * scan_data.scale)
-    return clamp(index, -1, palette_length)
+      const log = Math.log(value / scan_data.min)
+      const index = Math.floor(log * scan_data.scale)
+      return clamp(index, -1, palette_length)
+    } else {
+      // if the scale is negative, the color bar is inverted by the user, i. e. high < low
+      if (value == scan_data.max) {
+        return palette_length - 1
+      } else if (value > scan_data.min) {
+        return -1
+      } else if (value < scan_data.max) {
+        return palette_length
+      }
+
+      const log = Math.log(value / scan_data.min)
+      const index = Math.abs(Math.floor(log * scan_data.scale))
+      return clamp(index, -1, palette_length)
+    }
   }
 }

--- a/bokehjs/src/lib/models/mappers/log_color_mapper.ts
+++ b/bokehjs/src/lib/models/mappers/log_color_mapper.ts
@@ -1,5 +1,6 @@
 import {ContinuousColorMapper} from "./continuous_color_mapper"
 import type {Arrayable} from "core/types"
+import {logger} from "core/logging"
 import {min, max} from "core/util/arrayable"
 import {clamp} from "core/util/math"
 import type * as p from "core/properties"
@@ -8,6 +9,7 @@ export type LogScanData = {
   min: number
   max: number
   scale: number
+  is_reversed: boolean
 }
 
 export namespace LogColorMapper {
@@ -28,14 +30,15 @@ export class LogColorMapper extends ContinuousColorMapper {
   protected scan(data: Arrayable<number>, n: number): LogScanData {
     const low = this.low != null ? this.low : min(data)
     if (low <= 0) {
-      console.log(`LogColorMapper detects invalid value "${low}" for parameter "low".`)
+      logger.warn(`LogColorMapper detects invalid value "${low}" for parameter "low".`)
     }
     const high = this.high != null ? this.high : max(data)
     if (high <= 0) {
-      console.log(`LogColorMapper detects invalid value "${high}" for parameter "high".`)
+      logger.warn(`LogColorMapper detects invalid value "${high}" for parameter "high".`)
     }
     const scale = n / Math.log(high / low)  // subtract the low offset
-    return {max: high, min: low, scale}
+    const is_reversed = high < low
+    return {max: high, min: low, scale, is_reversed}
   }
 
   override index_to_value(index: number): number {
@@ -48,31 +51,26 @@ export class LogColorMapper extends ContinuousColorMapper {
 
     // This handles the edge case where value == high, since the code below maps
     // values exactly equal to high to palette.length when it should be one less.
-    if (0 < scan_data.scale) {
-      if (value == scan_data.max) {
-        return palette_length - 1
-      } else if (value > scan_data.max) {
-        return palette_length
-      } else if (value < scan_data.min) {
-        return -1
-      }
+    if (value == scan_data.max) {
+      return palette_length - 1
+    }
 
-      const log = Math.log(value / scan_data.min)
-      const index = Math.floor(log * scan_data.scale)
-      return clamp(index, -1, palette_length)
-    } else {
-      // if the scale is negative, the color bar is inverted by the user, i. e. high < low
-      if (value == scan_data.max) {
-        return palette_length - 1
-      } else if (value > scan_data.min) {
+    if (scan_data.is_reversed) {
+      if (value > scan_data.min) {
         return -1
       } else if (value < scan_data.max) {
         return palette_length
       }
-
-      const log = Math.log(value / scan_data.min)
-      const index = Math.abs(Math.floor(log * scan_data.scale))
-      return clamp(index, -1, palette_length)
+    } else {
+      if (value > scan_data.max) {
+        return palette_length
+      } else if (value < scan_data.min) {
+        return -1
+      }
     }
+
+    const log = Math.log(value / scan_data.min)
+    const index = Math.abs(Math.floor(log * scan_data.scale))
+    return clamp(index, -1, palette_length)
   }
 }

--- a/bokehjs/test/unit/models/mappers/log_color_mapper.ts
+++ b/bokehjs/test/unit/models/mappers/log_color_mapper.ts
@@ -60,5 +60,21 @@ describe("LogColorMapper module", () => {
       const vals = color_mapper.v_compute([0.5, 1, 10, 100, 101])
       expect(vals).to.be.equal(convert_to_uint32_palette(["pink", "red", "green", "blue", "orange"]))
     })
+
+    it("Should map colors if high value is grather than low value", () => {
+      const palette = ["red", "green", "blue"]
+      const color_mapper = new LogColorMapper({low: 1, high: 100, palette})
+
+      const vals = color_mapper.v_compute([0.5, 1, 10, 100, 100.5])
+      expect(vals).to.be.equal(convert_to_uint32_palette(["red", "red", "green", "blue", "blue"]))
+    })
+
+    it("Should map inverted colors if low value is grather than high value", () => {
+      const palette = ["red", "green", "blue"]
+      const color_mapper = new LogColorMapper({low: 100, high: 1, palette})
+
+      const vals = color_mapper.v_compute([0.5, 1, 10, 100, 100.5])
+      expect(vals).to.be.equal(convert_to_uint32_palette(["blue", "blue", "green", "red", "red"]))
+    })
   })
 })

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -2062,7 +2062,7 @@ describe("Bug", () => {
   })
 
   describe("in issue #7297", () => {
-    it("doesn't support inverted LogColorMapper when low is grater than high", async () => {
+    it("doesn't support reversed LogColorMapper when low is grater than high", async () => {
       const x = linspace(0.5, 10.5, 21)
       const y = linspace(0.5, 10.5, 21)
       const source = new ColumnDataSource({data: {x, y}})

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -16,6 +16,7 @@ import {
   CDSView,
   Canvas,
   CategoricalColorMapper,
+  ColorBar,
   Column,
   ColumnDataSource,
   CopyTool,
@@ -31,6 +32,7 @@ import {
   LegendItem,
   Line,
   LinearColorMapper,
+  LogColorMapper,
   Node,
   PanTool,
   Pane,
@@ -79,7 +81,7 @@ import type {DocJson, DocumentEvent} from "@bokehjs/document"
 import {Document, ModelChangedEvent, MessageSentEvent} from "@bokehjs/document"
 import {DocumentReady, RangesUpdate} from "@bokehjs/core/bokeh_events"
 import {gridplot} from "@bokehjs/api/gridplot"
-import {Spectral11, Viridis11, Viridis256} from "@bokehjs/api/palettes"
+import {Spectral11, Spectral6, Viridis11, Viridis256} from "@bokehjs/api/palettes"
 import {defer, paint, poll} from "@bokehjs/core/util/defer"
 import type {Field} from "@bokehjs/core/vectorization"
 import type {AxisType, ToolName} from "@bokehjs/api/figure"
@@ -2056,6 +2058,24 @@ describe("Bug", () => {
       await has_cursor_at(view, xy(3, 1), "default")
       await has_cursor_at(view, xy(2, 1), "default")
       await has_cursor_at(view, xy(2, 2), "default")
+    })
+  })
+
+  describe("in issue #7297", () => {
+    it("doesn't support inverted LogColorMapper when low is grater than high", async () => {
+      const x = linspace(0.5, 10.5, 21)
+      const y = linspace(0.5, 10.5, 21)
+      const source = new ColumnDataSource({data: {x, y}})
+
+      const p = fig([200, 200])
+      const cmap = new LogColorMapper({
+        palette: Spectral6, low: 10, high: 1, low_color: "gray", high_color: "black",
+      })
+      const cbar = new ColorBar({color_mapper: cmap})
+      p.scatter("x", "y", {color: {field: "x", transform: cmap}, size: 15, source})
+      p.add_layout(cbar, "right")
+
+      await display(p)
     })
   })
 })

--- a/docs/bokeh/source/docs/releases/3.10.0.rst
+++ b/docs/bokeh/source/docs/releases/3.10.0.rst
@@ -14,3 +14,4 @@ Bokeh version ``3.10.0`` (May 2026) is a minor milestone of Bokeh project.
 * Redesigned views' internals and components to use virtual DOM (:bokeh-pull:`14829`)
 * Support ``LightDark`` component auto/system option and add tri-state handling to toggle like components (:bokeh-pull:`14915`)
 * Make it easier to theme ``Tooltip`` component and migrate it to vDOM (:bokeh-pull:`14955`)
+* Fix broken inverted color mapping when using LogColorMapper (:bokeh-pull:`15035`)


### PR DESCRIPTION
This PR fixes the broken color mapping if a `LogColorMapper` is used and the mapping is inverted by the user given a `low` value grater than the `high` value.

- [x] issues: fixes #7297
- [x] tests added / passed

<img width="835" height="636" alt="grafik" src="https://github.com/user-attachments/assets/7714d9de-e803-4db9-a9cb-d61c68539e6b" />

<details><summary>code to reproduce</summary>

```python
import numpy as np

from bokeh.layouts import gridplot
from bokeh.models import ColumnDataSource
from bokeh.plotting import figure, show
from bokeh.transform import linear_cmap, log_cmap

x = np.linspace(0.5, 10.5, 21)
y = np.linspace(0.5, 10.5, 21)

source = ColumnDataSource(dict(x=x,y=y))

def make_plot(mode, title, inverted=False):
    low = 10 if inverted else 1
    high = 1 if inverted else 10

    if mode == 'log':
        cmap = log_cmap('x', "Spectral6", low, high, low_color='gray', high_color="black")
    elif mode == "linear":
        cmap = linear_cmap('x', "Spectral6", low, high, low_color='gray', high_color="black")
    else:
        raise ValueError(f"Got unexpected {mode=}.")
    
    p = figure(title=title, toolbar_location=None, tools='')
    r = p.scatter(x='x', y='y', color=cmap, size=15, source=source)
    color_bar = r.construct_color_bar()
    p.add_layout(color_bar, 'right')
    return p

p1 = make_plot('linear', title='Linear')
p2 = make_plot('log', title='Log')
p3 = make_plot('linear', title='Linear inverted', inverted=True)
p4 = make_plot('log', title='Log inverted', inverted=True)

show(gridplot([p1, p2, p3, p4], ncols=2, width=400, height=300, toolbar_location=None))
```
</details>