### PR TITLE
Drop generator support in views

### DIFF
--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -87,7 +87,7 @@ export function traverse_views(views: View[], fn: (view: View) => void): void {
       continue
     }
     visited.add(view)
-    queue.push(...view.children())
+    queue.push(...view.children_views())
     fn(view)
   }
 }

--- a/bokehjs/src/lib/core/dom_view.ts
+++ b/bokehjs/src/lib/core/dom_view.ts
@@ -80,7 +80,7 @@ export abstract class DOMView extends View {
   }
 
   r_after_render(): void {
-    for (const child_view of this.children()) {
+    for (const child_view of this.children_views()) {
       if (child_view instanceof DOMView) {
         child_view.r_after_render()
       }

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -146,9 +146,8 @@ export abstract class View implements ISignalable, Equatable {
     return Object.is(this, that)
   }
 
-  /** @deprecated use children_views */
-  public *children(): IterViews {
-    yield* this.children_views().filter((view) => view != null)
+  public children(): View[] {
+    return this.children_views().filter((view) => view != null)
   }
 
   public children_views(): ChildView[] {
@@ -189,7 +188,7 @@ export abstract class View implements ISignalable, Equatable {
   }
 
   serializable_children(): View[] {
-    return [...this.children()].filter((view) => view.model.is_syncable)
+    return this.children().filter((view) => view.model.is_syncable)
   }
 
   serializable_state(): SerializableState {

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -126,8 +126,8 @@ export abstract class View implements ISignalable, Equatable {
       return
     }
     this.disconnect_signals()
-    for (const view of this.children_views()) {
-      view?.remove()
+    for (const view of this.children()) {
+      view.remove()
     }
     this.owner.remove(this)
     this.removed.emit()

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -146,11 +146,6 @@ export abstract class View implements ISignalable, Equatable {
     return Object.is(this, that)
   }
 
-  /** @deprecated use children_views */
-  public *children(): IterViews {
-    yield* this.children_views()
-  }
-
   children_views(): View[] {
     return this._children_views().filter((view) => view != null)
   }

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -126,7 +126,7 @@ export abstract class View implements ISignalable, Equatable {
       return
     }
     this.disconnect_signals()
-    for (const view of this.children()) {
+    for (const view of this.children_views()) {
       view.remove()
     }
     this.owner.remove(this)
@@ -146,11 +146,16 @@ export abstract class View implements ISignalable, Equatable {
     return Object.is(this, that)
   }
 
-  public children(): View[] {
-    return this.children_views().filter((view) => view != null)
+  /** @deprecated use children_views */
+  public *children(): IterViews {
+    yield* this.children_views()
   }
 
-  public children_views(): ChildView[] {
+  children_views(): View[] {
+    return this._children_views().filter((view) => view != null)
+  }
+
+  protected _children_views(): ChildView[] {
     return []
   }
 
@@ -188,7 +193,7 @@ export abstract class View implements ISignalable, Equatable {
   }
 
   serializable_children(): View[] {
-    return this.children().filter((view) => view.model.is_syncable)
+    return this.children_views().filter((view) => view.model.is_syncable)
   }
 
   serializable_state(): SerializableState {
@@ -302,7 +307,7 @@ export abstract class View implements ISignalable, Equatable {
         } else if (child.model == target) {
           return child
         } else {
-          queue.push(...child.children())
+          queue.push(...child.children_views())
         }
       }
       return null

--- a/bokehjs/src/lib/core/view_manager.ts
+++ b/bokehjs/src/lib/core/view_manager.ts
@@ -26,7 +26,7 @@ abstract class AbstractViewQuery {
         query_result.push(view)
       }
 
-      for (const child of view.children()) {
+      for (const child of view.children_views()) {
         descend(child)
       }
     }

--- a/bokehjs/src/lib/models/annotations/arrow.ts
+++ b/bokehjs/src/lib/models/annotations/arrow.ts
@@ -33,8 +33,8 @@ export class ArrowView extends DataAnnotationView {
 
   protected _angles: ScreenArray
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.start, this.end]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.start, this.end]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/annotations/base_color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/base_color_bar.ts
@@ -63,8 +63,8 @@ export abstract class BaseColorBarView extends AnnotationView {
     return this._orientation
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this._axis_view, this._title_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this._axis_view, this._title_view]
   }
 
   override initialize(): void {

--- a/bokehjs/src/lib/models/annotations/contour_color_bar.ts
+++ b/bokehjs/src/lib/models/annotations/contour_color_bar.ts
@@ -18,8 +18,8 @@ export class ContourColorBarView extends BaseColorBarView {
   protected _fill_view: GlyphRendererView
   protected _line_view: GlyphRendererView
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this._fill_view, this._line_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this._fill_view, this._line_view]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/annotations/scale_bar.ts
+++ b/bokehjs/src/lib/models/annotations/scale_bar.ts
@@ -66,8 +66,8 @@ export class ScaleBarView extends AnnotationView {
   protected axis: ContinuousAxis
   protected axis_view: ContinuousAxisView
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.axis_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.axis_view]
   }
 
   protected axis_scale: Scale

--- a/bokehjs/src/lib/models/annotations/text_annotation.ts
+++ b/bokehjs/src/lib/models/annotations/text_annotation.ts
@@ -24,8 +24,8 @@ export abstract class TextAnnotationView extends AnnotationView {
 
   protected _text_view: BaseTextView
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this._text_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this._text_view]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/annotations/toolbar_panel.ts
+++ b/bokehjs/src/lib/models/annotations/toolbar_panel.ts
@@ -24,8 +24,8 @@ export class ToolbarPanelView extends AnnotationView {
     return super.has_finished() && this.toolbar_view.has_finished()
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.toolbar_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.toolbar_view]
   }
 
   toolbar_view: ToolbarView

--- a/bokehjs/src/lib/models/annotations/whisker.ts
+++ b/bokehjs/src/lib/models/annotations/whisker.ts
@@ -17,8 +17,8 @@ export class WhiskerView extends UpperLowerView {
   protected lower_head: ArrowHeadView | null
   protected upper_head: ArrowHeadView | null
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.lower_head, this.upper_head]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.lower_head, this.upper_head]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/axes/axis.ts
+++ b/bokehjs/src/lib/models/axes/axis.ts
@@ -101,8 +101,8 @@ export abstract class AxisView extends GuideRendererView {
     }
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this._axis_label_view, ...this._major_label_views.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this._axis_label_view, ...this._major_label_views.values()]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/dom/dom_element.ts
+++ b/bokehjs/src/lib/models/dom/dom_element.ts
@@ -24,8 +24,8 @@ export abstract class DOMElementView extends DOMNodeView {
 
   readonly child_views: ViewStorage<DOMNode | UIElement> = new Map()
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this.child_views.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this.child_views.values()]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/dom/html.ts
+++ b/bokehjs/src/lib/models/dom/html.ts
@@ -32,8 +32,8 @@ export class HTMLView extends DOMElementView {
     await build_views(this._refs, this.refs)
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this._refs.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this._refs.values()]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/dom/template.ts
+++ b/bokehjs/src/lib/models/dom/template.ts
@@ -24,8 +24,8 @@ export class TemplateView extends DOMElementView {
     await build_views(this._action_views, this.actions)
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this.action_views]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this.action_views]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/glyphs/glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/glyph.ts
@@ -100,8 +100,8 @@ export abstract class GlyphView extends DOMComponentView {
 
   readonly decorations: ViewStorage<Decoration> = new Map()
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this.decorations.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this.decorations.values()]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/glyphs/math_text_glyph.ts
+++ b/bokehjs/src/lib/models/glyphs/math_text_glyph.ts
@@ -15,8 +15,8 @@ export abstract class MathTextGlyphView extends TextView {
 
   protected _label_views: ViewStorage<BaseText> = new Map()
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this._label_views.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this._label_views.values()]
   }
 
   override has_finished(): boolean {

--- a/bokehjs/src/lib/models/graphics/decoration.ts
+++ b/bokehjs/src/lib/models/graphics/decoration.ts
@@ -15,8 +15,8 @@ export class DecorationView extends View {
 
   marking: MarkingView
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.marking]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.marking]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/layouts/layout_dom.ts
+++ b/bokehjs/src/lib/models/layouts/layout_dom.ts
@@ -102,8 +102,8 @@ export abstract class LayoutDOMView extends PaneView {
     })())
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this.child_views]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this.child_views]
   }
 
   abstract get child_models(): UIElement[]

