### PR TITLE
Fix parameter name mismatches in docstrings

### DIFF
--- a/src/bokeh/embed/bundle.py
+++ b/src/bokeh/embed/bundle.py
@@ -371,7 +371,7 @@ def _use_tables(all_objs: set[HasProps]) -> bool:
     ''' Whether a collection of Bokeh objects contains a TableWidget
 
     Args:
-        objs (seq[HasProps or Document]) :
+        all_objs (seq[HasProps or Document]) :
 
     Returns:
         bool
@@ -384,7 +384,7 @@ def _use_widgets(all_objs: set[HasProps]) -> bool:
     ''' Whether a collection of Bokeh objects contains a any Widget
 
     Args:
-        objs (seq[HasProps or Document]) :
+        all_objs (seq[HasProps or Document]) :
 
     Returns:
         bool
@@ -437,7 +437,7 @@ def _model_requires_mathjax(model: HasProps) -> bool:
 def _use_mathjax(all_objs: set[HasProps]) -> bool:
     ''' Whether a collection of Bokeh objects contains a model requesting MathJax
     Args:
-        objs (seq[HasProps or Document]) :
+        all_objs (seq[HasProps or Document]) :
     Returns:
         bool
     '''
@@ -450,7 +450,7 @@ def _use_gl(all_objs: set[HasProps]) -> bool:
     ''' Whether a collection of Bokeh objects contains a plot requesting WebGL
 
     Args:
-        objs (seq[HasProps or Document]) :
+        all_objs (seq[HasProps or Document]) :
 
     Returns:
         bool

--- a/src/bokeh/server/views/ws.py
+++ b/src/bokeh/server/views/ws.py
@@ -190,8 +190,8 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
         * Opening a new ServerConnection and sending it an ACK
 
         Args:
-            session_id (str) :
-                A session ID to for a session to connect to
+            token (str) :
+                A token containing the ID of the session to connect to
 
                 If no session exists with the given ID, a new session is made
 

--- a/src/bokeh/util/callback_manager.py
+++ b/src/bokeh/util/callback_manager.py
@@ -142,7 +142,7 @@ class PropertyCallbackManager:
 
         Args:
             attr (str) : an attribute name on this object
-            callback (callable) : a callback function to register
+            *callbacks (callable) : one or more callback functions to register
 
         Returns:
             None


### PR DESCRIPTION
Fixes several docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `src/bokeh/embed/bundle.py` | `_use_tables`, `_use_widgets`, `_use_mathjax`, `_use_gl` | `objs` | `all_objs` |
| `src/bokeh/server/views/ws.py` | `WSHandler._async_open` | `session_id` | `token` |
| `src/bokeh/util/callback_manager.py` | `PropertyCallbackManager.on_change` | `callback` | `*callbacks` |

Doc-only change; no behavior modified.