### PR TITLE
Exclude `sphinx` from type checking

### DIFF
--- a/examples/mypy.cfg
+++ b/examples/mypy.cfg
@@ -1,3 +1,8 @@
 [mypy]
 python_version = 3.11
 strict = true
+
+[mypy-sphinx]
+follow_imports = skip
+[mypy-sphinx.*]
+follow_imports = skip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,5 +297,5 @@ ignore_errors = false
 
 # TODO remove when we drop Python 3.11
 [[tool.mypy.overrides]]
-module = ["sphinx.*"]
+module = ["sphinx", "sphinx.*"]
 follow_imports = "skip"


### PR DESCRIPTION
Sphinx uses 3.12 type alias syntax and we still type check against Python 3.11.

fixes #15045
