### PR TITLE
Update selections when overlay changes

### DIFF
--- a/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/box_select_tool.ts
@@ -7,7 +7,7 @@ import type {FactorLike} from "../../ranges/factor_range"
 import type * as p from "core/properties"
 import type {SelectionMode, CoordinateUnits} from "core/enums"
 import {Dimensions, BoxOrigin} from "core/enums"
-import type {PanEvent, KeyEvent} from "core/ui_events"
+import type {PanEvent, KeyEvent, KeyModifiers} from "core/ui_events"
 import type {HitTestRect} from "core/geometry"
 import type {CoordinateMapper, LRTB} from "core/util/bbox"
 import * as icons from "styles/icons.css"
@@ -21,12 +21,13 @@ export class BoxSelectToolView extends RegionSelectToolView {
     const {pan} = this.model.overlay
     this.connect(pan, ([phase, ev]) => {
       if ((phase == "pan" && this._is_continuous(ev)) || phase == "pan:end") {
-        const {left, top, right, bottom} = this.model.overlay
-        if (!(left instanceof Coordinate) && !(top instanceof Coordinate) && !(right instanceof Coordinate) && !(bottom instanceof Coordinate)) {
-          const screen = this._compute_lrtb({left, right, top, bottom})
-          this._do_select([screen.left, screen.right], [screen.top, screen.bottom], false, this._select_mode(ev))
-        }
+        this._update_from_overlay(ev)
       }
+    })
+
+    const {overlay} = this.model.properties
+    this.on_transitive_change(overlay, () => {
+      this._update_from_overlay({ctrl: false, alt: false, shift: false})
     })
 
     const {active} = this.model.properties
@@ -35,6 +36,14 @@ export class BoxSelectToolView extends RegionSelectToolView {
         this._clear_overlay()
       }
     })
+  }
+
+  protected _update_from_overlay(mods: KeyModifiers): void {
+    const {left, top, right, bottom} = this.model.overlay
+    if (!(left instanceof Coordinate) && !(top instanceof Coordinate) && !(right instanceof Coordinate) && !(bottom instanceof Coordinate)) {
+      const screen = this._compute_lrtb({left, right, top, bottom})
+      this._do_select([screen.left, screen.right], [screen.top, screen.bottom], false, this._select_mode(mods))
+    }
   }
 
   protected _base_point: [number, number] | null

--- a/examples/interaction/widgets/slider_selection.py
+++ b/examples/interaction/widgets/slider_selection.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from bokeh.layouts import column
+from bokeh.models import BoxSelectTool, CustomJS, RangeSlider
+from bokeh.plotting import figure, show
+
+N = 4000
+x = np.random.random(size=N) * 100
+y = np.random.random(size=N) * 100
+radii = np.random.random(size=N) * 1.5
+colors = np.array([(r, g, 150) for r, g in zip(50+2*x, 30+2*y)], dtype=np.uint8)
+
+box_select = BoxSelectTool(persistent=True, continuous=True)
+plot = figure(tools=["pan", box_select, "hover"])
+plot.circle(x, y, radius=radii, fill_color=colors, fill_alpha=0.6, line_color=None)
+
+x_slider = RangeSlider(value=(10, 90), start=0, end=100)
+y_slider = RangeSlider(value=(10, 90), start=0, end=100)
+
+layout = column(x_slider, y_slider, plot)
+
+update_overlay = CustomJS(args=dict(x_slider=x_slider, y_slider=y_slider, box_select=box_select), code="""
+    const [x0, x1] = x_slider.value
+    const [y0, y1] = y_slider.value
+    const lrtb = {left: x0, right: x1, top: y1, bottom: y0}
+    box_select.overlay.setv(lrtb)
+""")
+
+x_slider.js_on_change("value", update_overlay)
+y_slider.js_on_change("value", update_overlay)
+
+update_sliders = CustomJS(args=dict(x_slider=x_slider, y_slider=y_slider), code="""
+    const {left: x0, right: x1, top: y1, bottom: y0} = this
+    x_slider.value = [x0, x1]
+    y_slider.value = [y0, y1]
+""")
+
+box_select.overlay.js_on_change("left", update_sliders)
+box_select.overlay.js_on_change("right", update_sliders)
+box_select.overlay.js_on_change("top", update_sliders)
+box_select.overlay.js_on_change("bottom", update_sliders)
+
+show(layout)


### PR DESCRIPTION
See the added example:

[Screencast from 2026-05-19 16-56-57.webm](https://github.com/user-attachments/assets/e200b9fa-c811-4357-8c4f-9ebee284294d)

Previously it required the following code to be appended to `update_overlay` to work:
```ts
    const view = cb_context.index.get_one(box_select)
    const screen_lrtb = view._compute_lrtb(lrtb)
    const {left, right, top, bottom} = screen_lrtb
    view._do_select([left, right], [top, bottom], true)
```

fixes #15065