### PR TITLE
Allow show() of a sequence of models in notebook output (fixes #14861)

### DIFF
--- a/src/bokeh/io/notebook.py
+++ b/src/bokeh/io/notebook.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 import json
 import os
 import urllib
+from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -56,6 +57,7 @@ if TYPE_CHECKING:
     )
     from ..embed.bundle import Bundle
     from ..model import Model
+    from ..models.ui import UIElement
     from ..resources import Resources
     from .state import State
 
@@ -593,21 +595,19 @@ def show_app(
     })
 
 @overload
-def show_doc(obj: Model, state: State) -> None: ...
+def show_doc(obj: Model | Sequence[UIElement], state: State) -> None: ...
 @overload
-def show_doc(obj: Model, state: State, notebook_handle: CommsHandle) -> CommsHandle: ...
+def show_doc(obj: Model | Sequence[UIElement], state: State, notebook_handle: CommsHandle) -> CommsHandle: ...
 
-def show_doc(obj: Model, state: State, notebook_handle: CommsHandle | None = None) -> CommsHandle | None:
+def show_doc(obj: Model | Sequence[UIElement], state: State, notebook_handle: CommsHandle | None = None) -> CommsHandle | None:
     '''
 
     '''
-    from collections.abc import Sequence
-
     # Notebook output only supports a single document root, but ``show`` accepts
     # a sequence of UIElements (which file and server output render directly).
     # Wrap such a sequence in a column layout here so the same call works in all
     # output modes instead of raising an opaque error. See issue #14861.
-    if isinstance(obj, Sequence) and not isinstance(obj, str | bytes):
+    if isinstance(obj, Sequence):
         from ..layouts import column
         obj = column(*obj)
 

--- a/src/bokeh/io/notebook.py
+++ b/src/bokeh/io/notebook.py
@@ -601,6 +601,16 @@ def show_doc(obj: Model, state: State, notebook_handle: CommsHandle | None = Non
     '''
 
     '''
+    from collections.abc import Sequence
+
+    # Notebook output only supports a single document root, but ``show`` accepts
+    # a sequence of UIElements (which file and server output render directly).
+    # Wrap such a sequence in a column layout here so the same call works in all
+    # output modes instead of raising an opaque error. See issue #14861.
+    if isinstance(obj, Sequence) and not isinstance(obj, str | bytes):
+        from ..layouts import column
+        obj = column(*obj)
+
     if obj not in state.document.roots:
         state.document.add_root(obj)
 

--- a/tests/unit/bokeh/io/test_notebook__io.py
+++ b/tests/unit/bokeh/io/test_notebook__io.py
@@ -77,6 +77,30 @@ def test_show_doc_no_server(mock_notebook_content: MagicMock,
     assert mock__publish_display_data.call_args[0] == expected_args
     assert mock__publish_display_data.call_args[1] == expected_kwargs
 
+@patch('bokeh.io.notebook.get_comms')
+@patch('bokeh.io.notebook.publish_display_data')
+@patch('bokeh.embed.notebook.notebook_content')
+def test_show_doc_wraps_sequence_in_layout(mock_notebook_content: MagicMock,
+                                           mock__publish_display_data: MagicMock,
+                                           mock_get_comms: MagicMock) -> None:
+    from bokeh.layouts import Column
+    from bokeh.models import Div
+
+    mock_get_comms.return_value = "comms"
+    s = State()
+    mock_notebook_content.return_value = ["notebook_script", "notebook_div", Document()]
+
+    child_0, child_1 = Div(), Div()
+
+    # A sequence of UIElements should not raise in notebook output mode (#14861);
+    # it is wrapped in a single column layout root.
+    binb.show_doc([child_0, child_1], s)
+
+    roots = list(s.document.roots)
+    assert len(roots) == 1
+    assert isinstance(roots[0], Column)
+    assert list(roots[0].children) == [child_0, child_1]
+
 
 class Test_push_notebook:
     @patch('bokeh.io.notebook.CommsHandle.comms', new_callable=PropertyMock)


### PR DESCRIPTION
- [x] issues: fixes #14861
- [x] tests added / passed
- [ ] release document entry (bug fix, no API change)

### Description

`show([model_a, model_b])` works with file and server output but raised an opaque error under `output_notebook()`:

```
AttributeError: 'list' object has no attribute 'references'
```

The notebook hook (`show_doc` in `src/bokeh/io/notebook.py`) only supports a single document root, and passed the list straight to `Document.add_root`, which later failed in `recompute()`.

Following the suggestion in the issue (wrap inputs in a "dummy column layout" so all output modes accept the same input), this PR wraps a sequence of UIElements in a `column(...)` layout inside `show_doc` before adding it as a root. Single-model calls are unchanged.

```python
from bokeh.io import output_notebook, show
from bokeh.models import PasswordInput
output_notebook()
show([PasswordInput(placeholder="..."), PasswordInput(title="Password:")])  # now renders instead of raising
```

### Testing

- Added `test_show_doc_wraps_sequence_in_layout` in `tests/unit/bokeh/io/test_notebook__io.py`, which drives the exact `show_doc([...])` path and asserts a single `Column` root wrapping the children.
- Existing `test_show_doc_no_server` still passes (single-model path unaffected).
- `ruff check` passes on the changed files.

### AI disclosure

Per Bokeh's AI Contribution Guidelines: I used Claude Code to help draft this change and its test. I reviewed and understand the fix, and verified it locally with the unit tests above.
