### PR TITLE
Fix `DataRange1d.range_padding` and related updates

### DIFF
--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -88,8 +88,24 @@ export class DataRange1d extends DataRange {
   override connect_signals(): void {
     super.connect_signals()
 
-    const {range_padding, range_padding_units} = this.properties
-    this.on_change([range_padding, range_padding_units], () => this._invalidate_dataranges())
+    const {
+      range_padding,
+      range_padding_units,
+      flipped,
+      follow,
+      follow_interval,
+      default_span,
+      only_visible,
+    } = this.properties
+    this.on_change([
+      range_padding,
+      range_padding_units,
+      flipped,
+      follow,
+      follow_interval,
+      default_span,
+      only_visible,
+    ], () => this._invalidate_dataranges())
   }
 
   protected _invalidate_dataranges(): void {

--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -85,6 +85,22 @@ export class DataRange1d extends DataRange {
 
   protected readonly _plot_bounds: Map<PlotView, Rect> = new Map()
 
+  override connect_signals(): void {
+    super.connect_signals()
+
+    const {range_padding, range_padding_units} = this.properties
+    this.on_change([range_padding, range_padding_units], () => this._invalidate_dataranges())
+  }
+
+  protected _invalidate_dataranges(): void {
+    this.have_updated_interactively = false
+
+    for (const plot of this.linked_plots) {
+      plot.invalidate_dataranges = true
+      plot.request_repaint()
+    }
+  }
+
   get min(): number {
     return Math.min(this.start, this.end)
   }

--- a/bokehjs/test/unit/models/ranges/data_range1d.ts
+++ b/bokehjs/test/unit/models/ranges/data_range1d.ts
@@ -1,6 +1,7 @@
 import {expect} from "#framework/assertions"
 
 import {Plot} from "@bokehjs/models/plots/plot"
+import type {RangeManager} from "@bokehjs/models/plots/range_manager"
 import {DataRange1d} from "@bokehjs/models/ranges/data_range1d"
 import {GlyphRenderer} from "@bokehjs/models/renderers/glyph_renderer"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
@@ -143,7 +144,7 @@ describe("DataRange1d", () => {
       const renderer = new GlyphRenderer({data_source: source, glyph})
       const p = new Plot({renderers: [renderer], y_range})
       const pv = await build_view(p)
-      const range_manager = (pv as any)._range_manager // XXX: protected
+      const range_manager = (pv as any)._range_manager as RangeManager // XXX: protected
 
       expect(y_range.start).to.be.equal(1)
       expect(y_range.end).to.be.equal(3)
@@ -156,6 +157,74 @@ describe("DataRange1d", () => {
 
       expect(y_range.start).to.be.equal(0)
       expect(y_range.end).to.be.equal(4)
+    })
+
+    it("should recompute (start, end) when range-defining properties change", async () => {
+      const check = async (
+        y_range: DataRange1d,
+        y: number[],
+        change: (range: DataRange1d) => void,
+        expected: [number, number],
+      ) => {
+        const source = new ColumnDataSource({data: {x: [0, 1], y}})
+        const glyph = new Scatter({x: {field: "x"}, y: {field: "y"}})
+        const renderer = new GlyphRenderer({data_source: source, glyph})
+        const p = new Plot({renderers: [renderer], y_range})
+        const pv = await build_view(p)
+        const range_manager = (pv as any)._range_manager as RangeManager // XXX: protected
+
+        expect(range_manager.invalidate_dataranges).to.be.false
+
+        change(y_range)
+
+        expect(range_manager.invalidate_dataranges).to.be.true
+        range_manager.update_dataranges()
+
+        expect(y_range.start).to.be.equal(expected[0])
+        expect(y_range.end).to.be.equal(expected[1])
+      }
+
+      await check(new DataRange1d({range_padding: 0}), [1, 3], (range) => range.flipped = true, [3, 1])
+      await check(
+        new DataRange1d({range_padding: 0, follow_interval: 1}),
+        [1, 3],
+        (range) => range.follow = "end",
+        [2, 3],
+      )
+      await check(
+        new DataRange1d({range_padding: 0, follow: "end", follow_interval: 10}),
+        [1, 3],
+        (range) => range.follow_interval = 1,
+        [2, 3],
+      )
+      await check(new DataRange1d({range_padding: 0}), [2, 2], (range) => range.default_span = 4, [0, 4])
+
+      const y_range = new DataRange1d({range_padding: 0, only_visible: false})
+      const visible_source = new ColumnDataSource({data: {x: [0, 1], y: [1, 3]}})
+      const invisible_source = new ColumnDataSource({data: {x: [0, 1], y: [10, 12]}})
+      const visible_glyph = new Scatter({x: {field: "x"}, y: {field: "y"}})
+      const invisible_glyph = new Scatter({x: {field: "x"}, y: {field: "y"}})
+      const visible_renderer = new GlyphRenderer({data_source: visible_source, glyph: visible_glyph})
+      const invisible_renderer = new GlyphRenderer({
+        data_source: invisible_source,
+        glyph: invisible_glyph,
+        visible: false,
+      })
+      const p = new Plot({renderers: [visible_renderer, invisible_renderer], y_range})
+      const pv = await build_view(p)
+      const range_manager = (pv as any)._range_manager as RangeManager // XXX: protected
+
+      expect(y_range.start).to.be.equal(1)
+      expect(y_range.end).to.be.equal(12)
+      expect(range_manager.invalidate_dataranges).to.be.false
+
+      y_range.only_visible = true
+
+      expect(range_manager.invalidate_dataranges).to.be.true
+      range_manager.update_dataranges()
+
+      expect(y_range.start).to.be.equal(1)
+      expect(y_range.end).to.be.equal(3)
     })
   })
 

--- a/bokehjs/test/unit/models/ranges/data_range1d.ts
+++ b/bokehjs/test/unit/models/ranges/data_range1d.ts
@@ -135,6 +135,28 @@ describe("DataRange1d", () => {
       expect(r.start).to.be.equal(4)
       expect(r.end).to.be.equal(10)
     })
+
+    it("should recompute (start, end) when range_padding changes", async () => {
+      const y_range = new DataRange1d({range_padding: 0, range_padding_units: "absolute"})
+      const source = new ColumnDataSource({data: {x: [0, 1], y: [1, 3]}})
+      const glyph = new Scatter({x: {field: "x"}, y: {field: "y"}})
+      const renderer = new GlyphRenderer({data_source: source, glyph})
+      const p = new Plot({renderers: [renderer], y_range})
+      const pv = await build_view(p)
+      const range_manager = (pv as any)._range_manager // XXX: protected
+
+      expect(y_range.start).to.be.equal(1)
+      expect(y_range.end).to.be.equal(3)
+      expect(range_manager.invalidate_dataranges).to.be.false
+
+      y_range.range_padding = 1
+
+      expect(range_manager.invalidate_dataranges).to.be.true
+      range_manager.update_dataranges()
+
+      expect(y_range.start).to.be.equal(0)
+      expect(y_range.end).to.be.equal(4)
+    })
   })
 
   describe("computed_renderers", () => {


### PR DESCRIPTION
fixes #15041
fixes #15028

Changing `range_padding` or `range_padding_units` on a `DataRange1d` now invalidates linked plot data ranges and requests a repaint, so the next range update recomputes `start` and `end` from the current data bounds and padding settings.

Tests:
- `node make lib:build`
- `node make test:unit --grep "should recompute .*range_padding" --screenshot=skip`
- `node make test:unit --grep "DataRange1d" --screenshot=skip`
- `node make eslint:lib eslint:test:unit`
- `git diff --check`
