### PR TITLE
Document config sync fix and add server based light_dark example using config (Codex based alternative)

### DIFF
--- a/examples/server/app/light_dark.py
+++ b/examples/server/app/light_dark.py
@@ -1,0 +1,32 @@
+from bokeh import events
+from bokeh.core.enums import ColorScheme
+from bokeh.io import curdoc
+from bokeh.layouts import row
+from bokeh.models import Div, Dropdown, LightDark
+
+
+def on_dropdown_click(event):
+    curdoc().config.color_scheme = event.item
+
+
+def on_config_color_scheme_change(attr, old, new):
+    div.text = f"Current scheme: {new}"
+
+
+color_scheme = ColorScheme.auto
+curdoc().config.color_scheme = color_scheme
+curdoc().title = "LightDark"
+curdoc().config.on_change("color_scheme", on_config_color_scheme_change)
+
+menu = [("Dark", ColorScheme.dark), ("Auto", ColorScheme.auto), ("Light", ColorScheme.light)]
+color_scheme_dropdown = Dropdown(label="Update color scheme", menu=menu)
+color_scheme_dropdown.on_event(events.MenuItemClick, on_dropdown_click)
+
+light_dark = LightDark()
+div = Div(text=f"Current scheme: {color_scheme}")
+
+curdoc().add_root(
+    row([color_scheme_dropdown, light_dark, div], stylesheets=[
+        ":host { background-color: light-dark(white, black); color: light-dark(black, white);}",
+    ]),
+)

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -142,10 +142,6 @@ class Document:
     _template_variables: dict[str, Any]
 
     def __init__(self, *, theme: Theme = default_theme, title: str = DEFAULT_TITLE) -> None:
-        self.callbacks = DocumentCallbackManager(self)
-        self.models = DocumentModelManager(self)
-        self.modules = DocumentModuleManager(self)
-
         self._config = DocumentConfig()
         self._roots = []
         self._template = FILE
@@ -154,6 +150,13 @@ class Document:
         self._title = title # avoid triggering title event
 
         self._session_context = None
+
+        self.callbacks = DocumentCallbackManager(self)
+        self.models = DocumentModelManager(self)
+        self.modules = DocumentModuleManager(self)
+
+        self.models.recompute()
+        self.models.flush_synced()
 
     # Properties --------------------------------------------------------------
 
@@ -169,9 +172,17 @@ class Document:
         ''' A list of all the root models in this document.
 
         '''
-        # TODO: config serialization
-        # return [*list(self._roots), self.config]
         return list(self._roots)
+
+    @property
+    def _all_roots(self) -> list[Model]:
+        ''' A list of all models that anchor the document's model graph.
+
+        Unlike :attr:`roots`, this includes models owned by the document that
+        aren't user-visible roots.
+
+        '''
+        return [*self._roots, self._config]
 
     @property
     def session_callbacks(self) -> list[SessionCallback]:
@@ -390,9 +401,7 @@ class Document:
             None
 
         '''
-        # TODO: config serialization. Not passing config here causes an
-        # `UnknownReferenceError`
-        deserializer = Deserializer([*list(self.models), self.config], setter=setter)
+        deserializer = Deserializer(list(self.models), setter=setter)
 
         try:
             patch: PatchJson = deserializer.deserialize(patch_json)
@@ -468,7 +477,7 @@ side of a communications channel while it was being removed on the other end.\
         title = doc_struct["title"]
 
         doc = Document()
-        doc._config = config
+        doc._set_config(config)
 
         for root in roots:
             doc.add_root(root)
@@ -852,6 +861,13 @@ side of a communications channel while it was being removed on the other end.\
 
     # Private methods ---------------------------------------------------------
 
+    def _set_config(self, config: DocumentConfig) -> None:
+        if self._config is config:
+            return
+
+        with self.models.freeze():
+            self._config = config
+
     def _destructively_move(self, dest_doc: Document) -> None:
         ''' Move all data in this doc to the dest_doc, leaving this doc empty.
 
@@ -879,15 +895,18 @@ side of a communications channel while it was being removed on the other end.\
                 root = next(iter(self.roots))
                 self.remove_root(root)
                 roots.append(root)
+            self._config = DocumentConfig()
 
         for root in roots:
             if root.document is not None:
                 raise RuntimeError(f"Somehow we didn't detach {root!r}")
 
