### PR TITLE
Fix resource leak in View.on_transitive_change

### DIFF
--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -84,7 +84,8 @@ export abstract class View implements ISignalable, Equatable {
   }
 
   disconnect<Args, Sender extends object>(signal: Signal<Args, Sender>, slot: Slot<Args, Sender>): boolean {
-    return signal.disconnect(slot, this)
+    const new_slot = this._slots.get(slot)
+    return new_slot != null ? signal.disconnect(new_slot, this) : false
   }
 
   constructor(options: View.Options) {
@@ -228,6 +229,8 @@ export abstract class View implements ISignalable, Equatable {
   }
 
   on_transitive_change<T>(property: Property<T>, fn: () => void, {recursive=false, signal=(obj) => obj.change}: TransitiveOpts = {}): void {
+    const slot = () => fn()
+
     const collect = () => {
       const value = property.is_unset ? [] : property.get_value()
       return HasProps.references(value, {recursive})
@@ -235,13 +238,13 @@ export abstract class View implements ISignalable, Equatable {
 
     const connect = (models: Iterable<HasProps>) => {
       for (const model of models) {
-        this.connect(signal(model), () => fn())
+        this.connect(signal(model), slot)
       }
     }
 
     const disconnect = (models: Iterable<HasProps>) => {
       for (const model of models) {
-        this.disconnect(signal(model), () => fn())
+        this.disconnect(signal(model), slot)
       }
     }
 

--- a/bokehjs/test/unit/core/view.ts
+++ b/bokehjs/test/unit/core/view.ts
@@ -51,6 +51,97 @@ export class SomeModel extends HasProps {
 describe("core/view", () => {
 
   describe("View", () => {
+    it("should disconnect a previously connected slot", async () => {
+      const model = new SomeModel()
+      const view = await build_view(model)
+
+      let calls = 0
+      const slot = () => calls++
+
+      expect(view.connect(model.change, slot)).to.be.true
+      model.change.emit()
+      expect(calls).to.be.equal(1)
+
+      expect(view.disconnect(model.change, slot)).to.be.true
+      model.change.emit()
+      expect(calls).to.be.equal(1)
+
+      expect(view.connect(model.change, slot)).to.be.true
+      model.change.emit()
+      expect(calls).to.be.equal(2)
+    })
+
+    it("should disconnect changes from former transitive references", async () => {
+      const child0 = new SomeModel()
+      const child1 = new SomeModel({children: [new SomeModel()]})
+      const model = new SomeModel({children: [child0]})
+      const view = await build_view(model)
+
+      let calls = 0
+      view.on_transitive_change(model.properties.children, () => calls++)
+
+      child0.change.emit()
+      expect(calls).to.be.equal(1)
+
+      model.children = [child1]
+      calls = 0
+
+      child0.change.emit()
+      expect(calls).to.be.equal(0)
+      child1.change.emit()
+      expect(calls).to.be.equal(1)
+
+      model.children = [child0]
+      calls = 0
+
+      child1.change.emit()
+      expect(calls).to.be.equal(0)
+      child0.change.emit()
+      expect(calls).to.be.equal(1)
+    })
+
+    it("should not accumulate slots for retained transitive references", async () => {
+      const child0 = new SomeModel()
+      const child1 = new SomeModel()
+      const model = new SomeModel({children: [child0]})
+      const view = await build_view(model)
+
+      let calls = 0
+      view.on_transitive_change(model.properties.children, () => calls++)
+
+      model.children = [child0, child1]
+      calls = 0
+
+      child0.change.emit()
+      expect(calls).to.be.equal(1)
+      child1.change.emit()
+      expect(calls).to.be.equal(2)
+    })
+
+    it("should disconnect changes from former recursive transitive references", async () => {
+      const leaf0 = new SomeModel()
+      const branch0 = new SomeModel({children: [leaf0]})
+      const leaf1 = new SomeModel()
+      const branch1 = new SomeModel({children: [leaf1, new SomeModel()]})
+      const model = new SomeModel({children: [branch0]})
+      const view = await build_view(model)
+
+      let calls = 0
+      view.on_transitive_change(model.properties.children, () => calls++, {recursive: true})
+
+      leaf0.change.emit()
+      expect(calls).to.be.equal(1)
+
+      model.children = [branch1]
+      calls = 0
+
+      branch0.change.emit()
+      leaf0.change.emit()
+      expect(calls).to.be.equal(0)
+      leaf1.change.emit()
+      expect(calls).to.be.equal(1)
+    })
+
     it("should support ViewQuery", async () => {
       const obj0 = new SomeModel()
       const obj1 = new SomeModel()


### PR DESCRIPTION
- [x] issues: fixes #15212
- [x] tests added / passed

@mattpap this iteration seems cleaner