### PR TITLE
fix: apply initial disabled state to controls

### DIFF
--- a/bokehjs/src/lib/models/widgets/control.ts
+++ b/bokehjs/src/lib/models/widgets/control.ts
@@ -17,6 +17,13 @@ export abstract class ControlView extends WidgetView {
       }
     })
   }
+
+  override after_render(): void {
+    super.after_render()
+    for (const el of this.controls()) {
+      toggle_attribute(el, "disabled", this.model.disabled)
+    }
+  }
 }
 
 export namespace Control {

--- a/bokehjs/test/unit/models/widgets/file_input.ts
+++ b/bokehjs/test/unit/models/widgets/file_input.ts
@@ -13,6 +13,12 @@ class _FileList extends Array<File> implements FileList {
 }
 
 describe("FileInputView", () => {
+  it("should render with disabled attribute when disabled=true on initial render", async () => {
+    const model = new FileInput({disabled: true})
+    const {view} = await display(model, null)
+    expect(view.input_el.hasAttribute("disabled")).to.be.true
+  })
+
   it("should allow reading files from a FileList", async () => {
     const model = new FileInput({accept: ".csv,.json.,.txt", multiple: false})
     const {view} = await display(model, null)

--- a/bokehjs/test/unit/models/widgets/text_input.ts
+++ b/bokehjs/test/unit/models/widgets/text_input.ts
@@ -5,6 +5,13 @@ import {TextInput} from "@bokehjs/models/widgets"
 import {ValueSubmit} from "@bokehjs/core/bokeh_events"
 
 describe("TextInput", () => {
+  it("should render with disabled attribute when disabled=true on initial render", async () => {
+    const input = new TextInput({disabled: true})
+    const {view} = await display(input, [200, 50])
+    const input_view = view.owner.get_one(input)
+    expect(input_view.input_el.hasAttribute("disabled")).to.be.true
+  })
+
   it("should support ValueSubmit event", async () => {
     const input = new TextInput({value: ""})
     const values: string[] = []


### PR DESCRIPTION
### Description

This PR fixes the initial disabled rendering state for input controls.

Previously, `ControlView` applied the disabled attribute through the `disabled` signal, which works when `disabled` is changed after render. However, when a control is created with `disabled=True` before initial render, the signal path does not necessarily apply the disabled attribute after the control DOM exists.

This change applies the current `model.disabled` state once in `ControlView.after_render()`, using the existing `toggle_attribute()` helper. This keeps the runtime behavior unchanged while making the initial render state consistent.

Focused unit tests were added for:

- `FileInput(disabled=True)`
- `TextInput(disabled=True)`

### Related issue

Fixes #15126

### Validation

- Ran `git diff --check`
- Attempted `node make test:unit --k "TextInput|FileInput"` locally, but the local BokehJS unit compile failed with many unrelated existing module/type resolution errors across the test suite.