-        if len(self.models) != 0:
-            raise RuntimeError(f"_all_models still had stuff in it: {self.models!r}")
+        if set(self.models) != self.config.references():
+            raise RuntimeError(
+                f"_all_models still had unexpected models in it: {self.models!r}",
+            )
 
-        dest_doc._config = config
+        dest_doc._set_config(config)
 
         for root in roots:
             dest_doc.add_root(root)

--- a/src/bokeh/document/models.py
+++ b/src/bokeh/document/models.py
@@ -211,7 +211,7 @@ class DocumentModelManager:
             return
 
         new_models: set[Model] = set()
-        for mr in document.roots:
+        for mr in document._all_roots:
             new_models |= mr.references()
 
         old_models = set(self._models.values())

--- a/tests/unit/bokeh/document/test_callbacks__document.py
+++ b/tests/unit/bokeh/document/test_callbacks__document.py
@@ -19,6 +19,7 @@ import pytest ; pytest
 # Standard library imports
 import gc
 import logging
+import weakref
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -55,9 +56,12 @@ class TestDocumentCallbackManager:
     def test_basic(self) -> None:
         d = Document()
         cm = bdc.DocumentCallbackManager(d)
+        ref = weakref.ref(d)
 
-        # module manager should only hold a weak ref
-        assert len(gc.get_referrers(d)) == 0
+        # callback manager should only hold a weak ref
+        del d
+        gc.collect()
+        assert ref() is None
 
         assert len(cm._message_callbacks) == 1
         assert cm._message_callbacks == {"bokeh_event": [cm.trigger_event]}

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -56,6 +56,7 @@ from bokeh.document.json import ModelChanged, PatchJson
 from bokeh.io.doc import curdoc
 from bokeh.model import DataModel
 from bokeh.models import ColumnDataSource
+from bokeh.models.ui.notifications import Notifications
 from bokeh.protocol.messages.patch_doc import patch_doc
 from bokeh.server.contexts import BokehSessionContext
 from bokeh.util.logconfig import basicConfig
@@ -167,33 +168,107 @@ class TestDocument:
         d.title = "Foo"
         assert d.title == "Foo"
 
