### PR TITLE
Fix dynamic FlexBox spacing updates

### DIFF
--- a/bokehjs/src/lib/models/layouts/flex_box.ts
+++ b/bokehjs/src/lib/models/layouts/flex_box.ts
@@ -13,8 +13,9 @@ export abstract class FlexBoxView extends LayoutDOMView {
 
   override connect_signals(): void {
     super.connect_signals()
-    const {children} = this.model.properties
+    const {children, spacing} = this.model.properties
     this.on_change(children, () => this.update_children())
+    this.on_change(spacing, () => this.invalidate_layout())
   }
 
   get child_models(): UIElement[] {

--- a/bokehjs/test/unit/models/layouts/row.ts
+++ b/bokehjs/test/unit/models/layouts/row.ts
@@ -1,4 +1,5 @@
 import {expect} from "#framework/assertions"
+import {display} from "#framework/layouts"
 
 import {Row} from "@bokehjs/models/layouts/row"
 
@@ -6,5 +7,17 @@ describe("Row", () => {
   it("should have empty children after initialization", () => {
     const r = new Row()
     expect(r.children).to.be.empty
+  })
+
+  it("should update spacing after initialization", async () => {
+    const r = new Row({spacing: 5, width: 100, height: 100})
+    const {view} = await display(r, [150, 150])
+
+    expect(getComputedStyle(view.el).gap).to.be.equal("5px")
+
+    r.spacing = 20
+    await view.ready
+
+    expect(getComputedStyle(view.el).gap).to.be.equal("20px")
   })
 })


### PR DESCRIPTION
issues: fixes #15030

## Summary

- listen for `spacing` changes in `FlexBoxView` and invalidate the layout so the CSS `gap` is recomputed
- add a rendered DOM regression test that changes a row from 5 px to 20 px spacing

The model property already changed correctly, but `FlexBoxView.connect_signals()` only listened to `children`. As a result, `_update_layout()` was never called again and the rendered gap stayed at its initial value.

## Validation

- RED: the new test reported a computed `5px` gap after setting `spacing = 20`
- `node make build`
- `node make test:unit --grep Row --grep Column`: 27 passed
- `node make test:unit --grep '^(?!.*mercator_tick_formatter module)'`: 2223 passed, 5 skipped
- `node make lint`
- `git diff --cached --check`

A complete local unit run additionally isolated one unchanged Node 26 floating-point formatting failure in `mercator_tick_formatter` (`−1.272e−14` versus `0`); the formatter implementation and test are byte-identical to `branch-3.10`.

## Checklist

- [x] issues: fixes #15030
- [x] tests added / passed
- [x] release document entry not required (bug fix with no API change)

## AI assistance disclosure

AI tools assisted with repository exploration and the initial patch draft. I reproduced the bug, reviewed and understood the final signal/layout flow, verified the regression test red before the fix and green after it, and ran the validation above.