--- a/bokehjs/src/lib/models/plots/grid_plot.ts
+++ b/bokehjs/src/lib/models/plots/grid_plot.ts
@@ -83,8 +83,8 @@ export class GridPlotView extends LayoutDOMView {
     await build_views(this._tool_views, tools, {parent: this})
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this._tool_views.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this._tool_views.values()]
   }
 
   get child_models(): UIElement[] {

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -202,8 +202,8 @@ export class PlotView extends LayoutDOMView implements Paintable {
   /*protected*/ readonly renderer_views: ViewStorage<Renderer> = new Map()
   /*protected*/ readonly tool_views: ViewStorage<Tool> = new Map()
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this.renderer_views.values(), ...this.tool_views.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this.renderer_views.values(), ...this.tool_views.values()]
   }
 
   get child_models(): LayoutDOM[] {

--- a/bokehjs/src/lib/models/renderers/composite_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/composite_renderer.ts
@@ -25,8 +25,8 @@ export abstract class CompositeRendererView extends RendererView {
     return this.computed_element_views
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this.renderer_views, ...this.element_views]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this.renderer_views, ...this.element_views]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/renderers/contour_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/contour_renderer.ts
@@ -16,8 +16,8 @@ export class ContourRendererView extends DataRendererView {
   fill_view: GlyphRendererView
   line_view: GlyphRendererView
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.fill_view, this.line_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.fill_view, this.line_view]
   }
 
   get glyph_view(): GlyphView {

--- a/bokehjs/src/lib/models/renderers/glyph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/glyph_renderer.ts
@@ -70,9 +70,9 @@ export class GlyphRendererView extends DataRendererView {
     return this.glyph
   }
 
-  override children_views(): ChildView[] {
+  override _children_views(): ChildView[] {
     return [
-      ...super.children_views(),
+      ...super._children_views(),
       this.cds_view,
       this.glyph,
       this.selection_glyph,

--- a/bokehjs/src/lib/models/renderers/graph_renderer.ts
+++ b/bokehjs/src/lib/models/renderers/graph_renderer.ts
@@ -28,8 +28,8 @@ export class GraphRendererView extends DataRendererView {
     return this.node_view.glyph
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.edge_view, this.node_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.edge_view, this.node_view]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/renderers/renderer.ts
+++ b/bokehjs/src/lib/models/renderers/renderer.ts
@@ -51,8 +51,8 @@ export abstract class RendererView extends StyledElementView implements visuals.
     return this._context_menu
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this._context_menu]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this._context_menu]
   }
 
   protected _coordinates?: CoordinateTransform

--- a/bokehjs/src/lib/models/tools/actions/examine_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/examine_tool.ts
@@ -19,8 +19,8 @@ export class ExamineToolView extends ActionToolView {
 
   dialog: DialogView
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.dialog]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.dialog]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/tools/inspectors/hover_tool.tsx
+++ b/bokehjs/src/lib/models/tools/inspectors/hover_tool.tsx
@@ -180,8 +180,8 @@ export class HoverToolView extends InspectToolView {
   protected _template_el?: HTMLElement
   protected _template_view?: ViewOf<DOMElement>
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this._ttviews.values(), this._template_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this._ttviews.values(), this._template_view]
   }
 
   protected async _update_filters(): Promise<void> {

--- a/bokehjs/src/lib/models/tools/toolbar.ts
+++ b/bokehjs/src/lib/models/tools/toolbar.ts
@@ -56,8 +56,8 @@ export class ToolbarView extends UIElementView {
     return !this.model.visible ? false : (!this.model.autohide || (this._visible ?? false))
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this._tool_button_views.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this._tool_button_views.values()]
   }
 
   override has_finished(): boolean {

--- a/bokehjs/src/lib/models/ui/dialog.ts
+++ b/bokehjs/src/lib/models/ui/dialog.ts
@@ -66,8 +66,8 @@ export class DialogView extends UIElementView {
   protected _title: ViewOf<UIElementLike>
   protected _content: ViewOf<UIElementLike>
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this._title, this._content]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this._title, this._content]
   }
 
   protected readonly _position = new InlineStyleSheet()

