### PR TITLE
Invalidate layout when `frame_{width,height,align}` changes

### DIFF
--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -998,6 +998,9 @@ export class PlotView extends LayoutDOMView implements Paintable {
       await this._update_renderers()
     })
 
+    const {frame_width, frame_height, frame_align} = this.model.properties
+    this.on_change([frame_width, frame_height, frame_align], () => this.invalidate_layout())
+
     const {min_border, min_border_top, min_border_bottom, min_border_left, min_border_right} = this.model.properties
     this.on_change([min_border, min_border_top, min_border_bottom, min_border_left, min_border_right], () => this.invalidate_layout())
 

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -2078,4 +2078,28 @@ describe("Bug", () => {
       await display(p)
     })
   })
+
+  describe("in issue #15080", () => {
+    it("doesn't allow to change frame width, height and align of a Plot", async () => {
+      const p = new Plot({frame_width: 100, frame_height: 200})
+      const {view} = await display(p, [300, 300])
+
+      expect(view.frame.bbox.width == 100)
+      expect(view.frame.bbox.height == 200)
+
+      p.frame_width = 150
+      p.frame_height = 275
+      await view.ready
+
+      expect(view.frame.bbox.width == 150)
+      expect(view.frame.bbox.height == 275)
+
+      p.frame_width = 160
+      p.frame_height = 180
+      await view.ready
+
+      expect(view.frame.bbox.width == 160)
+      expect(view.frame.bbox.height == 180)
+    })
+  })
 })


### PR DESCRIPTION
Connects missing signals for `frame_width`, `frame_height` and `frame_align`:

[Screencast from 2026-05-19 11-24-10.webm](https://github.com/user-attachments/assets/1cffb3c1-da47-444c-9326-72a173e3ad92)

fixes #15080