### PR TITLE
security: verify websocket token before payload parsing

### DIFF
--- a/src/bokeh/server/views/ws.py
+++ b/src/bokeh/server/views/ws.py
@@ -140,6 +140,14 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
             raise ProtocolError("No token received in subprotocol header")
 
         now = calendar.timegm(dt.datetime.now(tz=dt.UTC).timetuple())
+        if not check_token_signature(token,
+                                     signed=self.application.sign_sessions,
+                                     secret_key=self.application.secret_key):
+            session_id = get_session_id(token)
+            log.error("Token for session %r had invalid signature", session_id)
+            self.close()
+            raise ProtocolError("Invalid token signature")
+
         payload = get_token_payload(token)
         if 'session_expiry' not in payload:
             self.close()
@@ -147,12 +155,6 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
         elif now >= payload['session_expiry']:
             self.close()
             raise ProtocolError("Token is expired. Configure the app with a larger value for --session-token-expiration if necessary")
-        elif not check_token_signature(token,
-                                       signed=self.application.sign_sessions,
-                                       secret_key=self.application.secret_key):
-            session_id = get_session_id(token)
-            log.error("Token for session %r had invalid signature", session_id)
-            raise ProtocolError("Invalid token signature")
 
         try:
             self.application.io_loop.add_callback(self._async_open, self._token)

--- a/tests/unit/bokeh/server/views/test_ws.py
+++ b/tests/unit/bokeh/server/views/test_ws.py
@@ -19,7 +19,9 @@ import pytest ; pytest
 # Standard library imports
 import logging
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Generator
+from unittest import mock
 
 # External imports
 from tornado.httpclient import HTTPClientError, HTTPRequest
@@ -28,6 +30,7 @@ from tornado.websocket import WebSocketClosedError, websocket_connect
 
 # Bokeh imports
 from bokeh.application import Application
+from bokeh.protocol.exceptions import ProtocolError
 from bokeh.server.tornado import BokehTornado
 from bokeh.server.views.auth_request_handler import AuthRequestHandler
 from bokeh.util.logconfig import basicConfig
@@ -123,6 +126,26 @@ async def test_ws_handler_rejects_disallowed_origins(
     assert f"Refusing websocket connection from Origin {request_origin!r}" in caplog.text
     assert f"currently we allow origins {set(allowed_origins)!r}" in caplog.text
 
+
+def test_open_rejects_invalid_signed_token_before_payload() -> None:
+    handler = object.__new__(WSHandler)
+    handler._token = generate_jwt_token("bad-session", signed=True, secret_key="bar", extra_payload=dict(foo="bar"))
+    handler.application = SimpleNamespace(
+        sign_sessions=True,
+        secret_key="foo",
+        io_loop=SimpleNamespace(add_callback=mock.Mock()),
+    )
+    handler.close = mock.Mock()
+
+    with (
+        mock.patch.object(WSHandler, "selected_subprotocol", new_callable=mock.PropertyMock, return_value="bokeh"),
+        mock.patch("bokeh.server.views.ws.get_token_payload") as get_token_payload,
+        pytest.raises(ProtocolError, match="Invalid token signature"),
+    ):
+        WSHandler.open.__wrapped__(handler)
+
+    handler.close.assert_called_once()
+    get_token_payload.assert_not_called()
 
 #-----------------------------------------------------------------------------
 # Dev API


### PR DESCRIPTION
Fixes #15125

## Summary
- verify signed WebSocket session tokens before parsing token payloads
- keep expiry validation after signature validation
- add a regression test that rejects an invalid signed token without calling payload parsing

## Why
`WSHandler.open()` checked token expiry by parsing the token payload before checking the token signature. For signed-session deployments, this meant an invalid token could still force server-side payload handling before being rejected. Verifying the signature first keeps unauthenticated WebSocket tokens from reaching payload parsing.

## Testing
- `python -m pytest tests/unit/bokeh/server/views/test_ws.py -q -k "invalid_signed_token or uses_auth"`
- `python -m py_compile src/bokeh/server/views/ws.py tests/unit/bokeh/server/views/test_ws.py`

Note: running the full local `test_ws.py` file in this checkout still fails on the pre-existing missing async pytest plugin for the existing async test.