--- a/bokehjs/src/lib/models/ui/menus/menu.ts
+++ b/bokehjs/src/lib/models/ui/menus/menu.ts
@@ -28,8 +28,8 @@ export class MenuView extends UIElementView {
 
   protected _menu_views: ViewStorage<Menu> = new Map()
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this._menu_views.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this._menu_views.values()]
   }
 
   private _menu_items: MenuItemLike[] = []

--- a/bokehjs/src/lib/models/ui/pane.ts
+++ b/bokehjs/src/lib/models/ui/pane.ts
@@ -21,8 +21,8 @@ export class PaneView extends UIElementView {
     return this.elements.map((element) => this._element_views.get(element)).filter((view) => view != null)
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this.element_views]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this.element_views]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/ui/tooltip.tsx
+++ b/bokehjs/src/lib/models/ui/tooltip.tsx
@@ -77,8 +77,8 @@ export class TooltipView extends UIElementView {
 
   protected _element_view: ViewOf<DOMNode | UIElement> | null = null
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this._element_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this._element_view]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/ui/ui_element.ts
+++ b/bokehjs/src/lib/models/ui/ui_element.ts
@@ -109,8 +109,8 @@ export abstract class UIElementView extends StyledElementView {
 
   protected _context_menu: ViewOf<Menu> | null = null
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this._context_menu]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this._context_menu]
   }
 
   /**

--- a/bokehjs/src/lib/models/widgets/abstract_button.ts
+++ b/bokehjs/src/lib/models/widgets/abstract_button.ts
@@ -26,8 +26,8 @@ export abstract class AbstractButtonView extends ControlView {
     yield this.button_el
   }
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.label_view, this.icon_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.label_view, this.icon_view]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/widgets/help_button.ts
+++ b/bokehjs/src/lib/models/widgets/help_button.ts
@@ -11,8 +11,8 @@ export class HelpButtonView extends AbstractButtonView {
 
   protected tooltip: TooltipView
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.tooltip]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.tooltip]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/widgets/input_widget.ts
+++ b/bokehjs/src/lib/models/widgets/input_widget.ts
@@ -45,11 +45,11 @@ export abstract class InputWidgetView extends ControlView {
     yield this.input_el
   }
 
-  override children_views(): ChildView[] {
+  override _children_views(): ChildView[] {
     const {title, description} = this
     const title_view = title instanceof View ? [title] : []
     const description_view = description instanceof View ? [description] : []
-    return [...super.children_views(), ...title_view, ...description_view]
+    return [...super._children_views(), ...title_view, ...description_view]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -173,8 +173,8 @@ export class DataTableView extends WidgetView {
 
   protected wrapper_el: HTMLElement
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), this.cds_view]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.cds_view]
   }
 
   override async lazy_initialize(): Promise<void> {

--- a/bokehjs/test/unit/core/view.ts
+++ b/bokehjs/test/unit/core/view.ts
@@ -74,12 +74,12 @@ describe("core/view", () => {
 
       expect([...view5.views.all_views()]).to.be.equal([view5, view3, view0, view4, view1, view2])
 
-      expect([...view0.children()]).to.be.equal([])
-      expect([...view1.children()]).to.be.equal([])
-      expect([...view2.children()]).to.be.equal([])
-      expect([...view3.children()]).to.be.equal([view0])
-      expect([...view4.children()]).to.be.equal([view1, view2])
-      expect([...view5.children()]).to.be.equal([view3, view4])
+      expect([...view0.children_views()]).to.be.equal([])
+      expect([...view1.children_views()]).to.be.equal([])
+      expect([...view2.children_views()]).to.be.equal([])
+      expect([...view3.children_views()]).to.be.equal([view0])
+      expect([...view4.children_views()]).to.be.equal([view1, view2])
+      expect([...view5.children_views()]).to.be.equal([view3, view4])
     })
   })
 })

--- a/bokehjs/test/unit/core/view.ts
+++ b/bokehjs/test/unit/core/view.ts
@@ -10,15 +10,15 @@ import {Ref, List} from "@bokehjs/core/kinds"
 class SomeModelView extends View {
   declare model: SomeModel
 
-  protected _children_views: ViewStorage<HasProps> = new Map()
+  protected _children_views_map: ViewStorage<HasProps> = new Map()
 
-  override children_views(): ChildView[] {
-    return [...super.children_views(), ...this._children_views.values()]
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), ...this._children_views_map.values()]
   }
 
   override async lazy_initialize(): Promise<void> {
     await super.lazy_initialize()
-    await build_views(this._children_views, this.model.children, {parent: this})
+    await build_views(this._children_views_map, this.model.children, {parent: this})
   }
 }
 

--- a/bokehjs/test/unit/core/view.ts
+++ b/bokehjs/test/unit/core/view.ts
@@ -74,12 +74,12 @@ describe("core/view", () => {
 
       expect([...view5.views.all_views()]).to.be.equal([view5, view3, view0, view4, view1, view2])
 
-      expect([...view0.children_views()]).to.be.equal([])
-      expect([...view1.children_views()]).to.be.equal([])
-      expect([...view2.children_views()]).to.be.equal([])
-      expect([...view3.children_views()]).to.be.equal([view0])
-      expect([...view4.children_views()]).to.be.equal([view1, view2])
-      expect([...view5.children_views()]).to.be.equal([view3, view4])
+      expect(view0.children_views()).to.be.equal([])
+      expect(view1.children_views()).to.be.equal([])
+      expect(view2.children_views()).to.be.equal([])
+      expect(view3.children_views()).to.be.equal([view0])
+      expect(view4.children_views()).to.be.equal([view1, view2])
+      expect(view5.children_views()).to.be.equal([view3, view4])
     })
   })
 })


### PR DESCRIPTION
- [x] issues: fixes #15084
- [x] tests added / passed

`children_views` may become protected, given that it is the unfiltered version with possible null/undefined entries which is not directly used.

As this change may affect downstream usage (panel), this needs to be checked before merging (especially typing issues).
