### PR TITLE
reorder documentation strings in `enums.py`

### DIFF
--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -92,6 +92,7 @@ __all__ = (
     'Auto',
     'AutosizeMode',
     'AxisLabelStandoffMode',
+    'AxisType',
     'BuiltinFormatter',
     'ButtonType',
     'CalendarPosition',
@@ -237,7 +238,7 @@ def enumeration(*values: Any, case_sensitive: bool = True, quote: bool = False) 
             (default: False)
 
     Raises:
-        ValueError if values empty, if any value is not a string or not unique
+        ValueError: if ``values`` is empty or if any value is not a string or not unique
 
     Returns:
         Enumeration
@@ -268,110 +269,113 @@ def enumeration(*values: Any, case_sensitive: bool = True, quote: bool = False) 
 
     return type("Enumeration", (Enumeration,), attrs)()
 
-#: Alignment (vertical or horizontal) of a child item
 AlignType = Literal["start", "center", "end"]
+#: Alignment (vertical or horizontal) of a child item.
 Align = enumeration(AlignType)
 
-#: Horizontal alignment of a child item
 HAlignType = Literal["left", "center", "right"]
+#: Horizontal alignment of a child item.
 HAlign = enumeration(HAlignType)
 
-#: Vertical alignment of a child item
 VAlignType = Literal["top", "center", "bottom"]
+#: Vertical alignment of a child item.
 VAlign = enumeration(VAlignType)
 
-#: Specify to which items apply styling in a container (e.g. in a legend)
 AlternationPolicyType = Literal["none", "even", "odd", "every"]
+#: Specify to which items apply styling in a container (e.g. in a legend).
 AlternationPolicy = enumeration(AlternationPolicyType)
 
-#: Specify an anchor position on a box/frame
 AnchorType = Literal[
     "top_left",    "top_center",    "top_right",
     "center_left", "center_center", "center_right",
     "bottom_left", "bottom_center", "bottom_right",
     "top", "left", "center", "right", "bottom",
 ]
+#: Specify an anchor position on a box/frame.
 Anchor = enumeration(AnchorType)
 
-#: Specify the units for an angle value
 AngleUnitsType = Literal["deg", "rad", "grad", "turn"]
+#: Specify the units for an angle value.
 AngleUnits = enumeration(AngleUnitsType)
 
-#:
 AutoType = Literal["auto"]
+#:
 Auto = enumeration(AutoType)
 
-#: Specify autosize mode for DataTable
 AutosizeModeType = Literal["fit_columns", "fit_viewport", "force_fit", "none"]
-AutosizeMode = enumeration(AutosizeModeType)
+#: Specify autosize mode for DataTable.
+AutosizeMode = enumeration(Literal["fit_columns", "fit_viewport", "force_fit", "none"])
 
-#: Specify the reference point of the ``axis_label_standoff``
+AxisTypeType = Literal["linear", "log", "datetime", "timedelta", "mercator"]
+#: Specify the type of the axis.
+AxisType = enumeration(AxisTypeType)
+
 AxisLabelStandoffModeType = Literal["tick_labels", "axis"]
+#: Specify the reference point of the ``axis_label_standoff``.
 AxisLabelStandoffMode = enumeration(AxisLabelStandoffModeType)
 
-#: Names of built-in value formatters
 BuiltinFormatterType = Literal["raw", "basic", "numeral", "printf", "datetime"]
+#: Names of built-in value formatters.
 BuiltinFormatter = enumeration(BuiltinFormatterType)
 
-#: Specify a style for button widgets
 ButtonTypeType = Literal["default", "primary", "success", "warning", "danger", "light"]
+#: Specify a style for button widgets.
 ButtonType = enumeration(ButtonTypeType)
 
-#: Specify a position for the DatePicker calendar to display
 CalendarPositionType = Literal["auto", "above", "below"]
+#: Specify a position for the DatePicker calendar to display.
 CalendarPosition = enumeration(CalendarPositionType)
 
-#: Specify a color scheme for the document
 ColorSchemeType = Literal["auto", "light", "dark"]
+#: Specify a color scheme for the document.
 ColorScheme = enumeration(ColorSchemeType)
 
-#: Specify which tick to add additional context to
 ContextWhichType = Literal["start", "center", "end", "all"]
+#: Specify which tick to add additional context to.
 ContextWhich = enumeration(ContextWhichType)
 
-#: Specify units for mapping coordinates
 CoordinateUnitsType = Literal["canvas", "screen", "data"]
+#: Specify units for mapping coordinates.
 CoordinateUnits = enumeration(CoordinateUnitsType)
 
-#: Specify a named dashing pattern for stroking lines
 DashPatternType = Literal["solid", "dashed", "dotted", "dotdash", "dashdot"]
+#: Specify a named dashing pattern for stroking lines.
 DashPattern = enumeration(DashPatternType)
 
-#: Specify a format for printing dates
 DateFormatType = Literal[
     "ATOM", "W3C", "RFC-3339", "ISO-8601", "COOKIE", "RFC-822",
     "RFC-850", "RFC-1036", "RFC-1123", "RFC-2822", "RSS", "TIMESTAMP",
 ]
+#: Specify a format for printing dates.
 DateFormat = enumeration(DateFormatType)
 
-#: Specify a date/time scale
 DatetimeUnitsType = Literal[
     "microseconds", "milliseconds", "seconds", "minsec",
     "minutes", "hourmin", "hours", "days", "months", "years",
 ]
+#: Specify a date/time scale.
 DatetimeUnits = enumeration(DatetimeUnitsType)
 
-#: Specify a vertical/horizontal dimension
 DimensionType = Literal["width", "height"]
+#: Specify a vertical/horizontal dimension.
 Dimension = enumeration(DimensionType)
 
-#: Specify a vertical/horizontal dimensions
 DimensionsType = Literal["width", "height", "both"]
+#: Specify a vertical/horizontal dimensions.
 Dimensions = enumeration(DimensionsType)
 
-#: Specify a stroke direction for circles, wedges, etc.
 DirectionType = Literal["clock", "anticlock"]
+#: Specify a stroke direction for circles, wedges, etc.
 Direction = enumeration(DirectionType)
 
-#: Specify the flow behavior in CSS layouts.
 FlowModeType = Literal["block", "inline"]
+#: Specify the flow behavior in CSS layouts.
 FlowMode = enumeration(FlowModeType)
 
-#: Specify the font style for rendering text
 FontStyleType = Literal["normal", "italic", "bold", "bold italic"]
+#: Specify the font style for rendering text.
 FontStyle = enumeration(FontStyleType)
 
-#: Specify one of the built-in patterns for hatching fills
 HatchPatternType = Literal[
     "blank",
     "dot",
@@ -391,9 +395,11 @@ HatchPatternType = Literal[
     "vertical_wave",
     "criss_cross",
 ]
+#: Specify one of the built-in patterns for hatching fills.
 HatchPattern = enumeration(HatchPatternType)
 
-#: Specify one of the built-in patterns for hatching fills with a one-letter abbreviation
+HatchPatternAbbreviationType = Literal[" ", ".", "o", "-", "|", "+", '"', ":", "@", "/", "\\", "x", ",", "`", "v", ">", "*"]
+#: Specify one of the built-in patterns for hatching fills with a one-letter abbreviation.
 #:
 #: The abbreviations are mapped as follows:
 #:
@@ -416,74 +422,72 @@ HatchPattern = enumeration(HatchPatternType)
 #:     "v"  :  horizontal_wave
 #:     ">"  :  vertical_wave
 #:     "*"  :  criss_cross
-HatchPatternAbbreviationType = Literal[" ", ".", "o", "-", "|", "+", '"', ":", "@", "/", "\\", "x", ",", "`", "v", ">", "*"]
 HatchPatternAbbreviation = enumeration(HatchPatternAbbreviationType, quote=True)
 
-#: The orientation of the hex tiles
 HexTileOrientationType = Literal["pointytop", "flattop"]
+#: The orientation of the hex tiles.
 HexTileOrientation = enumeration(HexTileOrientationType)
 
-#: Specify whether events should be combined or collected as-is when a Document hold is in effect
 HoldPolicyType = Literal["combine", "collect"]
+#: Specify whether events should be combined or collected as-is when a Document hold is in effect.
 HoldPolicy = enumeration(HoldPolicyType)
 
-#: Specify a horizontal location in plot layouts
 HorizontalLocationType = Literal["left", "right"]
+#: Specify a horizontal location in plot layouts.
 HorizontalLocation = enumeration(HorizontalLocationType)
 
-#: Defines the coordinate space within an image
 ImageOriginType = Literal["bottom_left", "top_left", "bottom_right", "top_right"]
+#: Defines the coordinate space within an image.
 ImageOrigin = enumeration(ImageOriginType)
 
-#: Implicitly defined target of a node
 ImplicitTargetType = Literal["viewport", "canvas", "plot", "frame", "parent"]
+#: Implicitly defined target of a node.
 ImplicitTarget = enumeration(ImplicitTargetType)
 
-#: Specify a distribution to use for the Jitter class
 JitterRandomDistributionType = Literal["uniform", "normal"]
+#: Specify a distribution to use for the Jitter class.
 JitterRandomDistribution = enumeration(JitterRandomDistributionType)
 
-#: Keyboard modifier key used to configure tools or report in UI events
 KeyModifierType = Literal["shift", "ctrl", "alt"]
+#: Keyboard modifier key used to configure tools or report in UI events.
 KeyModifier = enumeration(KeyModifierType)
 
-#: Specify how labels are oriented with respect to an axis
 LabelOrientationType = Literal["horizontal", "vertical", "parallel", "normal"]
+#: Specify how labels are oriented with respect to an axis.
 LabelOrientation = enumeration(LabelOrientationType)
 
-#: Specify whether a dimension or coordinate is latitude or longitude
 LatLonType = Literal["lat", "lon"]
+#: Specify whether a dimension or coordinate is latitude or longitude.
 LatLon = enumeration(LatLonType)
 
-#: Specify how a legend should respond to click events
 LegendClickPolicyType = Literal["none", "hide", "mute"]
+#: Specify how a legend should respond to click events.
 LegendClickPolicy = enumeration(LegendClickPolicyType)
 
-#: Specify a fixed location for a legend
 LegendLocationType = AnchorType
+#: Specify a fixed location for a legend.
 LegendLocation = Anchor
 
-#: Specify how stroked lines should be terminated
 LineCapType = Literal["butt", "round", "square"]
+#: Specify how stroked lines should be terminated.
 LineCap = enumeration(LineCapType)
 
-#: Specify a named dash pattern for stroking lines
 LineDashType = Literal["solid", "dashed", "dotted", "dotdash", "dashdot"]
+#: Specify a named dash pattern for stroking lines.
 LineDash = enumeration(LineDashType)
 
-#: Specify how stroked lines should be joined together
 LineJoinType = Literal["miter", "round", "bevel"]
+#: Specify how stroked lines should be joined together.
 LineJoin = enumeration(LineJoinType)
 
-#: Specify a location in plot layouts
 LocationType = Literal["above", "below", "left", "right"]
+#: Specify a location in plot layouts.
 Location = enumeration(LocationType)
 
-#: Specify a style for a Google map
 MapTypeType = Literal["satellite", "roadmap", "terrain", "hybrid"]
+#: Specify a style for a Google map.
 MapType = enumeration(MapTypeType)
 
-#: Specify one of the built-in marker types
 MarkerTypeType = Literal[
     "asterisk", "circle", "circle_cross", "circle_dot", "circle_x",
     "circle_y", "cross", "dash", "diamond", "diamond_cross", "diamond_dot",
@@ -491,131 +495,131 @@ MarkerTypeType = Literal[
     "square_cross", "square_dot", "square_pin", "square_x", "star", "star_dot",
     "triangle", "triangle_dot", "triangle_pin", "x", "y",
 ]
+#: Specify one of the built-in marker types.
 MarkerType = enumeration(MarkerTypeType)
 
-#: Indicates in which dimensions an object (a renderer or an UI element) can be moved.
 MovableType = Literal["none", "x", "y", "both"]
+#: Indicates in which dimensions an object (a renderer or an UI element) can be moved.
 Movable = enumeration(MovableType)
 
-#: Specify one of the CSS4 named colors (https://www.w3.org/TR/css-color-4/#named-colors)
+#: Specify one of the |named CSS colors|.
 NamedColor = enumeration(*colors.named.__all__, case_sensitive=False)
 
-#: Specify a locale for printing numeric values
 NumeralLanguageType = Literal["be-nl", "chs", "cs", "da-dk", "de-ch", "de", "en",
                               "en-gb", "es-ES", "es", "et", "fi", "fr-CA", "fr-ch",
                               "fr", "hu", "it", "ja", "nl-nl", "pl", "pt-br",
                               "pt-pt", "ru", "ru-UA", "sk", "th", "tr", "uk-UA"]
+#: Specify a locale for printing numeric values.
 NumeralLanguage = enumeration(NumeralLanguageType)
 
-#: Specify a vertical/horizontal orientation for something
 OrientationType = Literal["horizontal", "vertical"]
+#: Specify a vertical/horizontal orientation for something.
 Orientation = enumeration(OrientationType)
 
-#: Names of pre-defined outline shapes (used in ``Text.outline_shape``)
 OutlineShapeNameType = Literal["none", "box", "rectangle", "square", "circle", "ellipse", "trapezoid", "parallelogram", "diamond", "triangle"]
+#: Names of pre-defined outline shapes (used in ``Text.outline_shape``).
 OutlineShapeName = enumeration(OutlineShapeNameType)
 
-#: Specify an output backend to render a plot area onto
 OutputBackendType = Literal["canvas", "svg", "webgl"]
+#: Specify an output backend to render a plot area onto.
 OutputBackend = enumeration(OutputBackendType)
 
-#: Whether range padding should be interpreted a percentage or and absolute quantity
 PaddingUnitsType = Literal["percent", "absolute"]
+#: Whether range padding should be interpreted a percentage or and absolute quantity.
 PaddingUnits = enumeration(PaddingUnitsType)
 
-#: Which direction click pan tool acts on.
 PanDirectionType = Literal["left", "right", "up", "down", "west", "east", "north", "south"]
+#: Which direction click pan tool acts on.
 PanDirection = enumeration(PanDirectionType)
 
-#: Specify the name of a palette from :ref:`bokeh.palettes`
 PaletteType = str # TODO
+#: Specify the name of a palette from :ref:`bokeh.palettes`.
 Palette = enumeration(*palettes.__palettes__)
 
-#: Placement of a layout element, in particular in border-style layouts
 PlaceType = Literal["above", "below", "left", "right", "center"]
+#: Placement of a layout element, in particular in border-style layouts.
 Place = enumeration(PlaceType)
 
-#: Specify which dimension or dimensions to use when measuring circle radius
 RadiusDimensionType = Literal["x", "y", "max", "min"]
+#: Specify which dimension or dimensions to use when measuring circle radius.
 RadiusDimension = enumeration(RadiusDimensionType)
 
-#: Specify a position in the render order for a renderer
 RenderLevelType = Literal["image", "underlay", "glyph", "guide", "annotation", "overlay"]
+#: Specify a position in the render order for a renderer.
 RenderLevel = enumeration(RenderLevelType)
 
-#: What reset actions should occur on a Plot reset
 ResetPolicyType = Literal["standard", "event_only"]
+#: What reset actions should occur on a Plot reset.
 ResetPolicy = enumeration(ResetPolicyType)
 
-#: Indicates in which dimensions an object (a renderer or an UI element) can be resized.
 ResizableType = Literal["none", "left", "right", "top", "bottom", "x", "y", "all"]
+#: Indicates in which dimensions an object (a renderer or an UI element) can be resized.
 Resizable = enumeration(ResizableType)
 
-#: Specify which resolutions should be used for stripping of leading zeros
 ResolutionTypeType = Literal["microseconds", "milliseconds", "seconds", "minsec", "minutes", "hourmin", "hours", "days", "months", "years"]
+#: Specify which resolutions should be used for stripping of leading zeros.
 ResolutionType = enumeration(ResolutionTypeType)
 
-#: Specify a policy for  how numbers should be rounded
 RoundingFunctionType = Literal["round", "nearest", "floor", "rounddown", "ceil", "roundup"]
+#: Specify a policy for  how numbers should be rounded.
 RoundingFunction = enumeration(RoundingFunctionType)
 
-#: Scrollbar policies
 ScrollbarPolicyType = Literal["auto", "visible", "hidden"]
+#: Scrollbar policies.
 ScrollbarPolicy = enumeration(ScrollbarPolicyType)
 
-#: Region selection modes
 RegionSelectionModeType = Literal["replace", "append", "intersect", "subtract", "xor"]
+#: Region selection modes.
 RegionSelectionMode = enumeration(RegionSelectionModeType)
 
-#: Selection modes
 SelectionModeType = Literal[RegionSelectionModeType, "toggle"]
+#: Selection modes.
 SelectionMode = enumeration(SelectionModeType)
 
-#: Sizing mode policies
 SizingModeType = Literal["stretch_width", "stretch_height", "stretch_both", "scale_width", "scale_height", "scale_both", "fixed", "inherit"]
+#: Sizing mode policies.
 SizingMode = enumeration(SizingModeType)
 
-#: Individual sizing mode policies
 SizingPolicyType = Literal["fixed", "fit", "min", "max"]
+#: Individual sizing mode policies.
 SizingPolicy = enumeration(SizingPolicyType)
 
-#: Specify sorting directions
 SortDirectionType = Literal["ascending", "descending"]
+#: Specify sorting directions.
 SortDirection = enumeration(SortDirectionType)
 
-#: Specify units for mapping values
 SpatialUnitsType = Literal["screen", "data"]
+#: Specify units for mapping values.
 SpatialUnits = enumeration(SpatialUnitsType)
 
-#: Specify a start/end value
 StartEndType = Literal["start", "end"]
+#: Specify a start/end value.
 StartEnd = enumeration(StartEndType)
 
-#: Specify a mode for stepwise interpolation
 StepModeType = Literal["before", "after", "center"]
-StepMode = enumeration(StepModeType)
+#: Specify a mode for stepwise interpolation.
+StepMode = enumeration(*["before", "after", "center"])
 
-#: Display mode in TeX
 TeXDisplayType = Literal["inline", "block", "auto"]
+#: Display mode in TeX.
 TeXDisplay = enumeration(TeXDisplayType)
 
-#: Specify the horizontal alignment for rendering text
 TextAlignType = Literal["left", "right", "center"]
+#: Specify the horizontal alignment for rendering text.
 TextAlign = enumeration(TextAlignType)
 
-#: Specify the baseline location for rendering text
 TextBaselineType = Literal["top", "middle", "bottom", "alphabetic", "hanging", "ideographic"]
+#: Specify the baseline location for rendering text.
 TextBaseline = enumeration(TextBaselineType)
 
-#: Specify how textures used as canvas patterns should repeat
 TextureRepetitionType = Literal["repeat", "repeat_x", "repeat_y", "no_repeat"]
+#: Specify how textures used as canvas patterns should repeat.
 TextureRepetition = enumeration(TextureRepetitionType)
 
-#: Specify which resolutions should be used for stripping of leading zeros
 TimedeltaResolutionTypeType = Literal["nanoseconds", "microseconds", "milliseconds", "seconds", "minsec", "minutes", "hourmin", "hours", "days"]
+#: Specify which resolutions should be used for stripping of leading zeros.
 TimedeltaResolutionType = enumeration(TimedeltaResolutionTypeType)
 
-#: Well known tool icon names
 ToolIconType = Literal[
     "append_mode",
     "arrow_down_to_bar",
@@ -691,9 +695,9 @@ ToolIconType = Literal[
     "zoom_in",
     "zoom_out",
 ]
+#: Well known tool icon names.
 ToolIcon = enumeration(ToolIconType)
 
-#: Known tool names/aliases
 ToolNameType = Literal[
   "auto_box_zoom",
   "box_select",
@@ -743,30 +747,31 @@ ToolNameType = Literal[
   "zoom_in",
   "zoom_out",
 ]
+#: Known tool names/aliases.
 ToolName = enumeration(ToolNameType)
 
-#: Specify an attachment for tooltips
 TooltipAttachmentType = Literal["horizontal", "vertical", "left", "right", "above", "below"]
+#: Specify an attachment for tooltips.
 TooltipAttachment = enumeration(TooltipAttachmentType)
 
-#: Specify how a format string for a tooltip field should be interpreted
 TooltipFieldFormatterType = Literal["numeral", "datetime", "printf"]
+#: Specify how a format string for a tooltip field should be interpreted.
 TooltipFieldFormatter = enumeration(TooltipFieldFormatterType)
 
-#: Grid track (row/column) sizing policies
 TrackPolicyType = Literal["auto", "min", "max", "flex", "fixed"]
+#: Grid track (row/column) sizing policies.
 TrackPolicy = enumeration(TrackPolicyType)
 
-#: Specify the vertical alignment for rendering text
 VerticalAlignType = Literal["top", "middle", "bottom"]
+#: Specify the vertical alignment for rendering text.
 VerticalAlign = enumeration(VerticalAlignType)
 
-#: Specify a vertical location in plot layouts
 VerticalLocationType = Literal["above", "below"]
+#: Specify a vertical location in plot layouts.
 VerticalLocation = enumeration(VerticalLocationType)
 
-#: Specify a which axis to use for windowed auto-ranging
 WindowAxisType = Literal["none", "x", "y"]
+#: Specify a which axis to use for windowed auto-ranging.
 WindowAxis = enumeration(WindowAxisType)
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -299,12 +299,12 @@ AngleUnitsType = Literal["deg", "rad", "grad", "turn"]
 AngleUnits = enumeration(AngleUnitsType)
 
 AutoType = Literal["auto"]
-#:
+#: Context dependent keyword that specifies the automated, default, computed, etc. behavior.
 Auto = enumeration(AutoType)
 
 AutosizeModeType = Literal["fit_columns", "fit_viewport", "force_fit", "none"]
 #: Specify autosize mode for DataTable.
-AutosizeMode = enumeration(Literal["fit_columns", "fit_viewport", "force_fit", "none"])
+AutosizeMode = enumeration(AutosizeModeType)
 
 AxisLabelStandoffModeType = Literal["tick_labels", "axis"]
 #: Specify the reference point of the ``axis_label_standoff``.

--- a/src/bokeh/core/enums.py
+++ b/src/bokeh/core/enums.py
@@ -306,13 +306,13 @@ AutosizeModeType = Literal["fit_columns", "fit_viewport", "force_fit", "none"]
 #: Specify autosize mode for DataTable.
 AutosizeMode = enumeration(Literal["fit_columns", "fit_viewport", "force_fit", "none"])
 
-AxisTypeType = Literal["linear", "log", "datetime", "timedelta", "mercator"]
-#: Specify the type of the axis.
-AxisType = enumeration(AxisTypeType)
-
 AxisLabelStandoffModeType = Literal["tick_labels", "axis"]
 #: Specify the reference point of the ``axis_label_standoff``.
 AxisLabelStandoffMode = enumeration(AxisLabelStandoffModeType)
+
+AxisTypeType = Literal["linear", "log", "datetime", "timedelta", "mercator"]
+#: Specify the type of the axis.
+AxisType = enumeration(AxisTypeType)
 
 BuiltinFormatterType = Literal["raw", "basic", "numeral", "printf", "datetime"]
 #: Names of built-in value formatters.

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -25,7 +25,12 @@ log = logging.getLogger(__name__)
 import numpy as np
 
 # Bokeh imports
-from ..core.enums import AxisType, HorizontalLocation, MarkerType, VerticalLocation
+from ..core.enums import (
+    AxisType,
+    HorizontalLocation,
+    MarkerType,
+    VerticalLocation,
+)
 from ..core.property.auto import Auto
 from ..core.property.container import List, Seq, Tuple
 from ..core.property.data_frame import EagerSeries, PandasGroupBy
@@ -1123,6 +1128,8 @@ RangeLike = Either(
     PandasGroupBy,
 )
 
+AxisInit = Nullable(Either(Auto, Enum(AxisType)))
+
 class FigureOptions(BaseFigureOptions):
 
     x_range = RangeLike(default=InstanceDefault(DataRange1d), help="""
@@ -1133,11 +1140,11 @@ class FigureOptions(BaseFigureOptions):
     Customize the y-range of the plot.
     """)
 
-    x_axis_type = Nullable(Either(Auto, Enum(AxisType)), default="auto", help="""
+    x_axis_type = AxisInit(default="auto", help="""
     The type of the x-axis.
     """)
 
-    y_axis_type = Nullable(Either(Auto, Enum(AxisType)), default="auto", help="""
+    y_axis_type = AxisInit(default="auto", help="""
     The type of the y-axis.
     """)
 

--- a/src/bokeh/plotting/_figure.py
+++ b/src/bokeh/plotting/_figure.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 import numpy as np
 
 # Bokeh imports
-from ..core.enums import HorizontalLocation, MarkerType, VerticalLocation
+from ..core.enums import AxisType, HorizontalLocation, MarkerType, VerticalLocation
 from ..core.property.auto import Auto
 from ..core.property.container import List, Seq, Tuple
 from ..core.property.data_frame import EagerSeries, PandasGroupBy
@@ -1123,8 +1123,6 @@ RangeLike = Either(
     PandasGroupBy,
 )
 
-AxisType = Nullable(Either(Auto, Enum("linear", "log", "datetime", "timedelta", "mercator")))
-
 class FigureOptions(BaseFigureOptions):
 
     x_range = RangeLike(default=InstanceDefault(DataRange1d), help="""
@@ -1135,11 +1133,11 @@ class FigureOptions(BaseFigureOptions):
     Customize the y-range of the plot.
     """)
 
-    x_axis_type = AxisType(default="auto", help="""
+    x_axis_type = Nullable(Either(Auto, Enum(AxisType)), default="auto", help="""
     The type of the x-axis.
     """)
 
-    y_axis_type = AxisType(default="auto", help="""
+    y_axis_type = Nullable(Either(Auto, Enum(AxisType)), default="auto", help="""
     The type of the y-axis.
     """)
 

--- a/tests/unit/bokeh/core/test_enums.py
+++ b/tests/unit/bokeh/core/test_enums.py
@@ -36,6 +36,7 @@ ALL = (
     'Auto',
     'AutosizeMode',
     'AxisLabelStandoffMode',
+    'AxisType',
     'BuiltinFormatter',
     'ButtonType',
     'CalendarPosition',


### PR DESCRIPTION
I was able to fix #15116 with moving all the documentations stings right before the types mentioned in `__all__`. I used Sphinx version `9.1.0`.

Here is a screenshot of the local build.

<img width="1266" height="575" alt="grafik" src="https://github.com/user-attachments/assets/a8404264-bffe-4037-a235-4ce6b90d3bfd" />

A moved the `AxisType` to `enums.py.`

- [x] issues: fixes #15116

I think this should be added to the `3.9.1` release, if possible.
