### PR TITLE
Clarify Document.to_json() docstring re: JSON-serializability (#14944)

### DIFF
--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -772,12 +772,26 @@ side of a communications channel while it was being removed on the other end.\
     def to_json(self, *, deferred: Literal[False]) -> DocJson: ...
 
     def to_json(self, *, deferred: bool = True) -> DocJson | Serialized[DocJson]:
-        ''' Convert this document to a JSON-serializable object.
+        ''' Convert this document to a serialized representation.
+
+        .. note::
+            Despite the name, the default return value is **not** directly
+            JSON-serializable. With ``deferred=True`` (the default), any binary
+            buffers are kept as references and the result is a ``Serialized``
+            wrapper, so e.g. ``json.dumps(doc.to_json())`` will raise
+            ``TypeError``. To obtain a JSON *string*, pass the result to
+            ``bokeh.core.json_encoder.serialize_json``. Alternatively, pass
+            ``deferred=False`` to inline any binary buffers as base64 and return
+            a plain ``dict`` that is directly JSON-serializable.
 
         Args:
-            deferred (bool) : encode buffers lazily as references or immediately as inline (base64)
+            deferred (bool) :
+                If ``True`` (default), encode binary buffers lazily as
+                references and return a ``Serialized`` wrapper. If ``False``,
+                encode buffers immediately as inline base64 and return a plain
+                ``DocJson`` dict that is directly JSON-serializable.
 
-        Return:
+        Returns:
             Serialized[DocJson] | DocJson
 
         '''


### PR DESCRIPTION
- [x] issues: fixes #14944
- [ ] tests added / passed (docstring-only change)
- [ ] release document entry (docs only, no behavior change)

### Description

`Document.to_json()` is documented as returning *"a JSON-serializable object"*, but with the default `deferred=True` it returns a `Serialized` wrapper, so `json.dumps(Document().to_json())` raises `TypeError: Object of type Serialized is not JSON serializable` (#14944).

As @mattpap explained in the issue, the `Serialized` return is intentional in 3.9 (it makes buffer management easier), and the larger naming/behavior cleanup is planned for 4.0 (`to_json()` returning a string, plus a `to_serializable()`). This PR therefore makes a **docs-only** change for the 3.x line: it updates the `to_json()` docstring so it no longer claims to return a directly-JSON-serializable object, and documents how to actually get JSON — which is exactly the confusion the reporter hit.

The new docstring explains:
- `deferred=True` (default) → a `Serialized` wrapper; use `bokeh.core.json_encoder.serialize_json(...)` to get a JSON string.
- `deferred=False` → a plain `dict` with buffers inlined as base64, directly JSON-serializable.

No behavior change; this just stops the docstring from being misleading while the 4.0 redesign is pending.

### Verification

I confirmed the documented behavior against `bokeh` 3.9.0:

```python
import json
from bokeh.document import Document
from bokeh.core.json_encoder import serialize_json

json.dumps(Document().to_json())                 # TypeError (Serialized)
json.dumps(Document().to_json(deferred=False))   # OK (plain dict)
serialize_json(Document().to_json())             # -> JSON string
```

`ruff check` passes and the module imports cleanly.

### AI disclosure

Per Bokeh's AI Contribution Guidelines: I used Claude Code to help investigate and draft this docstring change; I reviewed it, understand it, and verified the documented behavior locally.

> If you'd prefer an actual behavior change in 3.x (e.g. making the default directly serializable) rather than this doc clarification, happy to adjust — just wanted to start with the non-contentious fix that addresses the immediate confusion.
