### PR TITLE
Partially initialize models in defaults' tests

### DIFF
--- a/bokehjs/src/lib/models/ranges/factor_range.ts
+++ b/bokehjs/src/lib/models/ranges/factor_range.ts
@@ -1,7 +1,7 @@
 import {Range} from "./range"
 import {PaddingUnits} from "core/enums"
 import {Float, Or, Str, List, Tuple} from "core/kinds"
-import * as p from "core/properties"
+import type * as p from "core/properties"
 import {Signal0} from "core/signaling"
 import type {Arrayable} from "core/types"
 import {ScreenArray} from "core/types"
@@ -334,8 +334,8 @@ export class FactorRange extends Range {
       group_padding:       [ Float, 1.4 ],
       range_padding:       [ Float, 0 ],
       range_padding_units: [ PaddingUnits, "percent" ],
-      start:               [ Float, p.unset, {readonly: true} ],
-      end:                 [ Float, p.unset, {readonly: true} ],
+      start:               [ Float, 0, {readonly: true} ],
+      end:                 [ Float, 0, {readonly: true} ],
     }))
 
     this.internal<FactorRange.Internal>(({AnyRef}) => ({

--- a/bokehjs/test/defaults/index.ts
+++ b/bokehjs/test/defaults/index.ts
@@ -10,6 +10,7 @@ import {values, entries, dict} from "@bokehjs/core/util/object"
 import {is_equal} from "@bokehjs/core/util/eq"
 import {to_string} from "@bokehjs/core/util/pretty"
 import {Serializer} from "@bokehjs/core/serialization"
+import {unique_id} from "@bokehjs/core/util/string"
 
 import {default_resolver} from "@bokehjs/base"
 import {settings} from "@bokehjs/core/settings"
@@ -331,7 +332,13 @@ describe("Defaults", () => {
 
     fn(`bokehjs should implement serializable ${name} model and match defaults with bokeh`, () => {
       const model = default_resolver.get(name)
-      const obj: HasProps = new (model as any)() // TODO: instantiating a possibly abstract class?
+
+      // This will initialize abstract classes, which can lead to errors.
+      // However, given this is only partial initialization, i.e. we
+      // don't finalize instances or connect signals, then any code that
+      // may depend on fully initialized state will not run.
+      const obj: HasProps = new (model as any)({id: unique_id()})
+      obj.initialize_props({})
 
       const serializer = new DefaultsSerializer()
       const defaults = serializer.encode(obj)


### PR DESCRIPTION
This resolves an issue in PR #15216. Given that we only care about properties and their defaults, then partial initialization is exactly what we need this this case.

fixes #15222