### PR TITLE
Use correct types with `@pytest.mark.parametrize()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@
 /.mypy_cache/
 /.images-list
 examples-report.html
-examples.log
+/*.log
 
 # used by docker container
 .conda_docker

--- a/tests/support/plugins/log_file.py
+++ b/tests/support/plugins/log_file.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from datetime import datetime
 from typing import IO, Iterator
 
 # External imports
@@ -40,10 +41,14 @@ __all__ = (
 
 @pytest.fixture(scope="session")
 def log_file(request: pytest.FixtureRequest) -> Iterator[IO[str]]:
-    with open(request.config.option.log_file, 'w') as f:
+    log_file = request.config.option.log_file
+    if log_file is None:
+        dt = datetime.now().isoformat(timespec="seconds")
+        log_file = f"bokeh_{dt}.log"
+    with open(log_file, "w") as f:
         # Clean-out any existing log-file
         f.write("")
-    with open(request.config.option.log_file, 'a') as f:
+    with open(log_file, "a") as f:
         yield f
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/plotting/test__legends.py
+++ b/tests/unit/bokeh/plotting/test__legends.py
@@ -60,7 +60,7 @@ def test_pop_legend_kwarg(key: str) -> None:
     kws = {'foo': 10, key: 'bar'}
     assert bpl.pop_legend_kwarg(kws) == ({key: "bar"}, None)
 
-@pytest.mark.parametrize('keys', all_combinations(LEGEND_KWS))
+@pytest.mark.parametrize('keys', list(all_combinations(LEGEND_KWS)))
 def test_pop_legend_kwarg_error(keys: list[str]) -> None:
     kws = dict(zip(keys, range(len(keys))))
     with pytest.raises(ValueError):


### PR DESCRIPTION
Resolves issues with pytest 9.1.

fixes #15151 