### PR TITLE
Add pan_together property to PanTool

### DIFF
--- a/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/pan_tool.ts
@@ -10,6 +10,10 @@ import {Dimensions} from "core/enums"
 import type {SXY} from "core/util/bbox"
 import type {Scale} from "models/scales/scale"
 import * as icons from "styles/icons.css"
+import {Enum} from "core/kinds"
+
+const PanTogether = Enum("none", "cross", "all")
+type PanTogether = typeof PanTogether["__type__"]
 
 export function update_ranges(scales: Map<string, Scale>, p0: number, p1: number): RangeState {
   const r: RangeState = new Map()
@@ -28,7 +32,12 @@ export class PanToolView extends GestureToolView {
     sdy: number
   }
 
-  protected state: {last_dx: number, last_dy: number, dims: Dimensions} | null = null
+  protected state: {
+    last_dx: number
+    last_dy: number
+    dims: Dimensions
+    axis_coords?: {x_scale: Scale, y_scale: Scale}
+  } | null = null
 
   override cursor(sx: number, sy: number): string | null {
     if (this.state != null) {
@@ -42,7 +51,7 @@ export class PanToolView extends GestureToolView {
     return super.cursor(sx, sy)
   }
 
-  protected _interactive_dims({sx, sy}: SXY): Dimensions | null {
+  protected _interactive_dims({sx, sy}: SXY): {dims: Dimensions, axis_coords?: {x_scale: Scale, y_scale: Scale}} | null {
     const {dimensions} = this.model
     const {plot_view} = this
     const axis_view = plot_view.axis_views.find((view) => view.bbox.contains(sx, sy))
@@ -50,19 +59,21 @@ export class PanToolView extends GestureToolView {
       switch (axis_view.dimension) {
         case 0: {
           if (dimensions == "width" || dimensions == "both") {
-            return "width"
+            const {x_scale, y_scale} = axis_view.coordinates
+            return {dims: "width", axis_coords: {x_scale, y_scale}}
           }
           break
         }
         case 1: {
           if (dimensions == "height" || dimensions == "both") {
-            return "height"
+            const {x_scale, y_scale} = axis_view.coordinates
+            return {dims: "height", axis_coords: {x_scale, y_scale}}
           }
           break
         }
       }
     } else if (plot_view.frame.bbox.contains(sx, sy)) {
-      return "both"
+      return {dims: "both"}
     }
 
     return null
@@ -72,9 +83,10 @@ export class PanToolView extends GestureToolView {
     assert(this.state == null)
 
     const {sx, sy} = ev
-    const dims = this._interactive_dims({sx, sy})
-    if (dims != null) {
-      this.state = {last_dx: 0, last_dy: 0, dims}
+    const result = this._interactive_dims({sx, sy})
+    if (result != null) {
+      const {dims, axis_coords} = result
+      this.state = {last_dx: 0, last_dy: 0, dims, axis_coords}
       this.model.document?.interactive_start(this.plot_view.model)
     }
   }
@@ -118,31 +130,74 @@ export class PanToolView extends GestureToolView {
     const dims = this.model.dimensions
     const {x_scales, y_scales} = frame
 
-    const x_axis_only = state.dims == "width"
-    const y_axis_only = state.dims == "height"
-
-    // Here we are a bit careful to only update the range info for dimensions that
-    // are "in play". This is to avoid superfluous noise updates to dataranges that
-    // would cause windowed auto-ranging to turn off.
-
     let sdx: number
     let xrs: RangeState
-    if ((dims == "width" || dims == "both") && !y_axis_only) {
-      sdx = -new_dx
-      xrs = update_ranges(x_scales, sx_low, sx_high)
-    } else {
-      sdx = 0
-      xrs = new Map()
-    }
-
     let sdy: number
     let yrs: RangeState
-    if ((dims == "height" || dims == "both") && !x_axis_only) {
-      sdy = -new_dy
-      yrs = update_ranges(y_scales, sy_low, sy_high)
+
+    const {axis_coords} = state
+    if (axis_coords == null) {
+      // Gesture started inside the plot frame: pan all axes as constrained by `dims`.
+      // Here we are a bit careful to only update the range info for dimensions that
+      // are "in play". This is to avoid superfluous noise updates to dataranges that
+      // would cause windowed auto-ranging to turn off.
+      if (dims == "width" || dims == "both") {
+        sdx = -new_dx
+        xrs = update_ranges(x_scales, sx_low, sx_high)
+      } else {
+        sdx = 0
+        xrs = new Map()
+      }
+      if (dims == "height" || dims == "both") {
+        sdy = -new_dy
+        yrs = update_ranges(y_scales, sy_low, sy_high)
+      } else {
+        sdy = 0
+        yrs = new Map()
+      }
     } else {
-      sdy = 0
-      yrs = new Map()
+      // Gesture started on an axis: apply pan_together to select which scales move.
+      const {pan_together} = this.model
+      const {x_scale, y_scale} = axis_coords
+      const x_axis_only = state.dims == "width"
+
+      if (pan_together == "all") {
+        // Pan all axes in the same dimension as the interacted axis only.
+        if (x_axis_only) {
+          sdx = -new_dx
+          xrs = update_ranges(x_scales, sx_low, sx_high)
+          sdy = 0
+          yrs = new Map()
+        } else {
+          sdx = 0
+          xrs = new Map()
+          sdy = -new_dy
+          yrs = update_ranges(y_scales, sy_low, sy_high)
+        }
+      } else if (pan_together == "cross") {
+        // Pan only the interacted axis and its cross axis.
+        sdx = -new_dx
+        xrs = update_ranges(new Map([["x", x_scale]]), sx_low, sx_high)
+        sdy = -new_dy
+        yrs = update_ranges(new Map([["y", y_scale]]), sy_low, sy_high)
+      } else {
+        // "none": pan only the specific interacted axis.
+        if (x_axis_only) {
+          sdx = -new_dx
+          xrs = update_ranges(new Map([["x", x_scale]]), sx_low, sx_high)
+          sdy = 0
+          yrs = new Map()
+        } else {
+          sdx = 0
+          xrs = new Map()
+          sdy = -new_dy
+          yrs = update_ranges(new Map([["y", y_scale]]), sy_low, sy_high)
+        }
+      }
+
+      // Respect the model-level `dimensions` constraint even on axis gestures.
+      if (dims == "height") { sdx = 0; xrs = new Map() }
+      if (dims == "width")  { sdy = 0; yrs = new Map() }
     }
 
     state.last_dx = dx
@@ -158,6 +213,7 @@ export namespace PanTool {
 
   export type Props = GestureTool.Props & {
     dimensions: p.Property<Dimensions>
+    pan_together: p.Property<PanTogether>
   }
 }
 
@@ -175,7 +231,8 @@ export class PanTool extends GestureTool {
     this.prototype.default_view = PanToolView
 
     this.define<PanTool.Props>(() => ({
-      dimensions: [ Dimensions, "both" ],
+      dimensions:   [ Dimensions,   "both" ],
+      pan_together: [ PanTogether,  "all"  ],
     }))
 
     this.register_alias("pan", () => new PanTool({dimensions: "both"}))

--- a/bokehjs/test/unit/models/tools/gestures/pan_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/pan_tool.ts
@@ -8,6 +8,7 @@ import {PanTool} from "@bokehjs/models/tools/gestures/pan_tool"
 import type {PlotView} from "@bokehjs/models/plots/plot"
 import {Plot, Range1d, LinearAxis} from "@bokehjs/models"
 import {no_repeated} from "@bokehjs/core/util/iterator"
+import type {KeyModifiers} from "@bokehjs/core/ui_gestures"
 
 describe("PanTool", () => {
 
@@ -26,6 +27,33 @@ describe("PanTool", () => {
     return view
   }
 
+  async function mkplot_with_extra_y(tool: Tool): Promise<PlotView> {
+    const plot = new Plot({
+      width: 400,
+      height: 400,
+      min_border: 0,
+      x_range: new Range1d({start: 0, end: 1}),
+      y_range: new Range1d({start: 0, end: 1}),
+    })
+    plot.extra_y_ranges = {y2: new Range1d({start: 0, end: 10})}
+    plot.add_tools(tool)
+    plot.add_layout(new LinearAxis(), "left")
+    plot.add_layout(new LinearAxis({y_range_name: "y2"}), "right")
+    const {view} = await display(plot)
+    return view
+  }
+
+  function get_ranges(plot_view: PlotView) {
+    const xr  = plot_view.frame.x_range
+    const yr  = plot_view.frame.y_range
+    const y2r = plot_view.frame.y_ranges.get("y2") as Range1d
+    return {
+      x:  [xr.start,  xr.end]  as [number, number],
+      y:  [yr.start,  yr.end]  as [number, number],
+      y2: [y2r.start, y2r.end] as [number, number],
+    }
+  }
+
   function get_cursor(plot_view: PlotView): string {
     return getComputedStyle(plot_view.canvas_view.events_el).cursor
   }
@@ -38,6 +66,86 @@ describe("PanTool", () => {
     }
     expect([...no_repeated(cursors)]).to.be.equal([...no_repeated(["default", cursor, "default"])])
   }
+
+  describe("should support pan_together", () => {
+    const modifiers: KeyModifiers = {alt: false, ctrl: false, shift: false}
+    const native_ev = new PointerEvent("pointermove")
+
+    it("'all' panning on y-axis moves all y-ranges but not x", async () => {
+      const tool = new PanTool({dimensions: "both", pan_together: "all"})
+      const plot_view = await mkplot_with_extra_y(tool)
+      const tool_view = plot_view.owner.get_one(tool)
+
+      const left_axis = plot_view.axis_views.find((v) => v.panel.side == "left")!
+      const {hcenter: sx, vcenter: sy} = left_axis.bbox
+
+      tool_view._pan_start({type: "pan_start", sx, sy, dx: 0, dy: 0, modifiers, native: native_ev})
+      tool_view._update(0, 50)
+      tool_view._pan_end({type: "pan_end", sx, sy, dx: 0, dy: 50, modifiers, native: native_ev})
+
+      const {x, y, y2} = get_ranges(plot_view)
+      expect(x).to.be.equal([0, 1])      // x unchanged
+      expect(y).to.not.be.equal([0, 1])  // main y moved
+      expect(y2).to.not.be.equal([0, 10]) // extra y2 also moved ("all")
+    })
+
+    it("'none' panning on y-axis moves only the clicked y-range", async () => {
+      const tool = new PanTool({dimensions: "both", pan_together: "none"})
+      const plot_view = await mkplot_with_extra_y(tool)
+      const tool_view = plot_view.owner.get_one(tool)
+
+      const left_axis = plot_view.axis_views.find((v) => v.panel.side == "left")!
+      const {hcenter: sx, vcenter: sy} = left_axis.bbox
+
+      tool_view._pan_start({type: "pan_start", sx, sy, dx: 0, dy: 0, modifiers, native: native_ev})
+      tool_view._update(0, 50)
+      tool_view._pan_end({type: "pan_end", sx, sy, dx: 0, dy: 50, modifiers, native: native_ev})
+
+      const {x, y, y2} = get_ranges(plot_view)
+      expect(x).to.be.equal([0, 1])      // x unchanged
+      expect(y).to.not.be.equal([0, 1])  // main y moved
+      expect(y2).to.be.equal([0, 10])    // extra y2 NOT moved ("none")
+    })
+
+    it("'cross' panning on y-axis moves the clicked y-range and its cross x-range", async () => {
+      const tool = new PanTool({dimensions: "both", pan_together: "cross"})
+      const plot_view = await mkplot_with_extra_y(tool)
+      const tool_view = plot_view.owner.get_one(tool)
+
+      const left_axis = plot_view.axis_views.find((v) => v.panel.side == "left")!
+      const {hcenter: sx, vcenter: sy} = left_axis.bbox
+
+      // Pan in both directions to make x movement observable
+      tool_view._pan_start({type: "pan_start", sx, sy, dx: 0, dy: 0, modifiers, native: native_ev})
+      tool_view._update(50, 50)
+      tool_view._pan_end({type: "pan_end", sx, sy, dx: 50, dy: 50, modifiers, native: native_ev})
+
+      const {x, y, y2} = get_ranges(plot_view)
+      expect(x).to.not.be.equal([0, 1])  // x moved (cross of y-axis)
+      expect(y).to.not.be.equal([0, 1])  // main y moved
+      expect(y2).to.be.equal([0, 10])    // extra y2 NOT moved (only the cross pair)
+    })
+
+    it("panning inside the frame always moves all ranges regardless of pan_together", async () => {
+      for (const pan_together of ["all", "none", "cross"] as const) {
+        const tool = new PanTool({dimensions: "both", pan_together})
+        const plot_view = await mkplot_with_extra_y(tool)
+        const tool_view = plot_view.owner.get_one(tool)
+
+        // sx/sy inside the frame
+        const {hcenter: sx, vcenter: sy} = plot_view.frame.bbox
+
+        tool_view._pan_start({type: "pan_start", sx, sy, dx: 0, dy: 0, modifiers, native: native_ev})
+        tool_view._update(50, 50)
+        tool_view._pan_end({type: "pan_end", sx, sy, dx: 50, dy: 50, modifiers, native: native_ev})
+
+        const {x, y, y2} = get_ranges(plot_view)
+        expect(x).to.not.be.equal([0, 1])
+        expect(y).to.not.be.equal([0, 1])
+        expect(y2).to.not.be.equal([0, 10])
+      }
+    })
+  })
 
   describe("should support cursor", () => {
     it("width dimensions='both'", async () => {

--- a/docs/bokeh/source/docs/releases/3.10.0.rst
+++ b/docs/bokeh/source/docs/releases/3.10.0.rst
@@ -16,3 +16,4 @@ Bokeh version ``3.10.0`` (May 2026) is a minor milestone of Bokeh project.
 * Make it easier to theme ``Tooltip`` component and migrate it to vDOM (:bokeh-pull:`14955`)
 * Fix broken inverted color mapping when using LogColorMapper (:bokeh-pull:`15035`)
 * Simplified ``CustomJS`` construction with template strings (Python 3.14+) (:bokeh-pull:`14977`)
+* Added ``pan_together`` property to ``PanTool``, mirroring ``WheelZoomTool``'s ``zoom_together``, to control whether panning on an axis affects only that axis (``"none"``), its cross axis pair (``"cross"``), or all axes in the same dimension (``"all"``) (:bokeh-pull:`13325`)

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -474,6 +474,21 @@ class PanTool(Drag):
     height of the plot.
     """)
 
+    pan_together = Enum("none", "cross", "all", default="all", help="""
+    Defines the behavior of the tool when panning on an axis:
+
+    - ``"none"``
+        pan only the axis that's being interacted with. Any cross
+        axes nor any other axes in the dimension of this axis will be affected.
+    - ``"cross"``
+        pan the axis that's being interacted with and its cross
+        axis, if configured. No other axes in this or cross dimension will be
+        affected.
+    - ``"all"``
+        pan all axes in the dimension of the axis that's being
+        interacted with. All cross axes will be unaffected.
+    """)
+
 class ClickPanTool(PlotActionTool):
     ''' A tool that allows to pan a plot by a fixed amount by clicking a button.
 

--- a/src/bokeh/models/tools.pyi
+++ b/src/bokeh/models/tools.pyi
@@ -213,11 +213,13 @@ class ToolMenu(Menu):
 
 class _PanToolInit(_DragInit, total=False):
     dimensions: Dimensions
+    pan_together: Literal["none", "cross", "all"]
 
 class PanTool(Drag):
     def __init__(self, **kwargs: Unpack[_PanToolInit]) -> None: ...
 
     dimensions: Dimensions = ...
+    pan_together: Literal["none", "cross", "all"] = ...
 
 class _ClickPanToolInit(_PlotActionToolInit, total=False):
     direction: PanDirection

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -7010,6 +7010,7 @@
   PanTool: {
     __extends__: "Drag",
     dimensions: "both",
+    pan_together: "all",
   },
   PlotActionTool: {
     __extends__: "ActionTool",


### PR DESCRIPTION
WheelZoomTool has a zoom_together property ("none", "cross", "all") that controls which axes zoom when scrolling on an axis border. PanTool lacks the equivalent: dragging on an axis border always pans all axes in that dimension. This feature request adds a pan_together property to PanTool with the same semantics.

- [x] issues: fixes #13325 
- [x] tests added / passed : 4 unit tests added to pan_tool.ts — clean TypeScript compilation and linter.
- [x] release document entry (if new feature or API change)

Files modified in this PR :

src/bokeh/models/tools.py
src/bokeh/models/tools.pyi
bokehjs/src/lib/models/tools/gestures/pan_tool.ts
bokehjs/test/unit/models/tools/gestures/pan_tool.ts
tests/baselines/defaults.json5
docs/bokeh/source/docs/releases/3.10.0.rst