### PR TITLE
Fix incorrect tab focus on close when preceding tab is disabled (#15186)

### DIFF
--- a/bokehjs/src/lib/models/layouts/tabs.tsx
+++ b/bokehjs/src/lib/models/layouts/tabs.tsx
@@ -140,7 +140,7 @@ export class TabsView extends LayoutDOMView {
 
       const close_tab = (j: number = i) => {
         const new_tabs = remove_at(tabs, j)
-        
+
         const new_active = (() => {
           if (new_tabs.length == 0) {
             return 0
@@ -148,10 +148,14 @@ export class TabsView extends LayoutDOMView {
             return active - 1
           } else if (j === active) {
             for (let k = j; k < new_tabs.length; k++) {
-              if (!new_tabs[k].disabled) return k
+              if (!new_tabs[k].disabled) {
+                return k
+              }
             }
             for (let k = j - 1; k >= 0; k--) {
-              if (!new_tabs[k].disabled) return k
+              if (!new_tabs[k].disabled) {
+                return k
+              }
             }
             return 0
           } else {

--- a/bokehjs/src/lib/models/layouts/tabs.tsx
+++ b/bokehjs/src/lib/models/layouts/tabs.tsx
@@ -140,32 +140,24 @@ export class TabsView extends LayoutDOMView {
 
       const close_tab = (j: number = i) => {
         const new_tabs = remove_at(tabs, j)
-        let new_active = active
-
-        if (j < active) {
-          new_active = active - 1
-        } else if (j === active) {
-          let found = false
-          for (let k = j; k < new_tabs.length; k++) {
-            if (!new_tabs[k].disabled) {
-              new_active = k
-              found = true
-              break
+        
+        const new_active = (() => {
+          if (new_tabs.length == 0) {
+            return 0
+          } else if (j < active) {
+            return active - 1
+          } else if (j === active) {
+            for (let k = j; k < new_tabs.length; k++) {
+              if (!new_tabs[k].disabled) return k
             }
-          }
-          if (!found) {
             for (let k = j - 1; k >= 0; k--) {
-              if (!new_tabs[k].disabled) {
-                new_active = k
-                found = true
-                break
-              }
+              if (!new_tabs[k].disabled) return k
             }
+            return 0
+          } else {
+            return active
           }
-          if (!found) {
-            new_active = 0
-          }
-        }
+        })()
 
         this.model.active = new_active
         this.model.tabs = new_tabs

--- a/bokehjs/src/lib/models/layouts/tabs.tsx
+++ b/bokehjs/src/lib/models/layouts/tabs.tsx
@@ -129,6 +129,34 @@ export class TabsView extends LayoutDOMView {
 
     const location_cls = tabs_css[tabs_location]
 
+    const find_activable = (tabs_array: TabPanel[], i: number, dir: -1 | 1): number | null => {
+      const n = tabs_array.length
+      if (dir == 1) {
+        for (let j = i; j < n; j++) {
+          if (!tabs_array[j].disabled) {
+            return j
+          }
+        }
+        for (let j = 0; j < i; j++) {
+          if (!tabs_array[j].disabled) {
+            return j
+          }
+        }
+      } else {
+        for (let j = i; j >= 0; j--) {
+          if (!tabs_array[j].disabled) {
+            return j
+          }
+        }
+        for (let j = n - 1; j >= i; j--) {
+          if (!tabs_array[j].disabled) {
+            return j
+          }
+        }
+      }
+      return null
+    }
+
     const header_els = tabs.map((tab, i) => {
       const is_active = i == active
       const active_cls = is_active ? tabs_css.active : null
@@ -147,17 +175,9 @@ export class TabsView extends LayoutDOMView {
           } else if (j < active) {
             return active - 1
           } else if (j == active) {
-            for (let k = j; k < new_tabs.length; k++) {
-              if (!new_tabs[k].disabled) {
-                return k
-              }
-            }
-            for (let k = j - 1; k >= 0; k--) {
-              if (!new_tabs[k].disabled) {
-                return k
-              }
-            }
-            return 0
+            const dir = j == new_tabs.length ? -1 : 1
+            const start = dir == -1 ? j - 1 : j
+            return find_activable(new_tabs, start, dir) ?? 0
           } else {
             return active
           }
@@ -220,34 +240,6 @@ export class TabsView extends LayoutDOMView {
           return
         }
 
-        const find_activable = (i: number, dir: -1 | 1) => {
-          const n = tabs.length
-          if (dir == 1) {
-            for (let j = i; j < n; j++) {
-              if (!tabs[j].disabled) {
-                return j
-              }
-            }
-            for (let j = 0; j < i; j++) {
-              if (!tabs[j].disabled) {
-                return j
-              }
-            }
-          } else {
-            for (let j = i; j >= 0; j--) {
-              if (!tabs[j].disabled) {
-                return j
-              }
-            }
-            for (let j = n-1; j >= i; j--) {
-              if (!tabs[j].disabled) {
-                return j
-              }
-            }
-          }
-          return active
-        }
-
         switch (event.key as Keys) {
           case " ":
           case "Enter": {
@@ -262,34 +254,34 @@ export class TabsView extends LayoutDOMView {
           }
           case "ArrowLeft": {
             if (this.tabs_orientation == "horizontal") {
-              toggle_tab(find_activable(i-1, -1))
+              toggle_tab(find_activable(tabs, i-1, -1) ?? active)
             }
             break
           }
           case "ArrowRight": {
             if (this.tabs_orientation == "horizontal") {
-              toggle_tab(find_activable(i+1, +1))
+              toggle_tab(find_activable(tabs, i+1, +1) ?? active)
             }
             break
           }
           case "ArrowUp": {
             if (this.tabs_orientation == "vertical") {
-              toggle_tab(find_activable(i-1, -1))
+              toggle_tab(find_activable(tabs, i-1, -1) ?? active)
             }
             break
           }
           case "ArrowDown": {
             if (this.tabs_orientation == "vertical") {
-              toggle_tab(find_activable(i+1, +1))
+              toggle_tab(find_activable(tabs, i+1, +1) ?? active)
             }
             break
           }
           case "Home": {
-            toggle_tab(find_activable(0, +1))
+            toggle_tab(find_activable(tabs, 0, +1) ?? active)
             break
           }
           case "End": {
-            toggle_tab(find_activable(tabs.length-1, -1))
+            toggle_tab(find_activable(tabs, tabs.length-1, -1) ?? active)
             break
           }
           default:

--- a/bokehjs/src/lib/models/layouts/tabs.tsx
+++ b/bokehjs/src/lib/models/layouts/tabs.tsx
@@ -146,7 +146,7 @@ export class TabsView extends LayoutDOMView {
             return 0
           } else if (j < active) {
             return active - 1
-          } else if (j === active) {
+          } else if (j == active) {
             for (let k = j; k < new_tabs.length; k++) {
               if (!new_tabs[k].disabled) {
                 return k

--- a/bokehjs/src/lib/models/layouts/tabs.tsx
+++ b/bokehjs/src/lib/models/layouts/tabs.tsx
@@ -140,7 +140,33 @@ export class TabsView extends LayoutDOMView {
 
       const close_tab = (j: number = i) => {
         const new_tabs = remove_at(tabs, j)
-        const new_active = clamp(active, 0, new_tabs.length - 1)
+        let new_active = active
+
+        if (j < active) {
+          new_active = active - 1
+        } else if (j === active) {
+          let found = false
+          for (let k = j; k < new_tabs.length; k++) {
+            if (!new_tabs[k].disabled) {
+              new_active = k
+              found = true
+              break
+            }
+          }
+          if (!found) {
+            for (let k = j - 1; k >= 0; k--) {
+              if (!new_tabs[k].disabled) {
+                new_active = k
+                found = true
+                break
+              }
+            }
+          }
+          if (!found) {
+            new_active = 0
+          }
+        }
+
         this.model.active = new_active
         this.model.tabs = new_tabs
       }

--- a/bokehjs/test/unit/models/layouts/tabs.ts
+++ b/bokehjs/test/unit/models/layouts/tabs.ts
@@ -39,4 +39,24 @@ describe("Tabs", () => {
       expect(tab.tooltip.content).to.be.equal(`Tab #${i}`)
     }
   })
+
+  it("should update active tab correctly when active tab is closed", async () => {
+    const {build_view} = await import("@bokehjs/core/build_views")
+    const tabs = new_tabs(3)
+    tabs.active = 1
+    tabs.tabs[0].disabled = true
+    tabs.tabs[0].closable = true
+    tabs.tabs[1].closable = true
+    tabs.tabs[2].closable = true
+
+    const view = await build_view(tabs)
+    view.render_to(document.body)
+
+    const close_btns = view.shadow_el.querySelectorAll(".bk-close")
+    const close_btn = close_btns[1] as HTMLElement // The second tab is active, index 1
+    close_btn.click()
+
+    expect(tabs.active).to.be.equal(1) // was index 2, now shifted to index 1
+    expect(tabs.tabs.length).to.be.equal(2)
+  })
 })

--- a/bokehjs/test/unit/models/layouts/tabs.ts
+++ b/bokehjs/test/unit/models/layouts/tabs.ts
@@ -59,4 +59,79 @@ describe("Tabs", () => {
     expect(tabs.active).to.be.equal(1) // was index 2, now shifted to index 1
     expect(tabs.tabs.length).to.be.equal(2)
   })
+
+  it("should handle closing the last remaining tab", async () => {
+    const {build_view} = await import("@bokehjs/core/build_views")
+    const tabs = new_tabs(1)
+    tabs.active = 0
+    tabs.tabs[0].closable = true
+
+    const view = await build_view(tabs)
+    view.render_to(document.body)
+
+    const close_btn = view.shadow_el.querySelector(".bk-close") as HTMLElement
+    close_btn.click()
+
+    expect(tabs.active).to.be.equal(0)
+    expect(tabs.tabs.length).to.be.equal(0)
+  })
+
+  it("should handle closing a tab when zero activable tabs are left", async () => {
+    const {build_view} = await import("@bokehjs/core/build_views")
+    const tabs = new_tabs(2)
+    tabs.active = 1
+    tabs.tabs[0].disabled = true
+    tabs.tabs[0].closable = true
+    tabs.tabs[1].closable = true
+
+    const view = await build_view(tabs)
+    view.render_to(document.body)
+
+    const close_btns = view.shadow_el.querySelectorAll(".bk-close")
+    const close_btn = close_btns[1] as HTMLElement // The second tab is active
+    close_btn.click()
+
+    expect(tabs.active).to.be.equal(0) // Falls back to 0
+    expect(tabs.tabs.length).to.be.equal(1)
+  })
+
+  it("should select the 'lower' (left) tab when the 'higher' (right) tab is disabled", async () => {
+    const {build_view} = await import("@bokehjs/core/build_views")
+    const tabs = new_tabs(3)
+    tabs.active = 1
+    tabs.tabs[0].closable = true
+    tabs.tabs[1].closable = true
+    tabs.tabs[2].disabled = true
+    tabs.tabs[2].closable = true
+
+    const view = await build_view(tabs)
+    view.render_to(document.body)
+
+    const close_btns = view.shadow_el.querySelectorAll(".bk-close")
+    const close_btn = close_btns[1] as HTMLElement // The second tab is active
+    close_btn.click()
+
+    expect(tabs.active).to.be.equal(0) // Should select index 0 because index 2 is disabled
+    expect(tabs.tabs.length).to.be.equal(2)
+  })
+
+  it("should select the 'higher' (right) tab when the 'lower' (left) tab is disabled", async () => {
+    const {build_view} = await import("@bokehjs/core/build_views")
+    const tabs = new_tabs(3)
+    tabs.active = 1
+    tabs.tabs[0].disabled = true
+    tabs.tabs[0].closable = true
+    tabs.tabs[1].closable = true
+    tabs.tabs[2].closable = true
+
+    const view = await build_view(tabs)
+    view.render_to(document.body)
+
+    const close_btns = view.shadow_el.querySelectorAll(".bk-close")
+    const close_btn = close_btns[1] as HTMLElement // The second tab is active
+    close_btn.click()
+
+    expect(tabs.active).to.be.equal(1) // Should select old index 2, which is now index 1
+    expect(tabs.tabs.length).to.be.equal(2)
+  })
 })


### PR DESCRIPTION
 Summary
This PR fixes an issue where closing a tab could incorrectly focus a disabled tab and break keyboard navigation.

Root Cause
In `tabs.tsx`, the `close_tab` function computed the new active tab index using a naive `clamp` operation. This logic failed to check whether the newly computed active tab was `disabled`. Consequently, closing a tab often incorrectly shifted focus to an adjacent disabled tab, which short-circuited the `on_key` event handler and completely broke keyboard navigation across tabs.

 Solution
Updated the `close_tab` logic to safely calculate the new active tab:
- If a tab to the left of the active tab is closed, the active tab's index is explicitly decremented to maintain the same visual active tab.
- If the currently active tab is closed, the function now iterates through the remaining tabs to find the closest **non-disabled** tab, preferring tabs to the right, and then falling back to the left. 
- This guarantees that keyboard focus and navigation are properly maintained when deleting tabs.

Testing Performed
- Reproduced issue #15186 locally with a disabled tab and verified that closing the active tab now elegantly shifts focus to a non-disabled tab.
- Rebuilt BokehJS and verified that TypeScript compilation passes successfully.