+    def test_config_is_part_of_model_graph(self) -> None:
+        d = document.Document()
+
+        assert d.config.document is d
+        assert d.config.notifications is not None
+        assert d.config.notifications.document is d
+        assert d.config.id in d.models
+        assert d.config.notifications.id in d.models
+
+    def test_config_change_notification(self) -> None:
+        d = document.Document()
+        events: list[ModelChangedEvent] = []
+        d.on_change(lambda event: events.append(event))
+
+        d.config.notify_connection_status = False
+
+        assert len(events) == 1
+        assert events[0].model is d.config
+        assert events[0].attr == "notify_connection_status"
+        assert events[0].new is False
+
+    def test_nested_config_change_notification(self) -> None:
+        d = document.Document()
+        events: list[ModelChangedEvent] = []
+        d.on_change(lambda event: events.append(event))
+        assert d.config.notifications is not None
+
+        d.config.notifications.visible = False
+
+        assert len(events) == 1
+        assert events[0].model is d.config.notifications
+        assert events[0].attr == "visible"
+        assert events[0].new is False
+
+    def test_replacing_config_reference_updates_model_graph(self) -> None:
+        d = document.Document()
+        old = d.config.notifications
+        new = Notifications()
+        assert old is not None
+
+        d.config.notifications = new
+
+        assert old.document is None
+        assert old.id not in d.models
+        assert new.document is d
+        assert new.id in d.models
+
+    def test_deserialized_config_is_part_of_model_graph(self) -> None:
+        d = document.Document()
+        d.config.color_scheme = "dark"
+
+        copy = document.Document.from_json(d.to_json())
+
+        assert copy.config.color_scheme == "dark"
+        assert copy.config.document is copy
+        assert copy.config.id in copy.models
+        assert copy.config.notifications is not None
+        assert copy.config.notifications.document is copy
+        assert copy.config.notifications.id in copy.models
+
+    def test_config_patch_preserves_setter(self) -> None:
+        d = document.Document()
+        events: list[ModelChangedEvent] = []
+        d.on_change(lambda event: events.append(event))
+        setter = object()
+        event = ModelChangedEvent(d, d.config, "color_scheme", "dark")
+        patch = patch_doc.create([event]).content
+
+        d.apply_json_patch(patch, setter=setter)
+
+        assert d.config.color_scheme == "dark"
+        assert len(events) == 1
+        assert events[0].setter is setter
+
     def test_all_models(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         m = SomeModelInTestDocument()
         m2 = AnotherModelInTestDocument()
         m.child = m2
         d.add_root(m)
         assert len(d.roots) == 1
-        assert len(d.models) == 2
+        assert len(d.models) == 4
         m.child = None
-        assert len(d.models) == 1
+        assert len(d.models) == 3
         m.child = m2
-        assert len(d.models) == 2
+        assert len(d.models) == 4
         d.remove_root(m)
-        assert len(d.models) == 0
+        assert len(d.models) == 2
 
     def test_get_model_by_id(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         m = SomeModelInTestDocument()
         m2 = AnotherModelInTestDocument()
         m.child = m2
         d.add_root(m)
         assert len(d.roots) == 1
-        assert len(d.models) == 2
+        assert len(d.models) == 4
         assert d.get_model_by_id(m.id) == m
         assert d.get_model_by_id(m2.id) == m2
         assert d.get_model_by_id("not a valid ID") is None
@@ -201,13 +276,13 @@ class TestDocument:
     def test_get_model_by_name(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         m = SomeModelInTestDocument(name="foo")
         m2 = AnotherModelInTestDocument(name="bar")
         m.child = m2
         d.add_root(m)
         assert len(d.roots) == 1
-        assert len(d.models) == 2
+        assert len(d.models) == 4
         assert d.get_model_by_name(m.name) == m
         assert d.get_model_by_name(m2.name) == m2
         assert d.get_model_by_name("not a valid name") is None
@@ -325,7 +400,7 @@ class TestDocument:
     def test_all_models_with_multiple_references(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         root1 = SomeModelInTestDocument()
         root2 = SomeModelInTestDocument()
         child1 = AnotherModelInTestDocument()
@@ -334,24 +409,24 @@ class TestDocument:
         d.add_root(root1)
         d.add_root(root2)
         assert len(d.roots) == 2
-        assert len(d.models) == 3
+        assert len(d.models) == 5
         root1.child = None
-        assert len(d.models) == 3
+        assert len(d.models) == 5
         root2.child = None
-        assert len(d.models) == 2
+        assert len(d.models) == 4
         root1.child = child1
-        assert len(d.models) == 3
+        assert len(d.models) == 5
         root2.child = child1
-        assert len(d.models) == 3
+        assert len(d.models) == 5
         d.remove_root(root1)
-        assert len(d.models) == 2
+        assert len(d.models) == 4
         d.remove_root(root2)
-        assert len(d.models) == 0
+        assert len(d.models) == 2
 
     def test_all_models_with_cycles(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         root1 = SomeModelInTestDocument()
         root2 = SomeModelInTestDocument()
         child1 = SomeModelInTestDocument()
@@ -363,23 +438,23 @@ class TestDocument:
         print("adding root2")
         d.add_root(root2)
         assert len(d.roots) == 2
-        assert len(d.models) == 3
+        assert len(d.models) == 5
         print("clearing child of root1")
         root1.child = None
-        assert len(d.models) == 3
+        assert len(d.models) == 5
         print("clearing child of root2")
         root2.child = None
-        assert len(d.models) == 2
+        assert len(d.models) == 4
         print("putting child1 back in root1")
         root1.child = child1
-        assert len(d.models) == 3
+        assert len(d.models) == 5
 
         print("Removing root1")
         d.remove_root(root1)
-        assert len(d.models) == 1
+        assert len(d.models) == 3
         print("Removing root2")
         d.remove_root(root2)
-        assert len(d.models) == 0
+        assert len(d.models) == 2
 
     def test_change_notification(self) -> None:
         d = document.Document()
@@ -677,13 +752,13 @@ class TestDocument:
         assert d.title == "Foo"
         d.clear()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         assert d.title == "Foo" # do not reset title
 
     def test_serialization_one_model(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         root1 = SomeModelInTestDocument()
         d.add_root(root1)
         d.title = "Foo"
@@ -697,7 +772,7 @@ class TestDocument:
     def test_serialization_more_models(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         root1 = SomeModelInTestDocument(foo=42)
         root2 = SomeModelInTestDocument(foo=43)
         child1 = SomeModelInTestDocument(foo=44)
@@ -804,7 +879,7 @@ class TestDocument:
     def test_patch_integer_property(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         root1 = SomeModelInTestDocument(foo=42)
         root2 = SomeModelInTestDocument(foo=43)
         child1 = SomeModelInTestDocument(foo=44)
@@ -829,7 +904,7 @@ class TestDocument:
     def test_patch_spec_property(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         root1 = ModelWithSpecInTestDocument(foo=42)
         d.add_root(root1)
         assert len(d.roots) == 1
@@ -879,7 +954,7 @@ class TestDocument:
     def test_patch_reference_property(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         root1 = SomeModelInTestDocument(foo=42)
         root2 = SomeModelInTestDocument(foo=43)
         child1 = SomeModelInTestDocument(foo=44)
@@ -926,7 +1001,7 @@ class TestDocument:
     def test_patch_two_properties_at_once(self) -> None:
         d = document.Document()
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         root1 = SomeModelInTestDocument(foo=42)
         child1 = SomeModelInTestDocument(foo=43)
         root1.child = child1
@@ -1036,7 +1111,7 @@ class TestDocument:
         d = document.Document()
         set_curdoc(d)
         assert not d.roots
-        assert len(d.models) == 0
+        assert len(d.models) == 2
         p1 = figure(tools=[])
         N = 10
         x = np.linspace(0, 4 * np.pi, N)

--- a/tests/unit/bokeh/document/test_models.py
+++ b/tests/unit/bokeh/document/test_models.py
@@ -18,6 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 import gc
+import weakref
 from unittest.mock import MagicMock, patch
 
 # Bokeh imports
@@ -45,29 +46,32 @@ class TestDocumentModelManager:
         d = Document()
         dm = bdm.DocumentModelManager(d)
         assert len(dm) == 0
+        ref = weakref.ref(d)
 
-        # module manager should only hold a weak ref
-        assert len(gc.get_referrers(d)) == 0
+        # model manager should only hold a weak ref
+        del d
+        gc.collect()
+        assert ref() is None
 
     def test_len(self) -> None:
         d = Document()
         dm = d.models
-        assert len(dm) == 0
+        assert len(dm) == 2
 
         r1 = Row(children=[Div()])
         r2 = Row(children=[Div(), Div()])
 
         d.add_root(r1)
-        assert len(dm) == 2
+        assert len(dm) == 4
 
         d.add_root(r2)
-        assert len(dm) == 5
+        assert len(dm) == 7
 
         d.remove_root(r1)
-        assert len(dm) == 3
+        assert len(dm) == 5
 
         d.remove_root(r2)
-        assert len(dm) == 0
+        assert len(dm) == 2
 
     def test_setitem_getitem(self) -> None:
         d = Document()
@@ -118,7 +122,7 @@ class TestDocumentModelManager:
     def test_destroy(self) -> None:
         d = Document()
         dm = d.models
-        assert len(dm) == 0
+        assert len(dm) == 2
 
         m1 = Div()
         m2 = Div()
@@ -142,6 +146,7 @@ class TestDocumentModelManager:
     def test_freeze(self, mock_recompute: MagicMock) -> None:
         d = Document()
         dm = bdm.DocumentModelManager(d)
+        mock_recompute.reset_mock()
 
         assert dm._freeze_count == 0
 
@@ -162,7 +167,7 @@ class TestDocumentModelManager:
     def test_get_all_by_name(self) -> None:
         d = Document()
         dm = d.models
-        assert len(dm) == 0
+        assert len(dm) == 2
 
         m1 = Div(name="foo")
         m2 = Div(name="foo")
@@ -179,7 +184,7 @@ class TestDocumentModelManager:
     def test_get_all_by_id(self) -> None:
         d = Document()
         dm = d.models
-        assert len(dm) == 0
+        assert len(dm) == 2
 
         m1 = Div()
         m2 = Div()
@@ -194,7 +199,7 @@ class TestDocumentModelManager:
     def test_get_one_by_name(self) -> None:
         d = Document()
         dm = d.models
-        assert len(dm) == 0
+        assert len(dm) == 2
 
         m1 = Div(name="foo")
         m2 = Div(name="foo")
@@ -213,6 +218,7 @@ class TestDocumentModelManager:
     def test_invalidate(self, mock_recompute: MagicMock) -> None:
         d = Document()
         dm = bdm.DocumentModelManager(d)
+        mock_recompute.reset_mock()
 
         with dm.freeze():
             dm.invalidate()
@@ -227,7 +233,7 @@ class TestDocumentModelManager:
     def test_recompute(self) -> None:
         d = Document()
         dm = d.models
-        assert len(dm) == 0
+        assert len(dm) == 2
 
         r1 = Row(children=[Div(name="dr1")])
         r2 = Row(children=[Div(name="dr2"), Div(name="dr2")])
@@ -254,7 +260,7 @@ class TestDocumentModelManager:
     def test_seen(self) -> None:
         d = Document()
         dm = d.models
-        assert len(dm) == 0
+        assert len(dm) == 2
 
         m1 = Div()
         m2 = Div()
@@ -278,7 +284,7 @@ class TestDocumentModelManager:
     def test_update_name(self) -> None:
         d = Document()
         dm = d.models
-        assert len(dm) == 0
+        assert len(dm) == 2
 
         m1 = Div(name="foo")
         m2 = Div()
@@ -312,25 +318,26 @@ class TestDocumentModelManager:
         child1 = SomeModel()
         child2 = SomeModel()
         d = Document()
+        config_refs = d.config.references()
         d.add_root(child0)
         d.add_root(child1)
 
         assert d.models._new_models == {child0, child1}
-        assert d.models.synced_references == set()
+        assert d.models.synced_references == config_refs
         d.models.flush_synced()
         assert d.models._new_models == set()
-        assert d.models.synced_references == {child0, child1}
+        assert d.models.synced_references == config_refs | {child0, child1}
 
         d.add_root(child2)
         assert d.models._new_models == {child2}
-        assert d.models.synced_references == {child0, child1}
+        assert d.models.synced_references == config_refs | {child0, child1}
 
         child2.child = child0
         assert d.models._new_models == {child2}
-        assert d.models.synced_references == {child0, child1}
+        assert d.models.synced_references == config_refs | {child0, child1}
         d.models.flush_synced()
         assert d.models._new_models == set()
-        assert d.models.synced_references == {child0, child1, child2}
+        assert d.models.synced_references == config_refs | {child0, child1, child2}
 
     def test_flush_synced_with_fn(self) -> None:
         class SomeModel(Model, Local):
@@ -340,15 +347,16 @@ class TestDocumentModelManager:
         child1 = SomeModel()
         child2 = SomeModel(child=child0)
         d = Document()
+        config_refs = d.config.references()
         d.add_root(child0)
         d.add_root(child1)
         d.add_root(child2)
 
         assert d.models._new_models == {child0, child1, child2}
-        assert d.models.synced_references == set()
+        assert d.models.synced_references == config_refs
         d.models.flush_synced(lambda model: model.child is not None)
         assert d.models._new_models == {child2}
-        assert d.models.synced_references == {child0, child1}
+        assert d.models.synced_references == config_refs | {child0, child1}
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/document/test_modules.py
+++ b/tests/unit/bokeh/document/test_modules.py
@@ -20,6 +20,7 @@ import pytest ; pytest
 import gc
 import logging
 import sys
+import weakref
 
 # Bokeh imports
 from bokeh.document import Document
@@ -47,9 +48,12 @@ class TestDocumentModuleManager:
         d = Document()
         dm = bdm.DocumentModuleManager(d)
         assert len(dm) == 0
+        ref = weakref.ref(d)
 
         # module manager should only hold a weak ref
-        assert len(gc.get_referrers(d)) == 0
+        del d
+        gc.collect()
+        assert ref() is None
 
     def test_add(self) -> None:
         d = Document()

--- a/tests/unit/bokeh/io/test_doc.py
+++ b/tests/unit/bokeh/io/test_doc.py
@@ -17,6 +17,7 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import gc
 import weakref
 
 # Bokeh imports
@@ -85,9 +86,10 @@ def _doc():
 
 def test_patch_curdoc_weakref_raises() -> None:
     with bid.patch_curdoc(_doc()):
+        gc.collect()
         with pytest.raises(RuntimeError) as e:
             bid.curdoc()
-            assert str(e) == "Patched curdoc has been previously destroyed"
+        assert str(e.value) == "Patched curdoc has been previously destroyed"
 
 #-----------------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
- [x] issues: fixes #15020 potencially supersedes PR #15024
- [x] tests added / passed

Note:

The approach here uses a Codex generated alternative to the `DocumentConfig` model handling done over PR #15024
