### PR TITLE
Document `bokeh.document.models`

### DIFF
--- a/docs/bokeh/source/docs/reference/document/models.rst
+++ b/docs/bokeh/source/docs/reference/document/models.rst
@@ -1,0 +1,7 @@
+.. _bokeh.document.models:
+
+bokeh.document.models
+---------------------
+
+.. automodule:: bokeh.document.models
+    :members:

--- a/src/bokeh/document/models.py
+++ b/src/bokeh/document/models.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-''' Encapulate the management of Document models with a DocumentModelManager
+''' Encapsulate the management of Document models with a DocumentModelManager
 class.
 
 '''

--- a/src/bokeh/document/models.py
+++ b/src/bokeh/document/models.py
@@ -112,12 +112,12 @@ class DocumentModelManager:
 
     @contextlib.contextmanager
     def freeze(self) -> Generator[None, None, None]:
-        ''' Defer expensive model recompuation until intermediate updates are
+        ''' Defer expensive model recomputation until intermediate updates are
         complete.
 
         Making updates to the model graph might trigger events that cause more
         updates. This context manager can be used to prevent expensive model
-        recompuation from happening until all events have finished and the
+        recomputation from happening until all events have finished and the
         Document state is quiescent.
 
         Example:
@@ -126,7 +126,7 @@ class DocumentModelManager:
 
             with models.freeze():
                 # updates that might change the model graph, that might trigger
-                # updates that change the model graph, etc. Recompuation will
+                # updates that change the model graph, etc. Recomputation will
                 # happen once at the end.
 
         '''
@@ -199,7 +199,7 @@ class DocumentModelManager:
         the Document's current roots.
 
         This computation can be expensive. Use ``freeze`` to wrap operations
-        that update the model object graph to avoid over-recompuation
+        that update the model object graph to avoid over-recomputation
 
         .. note::
             Any models that remove during recomputation will be noted as


### PR DESCRIPTION
Fixes #14962

Adds a reference documentation page for `bokeh.document.models` so `DocumentModelManager.freeze()` appears in the generated API docs.

Also fixes a few typos in the surrounding docstrings.

I’m new to contributing to Bokeh, so please let me know if there is a preferred docs location or wording adjustment for this API.

Note: local pre-push hooks could not complete because my local environment has a NumPy 2.x incompatibility (`np.bool8` missing). This change is docs-only.