### PR TITLE
security: reject unsigned token request payloads

### DIFF
--- a/src/bokeh/server/contexts.py
+++ b/src/bokeh/server/contexts.py
@@ -184,6 +184,9 @@ class ApplicationContext:
     def sessions(self) -> Iterable[ServerSession]:
         return self._sessions.values()
 
+    def has_session(self, session_id: ID) -> bool:
+        return session_id in self._sessions or session_id in self._pending_sessions
+
     def run_load_hook(self) -> None:
         try:
             self._application.on_server_loaded(self.server_context)

--- a/src/bokeh/server/views/session_handler.py
+++ b/src/bokeh/server/views/session_handler.py
@@ -33,6 +33,7 @@ from bokeh.util.token import (
     generate_jwt_token,
     generate_session_id,
     get_session_id,
+    get_token_payload,
 )
 
 # Bokeh imports
@@ -96,6 +97,17 @@ class SessionHandler(AuthRequestHandler):
                 log.debug("Server received both token and session ID, expected only one")
                 raise HTTPError(status_code=403, reason="Both token and session ID were provided")
             session_id = get_session_id(token)
+            if not app.sign_sessions:
+                payload_keys = set(get_token_payload(token))
+                if payload_keys - {"session_expiry"}:
+                    log.error(
+                        "Unsigned token for session %r contained request payload",
+                        session_id,
+                    )
+                    raise HTTPError(
+                        status_code=403,
+                        reason="Unsigned token contained request payload",
+                    )
         elif session_id is None:
             if app.generate_session_ids:
                 session_id = generate_session_id(secret_key=app.secret_key,

--- a/src/bokeh/server/views/ws.py
+++ b/src/bokeh/server/views/ws.py
@@ -199,6 +199,13 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
         '''
         try:
             session_id = get_session_id(token)
+            if (
+                not self.application.sign_sessions
+                and not self.application_context.has_session(session_id)
+            ):
+                payload_keys = set(get_token_payload(token))
+                if payload_keys - {"session_expiry"}:
+                    raise ProtocolError("Unsigned token contained request payload")
             await self.application_context.create_session_if_needed(session_id, self.request, token)
             session = self.application_context.get_session(session_id)
 

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -631,6 +631,32 @@ async def test__use_provided_session_autoload_token(ManagedServerLoop: MSL) -> N
         assert 1 == len(sessions)
         assert expected == sessions[0].id
 
+async def test__reject_unsigned_autoload_token_with_request_payload(
+    ManagedServerLoop: MSL,
+) -> None:
+    application = Application()
+    with ManagedServerLoop(application) as server:
+        sessions = server.get_sessions('/')
+        assert 0 == len(sessions)
+
+        token = generate_jwt_token(
+            ID("foo"),
+            extra_payload={
+                "headers": {"X-User": "admin"},
+                "cookies": {"auth": "admin"},
+                "arguments": {"role": [b"admin"]},
+            },
+        )
+        with pytest.raises(HTTPError) as info:
+            await http_get(
+                server.io_loop,
+                autoload_url(server) + "&bokeh-token=" + token,
+            )
+        assert "Unsigned token contained request payload" in repr(info.value)
+
+        sessions = server.get_sessions('/')
+        assert 0 == len(sessions)
+
 async def test__use_provided_session_doc(ManagedServerLoop: MSL) -> None:
     application = Application()
     with ManagedServerLoop(application) as server:
@@ -661,6 +687,28 @@ async def test__use_provided_session_websocket(ManagedServerLoop: MSL) -> None:
         sessions = server.get_sessions('/')
         assert 1 == len(sessions)
         assert expected == sessions[0].id
+
+async def test__reject_unsigned_websocket_token_with_request_payload(
+    ManagedServerLoop: MSL,
+) -> None:
+    application = Application()
+    with ManagedServerLoop(application) as server:
+        sessions = server.get_sessions('/')
+        assert 0 == len(sessions)
+
+        token = generate_jwt_token(
+            ID("foo"),
+            extra_payload={"headers": {"X-User": "admin"}},
+        )
+        ws = await websocket_open(
+            server.io_loop,
+            ws_url(server),
+            subprotocols=["bokeh", token],
+        )
+        assert await ws.read_queue.get() is None
+
+        sessions = server.get_sessions('/')
+        assert 0 == len(sessions)
 
 async def test__autocreate_signed_session_autoload(ManagedServerLoop: MSL) -> None:
     application = Application()


### PR DESCRIPTION
Fixes #15124

## Summary

This PR prevents caller-supplied unsigned Bokeh session tokens from providing extra request-context payload fields when they are used to create sessions.

Unsigned tokens can still provide a session id and expiry for the existing compatibility path. Signed tokens keep the existing payload behavior. The change only rejects extra unsigned payload content from client-supplied HTTP tokens, and from websocket tokens when they would create a new session.

## Why

Bokeh exposes selected request headers, cookies, and arguments through `session_context.request`. Those values should come from the actual server request or from a signed server token, not from an unsigned token supplied by a client.

## Tests

```text
python -m pytest --asyncio-mode=auto tests/unit/bokeh/server/test_server__server.py::test__use_provided_session_autoload_token tests/unit/bokeh/server/test_server__server.py::test__reject_unsigned_autoload_token_with_request_payload tests/unit/bokeh/server/test_server__server.py::test__use_provided_session_websocket tests/unit/bokeh/server/test_server__server.py::test__reject_unsigned_websocket_token_with_request_payload tests/unit/bokeh/server/test_server__server.py::test__accept_session_websocket -q
python -m ruff check --select F401,F821 src/bokeh/server/views/session_handler.py src/bokeh/server/views/ws.py src/bokeh/server/contexts.py tests/unit/bokeh/server/test_server__server.py
python -m py_compile src/bokeh/server/views/session_handler.py src/bokeh/server/views/ws.py src/bokeh/server/contexts.py tests/unit/bokeh/server/test_server__server.py
git diff --check
```