### PR TITLE
Make Bokeh server usable by ASGI frameworks without Tornado

### DIFF
--- a/docs/bokeh/source/docs/first_steps/installation.rst
+++ b/docs/bokeh/source/docs/first_steps/installation.rst
@@ -39,9 +39,10 @@ Bokeh can be installed using either the Python package installer ``pip``, or
 
         .. code-block:: sh
 
-            pip install bokeh[all]
+            pip install "bokeh[all]"
 
         Available options are:
+
         * ``all`` - this includes ``extra``, ``export`` and ``sampledata``
         * ``extra`` - installs ``pandas``, etc.
         * ``export`` - install ``selenium``, etc.

--- a/docs/bokeh/source/docs/reference/server/asgi.rst
+++ b/docs/bokeh/source/docs/reference/server/asgi.rst
@@ -1,0 +1,7 @@
+.. _bokeh.server.asgi:
+
+bokeh.server.asgi
+-----------------
+
+.. automodule:: bokeh.server.asgi
+   :members:

--- a/docs/bokeh/source/docs/reference/server/asgi.rst
+++ b/docs/bokeh/source/docs/reference/server/asgi.rst
@@ -5,3 +5,6 @@ bokeh.server.asgi
 
 .. automodule:: bokeh.server.asgi
    :members:
+
+See :class:`~bokeh.server.auth.AuthPolicy` for framework-neutral
+authentication of ASGI HTTP and websocket requests.

--- a/docs/bokeh/source/docs/reference/server/auth.rst
+++ b/docs/bokeh/source/docs/reference/server/auth.rst
@@ -1,0 +1,7 @@
+.. _bokeh.server.auth:
+
+bokeh.server.auth
+-----------------
+
+.. automodule:: bokeh.server.auth
+   :members:

--- a/docs/bokeh/source/docs/user_guide/server/app.rst
+++ b/docs/bokeh/source/docs/user_guide/server/app.rst
@@ -396,6 +396,25 @@ plots. For more information, see
     trigger Python callbacks. For further details, see
     :bokeh-tree:`examples/server/api/notebook_embed.ipynb`
 
+Python callbacks in server sessions
+''''''''''''''''''''''''''''''''''''
+
+Bokeh executes synchronous session callbacks in a bounded worker executor, so
+expensive callback code does not occupy the server's event-loop thread. The
+document remains locked for the duration of the callback: callbacks belonging
+to one session execute serially, while callbacks for different sessions can
+execute concurrently. A synchronous callback may safely update its own
+document, but it should not assume that it is running on the event-loop thread.
+
+Asynchronous periodic, timeout, and next-tick callbacks execute on the event
+loop and retain the document lock across ``await`` expressions. They are useful
+for asynchronous I/O and APIs that require a running event loop. CPU-intensive
+work in an async callback should still be delegated to a thread or process
+executor.
+
+Unlocked callbacks are available when a long-running operation should not hold
+the session's document lock. See `Updating from unlocked callbacks`_ below.
+
 Updating from threads
 '''''''''''''''''''''
 

--- a/docs/bokeh/source/docs/user_guide/server/library.rst
+++ b/docs/bokeh/source/docs/user_guide/server/library.rst
@@ -67,21 +67,97 @@ websocket URLs. Equivalent complete examples are available for:
 
 The ASGI frontend handles Bokeh document, autoload, metadata, static asset, and
 websocket routes, as well as application startup and shutdown through ASGI
-lifespan events. Authentication should normally be applied by host-framework
-middleware. ASGI does not expose websocket ping frames, so transport keepalive
-should be configured on the ASGI server (for example, Uvicorn's websocket ping
-interval) rather than with Bokeh's ``keep_alive_milliseconds`` option.
+lifespan events. ASGI does not expose websocket ping frames, so transport
+keepalive should be configured on the ASGI server (for example, Uvicorn's
+websocket ping interval) rather than with Bokeh's
+``keep_alive_milliseconds`` option.
 
 ASGI servers send lifespan events to the top-level application. When Bokeh is
 mounted under a framework that does not propagate those events to mounts, such
 as FastAPI or Starlette, compose ``bokeh_app.core.start()`` and
 ``bokeh_app.core.stop()`` into the parent lifespan as shown above.
 
-Session document construction runs in a worker thread and is serialized per
-Bokeh application. Consequently, expensive synchronous application code does
-not block the event loop from accepting unrelated HTTP or websocket work.
-Different applications can initialize documents concurrently; initialization
-for a single application retains the historical serialized ordering.
+Authentication
+~~~~~~~~~~~~~~
+
+Authentication can be performed by the host framework, by a
+:class:`~bokeh.server.auth.AuthPolicy`, or by both. An auth policy protects
+Bokeh's dynamic HTTP routes and websocket handshake without importing an ASGI
+framework:
+
+.. code-block:: python
+
+   import os
+
+   from bokeh.server.asgi import BokehASGI
+   from bokeh.server.auth import AuthPolicy
+
+   async def authenticate(request):
+       authorization = request.headers.get("authorization")
+       if authorization == f"Bearer {os.environ['SITE_TOKEN']}":
+           return "alice"
+       return None
+
+   policy = AuthPolicy(
+       authenticate,
+       login_url="/login",
+       logout_url="/logout",
+   )
+
+   application = BokehASGI(
+       {"/": "bkapp.py"},
+       auth_policy=policy,
+       sign_sessions=True,
+       secret_key=os.environ["BOKEH_SECRET_KEY"].encode(),
+   )
+
+The authenticator may be synchronous or asynchronous. It returns the current
+user, or ``None`` to reject a request. Unauthenticated HTTP requests redirect
+to ``login_url``, when configured, and otherwise receive HTTP 401.
+Unauthenticated websockets are closed before Bokeh accepts them. Login and
+logout endpoints remain the responsibility of the host application.
+
+Authentication middleware such as Starlette's commonly stores its result in
+the ASGI ``scope["user"]`` value. Bokeh copies this to ``request.user``, so a
+policy can enforce the host framework's result. Configure the parent
+application's lifespan for this ``bokeh_app`` as shown above, then mount it:
+
+.. code-block:: python
+
+   def authenticate(request):
+       user = request.user
+       if user is not None and getattr(user, "is_authenticated", False):
+           return user
+       return None
+
+   bokeh_app = BokehASGI(
+       {"/": "bkapp.py"},
+       auth_policy=AuthPolicy(authenticate, login_url="/login"),
+   )
+   site.mount("/bokeh", bokeh_app)
+
+The authenticated user is subsequently available as
+``curdoc().session_context.request.user``. ASGI ``scope["state"]`` is similarly
+available to the authenticator as ``request.state``.
+
+Session tokens are bearer credentials, not a replacement for authenticating
+HTTP and websocket requests. Authenticated deployments should enable signed
+sessions and configure a strong shared secret. Token payloads are signed but
+not encrypted; use ``include_headers``, ``exclude_headers``,
+``include_cookies``, and ``exclude_cookies`` to avoid copying secrets into
+them.
+
+The older :class:`~bokeh.server.auth_provider.AuthProvider` and
+``--auth-module`` interfaces use Tornado request handlers and remain available
+for the Tornado frontend. They are not required by
+:class:`~bokeh.server.auth.AuthPolicy`.
+
+Session document construction runs in worker threads. Consequently, expensive
+synchronous application code does not block the event loop from accepting
+unrelated HTTP or websocket work, and independent sessions can initialize
+concurrently. Script applications serialize the temporary process-global
+state they require, including ``sys.path``, ``sys.argv``, and the working
+directory.
 
 Embedding in Tornado
 --------------------

--- a/docs/bokeh/source/docs/user_guide/server/library.rst
+++ b/docs/bokeh/source/docs/user_guide/server/library.rst
@@ -3,6 +3,57 @@
 Bokeh server APIs
 =================
 
+ASGI applications
+-----------------
+
+:class:`~bokeh.server.asgi.BokehASGI` is a framework-neutral ASGI 3 application
+that can be served directly or mounted inside another ASGI application. Bokeh
+does not select or install an ASGI server or framework:
+
+.. code-block:: python
+
+   from bokeh.application import Application
+   from bokeh.application.handlers.function import FunctionHandler
+   from bokeh.server.asgi import BokehASGI
+
+   def modify_document(doc):
+       ...
+
+   application = BokehASGI({"/plot": Application(FunctionHandler(modify_document))})
+
+Save this as ``main.py`` and serve it using any ASGI 3 server, for example
+``python -m uvicorn main:application``. To mount it in FastAPI or Starlette:
+
+.. code-block:: python
+
+   from fastapi import FastAPI
+
+   site = FastAPI()
+   site.mount("/bokeh", BokehASGI({"/": bokeh_application}))
+
+The mount's ASGI ``root_path`` is included automatically in Bokeh resource and
+websocket URLs. Equivalent complete examples are available for:
+
+* :bokeh-tree:`examples/server/api/asgi/fastapi_embed.py`
+* :bokeh-tree:`examples/server/api/asgi/starlette_embed.py`
+* :bokeh-tree:`examples/server/api/asgi/django_embed.py`
+
+The ASGI frontend handles Bokeh document, autoload, metadata, static asset, and
+websocket routes, as well as application startup and shutdown through ASGI
+lifespan events. Authentication should normally be applied by host-framework
+middleware. ASGI does not expose websocket ping frames, so transport keepalive
+should be configured on the ASGI server (for example, Uvicorn's websocket ping
+interval) rather than with Bokeh's ``keep_alive_milliseconds`` option.
+
+Session document construction runs in a worker thread and is serialized per
+Bokeh application. Consequently, expensive synchronous application code does
+not block the event loop from accepting unrelated HTTP or websocket work.
+Different applications can initialize documents concurrently; initialization
+for a single application retains the historical serialized ordering.
+
+Embedding in Tornado
+--------------------
+
 It can be useful to embed the Bokeh Server in a larger Tornado application, or a
 Jupyter notebook, and use the already existing Tornado ``IOloop``. Here is the
 basis for integration of Bokeh in such a scenario:

--- a/docs/bokeh/source/docs/user_guide/server/library.rst
+++ b/docs/bokeh/source/docs/user_guide/server/library.rst
@@ -12,24 +12,50 @@ does not select or install an ASGI server or framework:
 
 .. code-block:: python
 
-   from bokeh.application import Application
-   from bokeh.application.handlers.function import FunctionHandler
+   from pathlib import Path
+
    from bokeh.server.asgi import BokehASGI
 
-   def modify_document(doc):
-       ...
-
-   application = BokehASGI({"/plot": Application(FunctionHandler(modify_document))})
+   application = BokehASGI({"/plot": Path("bkapp.py")})
 
 Save this as ``main.py`` and serve it using any ASGI 3 server, for example
 ``python -m uvicorn main:application``. To mount it in FastAPI or Starlette:
 
 .. code-block:: python
 
+   from contextlib import asynccontextmanager
+   from pathlib import Path
+
    from fastapi import FastAPI
 
-   site = FastAPI()
-   site.mount("/bokeh", BokehASGI({"/": bokeh_application}))
+   from bokeh.server.asgi import BokehASGI
+
+   bokeh_app = BokehASGI({"/": Path("bkapp.py")})
+
+   @asynccontextmanager
+   async def lifespan(site):
+       # Mounted FastAPI/Starlette applications don't receive lifespan events.
+       await bokeh_app.core.start()
+       try:
+           yield
+       finally:
+           await bokeh_app.core.stop()
+
+   site = FastAPI(lifespan=lifespan)
+   site.mount("/bokeh", bokeh_app)
+
+Path applications use the same script format as ``bokeh serve``: their
+top-level code runs once per session and modifies :func:`~bokeh.io.curdoc`.
+Relative paths are resolved from the server process's working directory.
+Existing explicit application forms remain supported:
+
+.. code-block:: python
+
+   from bokeh.application import Application
+   from bokeh.application.handlers.function import FunctionHandler
+
+   explicit = Application(FunctionHandler(modify_document))
+   BokehASGI({"/explicit": explicit, "/callable": modify_document})
 
 The mount's ASGI ``root_path`` is included automatically in Bokeh resource and
 websocket URLs. Equivalent complete examples are available for:
@@ -37,6 +63,7 @@ websocket URLs. Equivalent complete examples are available for:
 * :bokeh-tree:`examples/server/api/asgi/fastapi_embed.py`
 * :bokeh-tree:`examples/server/api/asgi/starlette_embed.py`
 * :bokeh-tree:`examples/server/api/asgi/django_embed.py`
+* :bokeh-tree:`examples/server/api/asgi/framework_free.py`
 
 The ASGI frontend handles Bokeh document, autoload, metadata, static asset, and
 websocket routes, as well as application startup and shutdown through ASGI
@@ -44,6 +71,11 @@ lifespan events. Authentication should normally be applied by host-framework
 middleware. ASGI does not expose websocket ping frames, so transport keepalive
 should be configured on the ASGI server (for example, Uvicorn's websocket ping
 interval) rather than with Bokeh's ``keep_alive_milliseconds`` option.
+
+ASGI servers send lifespan events to the top-level application. When Bokeh is
+mounted under a framework that does not propagate those events to mounts, such
+as FastAPI or Starlette, compose ``bokeh_app.core.start()`` and
+``bokeh_app.core.stop()`` into the parent lifespan as shown above.
 
 Session document construction runs in a worker thread and is serialized per
 Bokeh application. Consequently, expensive synchronous application code does

--- a/docs/bokeh/source/docs/user_guide/server/library.rst
+++ b/docs/bokeh/source/docs/user_guide/server/library.rst
@@ -44,10 +44,13 @@ Save this as ``main.py`` and serve it using any ASGI 3 server, for example
    site = FastAPI(lifespan=lifespan)
    site.mount("/bokeh", bokeh_app)
 
-Path applications use the same script format as ``bokeh serve``: their
-top-level code runs once per session and modifies :func:`~bokeh.io.curdoc`.
-Relative paths are resolved from the server process's working directory.
-Existing explicit application forms remain supported:
+Path applications use the same formats as ``bokeh serve``. A path may identify
+a Python script or a directory-style application containing ``main.py`` or
+``main.ipynb``. Directory applications also support ``app_hooks.py``,
+``server_lifecycle.py``, ``static``, ``templates/index.html``, and
+``theme.yaml``. Application code runs once per session and modifies
+:func:`~bokeh.io.curdoc`. Relative paths are resolved from the server process's
+working directory. Existing explicit application forms remain supported:
 
 .. code-block:: python
 

--- a/examples/server/api/README.md
+++ b/examples/server/api/README.md
@@ -23,3 +23,8 @@ On Windows, the `num_procs=4` argument must be removed from the Server initialis
 Run with `python tornado_embed.py`.
 
 On Windows, the `num_procs=4` argument must be removed from the Server initialisation call on line 47.
+
+### `asgi/`
+
+Framework-neutral Bokeh ASGI mounting examples for FastAPI, Starlette, and
+Django. See [`asgi/README.md`](asgi/README.md) for installation and run commands.

--- a/examples/server/api/asgi/README.md
+++ b/examples/server/api/asgi/README.md
@@ -1,17 +1,28 @@
 # Embedding Bokeh in ASGI applications
 
 Each example mounts the framework-neutral `BokehASGI` application at `/bkapp`
-and leaves the rest of the site to its host framework.
+and leaves the rest of the site to its host application. `framework_free.py`
+shows the ASGI path dispatch directly, without another web framework. All four
+hosts render the shared `index.html` page and use `server_document()` to embed
+the same interactive signal-studio application directly into the host page.
+The Bokeh application in `bkapp.py` is an ordinary script application loaded
+by passing its `Path` directly to `BokehASGI`.
 
-From this directory, install an ASGI server and the framework for the example,
-then run one of:
+FastAPI and Starlette do not forward lifespan events to mounted applications.
+Those examples therefore start and stop Bokeh explicitly from the host
+application's lifespan context so that server load and unload hooks run.
+
+From this directory, install an ASGI server and any framework required by the
+chosen example, then run one of:
 
 ```sh
+python -m uvicorn framework_free:application --port 8000
 python -m uvicorn fastapi_embed:app --port 8000
 python -m uvicorn starlette_embed:app --port 8000
 python -m uvicorn django_embed:application --port 8000
 ```
 
 Open <http://localhost:8000/>. Uvicorn can be replaced with any ASGI 3 server,
-such as Hypercorn. FastAPI, Starlette, Django, and Uvicorn are example-only
-dependencies and are not required by Bokeh.
+such as Hypercorn. The framework-free example needs only Bokeh and an ASGI
+server. FastAPI, Starlette, and Django are example-only dependencies and are
+not required by Bokeh.

--- a/examples/server/api/asgi/README.md
+++ b/examples/server/api/asgi/README.md
@@ -1,0 +1,17 @@
+# Embedding Bokeh in ASGI applications
+
+Each example mounts the framework-neutral `BokehASGI` application at `/bkapp`
+and leaves the rest of the site to its host framework.
+
+From this directory, install an ASGI server and the framework for the example,
+then run one of:
+
+```sh
+python -m uvicorn fastapi_embed:app --port 8000
+python -m uvicorn starlette_embed:app --port 8000
+python -m uvicorn django_embed:application --port 8000
+```
+
+Open <http://localhost:8000/>. Uvicorn can be replaced with any ASGI 3 server,
+such as Hypercorn. FastAPI, Starlette, Django, and Uvicorn are example-only
+dependencies and are not required by Bokeh.

--- a/examples/server/api/asgi/bkapp.py
+++ b/examples/server/api/asgi/bkapp.py
@@ -1,0 +1,23 @@
+from bokeh.application import Application
+from bokeh.application.handlers.function import FunctionHandler
+from bokeh.layouts import column
+from bokeh.models import Slider
+from bokeh.plotting import figure
+
+
+def modify_document(doc):
+    slider = Slider(start=1, end=10, value=4, step=1, title="Power")
+    plot = figure(height=300, sizing_mode="stretch_width")
+    source = plot.line([], []).data_source
+
+    def update(attr=None, old=None, new=None):
+        x = list(range(11))
+        source.data = {"x": x, "y": [value**slider.value for value in x]}
+
+    slider.on_change("value", update)
+    update()
+    doc.add_root(column(slider, plot, sizing_mode="stretch_width"))
+    doc.title = "Embedded ASGI Bokeh application"
+
+
+application = Application(FunctionHandler(modify_document))

--- a/examples/server/api/asgi/bkapp.py
+++ b/examples/server/api/asgi/bkapp.py
@@ -1,30 +1,40 @@
 from __future__ import annotations
 
+# Standard library imports
 from typing import Any
 
+# External imports
 import numpy as np
 
+# Bokeh imports
 from bokeh.io import curdoc
-from bokeh.layouts import column, row
-from bokeh.models import ColumnDataSource, Div, Select, Slider, Toggle
+from bokeh.layouts import column
+from bokeh.models import ColumnDataSource, Div, GridBox, Select, Slider, Toggle
 from bokeh.plotting import figure
-
 
 waveform = Select(
     title="Waveform",
     value="Sine",
     options=["Sine", "Triangle", "Square", "Sawtooth"],
-    width=150,
+    sizing_mode="stretch_width",
+    min_width=0,
     name="waveform",
 )
-frequency = Slider(title="Frequency", start=0.5, end=5, value=1.5, step=0.1, width=220)
-amplitude = Slider(title="Amplitude", start=0.25, end=3, value=1.5, step=0.05, width=220)
-phase = Slider(title="Phase", start=0, end=360, value=20, step=1, width=220)
-animate = Toggle(label="Animate phase", active=True, button_type="success", width=150)
+frequency = Slider(title="Frequency", start=0.5, end=5, value=1.5, step=0.1, sizing_mode="stretch_width", min_width=0)
+amplitude = Slider(title="Amplitude", start=0.25, end=3, value=1.5, step=0.05, sizing_mode="stretch_width", min_width=0)
+phase = Slider(title="Phase", start=0, end=360, value=20, step=1, sizing_mode="stretch_width", min_width=0)
+animate = Toggle(
+    label="Animate phase",
+    active=True,
+    button_type="success",
+    sizing_mode="stretch_width",
+    min_width=0,
+    align="end",
+)
 
 source = ColumnDataSource(data={"x": [], "y": [], "zero": []}, name="signal-source")
 plot = figure(
-    height=330,
+    height=300,
     sizing_mode="stretch_width",
     output_backend="webgl",
     tools="pan,wheel_zoom,reset,save",
@@ -52,8 +62,17 @@ heading = Div(
         <div style="color:#94a3b8;margin-top:5px">Shape a waveform and watch Python callbacks update the document.</div>
     """,
     sizing_mode="stretch_width",
+    min_width=0,
 )
-metrics = Div(sizing_mode="stretch_width")
+metric_styles = {
+    "background": "#172033",
+    "border": "1px solid #334155",
+    "border-radius": "10px",
+    "padding": "10px 14px",
+}
+peak_metric = Div(height=64, sizing_mode="stretch_width", min_width=0, styles=metric_styles)
+rms_metric = Div(height=64, sizing_mode="stretch_width", min_width=0, styles=metric_styles)
+samples_metric = Div(height=64, sizing_mode="stretch_width", min_width=0, styles=metric_styles)
 
 samples = np.linspace(0, 6, 2001)
 zero = np.zeros_like(samples)
@@ -74,18 +93,17 @@ def update_data() -> None:
     peak = np.max(np.abs(y))
     rms = np.sqrt(np.mean(np.square(y)))
     source.data = {"x": samples, "y": y, "zero": zero}
-    metrics.text = f"""
-        <div style="display:flex;gap:12px;flex-wrap:wrap;margin:4px 0 2px">
-            <div style="background:#172033;border:1px solid #334155;border-radius:10px;padding:10px 14px;color:#94a3b8">
-                Peak <strong style="color:#f8fafc;margin-left:8px">{peak:.2f}</strong>
-            </div>
-            <div style="background:#172033;border:1px solid #334155;border-radius:10px;padding:10px 14px;color:#94a3b8">
-                RMS <strong style="color:#f8fafc;margin-left:8px">{rms:.2f}</strong>
-            </div>
-            <div style="background:#172033;border:1px solid #334155;border-radius:10px;padding:10px 14px;color:#94a3b8">
-                Samples <strong style="color:#f8fafc;margin-left:8px">{len(samples)}</strong>
-            </div>
-        </div>
+    peak_metric.text = f"""
+        <div style="color:#94a3b8;font-size:12px;line-height:16px;text-transform:uppercase;letter-spacing:.08em">Peak</div>
+        <strong style="color:#f8fafc;font-size:20px;line-height:24px">{peak:.2f}</strong>
+    """
+    rms_metric.text = f"""
+        <div style="color:#94a3b8;font-size:12px;line-height:16px;text-transform:uppercase;letter-spacing:.08em">RMS</div>
+        <strong style="color:#f8fafc;font-size:20px;line-height:24px">{rms:.2f}</strong>
+    """
+    samples_metric.text = f"""
+        <div style="color:#94a3b8;font-size:12px;line-height:16px;text-transform:uppercase;letter-spacing:.08em">Samples</div>
+        <strong style="color:#f8fafc;font-size:20px;line-height:24px">{len(samples)}</strong>
     """
 
 
@@ -103,20 +121,45 @@ for control in (waveform, frequency, amplitude, phase):
 
 update_data()
 doc = curdoc()
+doc.config.color_scheme = "dark"
 doc.add_periodic_callback(advance, 75)
 doc.template = """
     {% block preamble %}
     <style>
-      html, body { margin: 0; padding: 0; background: #0f172a; }
+      html, body { margin: 0; padding: 0; overflow-x: hidden; background: #0f172a; }
     </style>
     {% endblock %}
 """
+controls = GridBox(
+    children=[
+        (waveform, 0, 0),
+        (animate, 0, 1),
+        (frequency, 1, 0),
+        (amplitude, 1, 1),
+        (phase, 2, 0, 1, 2),
+    ],
+    cols="minmax(0, 1fr)",
+    spacing=(14, 16),
+    sizing_mode="stretch_width",
+    styles={
+        "background": "#111827",
+        "border": "1px solid #263449",
+        "border-radius": "12px",
+        "padding": "14px",
+    },
+)
+metric_grid = GridBox(
+    children=[(peak_metric, 0, 0), (rms_metric, 0, 1), (samples_metric, 0, 2)],
+    cols="minmax(0, 1fr)",
+    spacing=12,
+    sizing_mode="stretch_width",
+)
 doc.add_root(column(
     heading,
-    row(waveform, animate, sizing_mode="stretch_width"),
-    row(frequency, amplitude, phase, sizing_mode="stretch_width"),
-    metrics,
+    controls,
+    metric_grid,
     plot,
+    spacing=16,
     sizing_mode="stretch_width",
     styles={"background": "#0f172a", "padding": "20px", "border-radius": "14px"},
 ))

--- a/examples/server/api/asgi/bkapp.py
+++ b/examples/server/api/asgi/bkapp.py
@@ -1,23 +1,123 @@
-from bokeh.application import Application
-from bokeh.application.handlers.function import FunctionHandler
-from bokeh.layouts import column
-from bokeh.models import Slider
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from bokeh.io import curdoc
+from bokeh.layouts import column, row
+from bokeh.models import ColumnDataSource, Div, Select, Slider, Toggle
 from bokeh.plotting import figure
 
 
-def modify_document(doc):
-    slider = Slider(start=1, end=10, value=4, step=1, title="Power")
-    plot = figure(height=300, sizing_mode="stretch_width")
-    source = plot.line([], []).data_source
+waveform = Select(
+    title="Waveform",
+    value="Sine",
+    options=["Sine", "Triangle", "Square", "Sawtooth"],
+    width=150,
+    name="waveform",
+)
+frequency = Slider(title="Frequency", start=0.5, end=5, value=1.5, step=0.1, width=220)
+amplitude = Slider(title="Amplitude", start=0.25, end=3, value=1.5, step=0.05, width=220)
+phase = Slider(title="Phase", start=0, end=360, value=20, step=1, width=220)
+animate = Toggle(label="Animate phase", active=True, button_type="success", width=150)
 
-    def update(attr=None, old=None, new=None):
-        x = list(range(11))
-        source.data = {"x": x, "y": [value**slider.value for value in x]}
+source = ColumnDataSource(data={"x": [], "y": [], "zero": []}, name="signal-source")
+plot = figure(
+    height=330,
+    sizing_mode="stretch_width",
+    output_backend="webgl",
+    tools="pan,wheel_zoom,reset,save",
+    toolbar_location="above",
+    x_axis_label="Time (seconds)",
+    y_axis_label="Amplitude",
+)
+plot.varea(x="x", y1="zero", y2="y", source=source, fill_color="#38bdf8", fill_alpha=0.12)
+plot.line(x="x", y="y", source=source, line_color="#38bdf8", line_width=3)
+plot.background_fill_color = "#0f172a"
+plot.border_fill_color = "#0f172a"
+plot.outline_line_color = "#334155"
+plot.axis.axis_line_color = "#64748b"
+plot.axis.major_label_text_color = "#cbd5e1"
+plot.axis.axis_label_text_color = "#94a3b8"
+plot.grid.grid_line_color = "#334155"
+plot.grid.grid_line_alpha = 0.45
 
-    slider.on_change("value", update)
-    update()
-    doc.add_root(column(slider, plot, sizing_mode="stretch_width"))
-    doc.title = "Embedded ASGI Bokeh application"
+heading = Div(
+    text="""
+        <div style="color:#7dd3fc;font-size:12px;font-weight:700;letter-spacing:.16em;text-transform:uppercase">
+            Live Bokeh server session
+        </div>
+        <div style="color:#f8fafc;font-size:28px;font-weight:700;margin-top:5px">Signal studio</div>
+        <div style="color:#94a3b8;margin-top:5px">Shape a waveform and watch Python callbacks update the document.</div>
+    """,
+    sizing_mode="stretch_width",
+)
+metrics = Div(sizing_mode="stretch_width")
+
+samples = np.linspace(0, 6, 2001)
+zero = np.zeros_like(samples)
 
 
-application = Application(FunctionHandler(modify_document))
+def update_data() -> None:
+    theta = 2 * np.pi * frequency.value * samples + np.deg2rad(phase.value)
+    y = np.sin(theta)
+    if waveform.value == "Triangle":
+        y = 2 / np.pi * np.arcsin(y)
+    elif waveform.value == "Square":
+        y = np.where(y >= 0, 1.0, -1.0)
+    elif waveform.value == "Sawtooth":
+        cycles = theta / (2 * np.pi)
+        y = 2 * (cycles - np.floor(cycles + 0.5))
+
+    y *= amplitude.value
+    peak = np.max(np.abs(y))
+    rms = np.sqrt(np.mean(np.square(y)))
+    source.data = {"x": samples, "y": y, "zero": zero}
+    metrics.text = f"""
+        <div style="display:flex;gap:12px;flex-wrap:wrap;margin:4px 0 2px">
+            <div style="background:#172033;border:1px solid #334155;border-radius:10px;padding:10px 14px;color:#94a3b8">
+                Peak <strong style="color:#f8fafc;margin-left:8px">{peak:.2f}</strong>
+            </div>
+            <div style="background:#172033;border:1px solid #334155;border-radius:10px;padding:10px 14px;color:#94a3b8">
+                RMS <strong style="color:#f8fafc;margin-left:8px">{rms:.2f}</strong>
+            </div>
+            <div style="background:#172033;border:1px solid #334155;border-radius:10px;padding:10px 14px;color:#94a3b8">
+                Samples <strong style="color:#f8fafc;margin-left:8px">{len(samples)}</strong>
+            </div>
+        </div>
+    """
+
+
+def update(attr: str, old: Any, new: Any) -> None:
+    update_data()
+
+
+def advance() -> None:
+    if animate.active:
+        phase.value = (phase.value + 2) % 360
+
+
+for control in (waveform, frequency, amplitude, phase):
+    control.on_change("value", update)
+
+update_data()
+doc = curdoc()
+doc.add_periodic_callback(advance, 75)
+doc.template = """
+    {% block preamble %}
+    <style>
+      html, body { margin: 0; padding: 0; background: #0f172a; }
+    </style>
+    {% endblock %}
+"""
+doc.add_root(column(
+    heading,
+    row(waveform, animate, sizing_mode="stretch_width"),
+    row(frequency, amplitude, phase, sizing_mode="stretch_width"),
+    metrics,
+    plot,
+    sizing_mode="stretch_width",
+    styles={"background": "#0f172a", "padding": "20px", "border-radius": "14px"},
+))
+doc.title = "Bokeh ASGI signal studio"

--- a/examples/server/api/asgi/django_embed.py
+++ b/examples/server/api/asgi/django_embed.py
@@ -1,0 +1,46 @@
+import os
+
+from django.conf import settings
+from django.core.asgi import get_asgi_application
+from django.http import HttpResponse
+from django.urls import path
+
+from bokeh.server.asgi import BokehASGI
+
+from bkapp import application as bkapp
+
+
+async def index(request):
+    return HttpResponse(
+        '<h1>Django ASGI with Bokeh</h1><iframe src="/bkapp/" width="100%" height="450"></iframe>',
+    )
+
+
+urlpatterns = [path("", index)]
+
+if not settings.configured:
+    settings.configure(
+        DEBUG=True,
+        ROOT_URLCONF=__name__,
+        SECRET_KEY="development-only",
+        ALLOWED_HOSTS=["localhost", "127.0.0.1"],
+    )
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", __name__)
+django_application = get_asgi_application()
+bokeh_application = BokehASGI({"/": bkapp})
+
+
+async def application(scope, receive, send):
+    path_info = scope.get("path", "")
+    if scope["type"] == "lifespan":
+        # Django does not consume ASGI lifespan events, so Bokeh owns them.
+        await bokeh_application(scope, receive, send)
+    elif scope["type"] in ("http", "websocket") and (
+        path_info == "/bkapp" or path_info.startswith("/bkapp/")
+    ):
+        mounted_scope = dict(scope)
+        mounted_scope["root_path"] = scope.get("root_path", "") + "/bkapp"
+        await bokeh_application(mounted_scope, receive, send)
+    else:
+        await django_application(scope, receive, send)

--- a/examples/server/api/asgi/django_embed.py
+++ b/examples/server/api/asgi/django_embed.py
@@ -1,19 +1,26 @@
 import os
+from pathlib import Path
 
 from django.conf import settings
 from django.core.asgi import get_asgi_application
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.urls import path
+from jinja2 import Environment, FileSystemLoader
 
+from bokeh.embed import server_document
 from bokeh.server.asgi import BokehASGI
 
-from bkapp import application as bkapp
+template = Environment(loader=FileSystemLoader(Path(__file__).parent), autoescape=True).get_template("index.html")
 
 
-async def index(request):
-    return HttpResponse(
-        '<h1>Django ASGI with Bokeh</h1><iframe src="/bkapp/" width="100%" height="450"></iframe>',
-    )
+def render_page(root_path: str = "") -> str:
+    mount_url = f"{root_path.rstrip('/')}/bkapp"
+    bokeh_script = server_document(mount_url, relative_urls=True)
+    return template.render(framework="Django", bokeh_script=bokeh_script)
+
+
+async def index(request: HttpRequest) -> HttpResponse:
+    return HttpResponse(render_page(request.META.get("SCRIPT_NAME", "")))
 
 
 urlpatterns = [path("", index)]
@@ -28,7 +35,7 @@ if not settings.configured:
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", __name__)
 django_application = get_asgi_application()
-bokeh_application = BokehASGI({"/": bkapp})
+bokeh_application = BokehASGI({"/": Path(__file__).with_name("bkapp.py")})
 
 
 async def application(scope, receive, send):

--- a/examples/server/api/asgi/fastapi_embed.py
+++ b/examples/server/api/asgi/fastapi_embed.py
@@ -1,18 +1,40 @@
-from fastapi import FastAPI
-from fastapi.responses import HTMLResponse
+from contextlib import asynccontextmanager
+from pathlib import Path
 
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from jinja2 import Environment, FileSystemLoader
+
+from bokeh.embed import server_document
 from bokeh.server.asgi import BokehASGI
 
-from bkapp import application as bkapp
+bokeh_application = BokehASGI({"/": Path(__file__).with_name("bkapp.py")})
 
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Mounted Starlette/FastAPI applications don't receive lifespan events.
+    # Start and stop Bokeh from the parent application's lifespan instead.
+    await bokeh_application.core.start()
+    try:
+        yield
+    finally:
+        await bokeh_application.core.stop()
+
+
+app = FastAPI(lifespan=lifespan)
+template = Environment(loader=FileSystemLoader(Path(__file__).parent), autoescape=True).get_template("index.html")
+
+
+def render_page(root_path: str = "") -> str:
+    mount_url = f"{root_path.rstrip('/')}/bkapp"
+    bokeh_script = server_document(mount_url, relative_urls=True)
+    return template.render(framework="FastAPI", bokeh_script=bokeh_script)
 
 
 @app.get("/", response_class=HTMLResponse)
-async def index():
-    return '<h1>FastAPI with Bokeh</h1><iframe src="/bkapp/" width="100%" height="450"></iframe>'
+async def index(request: Request) -> HTMLResponse:
+    return HTMLResponse(render_page(request.scope.get("root_path", "")))
 
 
-# FastAPI delegates HTTP, websocket, and lifespan events below this mount.
-app.mount("/bkapp", BokehASGI({"/": bkapp}))
+app.mount("/bkapp", bokeh_application)

--- a/examples/server/api/asgi/fastapi_embed.py
+++ b/examples/server/api/asgi/fastapi_embed.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+from bokeh.server.asgi import BokehASGI
+
+from bkapp import application as bkapp
+
+
+app = FastAPI()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    return '<h1>FastAPI with Bokeh</h1><iframe src="/bkapp/" width="100%" height="450"></iframe>'
+
+
+# FastAPI delegates HTTP, websocket, and lifespan events below this mount.
+app.mount("/bkapp", BokehASGI({"/": bkapp}))

--- a/examples/server/api/asgi/framework_free.py
+++ b/examples/server/api/asgi/framework_free.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader
+
+from bokeh.embed import server_document
+from bokeh.server.asgi import BokehASGI
+
+type Message = dict[str, Any]
+type Receive = Callable[[], Awaitable[Message]]
+type Scope = dict[str, Any]
+type Send = Callable[[Message], Awaitable[None]]
+
+bokeh_application = BokehASGI({"/": Path(__file__).with_name("bkapp.py")})
+template = Environment(loader=FileSystemLoader(Path(__file__).parent), autoescape=True).get_template("index.html")
+
+
+def render_page(root_path: str = "") -> bytes:
+    mount_url = f"{root_path.rstrip('/')}/bkapp"
+    bokeh_script = server_document(mount_url, relative_urls=True)
+    return template.render(framework="framework-free ASGI", bokeh_script=bokeh_script).encode()
+
+
+async def response(send: Send, status: int, body: bytes, *, head: bool = False) -> None:
+    await send({
+        "type": "http.response.start",
+        "status": status,
+        "headers": [
+            (b"content-type", b"text/html; charset=utf-8"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+    })
+    await send({"type": "http.response.body", "body": b"" if head else body})
+
+
+async def application(scope: Scope, receive: Receive, send: Send) -> None:
+    """Dispatch a small site and a mounted Bokeh app using only ASGI."""
+    scope_type = scope["type"]
+    path = scope.get("path", "")
+
+    if scope_type == "lifespan":
+        await bokeh_application(scope, receive, send)
+    elif scope_type in ("http", "websocket") and (
+        path == "/bkapp" or path.startswith("/bkapp/")
+    ):
+        mounted_scope = dict(scope)
+        mounted_scope["root_path"] = scope.get("root_path", "") + "/bkapp"
+        await bokeh_application(mounted_scope, receive, send)
+    elif scope_type == "http":
+        method = scope["method"].upper()
+        if path == "/" and method in ("GET", "HEAD"):
+            page = render_page(scope.get("root_path", ""))
+            await response(send, 200, page, head=method == "HEAD")
+        else:
+            await response(send, 404, b"Not found", head=method == "HEAD")
+    elif scope_type == "websocket":
+        await send({"type": "websocket.close", "code": 1008, "reason": "Not found"})
+    else:
+        raise RuntimeError(f"Unsupported ASGI scope type {scope_type!r}")

--- a/examples/server/api/asgi/index.html
+++ b/examples/server/api/asgi/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bokeh with {{ framework }}</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: #e2e8f0;
+      background:
+        radial-gradient(circle at 15% 0%, rgba(14, 165, 233, .22), transparent 34rem),
+        radial-gradient(circle at 90% 12%, rgba(99, 102, 241, .18), transparent 30rem),
+        #070b14;
+    }
+    main { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0 56px; }
+    .eyebrow { color: #7dd3fc; font-size: 12px; font-weight: 800; letter-spacing: .18em; text-transform: uppercase; }
+    h1 { max-width: 100%; margin: 10px 0 12px; color: #f8fafc; font-size: clamp(34px, 5vw, 56px); line-height: 1.02; letter-spacing: -.045em; overflow-wrap: anywhere; }
+    h1 span { color: #38bdf8; }
+    .lede { max-width: 720px; margin: 0; color: #94a3b8; font-size: 18px; line-height: 1.6; }
+    .flow { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; margin: 26px 0; color: #94a3b8; font-size: 13px; }
+    .chip { padding: 7px 11px; border: 1px solid #334155; border-radius: 999px; background: rgba(15, 23, 42, .76); color: #cbd5e1; }
+    .frame {
+      overflow: hidden;
+      padding: 1px;
+      border: 1px solid rgba(125, 211, 252, .28);
+      border-radius: 18px;
+      background: linear-gradient(135deg, rgba(56, 189, 248, .5), rgba(99, 102, 241, .15));
+      box-shadow: 0 28px 90px rgba(0, 0, 0, .42);
+    }
+    .bar { display: flex; align-items: center; gap: 7px; height: 38px; padding: 0 14px; background: #111827; border-radius: 17px 17px 0 0; }
+    .dot { width: 9px; height: 9px; border-radius: 50%; background: #334155; }
+    .address { margin-left: 8px; color: #64748b; font: 11px ui-monospace, SFMono-Regular, monospace; }
+    .bokeh-host { min-width: 0; background: #0f172a; }
+    footer { display: flex; justify-content: space-between; gap: 16px; margin-top: 18px; color: #64748b; font-size: 12px; }
+    @media (max-width: 640px) { main { padding-top: 30px; } footer { flex-direction: column; } }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="eyebrow">ASGI integration example</div>
+    <h1>Bokeh meets <span>{{ framework }}</span></h1>
+    <p class="lede">A framework-owned page with a live, stateful Bokeh application mounted alongside it on the same event loop.</p>
+    <div class="flow">
+      <span class="chip">{{ framework }} host</span><span>→</span>
+      <span class="chip">BokehASGI mount</span><span>→</span>
+      <span class="chip">WebSocket session</span>
+    </div>
+    <section class="frame">
+      <div class="bar"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="address">/bkapp/autoload.js</span></div>
+      <div class="bokeh-host">{{ bokeh_script | safe }}</div>
+    </section>
+    <footer><span>Host page rendered by {{ framework }}</span><span>Bokeh document synchronized over WebSocket</span></footer>
+  </main>
+</body>
+</html>

--- a/examples/server/api/asgi/starlette_embed.py
+++ b/examples/server/api/asgi/starlette_embed.py
@@ -1,19 +1,41 @@
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.responses import HTMLResponse
 from starlette.routing import Mount, Route
 
+from bokeh.embed import server_document
 from bokeh.server.asgi import BokehASGI
 
-from bkapp import application as bkapp
+bokeh_application = BokehASGI({"/": Path(__file__).with_name("bkapp.py")})
+template = Environment(loader=FileSystemLoader(Path(__file__).parent), autoescape=True).get_template("index.html")
 
 
-async def index(request):
-    return HTMLResponse(
-        '<h1>Starlette with Bokeh</h1><iframe src="/bkapp/" width="100%" height="450"></iframe>',
-    )
+def render_page(root_path: str = "") -> str:
+    mount_url = f"{root_path.rstrip('/')}/bkapp"
+    bokeh_script = server_document(mount_url, relative_urls=True)
+    return template.render(framework="Starlette", bokeh_script=bokeh_script)
+
+
+async def index(request: Request) -> HTMLResponse:
+    return HTMLResponse(render_page(request.scope.get("root_path", "")))
+
+
+@asynccontextmanager
+async def lifespan(app: Starlette):
+    # Mounted Starlette applications don't receive lifespan events. Start and
+    # stop Bokeh from the parent application's lifespan instead.
+    await bokeh_application.core.start()
+    try:
+        yield
+    finally:
+        await bokeh_application.core.stop()
 
 
 app = Starlette(routes=[
     Route("/", index),
-    Mount("/bkapp", BokehASGI({"/": bkapp})),
-])
+    Mount("/bkapp", bokeh_application),
+], lifespan=lifespan)

--- a/examples/server/api/asgi/starlette_embed.py
+++ b/examples/server/api/asgi/starlette_embed.py
@@ -1,0 +1,19 @@
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse
+from starlette.routing import Mount, Route
+
+from bokeh.server.asgi import BokehASGI
+
+from bkapp import application as bkapp
+
+
+async def index(request):
+    return HTMLResponse(
+        '<h1>Starlette with Bokeh</h1><iframe src="/bkapp/" width="100%" height="450"></iframe>',
+    )
+
+
+app = Starlette(routes=[
+    Route("/", index),
+    Mount("/bkapp", BokehASGI({"/": bkapp})),
+])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ lint.exclude = [
     'node_modules',
 ]
 lint.per-file-ignores = {"__init__.py" = ["F403"]}
-lint.select = ["B", "COM", "E", "F", "NPY", "RUF", "TID", "UP", "W"]
+lint.select = ["B", "COM", "E", "F", "NPY", "PLC0414", "RUF", "TID", "UP", "W"]
 lint.ignore = [
     'B005', # Using .strip() with multi-character strings is misleading the reader
     'B006', # Do not use mutable data structures for argument defaults

--- a/src/bokeh/application/application.py
+++ b/src/bokeh/application/application.py
@@ -43,9 +43,8 @@ from ..document import Document
 from ..settings import settings
 
 if TYPE_CHECKING:
-    from tornado.httputil import HTTPServerRequest
-
     from ..core.types import ID
+    from ..server.request import RequestLike
     from ..server.session import ServerSession
     from .handlers.handler import Handler
 
@@ -245,7 +244,7 @@ class Application:
             await h.on_session_destroyed(session_context)
         return None
 
-    def process_request(self, request: HTTPServerRequest) -> dict[str, Any]:
+    def process_request(self, request: RequestLike) -> dict[str, Any]:
         ''' Processes incoming HTTP request returning a dictionary of
         additional data to add to the session_context.
 

--- a/src/bokeh/application/application.py
+++ b/src/bokeh/application/application.py
@@ -73,10 +73,8 @@ class Application:
 
     '''
 
-    # This is so that bokeh.io.show can check if a passed in object is an
-    # Application without having to import Application directly. This module
-    # depends on tornado and we have made a commitment that "basic" modules
-    # will function without bringing in tornado.
+    # This lets bokeh.io.show identify an Application without importing the
+    # application and server-facing modules solely for an isinstance check.
     _is_a_bokeh_application_class: ClassVar[bool] = True
 
     _static_path: str | None

--- a/src/bokeh/application/handlers/code.py
+++ b/src/bokeh/application/handlers/code.py
@@ -48,7 +48,7 @@ from typing import (
 
 # Bokeh imports
 from ...io.doc import curdoc, patch_curdoc
-from .code_runner import CodeRunner
+from .code_runner import CodeRunner, _hold_process_globals
 from .handler import Handler
 
 if TYPE_CHECKING:
@@ -163,9 +163,8 @@ class CodeHandler(Handler):
         # paths to custom models resolver.
         doc.modules.add(module)
 
-        with _monkeypatch_io(self._loggers):
-            with patch_curdoc(doc):
-                self._runner.run(module, self._make_post_doc_check(doc))
+        with patch_curdoc(doc), _hold_process_globals(), _monkeypatch_io(self._loggers):
+            self._runner.run(module, self._make_post_doc_check(doc))
 
     def url_path(self) -> str | None:
         ''' The last path component for the basename of the configured filename.

--- a/src/bokeh/application/handlers/code_runner.py
+++ b/src/bokeh/application/handlers/code_runner.py
@@ -25,8 +25,10 @@ log = logging.getLogger(__name__)
 import os
 import sys
 import traceback
+from contextlib import contextmanager
 from os.path import basename
-from typing import TYPE_CHECKING, Callable
+from threading import RLock
+from typing import TYPE_CHECKING, Callable, Generator
 
 # Bokeh imports
 from ...util.serialization import make_globally_unique_id
@@ -218,35 +220,47 @@ class CodeRunner:
                 are not met after code execution.
 
         '''
-        # Simulate the sys.path behaviour described here:
-        #
-        # https://docs.python.org/2/library/sys.html#sys.path
-        _cwd = os.getcwd()
-        _sys_path = list(sys.path)
-        _sys_argv = list(sys.argv)
-        sys.path.insert(0, os.path.dirname(self._path))
-        sys.argv = [os.path.basename(self._path), *self._argv]
-
         # XXX: self._code shouldn't be None at this point but types don't reflect this
         assert self._code is not None
 
-        try:
-            exec(self._code, module.__dict__)
+        with _hold_process_globals(), _patch_process_state(self._path, self._argv):
+            try:
+                exec(self._code, module.__dict__)
 
-            if post_check:
-                post_check()
-        except Exception as e:
-            handle_exception(self, e)
-        finally:
-            # undo sys.path, CWD fixups
-            os.chdir(_cwd)
-            sys.path = _sys_path
-            sys.argv = _sys_argv
-            self.ran = True
+                if post_check:
+                    post_check()
+            except Exception as e:
+                handle_exception(self, e)
+            finally:
+                self.ran = True
 
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+_PROCESS_GLOBALS_LOCK = RLock()
+
+@contextmanager
+def _hold_process_globals() -> Generator[None, None, None]:
+    with _PROCESS_GLOBALS_LOCK:
+        yield
+
+@contextmanager
+def _patch_process_state(path: PathLike, argv: list[str]) -> Generator[None, None, None]:
+    # Simulate the sys.path behaviour described here:
+    #
+    # https://docs.python.org/2/library/sys.html#sys.path
+    old_cwd = os.getcwd()
+    old_sys_path = list(sys.path)
+    old_sys_argv = list(sys.argv)
+    sys.path.insert(0, os.path.dirname(path))
+    sys.argv = [os.path.basename(path), *argv]
+    try:
+        yield
+    finally:
+        os.chdir(old_cwd)
+        sys.path = old_sys_path
+        sys.argv = old_sys_argv
 
 #-----------------------------------------------------------------------------
 # Code

--- a/src/bokeh/application/handlers/directory.py
+++ b/src/bokeh/application/handlers/directory.py
@@ -71,10 +71,9 @@ from .server_request_handler import ServerRequestHandler
 if TYPE_CHECKING:
     from types import ModuleType
 
-    from tornado.httputil import HTTPServerRequest
-
     from ...core.types import PathLike
     from ...document import Document
+    from ...server.request import RequestLike
     from ...themes import Theme
     from ..application import ServerContext, SessionContext
 
@@ -290,7 +289,7 @@ class DirectoryHandler(Handler):
         '''
         await self._lifecycle_handler.on_session_destroyed(session_context)
 
-    def process_request(self, request: HTTPServerRequest) -> dict[str, Any]:
+    def process_request(self, request: RequestLike) -> dict[str, Any]:
         ''' Processes incoming HTTP request returning a dictionary of
         additional data to add to the session_context.
 

--- a/src/bokeh/application/handlers/handler.py
+++ b/src/bokeh/application/handlers/handler.py
@@ -49,9 +49,8 @@ import traceback
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from tornado.httputil import HTTPServerRequest
-
     from ...document import Document
+    from ...server.request import RequestLike
     from ..application import ServerContext, SessionContext
     from .code_runner import CodeRunner
 
@@ -193,7 +192,7 @@ class Handler:
         '''
         pass
 
-    def process_request(self, request: HTTPServerRequest) -> dict[str, Any]:
+    def process_request(self, request: RequestLike) -> dict[str, Any]:
         ''' Processes incoming HTTP request returning a dictionary of
         additional data to add to the session_context.
 

--- a/src/bokeh/application/handlers/request_handler.py
+++ b/src/bokeh/application/handlers/request_handler.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from .handler import Handler
 
 if TYPE_CHECKING:
-    from tornado.httputil import HTTPServerRequest
+    from ...server.request import RequestLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -51,7 +51,7 @@ class RequestHandler(Handler):
 
     '''
 
-    _process_request: Callable[[HTTPServerRequest], dict[str, Any]]
+    _process_request: Callable[[RequestLike], dict[str, Any]]
 
     def __init__(self) -> None:
         super().__init__()
@@ -59,7 +59,7 @@ class RequestHandler(Handler):
 
     # Public methods ----------------------------------------------------------
 
-    def process_request(self, request: HTTPServerRequest) -> dict[str, Any]:
+    def process_request(self, request: RequestLike) -> dict[str, Any]:
         ''' Processes incoming HTTP request returning a dictionary of
         additional data to add to the session_context.
 
@@ -80,7 +80,7 @@ class RequestHandler(Handler):
 # Private API
 #-----------------------------------------------------------------------------
 
-def _return_empty(request: HTTPServerRequest) -> dict[str, Any]:
+def _return_empty(request: RequestLike) -> dict[str, Any]:
     return {}
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/client/session.py
+++ b/src/bokeh/client/session.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import quote_plus
 
 # Bokeh imports
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from ..protocol.messages.patch_doc import patch_doc
     from ..protocol.messages.server_info_reply import ServerInfo
     from ..server.callbacks import DocumentCallbackGroup
+    from ..util.asyncio import Loop
     from ..util.browser import BrowserLike, BrowserTarget
     from .connection import ClientConnection
     from .states import ErrorReason
@@ -317,7 +318,9 @@ class ClientSession:
         self._connection = ClientConnection(session=self, io_loop=io_loop, websocket_url=websocket_url, arguments=arguments, max_message_size=max_message_size)
 
         from ..server.callbacks import DocumentCallbackGroup
-        self._callbacks = DocumentCallbackGroup(self._connection.io_loop)
+        # Tornado's IOLoop exposes ``asyncio_loop`` at runtime, but its type
+        # declarations don't include that attribute required by ``Loop``.
+        self._callbacks = DocumentCallbackGroup(cast("Loop", self._connection.io_loop))
 
     def __enter__(self) -> ClientSession:
         '''

--- a/src/bokeh/client/session.py
+++ b/src/bokeh/client/session.py
@@ -34,7 +34,12 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    cast,
+)
 from urllib.parse import quote_plus
 
 # Bokeh imports
@@ -318,6 +323,7 @@ class ClientSession:
         self._connection = ClientConnection(session=self, io_loop=io_loop, websocket_url=websocket_url, arguments=arguments, max_message_size=max_message_size)
 
         from ..server.callbacks import DocumentCallbackGroup
+
         # Tornado's IOLoop exposes ``asyncio_loop`` at runtime, but its type
         # declarations don't include that attribute required by ``Loop``.
         self._callbacks = DocumentCallbackGroup(cast("Loop", self._connection.io_loop))

--- a/src/bokeh/document/__init__.py
+++ b/src/bokeh/document/__init__.py
@@ -42,6 +42,7 @@ log = logging.getLogger(__name__)
 __all__ = (
     'DEFAULT_TITLE',
     'Document',
+    'DocumentLike',
     'without_document_lock',
 )
 
@@ -51,7 +52,9 @@ __all__ = (
 
 from .document import DEFAULT_TITLE
 from .document import Document
-from .locking import without_document_lock
+from .locking import UnlockedDocumentProxy, without_document_lock
+
+type DocumentLike = Document | UnlockedDocumentProxy
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/document/callbacks.py
+++ b/src/bokeh/document/callbacks.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from ..core.has_props import Setter
     from ..model import Model
     from ..server.callbacks import SessionCallback
+    from . import DocumentLike
     from .document import Document
     from .events import (
         DocumentChangeCallback,
@@ -456,7 +457,7 @@ class DocumentCallbackManager:
 def invoke_with_curdoc(doc: Document, f: Callable[[], None]) -> None:
     from ..io.doc import patch_curdoc
 
-    curdoc: Document|UnlockedDocumentProxy = UnlockedDocumentProxy(doc) if getattr(f, "nolock", False) else doc
+    curdoc: DocumentLike = UnlockedDocumentProxy(doc) if getattr(f, "nolock", False) else doc
 
     with patch_curdoc(curdoc):
         return f()

--- a/src/bokeh/document/modules.py
+++ b/src/bokeh/document/modules.py
@@ -112,6 +112,10 @@ class DocumentModuleManager:
             # ones. Otherwise issue an error log message with details.
             referrers = get_referrers(module)
             referrers = [x for x in referrers if x is not sys.modules]
+            # Python introspection utilities, including inspect.getmodule(),
+            # make shallow snapshots of sys.modules. A snapshot held during
+            # document cleanup isn't an application module leak.
+            referrers = [x for x in referrers if not _is_sys_modules_snapshot(x)]
             referrers = [x for x in referrers if x is not self._modules]
             referrers = [x for x in referrers if not isinstance(x, FrameType)]
             if len(referrers) != 0:
@@ -138,6 +142,17 @@ class DocumentModuleManager:
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+def _is_sys_modules_snapshot(referrer: object) -> bool:
+    ''' Whether a referrer is a shallow snapshot of ``sys.modules``. '''
+    if not isinstance(referrer, dict) or referrer.get("sys") is not sys:
+        return False
+
+    missing = object()
+    return all(
+        isinstance(name, str) and sys.modules.get(name, missing) is value
+        for name, value in referrer.items()
+    )
 
 #-----------------------------------------------------------------------------
 # Code

--- a/src/bokeh/io/doc.py
+++ b/src/bokeh/io/doc.py
@@ -24,14 +24,11 @@ log = logging.getLogger(__name__)
 import weakref
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Generator, cast
+from typing import Generator, cast
 
 # Bokeh imports
-from ..document import Document
+from ..document import Document, DocumentLike
 from .state import curstate
-
-if TYPE_CHECKING:
-    from ..document.locking import UnlockedDocumentProxy
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -53,13 +50,18 @@ def curdoc() -> Document:
     Returns:
         Document : the current default document object.
 
+    .. note::
+        Inside a callback decorated with
+        :func:`~bokeh.document.without_document_lock`, this function returns
+        a restricted proxy that permits only safe next-tick callbacks.
+
     '''
     patched_curdocs = _PATCHED_CURDOCS.get()
     if len(patched_curdocs) > 0:
         doc = patched_curdocs[-1]()
         if doc is None:
             raise RuntimeError("Patched curdoc has been previously destroyed")
-        return cast(Document, doc) # UnlockedDocumentProxy -> Document
+        return cast(Document, doc) # UnlockedDocumentProxy enforces callback safety at runtime
     return curstate().document
 
 #-----------------------------------------------------------------------------
@@ -67,7 +69,7 @@ def curdoc() -> Document:
 #-----------------------------------------------------------------------------
 
 @contextmanager
-def patch_curdoc(doc: Document | UnlockedDocumentProxy) -> Generator[None]:
+def patch_curdoc(doc: DocumentLike) -> Generator[None]:
     ''' Temporarily override the value of ``curdoc()`` and then return it to
     its original state.
 
@@ -104,7 +106,7 @@ def set_curdoc(doc: Document) -> None:
 # Private API
 #-----------------------------------------------------------------------------
 
-_PATCHED_CURDOCS: ContextVar[tuple[weakref.ReferenceType[Document | UnlockedDocumentProxy], ...]] = \
+_PATCHED_CURDOCS: ContextVar[tuple[weakref.ReferenceType[DocumentLike], ...]] = \
     ContextVar("_PATCHED_CURDOCS", default=())
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/io/doc.py
+++ b/src/bokeh/io/doc.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import weakref
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Generator, cast
 
 # Bokeh imports
@@ -53,8 +54,9 @@ def curdoc() -> Document:
         Document : the current default document object.
 
     '''
-    if len(_PATCHED_CURDOCS) > 0:
-        doc = _PATCHED_CURDOCS[-1]()
+    patched_curdocs = _PATCHED_CURDOCS.get()
+    if len(patched_curdocs) > 0:
+        doc = patched_curdocs[-1]()
         if doc is None:
             raise RuntimeError("Patched curdoc has been previously destroyed")
         return cast(Document, doc) # UnlockedDocumentProxy -> Document
@@ -76,13 +78,12 @@ def patch_curdoc(doc: Document | UnlockedDocumentProxy) -> Generator[None]:
         doc (Document) : new Document to use for ``curdoc()``
 
     '''
-    global _PATCHED_CURDOCS
-    _PATCHED_CURDOCS.append(weakref.ref(doc))
+    token = _PATCHED_CURDOCS.set((*_PATCHED_CURDOCS.get(), weakref.ref(doc)))
     del doc
     try:
         yield
     finally:
-        _PATCHED_CURDOCS.pop()
+        _PATCHED_CURDOCS.reset(token)
 
 def set_curdoc(doc: Document) -> None:
     ''' Configure the current document (returned by curdoc()).
@@ -103,7 +104,8 @@ def set_curdoc(doc: Document) -> None:
 # Private API
 #-----------------------------------------------------------------------------
 
-_PATCHED_CURDOCS: list[weakref.ReferenceType[Document | UnlockedDocumentProxy]] = []
+_PATCHED_CURDOCS: ContextVar[tuple[weakref.ReferenceType[Document | UnlockedDocumentProxy], ...]] = \
+    ContextVar("_PATCHED_CURDOCS", default=())
 
 #-----------------------------------------------------------------------------
 # Code

--- a/src/bokeh/server/__init__.py
+++ b/src/bokeh/server/__init__.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-''' Provide a customizable Bokeh Server Tornadocore application.
+''' Provide Bokeh server applications and framework integrations.
 
 The architecture of Bokeh is such that high-level "model objects"
 (representing things like plots, ranges, axes, glyphs, etc.) are created
@@ -25,5 +25,9 @@ possibilities immediately open up:
 
 **This capability to synchronize between python and the browser is the main
 purpose of the Bokeh Server.**
+
+Use :class:`~bokeh.server.asgi.BokehASGI` with an ASGI server or framework.
+The Tornado frontend remains available through :class:`~bokeh.server.server.Server` and
+:class:`~bokeh.server.tornado.BokehTornado`.
 
 '''

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
     from ..application import Application
     from ..application.handlers.function import ModifyDoc
-    from ..core.types import ID
+    from ..core.types import ID, PathLike
     from .connection import ServerConnection
     from .contexts import ApplicationContext
 
@@ -112,11 +112,14 @@ class BokehASGI:
 
     This class does not depend on an ASGI framework or server. It can be
     served directly by Uvicorn or Hypercorn, or mounted in another ASGI app.
+    Applications may be supplied as :class:`~bokeh.application.application.Application`
+    objects, document-modifying callables, or paths to Bokeh application
+    scripts. Script paths are executed once for every new session.
     '''
 
     def __init__(
         self,
-        applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
+        applications: Mapping[str, Application | ModifyDoc | PathLike] | Application | ModifyDoc | PathLike,
         *,
         prefix: str | None = None,
         redirect_root: bool = True,

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -34,6 +34,7 @@ from ..util.token import check_token_signature, get_session_id, get_token_payloa
 from .core import BokehServerCore, SessionError
 from .protocol_handler import ProtocolHandler
 from .request import Cookie, Headers, ServerRequest
+from .util import check_allowlist
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
@@ -417,19 +418,7 @@ class BokehASGI:
         allowed = set(settings.allowed_ws_origin()) or self._core.websocket_origins
         if not allowed:
             return origin_host == request.host.lower()
-        return any(self._host_matches(origin_host, pattern.lower()) for pattern in allowed)
-
-    @staticmethod
-    def _host_matches(host: str, pattern: str) -> bool:
-        if pattern == "*":
-            return True
-        if ":" not in host:
-            host += ":80"
-        if ":" not in pattern:
-            pattern += ":80"
-        host_name, host_port = host.rsplit(":", 1)
-        pattern_name, pattern_port = pattern.rsplit(":", 1)
-        return host_port == pattern_port and (host_name == pattern_name or (pattern_name.startswith("*.") and host_name.endswith(pattern_name[1:])))
+        return check_allowlist(origin_host, [pattern.lower() for pattern in allowed])
 
     def _cors_headers(self, request: ServerRequest) -> list[tuple[bytes, bytes]]:
         origin = request.headers.get("origin")

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -31,6 +31,7 @@ from ..protocol.message import Message
 from ..protocol.receiver import Receiver
 from ..settings import settings
 from ..util.token import check_token_signature, get_session_id, get_token_payload
+from .auth import AuthPolicy
 from .core import BokehServerCore, SessionError
 from .protocol_handler import ProtocolHandler
 from .request import Cookie, Headers, ServerRequest
@@ -114,7 +115,9 @@ class BokehASGI:
     served directly by Uvicorn or Hypercorn, or mounted in another ASGI app.
     Applications may be supplied as :class:`~bokeh.application.application.Application`
     objects, document-modifying callables, or paths to Bokeh application
-    scripts. Script paths are executed once for every new session.
+    scripts. Script paths are executed once for every new session. Supply an
+    :class:`~bokeh.server.auth.AuthPolicy` to authenticate dynamic HTTP and
+    websocket requests without depending on an ASGI framework.
     '''
 
     def __init__(
@@ -123,10 +126,14 @@ class BokehASGI:
         *,
         prefix: str | None = None,
         redirect_root: bool = True,
+        auth_policy: AuthPolicy | None = None,
         **kwargs: Any,
     ) -> None:
+        if auth_policy is not None and auth_policy.logout_url is not None:
+            kwargs.setdefault("logout_url", auth_policy.logout_url)
         self._core = BokehServerCore(applications, prefix=prefix, **kwargs)
         self._redirect_root = redirect_root
+        self._auth_policy = auth_policy
         self._start_lock: asyncio.Lock | None = None
 
     @property
@@ -180,10 +187,6 @@ class BokehASGI:
             await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
             return
 
-        if route == "/" and "/" not in self._core.applications:
-            await self._root(send, head=method == "HEAD")
-            return
-
         if route.startswith("/static/extensions/"):
             relative = route.removeprefix("/static/extensions/")
             name, separator, artifact = relative.partition("/")
@@ -194,23 +197,32 @@ class BokehASGI:
             await self._static(send, Path(settings.bokehjs_path()), route.removeprefix("/static/"), head=method == "HEAD")
             return
 
+        if route == "/" and "/" not in self._core.applications:
+            if await self._authenticate_http(request, send, head=method == "HEAD"):
+                await self._root(send, head=method == "HEAD")
+            return
+
         resolved = self._resolve_application(route)
         if resolved is None:
             await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
             return
         context, suffix = resolved
 
+        if suffix.startswith("/static/"):
+            await self._static(send, context.application.static_path, suffix.removeprefix("/static/"), head=method == "HEAD")
+            return
+        if suffix == "/autoload.js" and method == "OPTIONS":
+            await self._response(send, 204, b"", "text/plain", extra_headers=self._cors_headers(request))
+            return
+        if not await self._authenticate_http(request, send, head=method == "HEAD"):
+            return
+
         if suffix in ("", "/"):
             await self._document(context, request, send, head=method == "HEAD")
         elif suffix == "/metadata":
             await self._metadata(context, send, head=method == "HEAD")
         elif suffix == "/autoload.js":
-            if method == "OPTIONS":
-                await self._response(send, 204, b"", "text/plain", extra_headers=self._cors_headers(request))
-            else:
-                await self._autoload(context, request, send, head=method == "HEAD")
-        elif suffix.startswith("/static/"):
-            await self._static(send, context.application.static_path, suffix.removeprefix("/static/"), head=method == "HEAD")
+            await self._autoload(context, request, send, head=method == "HEAD")
         else:
             await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
 
@@ -309,6 +321,9 @@ class BokehASGI:
         if not self._origin_allowed(request):
             await send({"type": "websocket.close", "code": 1008, "reason": "Origin is not allowed"})
             return
+        if not await self._authenticate(request):
+            await send({"type": "websocket.close", "code": 1008, "reason": "Authentication required"})
+            return
 
         await send({"type": "websocket.accept", "subprotocol": "bokeh"})
         transport = _ASGIWebSocketTransport(send)
@@ -382,7 +397,32 @@ class BokehASGI:
             host=host,
             query=query,
             root_path=scope.get("root_path", ""),
+            user=scope.get("user"),
+            state=scope.get("state") or {},
         )
+
+    async def _authenticate(self, request: ServerRequest) -> bool:
+        if self._auth_policy is None:
+            return True
+        request.user = await self._auth_policy.authenticate(request)
+        return request.user is not None
+
+    async def _authenticate_http(self, request: ServerRequest, send: Send, *, head: bool) -> bool:
+        if await self._authenticate(request):
+            return True
+        assert self._auth_policy is not None
+        if (login_url := self._auth_policy.get_login_url(request)) is not None:
+            await self._response(
+                send,
+                302,
+                b"",
+                "text/plain",
+                head=head,
+                extra_headers=[(b"location", login_url.encode())],
+            )
+        else:
+            await self._response(send, 401, b"Authentication required", "text/plain", head=head)
+        return False
 
     def _route_path(self, scope: Scope) -> str:
         path = scope.get("path", "/")

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+# Standard library imports
 import asyncio
 import binascii
 import calendar
@@ -22,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, urlparse
 
+# Bokeh imports
 from ..core.templates import AUTOLOAD_JS
 from ..embed.bundle import Script, bundle_for_objs_and_resources, extension_dirs
 from ..embed.elements import script_for_render_items
@@ -161,7 +163,7 @@ class BokehASGI:
             await self._lifespan(receive, send)
         elif scope_type == "http":
             await self._ensure_started()
-            await self._http(scope, receive, send)
+            await self._http(scope, send)
         elif scope_type == "websocket":
             await self._ensure_started()
             await self._websocket(scope, receive, send)
@@ -190,77 +192,90 @@ class BokehASGI:
                 await send({"type": "lifespan.shutdown.complete"})
                 return
 
-    async def _http(self, scope: Scope, receive: Receive, send: Send) -> None:
+    async def _http(self, scope: Scope, send: Send) -> None:
         request = self._request(scope)
         route = self._route_path(scope)
-        method = request.method.upper()
 
         if not route:
-            await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
+            await self._not_found(request, send)
             return
-
         if route.startswith("/static/"):
-            if method not in ("GET", "HEAD"):
-                await self._method_not_allowed(send, ("GET", "HEAD"))
-                return
-            root_context = self._core.applications.get("/")
-            root = root_context.application.static_path if root_context is not None else None
-            if root is not None:
-                await self._static(send, root, route.removeprefix("/static/"), head=method == "HEAD")
-            elif route.startswith("/static/extensions/"):
-                relative = route.removeprefix("/static/extensions/")
-                name, separator, artifact = relative.partition("/")
-                await self._static(send, extension_dirs.get(name), artifact if separator else "", head=method == "HEAD")
-            else:
-                await self._static(
-                    send,
-                    Path(settings.bokehjs_path()),
-                    route.removeprefix("/static/"),
-                    head=method == "HEAD",
-                )
+            await self._global_static(route, request, send)
             return
-
         if route == "/" and "/" not in self._core.applications:
-            if method not in ("GET", "HEAD"):
-                await self._method_not_allowed(send, ("GET", "HEAD"))
-                return
-            if await self._authenticate_http(request, send, head=method == "HEAD"):
-                await self._root(request, send, head=method == "HEAD")
+            await self._root(request, send)
             return
 
         resolved = self._resolve_application(route)
         if resolved is None:
-            await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
+            await self._not_found(request, send)
             return
         context, suffix = resolved
 
-        if suffix.startswith("/static/"):
-            if method not in ("GET", "HEAD"):
-                await self._method_not_allowed(send, ("GET", "HEAD"))
-                return
-            await self._static(send, context.application.static_path, suffix.removeprefix("/static/"), head=method == "HEAD")
-            return
-        if suffix == "/autoload.js" and method == "OPTIONS":
-            await self._response(send, 204, b"", "text/plain", extra_headers=self._cors_headers(request))
-            return
-        if suffix not in ("", "/", "/metadata", "/autoload.js"):
-            await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
-            return
-        if method not in ("GET", "HEAD"):
-            allowed = ("GET", "HEAD", "OPTIONS") if suffix == "/autoload.js" else ("GET", "HEAD")
-            await self._method_not_allowed(send, allowed)
-            return
-        if not await self._authenticate_http(request, send, head=method == "HEAD"):
-            return
-
         if suffix in ("", "/"):
-            await self._document(context, request, send, head=method == "HEAD")
+            await self._document(context, request, send)
         elif suffix == "/metadata":
-            await self._metadata(context, send, head=method == "HEAD")
+            await self._metadata(context, request, send)
+        elif suffix == "/autoload.js":
+            await self._autoload(context, request, send)
+        elif suffix.startswith("/static/"):
+            await self._application_static(context, suffix, request, send)
         else:
-            await self._autoload(context, request, send, head=method == "HEAD")
+            await self._not_found(request, send)
 
-    async def _document(self, context: ApplicationContext, request: ServerRequest, send: Send, *, head: bool) -> None:
+    async def _global_static(self, route: str, request: ServerRequest, send: Send) -> None:
+        method = request.method.upper()
+        if method not in ("GET", "HEAD"):
+            await self._method_not_allowed(send, ("GET", "HEAD"))
+            return
+
+        root_context = self._core.applications.get("/")
+        root = root_context.application.static_path if root_context is not None else None
+        if root is not None:
+            await self._serve_static(send, root, route.removeprefix("/static/"), head=method == "HEAD")
+        elif route.startswith("/static/extensions/"):
+            relative = route.removeprefix("/static/extensions/")
+            name, separator, artifact = relative.partition("/")
+            await self._serve_static(
+                send,
+                extension_dirs.get(name),
+                artifact if separator else "",
+                head=method == "HEAD",
+            )
+        else:
+            await self._serve_static(
+                send,
+                Path(settings.bokehjs_path()),
+                route.removeprefix("/static/"),
+                head=method == "HEAD",
+            )
+
+    async def _application_static(
+        self,
+        context: ApplicationContext,
+        suffix: str,
+        request: ServerRequest,
+        send: Send,
+    ) -> None:
+        method = request.method.upper()
+        if method not in ("GET", "HEAD"):
+            await self._method_not_allowed(send, ("GET", "HEAD"))
+            return
+        await self._serve_static(
+            send,
+            context.application.static_path,
+            suffix.removeprefix("/static/"),
+            head=method == "HEAD",
+        )
+
+    async def _document(self, context: ApplicationContext, request: ServerRequest, send: Send) -> None:
+        method = request.method.upper()
+        head = method == "HEAD"
+        if method not in ("GET", "HEAD"):
+            await self._method_not_allowed(send, ("GET", "HEAD"))
+            return
+        if not await self._authenticate_http(request, send, head=head):
+            return
         try:
             session = await self._core.create_session(context, request)
         except SessionError as error:
@@ -275,14 +290,31 @@ class BokehASGI:
         )
         await self._response(send, 200, page.encode(), "text/html; charset=UTF-8", head=head)
 
-    async def _metadata(self, context: ApplicationContext, send: Send, *, head: bool) -> None:
+    async def _metadata(self, context: ApplicationContext, request: ServerRequest, send: Send) -> None:
+        method = request.method.upper()
+        head = method == "HEAD"
+        if method not in ("GET", "HEAD"):
+            await self._method_not_allowed(send, ("GET", "HEAD"))
+            return
+        if not await self._authenticate_http(request, send, head=head):
+            return
         data = context.application.metadata
         if callable(data):
             data = data()
         body = json.dumps({"url": context.url, "data": data or {}}).encode()
         await self._response(send, 200, body, "application/json", head=head)
 
-    async def _autoload(self, context: ApplicationContext, request: ServerRequest, send: Send, *, head: bool) -> None:
+    async def _autoload(self, context: ApplicationContext, request: ServerRequest, send: Send) -> None:
+        method = request.method.upper()
+        if method == "OPTIONS":
+            await self._response(send, 204, b"", "text/plain", extra_headers=self._cors_headers(request))
+            return
+        head = method == "HEAD"
+        if method not in ("GET", "HEAD"):
+            await self._method_not_allowed(send, ("GET", "HEAD", "OPTIONS"))
+            return
+        if not await self._authenticate_http(request, send, head=head):
+            return
         try:
             session = await self._core.create_session(context, request)
         except SessionError as error:
@@ -309,7 +341,14 @@ class BokehASGI:
             send, 200, body, "application/javascript", head=head, extra_headers=self._cors_headers(request),
         )
 
-    async def _root(self, request: ServerRequest, send: Send, *, head: bool) -> None:
+    async def _root(self, request: ServerRequest, send: Send) -> None:
+        method = request.method.upper()
+        head = method == "HEAD"
+        if method not in ("GET", "HEAD"):
+            await self._method_not_allowed(send, ("GET", "HEAD"))
+            return
+        if not await self._authenticate_http(request, send, head=head):
+            return
         paths = sorted(self._core.app_paths)
         base = request.root_path.rstrip("/") + self._core.prefix
         if self._redirect_root and len(paths) == 1:
@@ -321,7 +360,7 @@ class BokehASGI:
         body = f"<!doctype html><title>Bokeh applications</title><h1>Bokeh applications</h1><ul>{items}</ul>".encode()
         await self._response(send, 200, body, "text/html; charset=UTF-8", head=head)
 
-    async def _static(self, send: Send, root: str | Path | None, relative: str, *, head: bool) -> None:
+    async def _serve_static(self, send: Send, root: str | Path | None, relative: str, *, head: bool) -> None:
         if root is None or not relative:
             await self._response(send, 404, b"Not found", "text/plain", head=head)
             return
@@ -567,6 +606,16 @@ class BokehASGI:
     def _argument(request: ServerRequest, name: str) -> str | None:
         values = request.arguments.get(name)
         return values[-1].decode("utf-8") if values else None
+
+    @staticmethod
+    async def _not_found(request: ServerRequest, send: Send) -> None:
+        await BokehASGI._response(
+            send,
+            404,
+            b"Not found",
+            "text/plain",
+            head=request.method.upper() == "HEAD",
+        )
 
     @staticmethod
     async def _method_not_allowed(send: Send, allowed: tuple[str, ...]) -> None:

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -9,12 +9,14 @@
 from __future__ import annotations
 
 import asyncio
+import binascii
 import calendar
 import datetime as dt
 import html
 import json
 import logging
 import mimetypes
+import zlib
 from http.cookies import SimpleCookie
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -74,14 +76,21 @@ class _WriteLock:
 
 
 class _ASGIWebSocketTransport:
-    def __init__(self, send: Send) -> None:
+    def __init__(self, send: Send, *, supports_close_reason: bool) -> None:
         self._send = send
+        self._supports_close_reason = supports_close_reason
         self.write_lock = _WriteLock()
         self.closed = False
 
     async def send_message(self, message: Message[Any]) -> None:
         if not self.closed:
-            await message.send(self)
+            try:
+                await message.send(self)
+            except OSError:
+                # ASGI servers raise OSError when the peer has disconnected.
+                # The corresponding websocket.disconnect event may still be
+                # waiting for the application to receive it.
+                self.closed = True
 
     async def write_message(self, message: bytes | str, binary: bool = False, locked: bool = True) -> None:
         if self.closed:
@@ -94,8 +103,8 @@ class _ASGIWebSocketTransport:
             data = message if isinstance(message, bytes) else message.encode("utf-8")
             await self._send({"type": "websocket.send", "bytes": data})
         else:
-            data = message.decode("utf-8") if isinstance(message, bytes) else message
-            await self._send({"type": "websocket.send", "text": data})
+            text = message.decode("utf-8") if isinstance(message, bytes) else message
+            await self._send({"type": "websocket.send", "text": text})
 
     def ping(self, data: bytes) -> None:
         # ASGI deliberately has no portable ping-frame event. ASGI servers
@@ -105,7 +114,13 @@ class _ASGIWebSocketTransport:
     async def close(self, code: int = 1000, reason: str = "") -> None:
         if not self.closed:
             self.closed = True
-            await self._send({"type": "websocket.close", "code": code, "reason": reason})
+            event: Event = {"type": "websocket.close", "code": code}
+            if self._supports_close_reason:
+                event["reason"] = reason
+            try:
+                await self._send(event)
+            except OSError:
+                pass
 
 
 class BokehASGI:
@@ -171,6 +186,7 @@ class BokehASGI:
                 await send({"type": "lifespan.startup.complete"})
             elif event["type"] == "lifespan.shutdown":
                 await self._core.stop()
+                self._start_lock = None
                 await send({"type": "lifespan.shutdown.complete"})
                 return
 
@@ -179,27 +195,37 @@ class BokehASGI:
         route = self._route_path(scope)
         method = request.method.upper()
 
-        if method not in ("GET", "HEAD", "OPTIONS"):
-            await self._response(send, 405, b"Method not allowed", "text/plain", head=method == "HEAD")
-            return
-
         if not route:
             await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
             return
 
-        if route.startswith("/static/extensions/"):
-            relative = route.removeprefix("/static/extensions/")
-            name, separator, artifact = relative.partition("/")
-            root = extension_dirs.get(name)
-            await self._static(send, root, artifact if separator else "", head=method == "HEAD")
-            return
         if route.startswith("/static/"):
-            await self._static(send, Path(settings.bokehjs_path()), route.removeprefix("/static/"), head=method == "HEAD")
+            if method not in ("GET", "HEAD"):
+                await self._method_not_allowed(send, ("GET", "HEAD"))
+                return
+            root_context = self._core.applications.get("/")
+            root = root_context.application.static_path if root_context is not None else None
+            if root is not None:
+                await self._static(send, root, route.removeprefix("/static/"), head=method == "HEAD")
+            elif route.startswith("/static/extensions/"):
+                relative = route.removeprefix("/static/extensions/")
+                name, separator, artifact = relative.partition("/")
+                await self._static(send, extension_dirs.get(name), artifact if separator else "", head=method == "HEAD")
+            else:
+                await self._static(
+                    send,
+                    Path(settings.bokehjs_path()),
+                    route.removeprefix("/static/"),
+                    head=method == "HEAD",
+                )
             return
 
         if route == "/" and "/" not in self._core.applications:
+            if method not in ("GET", "HEAD"):
+                await self._method_not_allowed(send, ("GET", "HEAD"))
+                return
             if await self._authenticate_http(request, send, head=method == "HEAD"):
-                await self._root(send, head=method == "HEAD")
+                await self._root(request, send, head=method == "HEAD")
             return
 
         resolved = self._resolve_application(route)
@@ -209,10 +235,20 @@ class BokehASGI:
         context, suffix = resolved
 
         if suffix.startswith("/static/"):
+            if method not in ("GET", "HEAD"):
+                await self._method_not_allowed(send, ("GET", "HEAD"))
+                return
             await self._static(send, context.application.static_path, suffix.removeprefix("/static/"), head=method == "HEAD")
             return
         if suffix == "/autoload.js" and method == "OPTIONS":
             await self._response(send, 204, b"", "text/plain", extra_headers=self._cors_headers(request))
+            return
+        if suffix not in ("", "/", "/metadata", "/autoload.js"):
+            await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
+            return
+        if method not in ("GET", "HEAD"):
+            allowed = ("GET", "HEAD", "OPTIONS") if suffix == "/autoload.js" else ("GET", "HEAD")
+            await self._method_not_allowed(send, allowed)
             return
         if not await self._authenticate_http(request, send, head=method == "HEAD"):
             return
@@ -221,10 +257,8 @@ class BokehASGI:
             await self._document(context, request, send, head=method == "HEAD")
         elif suffix == "/metadata":
             await self._metadata(context, send, head=method == "HEAD")
-        elif suffix == "/autoload.js":
-            await self._autoload(context, request, send, head=method == "HEAD")
         else:
-            await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
+            await self._autoload(context, request, send, head=method == "HEAD")
 
     async def _document(self, context: ApplicationContext, request: ServerRequest, send: Send, *, head: bool) -> None:
         try:
@@ -275,13 +309,14 @@ class BokehASGI:
             send, 200, body, "application/javascript", head=head, extra_headers=self._cors_headers(request),
         )
 
-    async def _root(self, send: Send, *, head: bool) -> None:
+    async def _root(self, request: ServerRequest, send: Send, *, head: bool) -> None:
         paths = sorted(self._core.app_paths)
+        base = request.root_path.rstrip("/") + self._core.prefix
         if self._redirect_root and len(paths) == 1:
-            await self._response(send, 302, b"", "text/plain", head=head, extra_headers=[(b"location", (self._core.prefix + paths[0]).encode())])
+            await self._response(send, 302, b"", "text/plain", head=head, extra_headers=[(b"location", (base + paths[0]).encode())])
             return
         items = "".join(
-            f'<li><a href="{html.escape(self._core.prefix + path)}">{html.escape(path)}</a></li>' for path in paths
+            f'<li><a href="{html.escape(base + path)}">{html.escape(path)}</a></li>' for path in paths
         )
         body = f"<!doctype html><title>Bokeh applications</title><h1>Bokeh applications</h1><ul>{items}</ul>".encode()
         await self._response(send, 200, body, "text/html; charset=UTF-8", head=head)
@@ -295,42 +330,68 @@ class BokehASGI:
         if not path.is_relative_to(root_path) or not path.is_file():
             await self._response(send, 404, b"Not found", "text/plain", head=head)
             return
-        body = await asyncio.to_thread(path.read_bytes)
         content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
-        await self._response(send, 200, body, content_type, head=head)
+        size = (await asyncio.to_thread(path.stat)).st_size
+        headers = [(b"content-type", content_type.encode()), (b"content-length", str(size).encode())]
+        await send({"type": "http.response.start", "status": 200, "headers": headers})
+        if head:
+            await send({"type": "http.response.body", "body": b""})
+            return
+
+        stream = await asyncio.to_thread(path.open, "rb")
+        try:
+            while chunk := await asyncio.to_thread(stream.read, 64*1024):
+                await send({"type": "http.response.body", "body": chunk, "more_body": True})
+        finally:
+            await asyncio.to_thread(stream.close)
+        await send({"type": "http.response.body", "body": b""})
 
     async def _websocket(self, scope: Scope, receive: Receive, send: Send) -> None:
+        transport = _ASGIWebSocketTransport(
+            send,
+            supports_close_reason=self._supports_websocket_close_reason(scope),
+        )
+        event = await receive()
+        if event["type"] == "websocket.disconnect":
+            return
+        if event["type"] != "websocket.connect":
+            await transport.close(1002, "Expected websocket.connect")
+            return
+
         route = self._route_path(scope)
         if not route:
-            await send({"type": "websocket.close", "code": 1008, "reason": "Unknown Bokeh application"})
+            await transport.close(1008, "Unknown Bokeh application")
             return
         resolved = self._resolve_application(route)
         if resolved is None or resolved[1] != "/ws":
-            await send({"type": "websocket.close", "code": 1008, "reason": "Unknown Bokeh application"})
+            await transport.close(1008, "Unknown Bokeh application")
             return
         context, _ = resolved
         subprotocols = scope.get("subprotocols", [])
         if len(subprotocols) != 2 or subprotocols[0] != "bokeh":
-            await send({"type": "websocket.close", "code": 1002, "reason": "Bokeh subprotocol and token required"})
+            await transport.close(1002, "Bokeh subprotocol and token required")
             return
         token = subprotocols[1]
         if not self._valid_websocket_token(token):
-            await send({"type": "websocket.close", "code": 1008, "reason": "Invalid or expired token"})
+            await transport.close(1008, "Invalid or expired token")
             return
         request = self._request(scope)
         if not self._origin_allowed(request):
-            await send({"type": "websocket.close", "code": 1008, "reason": "Origin is not allowed"})
+            await transport.close(1008, "Origin is not allowed")
             return
         if not await self._authenticate(request):
-            await send({"type": "websocket.close", "code": 1008, "reason": "Authentication required"})
+            await transport.close(1008, "Authentication required")
             return
 
-        await send({"type": "websocket.accept", "subprotocol": "bokeh"})
-        transport = _ASGIWebSocketTransport(send)
+        try:
+            await send({"type": "websocket.accept", "subprotocol": "bokeh"})
+        except OSError:
+            transport.closed = True
+            return
         connection: ServerConnection | None = None
         try:
             session_id = get_session_id(token)
-            session = await context.create_session_if_needed(session_id, request, token)
+            session = await self._core.create_session_if_needed(context, session_id, request, token)
             protocol = Protocol()
             receiver = Receiver(protocol)
             handler = ProtocolHandler()
@@ -363,16 +424,21 @@ class BokehASGI:
             await transport.close(1011, "Bokeh server internal error")
         finally:
             transport.closed = True
-            if connection is not None:
+            if connection is not None and getattr(connection, "_session", None) is not None:
                 connection.session.notify_connection_lost()
                 self._core.client_lost(connection)
 
     def _request(self, scope: Scope) -> ServerRequest:
         header_values: dict[str, str] = {}
         for raw_name, raw_value in scope.get("headers", []):
-            name = raw_name.decode("latin-1")
+            # ASGI requires response header names to be lower-case and strongly
+            # recommends the same for request headers, but applications can be
+            # hosted behind adapters that preserve their original casing. Use
+            # a canonical key so repeated headers are combined regardless of
+            # how those adapters cased each occurrence.
+            name = raw_name.decode("latin-1").lower()
             value = raw_value.decode("latin-1")
-            separator = "; " if name.lower() == "cookie" else ", "
+            separator = "; " if name == "cookie" else ", "
             header_values[name] = separator.join(filter(None, (header_values.get(name), value)))
         headers = Headers(header_values)
         cookie = SimpleCookie()
@@ -381,7 +447,15 @@ class BokehASGI:
         cookies = {name: Cookie(morsel.value) for name, morsel in cookie.items()}
         query_bytes = scope.get("query_string", b"")
         query = query_bytes.decode("latin-1")
-        arguments = {name: [value.encode("utf-8") for value in values] for name, values in parse_qs(query, keep_blank_values=True).items()}
+        arguments = {
+            name: [value.encode("latin-1") for value in values]
+            for name, values in parse_qs(
+                query,
+                keep_blank_values=True,
+                encoding="latin-1",
+                errors="strict",
+            ).items()
+        }
         path = scope.get("path", "/")
         client = scope.get("client")
         host = headers.get("host", "")
@@ -426,8 +500,8 @@ class BokehASGI:
 
     def _route_path(self, scope: Scope) -> str:
         path = scope.get("path", "/")
-        root_path = scope.get("root_path", "")
-        if root_path and path.startswith(root_path):
+        root_path = scope.get("root_path", "").rstrip("/")
+        if root_path and (path == root_path or path.startswith(root_path + "/")):
             path = path[len(root_path):] or "/"
         prefix = self._core.prefix
         if prefix:
@@ -446,12 +520,25 @@ class BokehASGI:
         return None
 
     def _valid_websocket_token(self, token: str) -> bool:
-        if not check_token_signature(token, signed=self._core.sign_sessions, secret_key=self._core.secret_key):
+        try:
+            if not check_token_signature(token, signed=self._core.sign_sessions, secret_key=self._core.secret_key):
+                return False
+            session_id = get_session_id(token)
+            payload = get_token_payload(token)
+        except (AttributeError, binascii.Error, json.JSONDecodeError, KeyError, TypeError, UnicodeError, zlib.error):
             return False
-        payload = get_token_payload(token)
         expiry = payload.get("session_expiry")
         now = calendar.timegm(dt.datetime.now(tz=dt.UTC).timetuple())
-        return isinstance(expiry, int) and now < expiry
+        return isinstance(session_id, str) and bool(session_id) and isinstance(expiry, int) and now < expiry
+
+    @staticmethod
+    def _supports_websocket_close_reason(scope: Scope) -> bool:
+        version = scope.get("asgi", {}).get("spec_version", "2.0")
+        try:
+            major, minor = (int(part) for part in version.split(".", 1))
+        except (AttributeError, TypeError, ValueError):
+            return False
+        return (major, minor) >= (2, 3)
 
     def _origin_allowed(self, request: ServerRequest) -> bool:
         origin = request.headers.get("origin")
@@ -470,7 +557,7 @@ class BokehASGI:
             (b"access-control-allow-origin", allow_origin.encode()),
             (b"access-control-allow-headers", b"*"),
             (b"access-control-allow-credentials", b"true"),
-            (b"access-control-allow-methods", b"PUT, GET, OPTIONS"),
+            (b"access-control-allow-methods", b"GET, HEAD, OPTIONS"),
         ]
         if allow_origin != "*":
             headers.append((b"vary", b"Origin"))
@@ -482,6 +569,16 @@ class BokehASGI:
         return values[-1].decode("utf-8") if values else None
 
     @staticmethod
+    async def _method_not_allowed(send: Send, allowed: tuple[str, ...]) -> None:
+        await BokehASGI._response(
+            send,
+            405,
+            b"Method not allowed",
+            "text/plain",
+            extra_headers=[(b"allow", ", ".join(allowed).encode())],
+        )
+
+    @staticmethod
     async def _response(
         send: Send,
         status: int,
@@ -491,7 +588,12 @@ class BokehASGI:
         head: bool = False,
         extra_headers: list[tuple[bytes, bytes]] | None = None,
     ) -> None:
-        headers = [(b"content-type", content_type.encode()), (b"content-length", str(len(body)).encode())]
+        headers: list[tuple[bytes, bytes]] = []
+        if not (100 <= status < 200 or status in (204, 304)):
+            headers.extend([
+                (b"content-type", content_type.encode()),
+                (b"content-length", str(len(body)).encode()),
+            ])
         headers.extend(extra_headers or ())
         await send({"type": "http.response.start", "status": status, "headers": headers})
         await send({"type": "http.response.body", "body": b"" if head else body})

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -132,9 +132,10 @@ class BokehASGI:
     served directly by Uvicorn or Hypercorn, or mounted in another ASGI app.
     Applications may be supplied as :class:`~bokeh.application.application.Application`
     objects, document-modifying callables, or paths to Bokeh application
-    scripts. Script paths are executed once for every new session. Supply an
-    :class:`~bokeh.server.auth.AuthPolicy` to authenticate dynamic HTTP and
-    websocket requests without depending on an ASGI framework.
+    scripts or directories. Script and directory applications are executed
+    once for every new session. Supply an :class:`~bokeh.server.auth.AuthPolicy`
+    to authenticate dynamic HTTP and websocket requests without depending on
+    an ASGI framework.
     '''
 
     def __init__(

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -1,0 +1,465 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc. and contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' A framework-neutral ASGI frontend for Bokeh server applications. '''
+
+from __future__ import annotations
+
+import asyncio
+import calendar
+import datetime as dt
+import html
+import json
+import logging
+import mimetypes
+from http.cookies import SimpleCookie
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import parse_qs, urlparse
+
+from ..core.templates import AUTOLOAD_JS
+from ..embed.bundle import Script, bundle_for_objs_and_resources, extension_dirs
+from ..embed.elements import script_for_render_items
+from ..embed.server import server_html_page_for_session
+from ..embed.util import RenderItem
+from ..protocol import Protocol
+from ..protocol.exceptions import MessageError, ProtocolError, ValidationError
+from ..protocol.message import Message
+from ..protocol.receiver import Receiver
+from ..settings import settings
+from ..util.token import check_token_signature, get_session_id, get_token_payload
+from .core import BokehServerCore, SessionError
+from .protocol_handler import ProtocolHandler
+from .request import Cookie, Headers, ServerRequest
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Mapping
+
+    from ..application import Application
+    from ..application.handlers.function import ModifyDoc
+    from ..core.types import ID
+    from .connection import ServerConnection
+    from .contexts import ApplicationContext
+
+    type Scope = dict[str, Any]
+    type Event = dict[str, Any]
+    type Receive = Callable[[], Awaitable[Event]]
+    type Send = Callable[[Event], Awaitable[None]]
+
+log = logging.getLogger(__name__)
+
+__all__ = ("BokehASGI",)
+
+
+class _WriteLock:
+    ''' Adapt an asyncio lock to the historical ``with await lock.acquire()`` API. '''
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> _WriteLock:
+        await self._lock.acquire()
+        return self
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *args: object) -> None:
+        self._lock.release()
+
+
+class _ASGIWebSocketTransport:
+    def __init__(self, send: Send) -> None:
+        self._send = send
+        self.write_lock = _WriteLock()
+        self.closed = False
+
+    async def send_message(self, message: Message[Any]) -> None:
+        if not self.closed:
+            await message.send(self)
+
+    async def write_message(self, message: bytes | str, binary: bool = False, locked: bool = True) -> None:
+        if self.closed:
+            return
+        if locked:
+            with await self.write_lock.acquire():
+                await self.write_message(message, binary=binary, locked=False)
+            return
+        if binary:
+            data = message if isinstance(message, bytes) else message.encode("utf-8")
+            await self._send({"type": "websocket.send", "bytes": data})
+        else:
+            data = message.decode("utf-8") if isinstance(message, bytes) else message
+            await self._send({"type": "websocket.send", "text": data})
+
+    def ping(self, data: bytes) -> None:
+        # ASGI deliberately has no portable ping-frame event. ASGI servers
+        # provide transport-level keepalive configuration instead.
+        pass
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        if not self.closed:
+            self.closed = True
+            await self._send({"type": "websocket.close", "code": code, "reason": reason})
+
+
+class BokehASGI:
+    ''' Host one or more Bokeh applications using the standard ASGI protocol.
+
+    This class does not depend on an ASGI framework or server. It can be
+    served directly by Uvicorn or Hypercorn, or mounted in another ASGI app.
+    '''
+
+    def __init__(
+        self,
+        applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
+        *,
+        prefix: str | None = None,
+        redirect_root: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        self._core = BokehServerCore(applications, prefix=prefix, **kwargs)
+        self._redirect_root = redirect_root
+        self._start_lock: asyncio.Lock | None = None
+
+    @property
+    def core(self) -> BokehServerCore:
+        return self._core
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope_type = scope["type"]
+        if scope_type == "lifespan":
+            await self._lifespan(receive, send)
+        elif scope_type == "http":
+            await self._ensure_started()
+            await self._http(scope, receive, send)
+        elif scope_type == "websocket":
+            await self._ensure_started()
+            await self._websocket(scope, receive, send)
+        else:
+            raise RuntimeError(f"Unsupported ASGI scope type {scope_type!r}")
+
+    async def _ensure_started(self) -> None:
+        if self._start_lock is None:
+            self._start_lock = asyncio.Lock()
+        async with self._start_lock:
+            await self._core.start()
+
+    async def _lifespan(self, receive: Receive, send: Send) -> None:
+        while True:
+            event = await receive()
+            if event["type"] == "lifespan.startup":
+                try:
+                    await self._ensure_started()
+                except Exception as error:
+                    await send({"type": "lifespan.startup.failed", "message": str(error)})
+                    return
+                await send({"type": "lifespan.startup.complete"})
+            elif event["type"] == "lifespan.shutdown":
+                await self._core.stop()
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+    async def _http(self, scope: Scope, receive: Receive, send: Send) -> None:
+        request = self._request(scope)
+        route = self._route_path(scope)
+        method = request.method.upper()
+
+        if method not in ("GET", "HEAD", "OPTIONS"):
+            await self._response(send, 405, b"Method not allowed", "text/plain", head=method == "HEAD")
+            return
+
+        if not route:
+            await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
+            return
+
+        if route == "/" and "/" not in self._core.applications:
+            await self._root(send, head=method == "HEAD")
+            return
+
+        if route.startswith("/static/extensions/"):
+            relative = route.removeprefix("/static/extensions/")
+            name, separator, artifact = relative.partition("/")
+            root = extension_dirs.get(name)
+            await self._static(send, root, artifact if separator else "", head=method == "HEAD")
+            return
+        if route.startswith("/static/"):
+            await self._static(send, Path(settings.bokehjs_path()), route.removeprefix("/static/"), head=method == "HEAD")
+            return
+
+        resolved = self._resolve_application(route)
+        if resolved is None:
+            await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
+            return
+        context, suffix = resolved
+
+        if suffix in ("", "/"):
+            await self._document(context, request, send, head=method == "HEAD")
+        elif suffix == "/metadata":
+            await self._metadata(context, send, head=method == "HEAD")
+        elif suffix == "/autoload.js":
+            if method == "OPTIONS":
+                await self._response(send, 204, b"", "text/plain", extra_headers=self._cors_headers(request))
+            else:
+                await self._autoload(context, request, send, head=method == "HEAD")
+        elif suffix.startswith("/static/"):
+            await self._static(send, context.application.static_path, suffix.removeprefix("/static/"), head=method == "HEAD")
+        else:
+            await self._response(send, 404, b"Not found", "text/plain", head=method == "HEAD")
+
+    async def _document(self, context: ApplicationContext, request: ServerRequest, send: Send, *, head: bool) -> None:
+        try:
+            session = await self._core.create_session(context, request)
+        except SessionError as error:
+            await self._response(send, error.status, error.reason.encode(), "text/plain", head=head)
+            return
+        page = server_html_page_for_session(
+            session,
+            resources=self._core.resources(root_path=request.root_path),
+            title=session.document.title,
+            template=session.document.template,
+            template_variables=session.document.template_variables,
+        )
+        await self._response(send, 200, page.encode(), "text/html; charset=UTF-8", head=head)
+
+    async def _metadata(self, context: ApplicationContext, send: Send, *, head: bool) -> None:
+        data = context.application.metadata
+        if callable(data):
+            data = data()
+        body = json.dumps({"url": context.url, "data": data or {}}).encode()
+        await self._response(send, 200, body, "application/json", head=head)
+
+    async def _autoload(self, context: ApplicationContext, request: ServerRequest, send: Send, *, head: bool) -> None:
+        try:
+            session = await self._core.create_session(context, request)
+        except SessionError as error:
+            await self._response(send, error.status, error.reason.encode(), "text/plain", head=head)
+            return
+        element_id = self._argument(request, "bokeh-autoload-element")
+        if not element_id:
+            await self._response(send, 400, b"No bokeh-autoload-element query parameter", "text/plain", head=head)
+            return
+        app_path = self._argument(request, "bokeh-app-path") or "/"
+        absolute_url = self._argument(request, "bokeh-absolute-url")
+        server_url = None
+        if absolute_url:
+            uri = urlparse(absolute_url)
+            server_url = f"{uri.scheme}://{uri.netloc}"
+        resources = None if self._argument(request, "resources") == "none" else self._core.resources(
+            server_url, root_path=request.root_path,
+        )
+        bundle = bundle_for_objs_and_resources(None, resources)
+        render_items = [RenderItem(token=session.token, elementid=cast("ID", element_id), use_for_title=False)]
+        bundle.add(Script(script_for_render_items({}, render_items, app_path=app_path, absolute_url=absolute_url)))
+        body = AUTOLOAD_JS.render(bundle=bundle, elementid=element_id).encode()
+        await self._response(
+            send, 200, body, "application/javascript", head=head, extra_headers=self._cors_headers(request),
+        )
+
+    async def _root(self, send: Send, *, head: bool) -> None:
+        paths = sorted(self._core.app_paths)
+        if self._redirect_root and len(paths) == 1:
+            await self._response(send, 302, b"", "text/plain", head=head, extra_headers=[(b"location", (self._core.prefix + paths[0]).encode())])
+            return
+        items = "".join(
+            f'<li><a href="{html.escape(self._core.prefix + path)}">{html.escape(path)}</a></li>' for path in paths
+        )
+        body = f"<!doctype html><title>Bokeh applications</title><h1>Bokeh applications</h1><ul>{items}</ul>".encode()
+        await self._response(send, 200, body, "text/html; charset=UTF-8", head=head)
+
+    async def _static(self, send: Send, root: str | Path | None, relative: str, *, head: bool) -> None:
+        if root is None or not relative:
+            await self._response(send, 404, b"Not found", "text/plain", head=head)
+            return
+        root_path = Path(root).resolve()
+        path = (root_path / relative).resolve()
+        if not path.is_relative_to(root_path) or not path.is_file():
+            await self._response(send, 404, b"Not found", "text/plain", head=head)
+            return
+        body = await asyncio.to_thread(path.read_bytes)
+        content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        await self._response(send, 200, body, content_type, head=head)
+
+    async def _websocket(self, scope: Scope, receive: Receive, send: Send) -> None:
+        route = self._route_path(scope)
+        if not route:
+            await send({"type": "websocket.close", "code": 1008, "reason": "Unknown Bokeh application"})
+            return
+        resolved = self._resolve_application(route)
+        if resolved is None or resolved[1] != "/ws":
+            await send({"type": "websocket.close", "code": 1008, "reason": "Unknown Bokeh application"})
+            return
+        context, _ = resolved
+        subprotocols = scope.get("subprotocols", [])
+        if len(subprotocols) != 2 or subprotocols[0] != "bokeh":
+            await send({"type": "websocket.close", "code": 1002, "reason": "Bokeh subprotocol and token required"})
+            return
+        token = subprotocols[1]
+        if not self._valid_websocket_token(token):
+            await send({"type": "websocket.close", "code": 1008, "reason": "Invalid or expired token"})
+            return
+        request = self._request(scope)
+        if not self._origin_allowed(request):
+            await send({"type": "websocket.close", "code": 1008, "reason": "Origin is not allowed"})
+            return
+
+        await send({"type": "websocket.accept", "subprotocol": "bokeh"})
+        transport = _ASGIWebSocketTransport(send)
+        connection: ServerConnection | None = None
+        try:
+            session_id = get_session_id(token)
+            session = await context.create_session_if_needed(session_id, request, token)
+            protocol = Protocol()
+            receiver = Receiver(protocol)
+            handler = ProtocolHandler()
+            connection = self._core.new_connection(protocol, transport, context, session)
+            await transport.send_message(protocol.create("ACK"))
+
+            while True:
+                event = await receive()
+                if event["type"] == "websocket.disconnect":
+                    break
+                if event["type"] != "websocket.receive":
+                    continue
+                fragment = event.get("bytes")
+                if fragment is None:
+                    fragment = event.get("text")
+                if fragment is None:
+                    continue
+                message = await receiver.consume(fragment)
+                if message is not None:
+                    work = await handler.handle(message, connection)
+                    if isinstance(work, Message):
+                        await transport.send_message(work)
+                    elif work is not None:
+                        raise ProtocolError(f"expected a Message not {work!r}")
+        except (MessageError, ProtocolError, ValidationError) as error:
+            log.error("Bokeh websocket protocol error: %s", error)
+            await transport.close(1002, str(error))
+        except Exception:
+            log.exception("Bokeh websocket internal error")
+            await transport.close(1011, "Bokeh server internal error")
+        finally:
+            transport.closed = True
+            if connection is not None:
+                connection.session.notify_connection_lost()
+                self._core.client_lost(connection)
+
+    def _request(self, scope: Scope) -> ServerRequest:
+        header_values: dict[str, str] = {}
+        for raw_name, raw_value in scope.get("headers", []):
+            name = raw_name.decode("latin-1")
+            value = raw_value.decode("latin-1")
+            separator = "; " if name.lower() == "cookie" else ", "
+            header_values[name] = separator.join(filter(None, (header_values.get(name), value)))
+        headers = Headers(header_values)
+        cookie = SimpleCookie()
+        if value := headers.get("cookie"):
+            cookie.load(value)
+        cookies = {name: Cookie(morsel.value) for name, morsel in cookie.items()}
+        query_bytes = scope.get("query_string", b"")
+        query = query_bytes.decode("latin-1")
+        arguments = {name: [value.encode("utf-8") for value in values] for name, values in parse_qs(query, keep_blank_values=True).items()}
+        path = scope.get("path", "/")
+        client = scope.get("client")
+        host = headers.get("host", "")
+        return ServerRequest(
+            method=scope.get("method", "GET"),
+            uri=f"{path}?{query}" if query else path,
+            path=path,
+            arguments=arguments,
+            headers=headers,
+            cookies=cookies,
+            remote_ip=client[0] if client else None,
+            protocol=scope.get("scheme", "http"),
+            host=host,
+            query=query,
+            root_path=scope.get("root_path", ""),
+        )
+
+    def _route_path(self, scope: Scope) -> str:
+        path = scope.get("path", "/")
+        root_path = scope.get("root_path", "")
+        if root_path and path.startswith(root_path):
+            path = path[len(root_path):] or "/"
+        prefix = self._core.prefix
+        if prefix:
+            if path == prefix:
+                return "/"
+            if not path.startswith(prefix + "/"):
+                return ""
+            path = path[len(prefix):]
+        return path or "/"
+
+    def _resolve_application(self, route: str) -> tuple[ApplicationContext, str] | None:
+        for path in sorted(self._core.applications, key=len, reverse=True):
+            base = "" if path == "/" else path
+            if route == base or route == base + "/" or route.startswith(base + "/"):
+                return self._core.applications[path], route[len(base):]
+        return None
+
+    def _valid_websocket_token(self, token: str) -> bool:
+        if not check_token_signature(token, signed=self._core.sign_sessions, secret_key=self._core.secret_key):
+            return False
+        payload = get_token_payload(token)
+        expiry = payload.get("session_expiry")
+        now = calendar.timegm(dt.datetime.now(tz=dt.UTC).timetuple())
+        return isinstance(expiry, int) and now < expiry
+
+    def _origin_allowed(self, request: ServerRequest) -> bool:
+        origin = request.headers.get("origin")
+        if origin is None:
+            return True
+        origin_host = urlparse(origin).netloc.lower()
+        allowed = set(settings.allowed_ws_origin()) or self._core.websocket_origins
+        if not allowed:
+            return origin_host == request.host.lower()
+        return any(self._host_matches(origin_host, pattern.lower()) for pattern in allowed)
+
+    @staticmethod
+    def _host_matches(host: str, pattern: str) -> bool:
+        if pattern == "*":
+            return True
+        if ":" not in host:
+            host += ":80"
+        if ":" not in pattern:
+            pattern += ":80"
+        host_name, host_port = host.rsplit(":", 1)
+        pattern_name, pattern_port = pattern.rsplit(":", 1)
+        return host_port == pattern_port and (host_name == pattern_name or (pattern_name.startswith("*.") and host_name.endswith(pattern_name[1:])))
+
+    def _cors_headers(self, request: ServerRequest) -> list[tuple[bytes, bytes]]:
+        origin = request.headers.get("origin")
+        allow_origin = origin if origin is not None and self._origin_allowed(request) else "*"
+        headers = [
+            (b"access-control-allow-origin", allow_origin.encode()),
+            (b"access-control-allow-headers", b"*"),
+            (b"access-control-allow-credentials", b"true"),
+            (b"access-control-allow-methods", b"PUT, GET, OPTIONS"),
+        ]
+        if allow_origin != "*":
+            headers.append((b"vary", b"Origin"))
+        return headers
+
+    @staticmethod
+    def _argument(request: ServerRequest, name: str) -> str | None:
+        values = request.arguments.get(name)
+        return values[-1].decode("utf-8") if values else None
+
+    @staticmethod
+    async def _response(
+        send: Send,
+        status: int,
+        body: bytes,
+        content_type: str,
+        *,
+        head: bool = False,
+        extra_headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        headers = [(b"content-type", content_type.encode()), (b"content-length", str(len(body)).encode())]
+        headers.extend(extra_headers or ())
+        await send({"type": "http.response.start", "status": status, "headers": headers})
+        await send({"type": "http.response.body", "body": b"" if head else body})

--- a/src/bokeh/server/auth.py
+++ b/src/bokeh/server/auth.py
@@ -1,0 +1,69 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Framework-neutral authentication policy for Bokeh server frontends. '''
+
+from __future__ import annotations
+
+# Standard library imports
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+# Bokeh imports
+from .request import ServerRequest
+
+__all__ = (
+    'AuthPolicy',
+)
+
+type Authenticator = Callable[[ServerRequest], Any | None | Awaitable[Any | None]]
+type LoginURL = str | Callable[[ServerRequest], str | None]
+
+
+class AuthPolicy:
+    ''' Authenticate Bokeh requests without depending on a web framework.
+
+    The authenticator receives a framework-neutral
+    :class:`~bokeh.server.request.ServerRequest` and returns an authenticated
+    user, or ``None`` to reject the request. Both synchronous and asynchronous
+    authenticators are supported.
+
+    Args:
+        authenticator: Function that authenticates an HTTP or websocket
+            request and returns its user.
+        login_url: Optional URL, or request-dependent URL function, used to
+            redirect unauthenticated HTTP requests. Without one, Bokeh returns
+            HTTP 401.
+        logout_url: Optional URL exposed as
+            ``curdoc().session_context.logout_url``. The host application is
+            responsible for implementing the endpoint.
+
+    '''
+
+    def __init__(self, authenticator: Authenticator, *, login_url: LoginURL | None = None,
+            logout_url: str | None = None) -> None:
+        self._authenticator = authenticator
+        self._login_url = login_url
+        self._logout_url = logout_url
+
+    async def authenticate(self, request: ServerRequest) -> Any | None:
+        ''' Return the authenticated user for a request, or ``None``. '''
+        user = self._authenticator(request)
+        if inspect.isawaitable(user):
+            user = await user
+        return user
+
+    def get_login_url(self, request: ServerRequest) -> str | None:
+        ''' Return the login URL for an unauthenticated HTTP request. '''
+        if callable(self._login_url):
+            return self._login_url(request)
+        return self._login_url
+
+    @property
+    def logout_url(self) -> str | None:
+        ''' The logout URL exposed to authenticated Bokeh sessions. '''
+        return self._logout_url

--- a/src/bokeh/server/callbacks.py
+++ b/src/bokeh/server/callbacks.py
@@ -25,11 +25,9 @@ log = logging.getLogger(__name__)
 from typing import TYPE_CHECKING, Callable, Sequence
 
 # Bokeh imports
-from ..util.tornado import _CallbackGroup
+from ..util.asyncio import Loop, _CallbackGroup
 
 if TYPE_CHECKING:
-    from tornado.ioloop import IOLoop
-
     from ..core.types import ID
 
 #-----------------------------------------------------------------------------
@@ -171,7 +169,7 @@ class DocumentCallbackGroup:
     '''
 
     '''
-    def __init__(self, io_loop: IOLoop) -> None:
+    def __init__(self, io_loop: Loop) -> None:
         '''
 
         '''

--- a/src/bokeh/server/connection.py
+++ b/src/bokeh/server/connection.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from ..protocol.message import Message
     from .contexts import ApplicationContext
     from .session import ServerSession
-    from .views.ws import WSHandler
+    from .transport import WebSocketTransport
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -51,7 +51,7 @@ class ServerConnection:
 
     _session: ServerSession | None
 
-    def __init__(self, protocol: Protocol, socket: WSHandler,
+    def __init__(self, protocol: Protocol, socket: WebSocketTransport,
             application_context: ApplicationContext, session: ServerSession) -> None:
         self._protocol = protocol
         self._socket = socket

--- a/src/bokeh/server/contexts.py
+++ b/src/bokeh/server/contexts.py
@@ -165,9 +165,16 @@ class ApplicationContext:
         self._url = url
         self._logout_url = logout_url
 
-    def _requires_worker_initialization(self) -> bool:
+    def _can_initialize_document_in_worker(self) -> bool:
+        from ..application.handlers.code import CodeHandler
+        from ..application.handlers.directory import DirectoryHandler
         from ..application.handlers.document_lifecycle import DocumentLifecycleHandler
-        return any(not isinstance(handler, DocumentLifecycleHandler) for handler in self._application._handlers)
+
+        handlers = [
+            handler for handler in self._application._handlers
+            if not isinstance(handler, DocumentLifecycleHandler)
+        ]
+        return bool(handlers) and all(not isinstance(handler, (CodeHandler, DirectoryHandler)) for handler in handlers)
 
     @property
     def io_loop(self) -> Loop | None:
@@ -241,9 +248,11 @@ class ApplicationContext:
             await asyncio.gather(*pending, return_exceptions=True)
 
     async def _initialize_document_async(self, doc: Document) -> None:
-        if not self._requires_worker_initialization():
-            # Preserve immediate creation for an empty Application. The
-            # lifecycle handler does not execute user document code.
+        if not self._can_initialize_document_in_worker():
+            # Code handlers temporarily patch process-global state such as
+            # sys.path, sys.argv, cwd, and bokeh.io functions. Run them on the
+            # event-loop thread so no unrelated request can observe that state.
+            # This also preserves immediate creation for an empty Application.
             self._application.initialize_document(doc)
             return
 
@@ -292,9 +301,8 @@ class ApplicationContext:
         except Exception as e:
             log.error("Failed to run session creation hooks %r", e, exc_info=True)
 
-        # Application code is arbitrary synchronous Python and can be
-        # expensive. Keeping it on the event-loop thread prevents the
-        # server from accepting unrelated HTTP and websocket work.
+        # Safe synchronous application code can run in a worker. Handlers that
+        # patch process-global state remain on the event-loop thread.
         await self._initialize_document_async(doc)
 
         io_loop = self._loop or asyncio.get_running_loop()
@@ -312,24 +320,34 @@ class ApplicationContext:
             raise ProtocolError("No such session " + session_id)
 
     async def _discard_session(self, session: ServerSession, should_discard: Callable[[ServerSession], bool]) -> None:
+        # Cleanup and orderly shutdown can independently retain the same
+        # session in a snapshot. Treat a session that another path already
+        # removed as successfully discarded rather than destroying it twice.
+        if self._sessions.get(session.id) is not session:
+            return
         if session.connection_count > 0:
             raise RuntimeError("Should not be discarding a session with open connections")
         log.debug("Discarding session %r last in use %r milliseconds ago", session.id, session.milliseconds_since_last_unsubscribe)
 
         session_context = self._session_contexts[session.id]
+        discarded = False
 
         # session.destroy() wants the document lock so it can shut down the document
         # callbacks.
-        def do_discard() -> None:
+        async def do_discard() -> None:
+            nonlocal discarded
             # while we awaited for the document lock, the discard-worthiness of the
             # session may have changed.
             # However, since we have the document lock, our own lock will cause the
             # block count to be 1. If there's any other block count besides our own,
             # we want to skip session destruction though.
+            if self._sessions.get(session.id) is not session:
+                return
             if should_discard(session) and session.expiration_blocked_count == 1:
                 session.destroy()
                 del self._sessions[session.id]
                 del self._session_contexts[session.id]
+                discarded = True
                 log.debug("Session %r was successfully discarded", session.id)
             else:
                 log.warning(f"Session {session.id!r} was scheduled to discard but came back to life")
@@ -337,13 +355,21 @@ class ApplicationContext:
 
         # session lifecycle hooks are supposed to be called outside the document lock,
         # we only run these if we actually ended up destroying the session.
-        if session_context.destroyed:
+        if discarded:
             try:
                 await self._application.on_session_destroyed(session_context)
             except Exception as e:
                 log.error("Failed to run session destroy hooks %r", e, exc_info=True)
 
         return None
+
+    async def _shutdown_sessions(self) -> None:
+        for session in list(self._sessions.values()):
+            if session.connection_count > 0:
+                log.warning("Session %r still has open connections during shutdown", session.id)
+                continue
+            session._stop_callbacks()
+            await self._discard_session(session, lambda session: session.connection_count == 0)
 
     async def _cleanup_sessions(self, unused_session_linger_milliseconds: int) -> None:
         def should_discard_ignoring_block(session: ServerSession) -> bool:

--- a/src/bokeh/server/contexts.py
+++ b/src/bokeh/server/contexts.py
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import asyncio
-import threading
 import weakref
 from typing import (
     TYPE_CHECKING,
@@ -151,7 +150,7 @@ class ApplicationContext:
     '''
 
     _sessions: dict[ID, ServerSession]
-    _pending_sessions: dict[ID, asyncio.Future[ServerSession]]
+    _pending_sessions: dict[ID, asyncio.Task[ServerSession]]
     _session_contexts: dict[ID, SessionContext]
     _server_context: BokehServerContext
 
@@ -165,15 +164,6 @@ class ApplicationContext:
         self._server_context = BokehServerContext(self)
         self._url = url
         self._logout_url = logout_url
-        # Application handlers commonly retain mutable execution state. Run
-        # document initialization away from the event loop, but serialize it
-        # per application to preserve the ordering guarantees of the Tornado
-        # implementation.
-        self._document_init_lock = threading.Lock()
-
-    def _initialize_document(self, doc: Document) -> None:
-        with self._document_init_lock:
-            self._application.initialize_document(doc)
 
     def _requires_worker_initialization(self) -> bool:
         from ..application.handlers.document_lifecycle import DocumentLifecycleHandler
@@ -218,74 +208,100 @@ class ApplicationContext:
         if len(session_id) == 0:
             raise ProtocolError("Session ID must not be empty")
 
-        if session_id not in self._sessions and \
-           session_id not in self._pending_sessions:
-            future = self._pending_sessions[session_id] = asyncio.get_running_loop().create_future()
+        if session_id in self._sessions:
+            return self._sessions[session_id]
 
-            doc = Document()
+        pending = self._pending_sessions.get(session_id)
+        if pending is None:
+            pending = self._pending_sessions[session_id] = asyncio.create_task(
+                self._create_session(session_id, request, token),
+            )
+            pending.add_done_callback(lambda task: self._session_creation_done(session_id, task))
 
-            session_context = BokehSessionContext(session_id,
-                                                  self.server_context,
-                                                  doc,
-                                                  logout_url=self._logout_url)
-            if request is not None:
-                payload = get_token_payload(token) if token else {}
-                if ('cookies' in payload and 'headers' in payload
-                    and 'Cookie' not in payload['headers']):
-                    # Restore Cookie header from cookies dictionary
-                    payload['headers']['Cookie'] = '; '.join([
-                        f'{k}={v}' for k, v in payload['cookies'].items()
-                    ])
-                # using private attr so users only have access to a read-only property
-                session_context._request = _RequestProxy(request,
-                                                         arguments=payload.get('arguments'),
-                                                         cookies=payload.get('cookies'),
-                                                         headers=payload.get('headers'))
-            session_context._token = token
+        # Session initialization belongs to the application context, not to
+        # whichever HTTP or websocket request happened to start it. A dropped
+        # request must not cancel work that other waiters may still need.
+        return await asyncio.shield(pending)
 
-            # expose the session context to the document
-            # use the _attribute to set the public property .session_context
-            doc._session_context = weakref.ref(session_context)
-
-            try:
-                await self._application.on_session_created(session_context)
-            except Exception as e:
-                log.error("Failed to run session creation hooks %r", e, exc_info=True)
-
-            # Application code is arbitrary synchronous Python and can be
-            # expensive. Keeping it on the event-loop thread prevents the
-            # server from accepting unrelated HTTP and websocket work.
-            try:
-                if self._requires_worker_initialization():
-                    await asyncio.to_thread(self._initialize_document, doc)
-                else:
-                    # Preserve immediate creation for an empty Application. The
-                    # lifecycle handler does not execute user document code.
-                    self._initialize_document(doc)
-            except BaseException as error:
-                del self._pending_sessions[session_id]
-                future.set_exception(error)
-                # The initiating request observes the original exception. Mark
-                # it retrieved here in case there were no concurrent waiters.
-                future.exception()
-                raise
-
-            session = ServerSession(session_id, doc, io_loop=self._loop, token=token)
+    def _session_creation_done(self, session_id: ID, task: asyncio.Task[ServerSession]) -> None:
+        if self._pending_sessions.get(session_id) is task:
             del self._pending_sessions[session_id]
-            self._sessions[session_id] = session
-            session_context._set_session(session)
-            self._session_contexts[session_id] = session_context
 
-            # notify anyone waiting on the pending session
-            future.set_result(session)
+        if not task.cancelled() and (exception := task.exception()) is not None:
+            log.error("Failed to create session %r: %s", session_id, exception, exc_info=exception)
 
-        if session_id in self._pending_sessions:
-            # another create_session_if_needed is working on
-            # creating this session
-            session = await self._pending_sessions[session_id]
-        else:
-            session = self._sessions[session_id]
+    def _cancel_pending_sessions(self) -> tuple[asyncio.Task[ServerSession], ...]:
+        pending = tuple(self._pending_sessions.values())
+        for task in pending:
+            task.cancel()
+        return pending
 
+    async def _shutdown_pending_sessions(self) -> None:
+        if pending := self._cancel_pending_sessions():
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    async def _initialize_document_async(self, doc: Document) -> None:
+        if not self._requires_worker_initialization():
+            # Preserve immediate creation for an empty Application. The
+            # lifecycle handler does not execute user document code.
+            self._application.initialize_document(doc)
+            return
+
+        worker = asyncio.create_task(asyncio.to_thread(self._application.initialize_document, doc))
+        try:
+            await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            # Executor work cannot be stopped once running. Keep the session
+            # creation task alive until it has finished so orderly shutdown can
+            # run application unload hooks after initialization code exits.
+            try:
+                await worker
+            except Exception as error:
+                log.error("Failed to initialize cancelled session: %s", error, exc_info=error)
+            raise
+
+    async def _create_session(self, session_id: ID, request: RequestLike | None = None,
+            token: str | None = None) -> ServerSession:
+        doc = Document()
+
+        session_context = BokehSessionContext(session_id,
+                                              self.server_context,
+                                              doc,
+                                              logout_url=self._logout_url)
+        if request is not None:
+            payload = get_token_payload(token) if token else {}
+            if ('cookies' in payload and 'headers' in payload
+                and 'Cookie' not in payload['headers']):
+                # Restore Cookie header from cookies dictionary
+                payload['headers']['Cookie'] = '; '.join([
+                    f'{k}={v}' for k, v in payload['cookies'].items()
+                ])
+            # using private attr so users only have access to a read-only property
+            session_context._request = _RequestProxy(request,
+                                                     arguments=payload.get('arguments'),
+                                                     cookies=payload.get('cookies'),
+                                                     headers=payload.get('headers'))
+        session_context._token = token
+
+        # expose the session context to the document
+        # use the _attribute to set the public property .session_context
+        doc._session_context = weakref.ref(session_context)
+
+        try:
+            await self._application.on_session_created(session_context)
+        except Exception as e:
+            log.error("Failed to run session creation hooks %r", e, exc_info=True)
+
+        # Application code is arbitrary synchronous Python and can be
+        # expensive. Keeping it on the event-loop thread prevents the
+        # server from accepting unrelated HTTP and websocket work.
+        await self._initialize_document_async(doc)
+
+        io_loop = self._loop or asyncio.get_running_loop()
+        session = ServerSession(session_id, doc, io_loop=io_loop, token=token)
+        self._sessions[session_id] = session
+        session_context._set_session(session)
+        self._session_contexts[session_id] = session_context
         return session
 
     def get_session(self, session_id: ID) -> ServerSession:

--- a/src/bokeh/server/contexts.py
+++ b/src/bokeh/server/contexts.py
@@ -21,6 +21,8 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
+import threading
 import weakref
 from typing import (
     TYPE_CHECKING,
@@ -31,17 +33,11 @@ from typing import (
     cast,
 )
 
-# External imports
-from tornado.concurrent import Future
-
-if TYPE_CHECKING:
-    from tornado.httputil import HTTPServerRequest
-    from tornado.ioloop import IOLoop
-
 # Bokeh imports
 from ..application.application import ServerContext, SessionContext
 from ..document import Document
 from ..protocol.exceptions import ProtocolError
+from ..util.asyncio import Loop
 from ..util.token import get_token_payload
 from .session import ServerSession
 
@@ -49,6 +45,7 @@ if TYPE_CHECKING:
     from ..application.application import Application
     from ..core.types import ID
     from ..util.token import TokenPayload
+    from .request import RequestLike
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -154,11 +151,11 @@ class ApplicationContext:
     '''
 
     _sessions: dict[ID, ServerSession]
-    _pending_sessions: dict[ID, Future[ServerSession]]
+    _pending_sessions: dict[ID, asyncio.Future[ServerSession]]
     _session_contexts: dict[ID, SessionContext]
     _server_context: BokehServerContext
 
-    def __init__(self, application: Application, io_loop: IOLoop | None = None,
+    def __init__(self, application: Application, io_loop: Loop | None = None,
             url: str | None = None, logout_url: str | None = None):
         self._application = application
         self._loop = io_loop
@@ -168,9 +165,18 @@ class ApplicationContext:
         self._server_context = BokehServerContext(self)
         self._url = url
         self._logout_url = logout_url
+        # Application handlers commonly retain mutable execution state. Run
+        # document initialization away from the event loop, but serialize it
+        # per application to preserve the ordering guarantees of the Tornado
+        # implementation.
+        self._document_init_lock = threading.Lock()
+
+    def _initialize_document(self, doc: Document) -> None:
+        with self._document_init_lock:
+            self._application.initialize_document(doc)
 
     @property
-    def io_loop(self) -> IOLoop | None:
+    def io_loop(self) -> Loop | None:
         return self._loop
 
     @property
@@ -201,7 +207,7 @@ class ApplicationContext:
         except Exception as e:
             log.error(f"Error in server unloaded hook {e!r}", exc_info=True)
 
-    async def create_session_if_needed(self, session_id: ID, request: HTTPServerRequest | None = None,
+    async def create_session_if_needed(self, session_id: ID, request: RequestLike | None = None,
             token: str | None = None) -> ServerSession:
         # this is because empty session_ids would be "falsey" and
         # potentially open up a way for clients to confuse us
@@ -210,7 +216,7 @@ class ApplicationContext:
 
         if session_id not in self._sessions and \
            session_id not in self._pending_sessions:
-            future = self._pending_sessions[session_id] = Future()
+            future = self._pending_sessions[session_id] = asyncio.get_running_loop().create_future()
 
             doc = Document()
 
@@ -242,7 +248,10 @@ class ApplicationContext:
             except Exception as e:
                 log.error("Failed to run session creation hooks %r", e, exc_info=True)
 
-            self._application.initialize_document(doc)
+            # Application code is arbitrary synchronous Python and can be
+            # expensive. Keeping it on the event-loop thread prevents the
+            # server from accepting unrelated HTTP and websocket work.
+            await asyncio.to_thread(self._initialize_document, doc)
 
             session = ServerSession(session_id, doc, io_loop=self._loop, token=token)
             del self._pending_sessions[session_id]
@@ -335,7 +344,7 @@ class _RequestProxy:
 
     def __init__(
         self,
-        request: HTTPServerRequest,
+        request: RequestLike,
         arguments: dict[str, bytes | list[bytes]] | None = None,
         cookies: dict[str, str] | None = None,
         headers: dict[str, str | list[str]] | None = None,

--- a/src/bokeh/server/contexts.py
+++ b/src/bokeh/server/contexts.py
@@ -175,6 +175,10 @@ class ApplicationContext:
         with self._document_init_lock:
             self._application.initialize_document(doc)
 
+    def _requires_worker_initialization(self) -> bool:
+        from ..application.handlers.document_lifecycle import DocumentLifecycleHandler
+        return any(not isinstance(handler, DocumentLifecycleHandler) for handler in self._application._handlers)
+
     @property
     def io_loop(self) -> Loop | None:
         return self._loop
@@ -251,7 +255,20 @@ class ApplicationContext:
             # Application code is arbitrary synchronous Python and can be
             # expensive. Keeping it on the event-loop thread prevents the
             # server from accepting unrelated HTTP and websocket work.
-            await asyncio.to_thread(self._initialize_document, doc)
+            try:
+                if self._requires_worker_initialization():
+                    await asyncio.to_thread(self._initialize_document, doc)
+                else:
+                    # Preserve immediate creation for an empty Application. The
+                    # lifecycle handler does not execute user document code.
+                    self._initialize_document(doc)
+            except BaseException as error:
+                del self._pending_sessions[session_id]
+                future.set_exception(error)
+                # The initiating request observes the original exception. Mark
+                # it retrieved here in case there were no concurrent waiters.
+                future.exception()
+                raise
 
             session = ServerSession(session_id, doc, io_loop=self._loop, token=token)
             del self._pending_sessions[session_id]

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Mapping, Sequence
+from os import PathLike as OSPathLike
 from typing import TYPE_CHECKING, Any, Protocol as TypingProtocol, cast
 from urllib.parse import urljoin
 
@@ -24,7 +25,7 @@ from .contexts import ApplicationContext
 
 if TYPE_CHECKING:
     from ..application.handlers.function import ModifyDoc
-    from ..core.types import ID
+    from ..core.types import ID, PathLike
     from ..protocol import Protocol
     from .request import RequestLike
     from .session import ServerSession
@@ -147,7 +148,7 @@ class BokehServerCore(SessionConfig):
 
     def __init__(
         self,
-        applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
+        applications: Mapping[str, Application | ModifyDoc | PathLike] | Application | ModifyDoc | PathLike,
         *,
         absolute_url: str | None = None,
         prefix: str | None = None,
@@ -168,11 +169,22 @@ class BokehServerCore(SessionConfig):
     ) -> None:
         from ..application.handlers.document_lifecycle import DocumentLifecycleHandler
         from ..application.handlers.function import FunctionHandler
+        from ..application.handlers.script import ScriptHandler
 
-        if callable(applications):
-            applications = Application(FunctionHandler(applications))
-        if isinstance(applications, Application):
-            applications = {"/": applications}
+        def as_application(spec: Application | ModifyDoc | PathLike) -> Application:
+            if isinstance(spec, Application):
+                return spec
+            if isinstance(spec, (str, OSPathLike)):
+                handler = ScriptHandler(filename=spec)
+                if handler.failed:
+                    raise RuntimeError(f"Error loading {spec}:\n\n{handler.error}\n{handler.error_detail}")
+                return Application(handler)
+            if callable(spec):
+                return Application(FunctionHandler(spec))
+            raise TypeError(f"Expected an Application, callable, or script path, got {type(spec).__name__}")
+
+        if isinstance(applications, (Application, str, OSPathLike)) or callable(applications):
+            applications = {"/": as_application(applications)}
         else:
             applications = dict(applications)
 
@@ -182,8 +194,7 @@ class BokehServerCore(SessionConfig):
                 raise ValueError(f"Application path {url!r} must start with a slash")
             if url != "/":
                 url = url.rstrip("/")
-            if callable(app):
-                app = Application(FunctionHandler(app))
+            app = as_application(app)
             if all(not isinstance(handler, DocumentLifecycleHandler) for handler in app._handlers):
                 app.add(DocumentLifecycleHandler())
             normalized[url] = app

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 from collections.abc import Iterable, Mapping, Sequence
 from os import PathLike as OSPathLike
+from os.path import isdir
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -184,6 +185,7 @@ class BokehServerCore(SessionConfig):
         session_token_expiration: int = DEFAULT_SESSION_TOKEN_EXPIRATION,
         logout_url: str | None = None,
     ) -> None:
+        from ..application.handlers.directory import DirectoryHandler
         from ..application.handlers.document_lifecycle import DocumentLifecycleHandler
         from ..application.handlers.function import FunctionHandler
         from ..application.handlers.script import ScriptHandler
@@ -192,7 +194,7 @@ class BokehServerCore(SessionConfig):
             if isinstance(spec, Application):
                 return spec
             if isinstance(spec, (str, OSPathLike)):
-                handler = ScriptHandler(filename=spec)
+                handler = DirectoryHandler(filename=spec) if isdir(spec) else ScriptHandler(filename=spec)
                 if handler.failed:
                     raise RuntimeError(f"Error loading {spec}:\n\n{handler.error}\n{handler.error_detail}")
                 return Application(handler)

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -75,7 +75,7 @@ class SessionConfig(TypingProtocol):
 
 
 async def create_session(config: SessionConfig, context: ApplicationContext, request: RequestLike) -> ServerSession:
-    '''Resolve, validate, and create a session from an HTTP request. '''
+    '''Resolve, validate, and create a session from an HTTP request.'''
     token = _argument(request, "bokeh-token")
     session_id = cast("ID | None", _argument(request, "bokeh-session-id"))
     header_session_id = request.headers.get("Bokeh-Session-Id")

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from os import PathLike as OSPathLike
 from typing import TYPE_CHECKING, Any, Protocol as TypingProtocol, cast
 from urllib.parse import urljoin
@@ -97,8 +97,11 @@ async def create_session(config: SessionConfig, context: ApplicationContext, req
     if token is None:
         headers = _filtered_headers(config, request)
         cookies = _filtered_cookies(config, request)
-        if cookies and "Cookie" in headers and "Cookie" not in (config.include_headers or []):
-            del headers["Cookie"]
+        included_headers = {name.lower() for name in config.include_headers or ()}
+        if "cookie" not in included_headers:
+            for name in list(headers):
+                if name.lower() == "cookie":
+                    del headers[name]
         payload: dict[str, Any] = {
             "headers": headers,
             "cookies": cookies,
@@ -126,6 +129,7 @@ def _argument(request: RequestLike, name: str) -> str | None:
 
 
 def _filtered_headers(config: SessionConfig, request: RequestLike) -> dict[str, str]:
+    allowed: Iterable[str]
     if config.include_headers is None:
         excluded = {name.lower() for name in config.exclude_headers or ()}
         allowed = (name for name in request.headers if name.lower() not in excluded)
@@ -135,6 +139,7 @@ def _filtered_headers(config: SessionConfig, request: RequestLike) -> dict[str, 
 
 
 def _filtered_cookies(config: SessionConfig, request: RequestLike) -> dict[str, str]:
+    allowed: Iterable[str]
     if config.include_cookies is None:
         excluded = set(config.exclude_cookies or ())
         allowed = (name for name in request.cookies if name not in excluded)
@@ -242,6 +247,8 @@ class BokehServerCore(SessionConfig):
         self._clients: set[ServerConnection] = set()
         self._jobs: list[_AsyncPeriodic] = []
         self._started = False
+        self._stopping = False
+        self._stop_task: asyncio.Task[None] | None = None
 
     @property
     def applications(self) -> Mapping[str, ApplicationContext]:
@@ -299,6 +306,8 @@ class BokehServerCore(SessionConfig):
             context._loop = loop
 
     async def start(self) -> None:
+        if self._stopping:
+            raise RuntimeError("Bokeh server core is stopping")
         if self._started:
             return
         if self._loop is None:
@@ -314,19 +323,71 @@ class BokehServerCore(SessionConfig):
             self._jobs.append(_AsyncPeriodic(self._keep_alive, self._keep_alive_milliseconds, self._loop))
         for job in self._jobs:
             job.start()
-        await asyncio.gather(*(asyncio.to_thread(context.run_load_hook) for context in self._applications.values()))
+        for context in self._applications.values():
+            context.run_load_hook()
 
     async def stop(self) -> None:
+        if self._stop_task is not None:
+            await asyncio.shield(self._stop_task)
+            return
         if not self._started:
             return
-        for job in self._jobs:
-            job.stop()
-        self._jobs.clear()
-        await asyncio.gather(*(context._shutdown_pending_sessions() for context in self._applications.values()))
-        await asyncio.gather(*(asyncio.to_thread(context.run_unload_hook) for context in self._applications.values()))
-        for connection in list(self._clients):
-            self.client_lost(connection)
-        self._started = False
+        self._stopping = True
+        task = self._stop_task = asyncio.create_task(self._stop())
+        task.add_done_callback(self._stop_done)
+        await asyncio.shield(task)
+
+    async def _stop(self) -> None:
+        try:
+            jobs = tuple(self._jobs)
+            for job in jobs:
+                job.stop()
+            self._jobs.clear()
+            pending_sessions = tuple(
+                task
+                for context in self._applications.values()
+                for task in context._cancel_pending_sessions()
+            )
+
+            async def wait_for_pending_sessions() -> None:
+                if pending_sessions:
+                    await asyncio.gather(*pending_sessions, return_exceptions=True)
+
+            await asyncio.gather(
+                *(job.wait() for job in jobs),
+                wait_for_pending_sessions(),
+            )
+            for connection in list(self._clients):
+                self.client_lost(connection)
+            await asyncio.gather(*(context._shutdown_sessions() for context in self._applications.values()))
+            for context in self._applications.values():
+                context.run_unload_hook()
+
+            if not self._clients and all(not list(context.sessions) for context in self._applications.values()):
+                self._loop = None
+                for context in self._applications.values():
+                    context._loop = None
+        finally:
+            self._started = False
+            self._stopping = False
+
+    def _stop_done(self, task: asyncio.Task[None]) -> None:
+        if self._stop_task is task:
+            self._stop_task = None
+        if task.cancelled():
+            self._started = False
+            self._stopping = False
+        else:
+            # Retrieve failures even when the caller awaiting stop() was itself
+            # cancelled. Awaiting the completed task still propagates them to
+            # any other caller.
+            task.exception()
+
+    def _require_running(self) -> None:
+        if self._stopping:
+            raise RuntimeError("Bokeh server core is stopping")
+        if not self._started:
+            raise RuntimeError("Bokeh server core is not running")
 
     def resources(self, absolute_url: str | bool | None = None, *, root_path: str = "") -> Resources:
         mode = settings.resources(default="server")
@@ -340,10 +401,17 @@ class BokehServerCore(SessionConfig):
         return Resources(mode=mode)
 
     async def create_session(self, context: ApplicationContext, request: RequestLike) -> ServerSession:
+        self._require_running()
         return await create_session(self, context, request)
+
+    async def create_session_if_needed(self, context: ApplicationContext, session_id: ID,
+            request: RequestLike | None = None, token: str | None = None) -> ServerSession:
+        self._require_running()
+        return await context.create_session_if_needed(session_id, request, token)
 
     def new_connection(self, protocol: Protocol, transport: WebSocketTransport,
             application_context: ApplicationContext, session: ServerSession) -> ServerConnection:
+        self._require_running()
         connection = ServerConnection(protocol, transport, application_context, session)
         self._clients.add(connection)
         return connection

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -322,6 +322,7 @@ class BokehServerCore(SessionConfig):
         for job in self._jobs:
             job.stop()
         self._jobs.clear()
+        await asyncio.gather(*(context._shutdown_pending_sessions() for context in self._applications.values()))
         await asyncio.gather(*(asyncio.to_thread(context.run_unload_hook) for context in self._applications.values()))
         for connection in list(self._clients):
             self.client_lost(connection)

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -8,18 +8,30 @@
 
 from __future__ import annotations
 
+# Standard library imports
 import asyncio
 import logging
 from collections.abc import Iterable, Mapping, Sequence
 from os import PathLike as OSPathLike
-from typing import TYPE_CHECKING, Any, Protocol as TypingProtocol, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Protocol as TypingProtocol,
+    cast,
+)
 from urllib.parse import urljoin
 
+# Bokeh imports
 from ..application import Application
 from ..resources import Resources
 from ..settings import settings
 from ..util.asyncio import _AsyncPeriodic
-from ..util.token import check_token_signature, generate_jwt_token, generate_session_id, get_session_id
+from ..util.token import (
+    check_token_signature,
+    generate_jwt_token,
+    generate_session_id,
+    get_session_id,
+)
 from .connection import ServerConnection
 from .contexts import ApplicationContext
 

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -1,0 +1,367 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc. and contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Framework-neutral state and lifecycle management for Bokeh servers. '''
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Protocol as TypingProtocol, cast
+from urllib.parse import urljoin
+
+from ..application import Application
+from ..resources import Resources
+from ..settings import settings
+from ..util.asyncio import _AsyncPeriodic
+from ..util.token import check_token_signature, generate_jwt_token, generate_session_id, get_session_id
+from .connection import ServerConnection
+from .contexts import ApplicationContext
+
+if TYPE_CHECKING:
+    from ..application.handlers.function import ModifyDoc
+    from ..core.types import ID
+    from ..protocol import Protocol
+    from .request import RequestLike
+    from .session import ServerSession
+    from .transport import WebSocketTransport
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CHECK_UNUSED_MS = 17_000
+DEFAULT_KEEP_ALIVE_MS = 37_000
+DEFAULT_STATS_LOG_FREQ_MS = 15_000
+DEFAULT_UNUSED_LIFETIME_MS = 15_000
+DEFAULT_SESSION_TOKEN_EXPIRATION = 300
+DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES = 20*1024*1024
+
+__all__ = (
+    "BokehServerCore",
+    "SessionError",
+    "create_session",
+)
+
+
+class SessionError(Exception):
+    ''' An HTTP-compatible error raised while resolving a server session. '''
+
+    def __init__(self, status: int, reason: str) -> None:
+        super().__init__(reason)
+        self.status = status
+        self.reason = reason
+
+
+class SessionConfig(TypingProtocol):
+    @property
+    def secret_key(self) -> bytes | None: ...
+    @property
+    def sign_sessions(self) -> bool: ...
+    @property
+    def generate_session_ids(self) -> bool: ...
+    @property
+    def session_token_expiration(self) -> int: ...
+    @property
+    def include_headers(self) -> list[str] | None: ...
+    @property
+    def exclude_headers(self) -> list[str] | None: ...
+    @property
+    def include_cookies(self) -> list[str] | None: ...
+    @property
+    def exclude_cookies(self) -> list[str] | None: ...
+
+
+async def create_session(config: SessionConfig, context: ApplicationContext, request: RequestLike) -> ServerSession:
+    '''Resolve, validate, and create a session from an HTTP request. '''
+    token = _argument(request, "bokeh-token")
+    session_id = cast("ID | None", _argument(request, "bokeh-session-id"))
+    header_session_id = request.headers.get("Bokeh-Session-Id")
+    if header_session_id is not None:
+        if session_id is not None:
+            raise SessionError(403, "session ID was provided as an argument and header")
+        session_id = cast("ID", header_session_id)
+
+    if token is not None:
+        if session_id is not None:
+            raise SessionError(403, "Both token and session ID were provided")
+        session_id = get_session_id(token)
+    elif session_id is None:
+        if not config.generate_session_ids:
+            raise SessionError(403, "No bokeh-session-id provided")
+        session_id = generate_session_id(secret_key=config.secret_key, signed=config.sign_sessions)
+
+    if token is None:
+        headers = _filtered_headers(config, request)
+        cookies = _filtered_cookies(config, request)
+        if cookies and "Cookie" in headers and "Cookie" not in (config.include_headers or []):
+            del headers["Cookie"]
+        payload: dict[str, Any] = {
+            "headers": headers,
+            "cookies": cookies,
+            "arguments": dict(request.arguments),
+        }
+        payload.update(context.application.process_request(request))
+        token = generate_jwt_token(
+            session_id,
+            secret_key=config.secret_key,
+            signed=config.sign_sessions,
+            expiration=config.session_token_expiration,
+            extra_payload=payload,
+        )
+
+    if not check_token_signature(token, secret_key=config.secret_key, signed=config.sign_sessions):
+        raise SessionError(403, "Invalid token or session ID")
+    return await context.create_session_if_needed(session_id, request, token)
+
+
+def _argument(request: RequestLike, name: str) -> str | None:
+    values = request.arguments.get(name)
+    if not values:
+        return None
+    return values[-1].decode("utf-8")
+
+
+def _filtered_headers(config: SessionConfig, request: RequestLike) -> dict[str, str]:
+    if config.include_headers is None:
+        excluded = {name.lower() for name in config.exclude_headers or ()}
+        allowed = (name for name in request.headers if name.lower() not in excluded)
+    else:
+        allowed = config.include_headers
+    return {name: request.headers[name] for name in allowed if name in request.headers}
+
+
+def _filtered_cookies(config: SessionConfig, request: RequestLike) -> dict[str, str]:
+    if config.include_cookies is None:
+        excluded = set(config.exclude_cookies or ())
+        allowed = (name for name in request.cookies if name not in excluded)
+    else:
+        allowed = config.include_cookies
+    return {name: request.cookies[name].value for name in allowed if name in request.cookies}
+
+
+class BokehServerCore(SessionConfig):
+    ''' Transport-independent Bokeh application, session, and connection state. '''
+
+    def __init__(
+        self,
+        applications: Mapping[str, Application | ModifyDoc] | Application | ModifyDoc,
+        *,
+        absolute_url: str | None = None,
+        prefix: str | None = None,
+        extra_websocket_origins: Sequence[str] | None = None,
+        secret_key: bytes | None = settings.secret_key_bytes(),
+        sign_sessions: bool = settings.sign_sessions(),
+        generate_session_ids: bool = True,
+        keep_alive_milliseconds: int = DEFAULT_KEEP_ALIVE_MS,
+        check_unused_sessions_milliseconds: int = DEFAULT_CHECK_UNUSED_MS,
+        unused_session_lifetime_milliseconds: int = DEFAULT_UNUSED_LIFETIME_MS,
+        stats_log_frequency_milliseconds: int = DEFAULT_STATS_LOG_FREQ_MS,
+        include_headers: list[str] | None = None,
+        include_cookies: list[str] | None = None,
+        exclude_headers: list[str] | None = None,
+        exclude_cookies: list[str] | None = None,
+        session_token_expiration: int = DEFAULT_SESSION_TOKEN_EXPIRATION,
+        logout_url: str | None = None,
+    ) -> None:
+        from ..application.handlers.document_lifecycle import DocumentLifecycleHandler
+        from ..application.handlers.function import FunctionHandler
+
+        if callable(applications):
+            applications = Application(FunctionHandler(applications))
+        if isinstance(applications, Application):
+            applications = {"/": applications}
+        else:
+            applications = dict(applications)
+
+        normalized: dict[str, Application] = {}
+        for url, app in applications.items():
+            if not url.startswith("/"):
+                raise ValueError(f"Application path {url!r} must start with a slash")
+            if url != "/":
+                url = url.rstrip("/")
+            if callable(app):
+                app = Application(FunctionHandler(app))
+            if all(not isinstance(handler, DocumentLifecycleHandler) for handler in app._handlers):
+                app.add(DocumentLifecycleHandler())
+            normalized[url] = app
+
+        if keep_alive_milliseconds < 0:
+            raise ValueError("keep_alive_milliseconds must be >= 0")
+        if check_unused_sessions_milliseconds <= 0:
+            raise ValueError("check_unused_sessions_milliseconds must be > 0")
+        if unused_session_lifetime_milliseconds <= 0:
+            raise ValueError("unused_session_lifetime_milliseconds must be > 0")
+        if stats_log_frequency_milliseconds <= 0:
+            raise ValueError("stats_log_frequency_milliseconds must be > 0")
+        if session_token_expiration <= 0:
+            raise ValueError("session_token_expiration must be > 0")
+        if exclude_cookies and include_cookies:
+            raise ValueError("Declare either an include or an exclude list for the cookies, not both.")
+        if exclude_headers and include_headers:
+            raise ValueError("Declare either an include or an exclude list for the headers, not both.")
+
+        prefix = "" if prefix is None else prefix.strip("/")
+        self._prefix = f"/{prefix}" if prefix else ""
+        self._absolute_url = absolute_url
+        self._websocket_origins = set(extra_websocket_origins or ())
+        self._secret_key = secret_key
+        self._sign_sessions = sign_sessions
+        self._generate_session_ids = generate_session_ids
+        self._session_token_expiration = session_token_expiration
+        self._include_headers = include_headers
+        self._exclude_headers = exclude_headers
+        self._include_cookies = include_cookies
+        self._exclude_cookies = exclude_cookies
+        self._keep_alive_milliseconds = keep_alive_milliseconds
+        self._check_unused_sessions_milliseconds = check_unused_sessions_milliseconds
+        self._unused_session_lifetime_milliseconds = unused_session_lifetime_milliseconds
+        self._stats_log_frequency_milliseconds = stats_log_frequency_milliseconds
+
+        self._applications: dict[str, ApplicationContext] = {}
+        for url, app in normalized.items():
+            app_logout_url = logout_url
+            if app_logout_url is not None:
+                app_logout_url = urljoin(self._prefix + "/", app_logout_url.lstrip("/"))
+            self._applications[url] = ApplicationContext(app, url=url, logout_url=app_logout_url)
+
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._clients: set[ServerConnection] = set()
+        self._jobs: list[_AsyncPeriodic] = []
+        self._started = False
+
+    @property
+    def applications(self) -> Mapping[str, ApplicationContext]:
+        return self._applications
+
+    @property
+    def app_paths(self) -> set[str]:
+        return set(self._applications)
+
+    @property
+    def prefix(self) -> str:
+        return self._prefix
+
+    @property
+    def websocket_origins(self) -> set[str]:
+        return self._websocket_origins
+
+    @property
+    def secret_key(self) -> bytes | None:
+        return self._secret_key
+
+    @property
+    def sign_sessions(self) -> bool:
+        return self._sign_sessions
+
+    @property
+    def generate_session_ids(self) -> bool:
+        return self._generate_session_ids
+
+    @property
+    def session_token_expiration(self) -> int:
+        return self._session_token_expiration
+
+    @property
+    def include_headers(self) -> list[str] | None:
+        return self._include_headers
+
+    @property
+    def exclude_headers(self) -> list[str] | None:
+        return self._exclude_headers
+
+    @property
+    def include_cookies(self) -> list[str] | None:
+        return self._include_cookies
+
+    @property
+    def exclude_cookies(self) -> list[str] | None:
+        return self._exclude_cookies
+
+    def initialize(self, loop: asyncio.AbstractEventLoop) -> None:
+        if self._loop is not None and self._loop is not loop:
+            raise RuntimeError("BokehServerCore is already bound to another event loop")
+        self._loop = loop
+        for context in self._applications.values():
+            context._loop = loop
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        if self._loop is None:
+            self.initialize(asyncio.get_running_loop())
+        assert self._loop is not None
+        self._started = True
+
+        self._jobs = [
+            _AsyncPeriodic(self._log_stats, self._stats_log_frequency_milliseconds, self._loop),
+            _AsyncPeriodic(self._cleanup_sessions, self._check_unused_sessions_milliseconds, self._loop),
+        ]
+        if self._keep_alive_milliseconds:
+            self._jobs.append(_AsyncPeriodic(self._keep_alive, self._keep_alive_milliseconds, self._loop))
+        for job in self._jobs:
+            job.start()
+        await asyncio.gather(*(asyncio.to_thread(context.run_load_hook) for context in self._applications.values()))
+
+    async def stop(self) -> None:
+        if not self._started:
+            return
+        for job in self._jobs:
+            job.stop()
+        self._jobs.clear()
+        await asyncio.gather(*(asyncio.to_thread(context.run_unload_hook) for context in self._applications.values()))
+        for connection in list(self._clients):
+            self.client_lost(connection)
+        self._started = False
+
+    def resources(self, absolute_url: str | bool | None = None, *, root_path: str = "") -> Resources:
+        mode = settings.resources(default="server")
+        if mode in ("server", "server-dev"):
+            if absolute_url is True:
+                absolute_url = self._absolute_url
+            if absolute_url is None or absolute_url is False:
+                absolute_url = "/"
+            resource_path = root_path.rstrip("/") + self._prefix
+            return Resources(mode=mode, root_url=urljoin(absolute_url, resource_path))
+        return Resources(mode=mode)
+
+    async def create_session(self, context: ApplicationContext, request: RequestLike) -> ServerSession:
+        return await create_session(self, context, request)
+
+    def new_connection(self, protocol: Protocol, transport: WebSocketTransport,
+            application_context: ApplicationContext, session: ServerSession) -> ServerConnection:
+        connection = ServerConnection(protocol, transport, application_context, session)
+        self._clients.add(connection)
+        return connection
+
+    def client_lost(self, connection: ServerConnection) -> None:
+        self._clients.discard(connection)
+        connection.detach_session()
+
+    def get_session(self, app_path: str, session_id: ID) -> ServerSession:
+        if app_path not in self._applications:
+            raise ValueError(f"Application {app_path} does not exist on this server")
+        return self._applications[app_path].get_session(session_id)
+
+    def get_sessions(self, app_path: str) -> list[ServerSession]:
+        if app_path not in self._applications:
+            raise ValueError(f"Application {app_path} does not exist on this server")
+        return list(self._applications[app_path].sessions)
+
+    async def _cleanup_sessions(self) -> None:
+        for context in self._applications.values():
+            await context._cleanup_sessions(self._unused_session_lifetime_milliseconds)
+
+    def _log_stats(self) -> None:
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug("%d clients connected", len(self._clients))
+            for path, context in self._applications.items():
+                sessions = list(context.sessions)
+                unused = sum(session.connection_count == 0 for session in sessions)
+                log.debug("%s has %d sessions with %d unused", path, len(sessions), unused)
+
+    def _keep_alive(self) -> None:
+        for connection in list(self._clients):
+            connection.send_ping()

--- a/src/bokeh/server/request.py
+++ b/src/bokeh/server/request.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 # Standard library imports
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Any, Protocol
 
 __all__ = (
     'ServerRequest',
@@ -70,3 +70,5 @@ class ServerRequest:
     host: str = ""
     query: str = ""
     root_path: str = ""
+    user: Any = None
+    state: Mapping[str, Any] = field(default_factory=dict)

--- a/src/bokeh/server/request.py
+++ b/src/bokeh/server/request.py
@@ -18,15 +18,22 @@ __all__ = (
 )
 
 class CookieValue(Protocol):
-    value: str
+    @property
+    def value(self) -> str: ...
 
 class RequestLike(Protocol):
-    method: str
-    uri: str
-    path: str
-    arguments: Mapping[str, list[bytes]]
-    headers: Mapping[str, str]
-    cookies: Mapping[str, CookieValue]
+    @property
+    def method(self) -> str: ...
+    @property
+    def uri(self) -> str: ...
+    @property
+    def path(self) -> str: ...
+    @property
+    def arguments(self) -> Mapping[str, list[bytes]]: ...
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+    @property
+    def cookies(self) -> Mapping[str, CookieValue]: ...
 
 class Headers(Mapping[str, str]):
     ''' A small, case-insensitive HTTP header mapping. '''

--- a/src/bokeh/server/request.py
+++ b/src/bokeh/server/request.py
@@ -1,0 +1,65 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Framework-neutral HTTP request types used by Bokeh server applications. '''
+
+from __future__ import annotations
+
+# Standard library imports
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from typing import Protocol
+
+__all__ = (
+    'ServerRequest',
+)
+
+class CookieValue(Protocol):
+    value: str
+
+class RequestLike(Protocol):
+    method: str
+    uri: str
+    path: str
+    arguments: Mapping[str, list[bytes]]
+    headers: Mapping[str, str]
+    cookies: Mapping[str, CookieValue]
+
+class Headers(Mapping[str, str]):
+    ''' A small, case-insensitive HTTP header mapping. '''
+
+    def __init__(self, values: Mapping[str, str] | None = None) -> None:
+        self._values: dict[str, tuple[str, str]] = {}
+        if values is not None:
+            for name, value in values.items():
+                self._values[name.lower()] = (name, value)
+
+    def __getitem__(self, name: str) -> str:
+        return self._values[name.lower()][1]
+
+    def __iter__(self) -> Iterator[str]:
+        return (name for name, _ in self._values.values())
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+@dataclass(frozen=True)
+class Cookie:
+    value: str
+
+@dataclass
+class ServerRequest:
+    method: str
+    uri: str
+    path: str
+    arguments: dict[str, list[bytes]] = field(default_factory=dict)
+    headers: Headers = field(default_factory=Headers)
+    cookies: dict[str, Cookie] = field(default_factory=dict)
+    remote_ip: str | None = None
+    protocol: str = "http"
+    host: str = ""
+    query: str = ""
+    root_path: str = ""

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -63,7 +63,7 @@ from ..server.auth_provider import AuthModule, AuthProvider, NullAuth
 from ..settings import settings
 from ..util.options import Options
 from .tornado import DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES, BokehTornado
-from .util import bind_sockets, create_hosts_allowlist
+from .util import create_hosts_allowlist
 
 if TYPE_CHECKING:
     from ..application.application import Application
@@ -79,11 +79,23 @@ if TYPE_CHECKING:
 __all__ = (
     'BaseServer',
     'Server',
+    'bind_sockets',
 )
 
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------
+
+def bind_sockets(address: str | None, port: int) -> tuple[list[socket.socket], int]:
+    '''Bind sockets to one port, including when the OS selects the port.'''
+    sockets = netutil.bind_sockets(port=port or 0, address=address)
+    assert sockets
+    ports = {sock.getsockname()[1] for sock in sockets}
+    assert len(ports) == 1, "Multiple ports assigned??"
+    actual_port = ports.pop()
+    if port:
+        assert actual_port == port
+    return sockets, actual_port
 
 class BaseServer:
     ''' Explicitly coordinate the level Tornado components required to run a

--- a/src/bokeh/server/server.py
+++ b/src/bokeh/server/server.py
@@ -46,7 +46,12 @@ import atexit
 import signal
 import socket
 import sys
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Mapping,
+    cast,
+)
 
 # External imports
 from tornado import netutil, version as tornado_version
@@ -135,6 +140,7 @@ class BaseServer:
 
         self._started = False
         self._stopped = False
+        self._stop_task: asyncio.Task[None] | None = None
 
         self._http = http_server
         self._loop = io_loop
@@ -176,14 +182,56 @@ class BaseServer:
             wait (bool):
                 Whether to wait for orderly cleanup (default: True)
 
+                A synchronous call made from the server's own running event
+                loop cannot block that loop. In that case cleanup is scheduled
+                and this method returns; await :meth:`wait_until_stopped` for
+                the completion barrier. Async callers may instead use
+                :meth:`stop_async` directly.
+
         Returns:
             None
 
         '''
         assert not self._stopped, "Already stopped"
         self._stopped = True
-        self._tornado.stop(wait)
         self._http.stop()
+
+        asyncio_loop = cast(asyncio.AbstractEventLoop, getattr(self._loop, "asyncio_loop"))
+        if wait and asyncio_loop.is_running():
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            if running_loop is asyncio_loop:
+                assert running_loop is not None
+                # A synchronous method cannot block the event-loop thread. Keep
+                # ownership of the task, and expose stop_async()/wait_until_stopped()
+                # to callers that need a completion barrier before stopping it.
+                self._tornado._begin_shutdown()
+                self._stop_task = running_loop.create_task(self._tornado.stop_async())
+                return
+
+        self._tornado.stop(wait)
+
+    async def stop_async(self) -> None:
+        '''Stop the Bokeh Server and await orderly application cleanup.
+
+        Use this instead of :meth:`stop` from async code when subsequent work
+        depends on all sessions and lifecycle hooks having finished. Like
+        :meth:`stop`, this method may only be called once.
+
+        '''
+
+        assert not self._stopped, "Already stopped"
+        self._stopped = True
+        self._http.stop()
+        await self._tornado.stop_async()
+
+    async def wait_until_stopped(self) -> None:
+        '''Wait for same-loop cleanup scheduled by :meth:`stop` to complete.'''
+
+        if self._stop_task is not None:
+            await self._stop_task
 
     def unlisten(self) -> None:
         ''' Stop listening on ports. The server will no longer be usable after

--- a/src/bokeh/server/session.py
+++ b/src/bokeh/server/session.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
 import inspect
 import time
 from copy import copy
@@ -33,14 +34,9 @@ from typing import (
     cast,
 )
 
-# External imports
-from tornado import locks
-
-if TYPE_CHECKING:
-    from tornado.ioloop import IOLoop
-
 # Bokeh imports
 from ..events import ConnectionLost
+from ..util.asyncio import Loop
 from ..util.token import generate_jwt_token
 from .callbacks import DocumentCallbackGroup
 
@@ -86,7 +82,7 @@ def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
             return None
         self.block_expiration()
         try:
-            with await self._lock.acquire():
+            async with self._lock:
                 if self._pending_writes is not None:
                     raise RuntimeError("internal class invariant violated: _pending_writes " + \
                                        "should be None if lock is not held")
@@ -129,7 +125,7 @@ class ServerSession:
     _current_patch_connection: ServerConnection | None
     _pending_writes: list[Awaitable[None]] | None
 
-    def __init__(self, session_id: ID, document: Document, io_loop: IOLoop | None = None, token: str | None = None) -> None:
+    def __init__(self, session_id: ID, document: Document, io_loop: Loop | None = None, token: str | None = None) -> None:
         if session_id is None:
             raise ValueError("Sessions must have an id")
         if document is None:
@@ -140,7 +136,7 @@ class ServerSession:
         self._loop = io_loop
         self._subscribed_connections = set()
         self._last_unsubscribe_time = current_time()
-        self._lock = locks.Lock()
+        self._lock = asyncio.Lock()
         self._current_patch_connection = None
         self._document.callbacks.on_change_dispatch_to(self)
         self._callbacks = DocumentCallbackGroup(cast(Any, io_loop))

--- a/src/bokeh/server/session.py
+++ b/src/bokeh/server/session.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # Standard library imports
 import asyncio
 import inspect
+import threading
 import time
 from copy import copy
 from functools import wraps
@@ -87,12 +88,35 @@ def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
                     raise RuntimeError("internal class invariant violated: _pending_writes " + \
                                        "should be None if lock is not held")
                 self._pending_writes = []
+                error: BaseException | None = None
+                result: Any = None
                 try:
-                    result = func(self, *args, **kwargs)
-                    if inspect.isawaitable(result):
-                        # Note that this must not be outside of the critical section.
-                        # Otherwise, the async callback will be ran without document locking.
+                    # Document operations are serialized by the per-session
+                    # lock, but arbitrary synchronous user callbacks must not
+                    # occupy the shared event-loop thread. ``to_thread`` uses
+                    # the loop's bounded executor and propagates context vars,
+                    # including the active ``curdoc()`` context.
+                    worker = asyncio.create_task(asyncio.to_thread(func, self, *args, **kwargs))
+                    cancelled: asyncio.CancelledError | None = None
+                    while True:
+                        try:
+                            result = await asyncio.shield(worker)
+                            break
+                        except asyncio.CancelledError as cancellation:
+                            # A running thread cannot be cancelled. Keep the
+                            # document lock and pending-write state alive until
+                            # it finishes, then propagate cancellation.
+                            cancelled = cancellation
+                    if cancelled is not None:
+                        if inspect.iscoroutine(result):
+                            result.close()
+                        error = cancelled
+                    elif inspect.isawaitable(result):
+                        # Async callbacks continue on the event loop while
+                        # retaining the document lock across awaits.
                         result = await result
+                except BaseException as callback_error:
+                    error = callback_error
                 finally:
                     # we want to be very sure we reset this or we'll
                     # keep hitting the RuntimeError above as soon as
@@ -101,6 +125,8 @@ def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
                     self._pending_writes = None
                 for p in pending_writes:
                     await p
+                if error is not None:
+                    raise error
             return result
         finally:
             self.unblock_expiration()
@@ -135,6 +161,7 @@ class ServerSession:
         self._document = document
         self._loop = io_loop
         self._subscribed_connections = set()
+        self._connections_lock = threading.Lock()
         self._last_unsubscribe_time = current_time()
         self._lock = asyncio.Lock()
         self._current_patch_connection = None
@@ -202,20 +229,24 @@ class ServerSession:
 
     def subscribe(self, connection: ServerConnection) -> None:
         """This should only be called by ``ServerConnection.subscribe_session`` or our book-keeping will be broken"""
-        self._subscribed_connections.add(connection)
+        with self._connections_lock:
+            self._subscribed_connections.add(connection)
 
     def unsubscribe(self, connection: ServerConnection) -> None:
         """This should only be called by ``ServerConnection.unsubscribe_session`` or our book-keeping will be broken"""
-        self._subscribed_connections.discard(connection)
-        self._last_unsubscribe_time = current_time()
+        with self._connections_lock:
+            self._subscribed_connections.discard(connection)
+            self._last_unsubscribe_time = current_time()
 
     @property
     def connection_count(self) -> int:
-        return len(self._subscribed_connections)
+        with self._connections_lock:
+            return len(self._subscribed_connections)
 
     @property
     def milliseconds_since_last_unsubscribe(self) -> float:
-        return current_time() - self._last_unsubscribe_time
+        with self._connections_lock:
+            return current_time() - self._last_unsubscribe_time
 
     @_needs_document_lock
     def with_document_locked[T](self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
@@ -243,7 +274,9 @@ class ServerSession:
         # TODO (havocp): our "change sync" protocol is flawed because if both
         # sides change the same attribute at the same time, they will each end
         # up with the state of the other and their final states will differ.
-        for connection in self._subscribed_connections:
+        with self._connections_lock:
+            connections = list(self._subscribed_connections)
+        for connection in connections:
             if may_suppress and connection is self._current_patch_connection:
                 continue
             self._pending_writes.append(connection.send_patch_document(event))

--- a/src/bokeh/server/session.py
+++ b/src/bokeh/server/session.py
@@ -103,15 +103,29 @@ def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
                             result = await asyncio.shield(worker)
                             break
                         except asyncio.CancelledError as cancellation:
+                            if worker.done():
+                                if worker.cancelled():
+                                    error = cancelled or cancellation
+                                else:
+                                    try:
+                                        result = worker.result()
+                                    except BaseException as worker_error:
+                                        error = cancelled or worker_error
+                                    else:
+                                        cancelled = cancelled or cancellation
+                                break
                             # A running thread cannot be cancelled. Keep the
                             # document lock and pending-write state alive until
                             # it finishes, then propagate cancellation.
-                            cancelled = cancellation
-                    if cancelled is not None:
+                            cancelled = cancelled or cancellation
+                        except BaseException as worker_error:
+                            error = cancelled or worker_error
+                            break
+                    if error is None and cancelled is not None:
                         if inspect.iscoroutine(result):
                             result.close()
                         error = cancelled
-                    elif inspect.isawaitable(result):
+                    elif error is None and inspect.isawaitable(result):
                         # Async callbacks continue on the event loop while
                         # retaining the document lock across awaits.
                         result = await result
@@ -214,6 +228,10 @@ class ServerSession:
 
         self._callbacks.remove_all_callbacks()
         del self._callbacks
+
+    def _stop_callbacks(self) -> None:
+        """Prevent new document callbacks while orderly shutdown takes the lock."""
+        self._callbacks.remove_all_callbacks()
 
     def request_expiration(self) -> None:
         """ Used in test suite for now. Forces immediate expiration if no connections."""

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -664,6 +664,9 @@ class BokehTornado(TornadoApplication):
 
         '''
 
+        for context in self._applications.values():
+            context._cancel_pending_sessions()
+
         # TODO should probably close all connections and shut down all sessions here
         for context in self._applications.values():
             context.run_unload_hook()

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -52,6 +52,14 @@ from ..util.dependencies import import_optional
 from ..util.strings import format_docstring
 from .auth_provider import NullAuth
 from .connection import ServerConnection
+from .core import (
+    DEFAULT_CHECK_UNUSED_MS,
+    DEFAULT_KEEP_ALIVE_MS,
+    DEFAULT_SESSION_TOKEN_EXPIRATION,
+    DEFAULT_STATS_LOG_FREQ_MS,
+    DEFAULT_UNUSED_LIFETIME_MS,
+    DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
+)
 from .contexts import ApplicationContext
 from .urls import per_app_patterns, toplevel_patterns
 from .views.ico_handler import IcoHandler
@@ -71,13 +79,7 @@ if TYPE_CHECKING:
 # Globals and constants
 #-----------------------------------------------------------------------------
 
-DEFAULT_CHECK_UNUSED_MS                  = 17000
-DEFAULT_KEEP_ALIVE_MS                    = 37000  # heroku, nginx default to 60s timeout, so use less than that
 DEFAULT_MEM_LOG_FREQ_MS                  = 0
-DEFAULT_STATS_LOG_FREQ_MS                = 15000
-DEFAULT_UNUSED_LIFETIME_MS               = 15000
-DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES = 20*1024*1024
-DEFAULT_SESSION_TOKEN_EXPIRATION         = 300
 
 __all__ = (
     'BokehTornado',

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
 import gc
 import os
 import sys
@@ -32,6 +33,7 @@ from typing import (
     Any,
     Mapping,
     Sequence,
+    cast,
 )
 from urllib.parse import urljoin
 
@@ -52,6 +54,7 @@ from ..util.dependencies import import_optional
 from ..util.strings import format_docstring
 from .auth_provider import NullAuth
 from .connection import ServerConnection
+from .contexts import ApplicationContext
 from .core import (
     DEFAULT_CHECK_UNUSED_MS,
     DEFAULT_KEEP_ALIVE_MS,
@@ -59,8 +62,8 @@ from .core import (
     DEFAULT_STATS_LOG_FREQ_MS,
     DEFAULT_UNUSED_LIFETIME_MS,
     DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
+    create_session as _create_session,
 )
-from .contexts import ApplicationContext
 from .urls import per_app_patterns, toplevel_patterns
 from .views.ico_handler import IcoHandler
 from .views.root_handler import RootHandler
@@ -71,7 +74,9 @@ if TYPE_CHECKING:
     from ..application.handlers.function import ModifyDoc
     from ..core.types import ID
     from ..protocol import Protocol
+    from ..util.asyncio import Loop
     from .auth_provider import AuthProvider
+    from .request import RequestLike
     from .session import ServerSession
     from .urls import RouteContext, URLRoutes
 
@@ -404,6 +409,11 @@ class BokehTornado(TornadoApplication):
                 # (urljoin treats a leading-slash second arg as an absolute path and discards the base)
                 logout_url = urljoin(self._prefix + "/", logout_url.lstrip("/"))
             self._applications[url] = ApplicationContext(app, url=url, logout_url=logout_url)
+        self._stopping = False
+        self._shutdown_pending_sessions: tuple[asyncio.Task[ServerSession], ...] = ()
+        self._stop_task: asyncio.Task[None] | None = None
+        self._cleanup_idle = asyncio.Event()
+        self._cleanup_idle.set()
 
         extra_patterns = extra_patterns or []
         extra_patterns.extend(self.auth_provider.endpoints)
@@ -472,9 +482,14 @@ class BokehTornado(TornadoApplication):
         self._loop = io_loop
 
         for app_context in self._applications.values():
-            app_context._loop = self._loop
+            app_context._loop = cast("Loop", self._loop)
 
         self._clients = set()
+        self._stopping = False
+        self._shutdown_pending_sessions = ()
+        self._stop_task = None
+        self._cleanup_idle = asyncio.Event()
+        self._cleanup_idle.set()
 
         self._stats_job = PeriodicCallback(self._log_stats,
                                            self._stats_log_frequency_milliseconds)
@@ -643,6 +658,8 @@ class BokehTornado(TornadoApplication):
         startup hooks defined by the configured Bokeh applications will be run.
 
         '''
+        if self._stopping:
+            raise RuntimeError("Bokeh Tornado application is stopping")
         self._stats_job.start()
         if self._mem_job is not None:
             self._mem_job.start()
@@ -652,6 +669,59 @@ class BokehTornado(TornadoApplication):
 
         for context in self._applications.values():
             self._loop.add_callback(context.run_load_hook)
+
+    def _stop_jobs(self) -> None:
+        self._stats_job.stop()
+        if self._mem_job is not None:
+            self._mem_job.stop()
+        self._cleanup_job.stop()
+        if self._ping_job is not None:
+            self._ping_job.stop()
+
+    def _begin_shutdown(self) -> None:
+        if self._stopping:
+            return
+        self._stopping = True
+        self._stop_jobs()
+        self._shutdown_pending_sessions = tuple(
+            task
+            for context in self._applications.values()
+            for task in context._cancel_pending_sessions()
+        )
+
+    def _require_running(self) -> None:
+        if self._stopping:
+            raise RuntimeError("Bokeh Tornado application is stopping")
+
+    def _stop_without_waiting(self) -> None:
+        self._begin_shutdown()
+        for connection in list(self._clients):
+            self.client_lost(connection)
+        for context in self._applications.values():
+            context.run_unload_hook()
+        self._clients.clear()
+
+    async def stop_async(self) -> None:
+        '''Stop the Bokeh Server application and await orderly cleanup.'''
+
+        self._begin_shutdown()
+        if self._stop_task is None:
+            self._stop_task = asyncio.create_task(self._finish_stop())
+        elif self._stop_task.done():
+            self._stop_task.result()
+            return
+        await asyncio.shield(self._stop_task)
+
+    async def _finish_stop(self) -> None:
+        pending = asyncio.gather(*self._shutdown_pending_sessions, return_exceptions=True)
+        await asyncio.gather(self._cleanup_idle.wait(), pending)
+
+        for connection in list(self._clients):
+            self.client_lost(connection)
+        await asyncio.gather(*(context._shutdown_sessions() for context in self._applications.values()))
+        for context in self._applications.values():
+            context.run_unload_hook()
+        self._clients.clear()
 
     def stop(self, wait: bool = True) -> None:
         ''' Stop the Bokeh Server application.
@@ -664,27 +734,46 @@ class BokehTornado(TornadoApplication):
 
         '''
 
-        for context in self._applications.values():
-            context._cancel_pending_sessions()
+        if not wait:
+            self._stop_without_waiting()
+            return None
 
-        # TODO should probably close all connections and shut down all sessions here
-        for context in self._applications.values():
-            context.run_unload_hook()
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
 
-        self._stats_job.stop()
-        if self._mem_job is not None:
-            self._mem_job.stop()
-        self._cleanup_job.stop()
-        if self._ping_job is not None:
-            self._ping_job.stop()
-
-        self._clients.clear()
+        tornado_loop = getattr(self, "_loop", None)
+        asyncio_loop = getattr(tornado_loop, "asyncio_loop", None)
+        if asyncio_loop is None:
+            if running_loop is not None:
+                raise RuntimeError("Cannot synchronously wait on a running event loop; use 'await stop_async()'")
+            asyncio.run(self.stop_async())
+            return None
+        if asyncio_loop.is_running():
+            if running_loop is asyncio_loop:
+                raise RuntimeError("Cannot synchronously wait on a running event loop; use 'await stop_async()'")
+            future = asyncio.run_coroutine_threadsafe(self.stop_async(), asyncio_loop)
+            future.result()
+            return None
+        asyncio_loop.run_until_complete(self.stop_async())
+        return None
 
     def new_connection(self, protocol: Protocol, socket: WSHandler,
             application_context: ApplicationContext, session: ServerSession) -> ServerConnection:
+        self._require_running()
         connection = ServerConnection(protocol, socket, application_context, session)
         self._clients.add(connection)
         return connection
+
+    async def create_session(self, application_context: ApplicationContext, request: RequestLike) -> ServerSession:
+        self._require_running()
+        return await _create_session(self, application_context, request)
+
+    async def create_session_if_needed(self, application_context: ApplicationContext, session_id: ID,
+            request: RequestLike | None = None, token: str | None = None) -> ServerSession:
+        self._require_running()
+        return await application_context.create_session_if_needed(session_id, request, token)
 
     def client_lost(self, connection: ServerConnection) -> None:
         self._clients.discard(connection)
@@ -729,8 +818,12 @@ class BokehTornado(TornadoApplication):
 
     async def _cleanup_sessions(self) -> None:
         log.trace("Running session cleanup job") # type: ignore[attr-defined]
-        for app in self._applications.values():
-            await app._cleanup_sessions(self._unused_session_lifetime_milliseconds)
+        self._cleanup_idle.clear()
+        try:
+            for app in self._applications.values():
+                await app._cleanup_sessions(self._unused_session_lifetime_milliseconds)
+        finally:
+            self._cleanup_idle.set()
         return None
 
     def _log_stats(self) -> None:

--- a/src/bokeh/server/transport.py
+++ b/src/bokeh/server/transport.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+# Standard library imports
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:

--- a/src/bokeh/server/transport.py
+++ b/src/bokeh/server/transport.py
@@ -4,10 +4,18 @@
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-''' Compatibility imports for code that previously used Bokeh's Tornado utilities. '''
+''' Framework-neutral transport protocols for Bokeh server connections. '''
 
 from __future__ import annotations
 
-from .asyncio import _AsyncPeriodic, _CallbackGroup # noqa: F401
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from ..protocol.message import Message
 
 __all__ = ()
+
+class WebSocketTransport(Protocol):
+    async def send_message(self, message: Message[Any]) -> None: ...
+
+    def ping(self, data: bytes) -> None: ...

--- a/src/bokeh/server/util.py
+++ b/src/bokeh/server/util.py
@@ -27,9 +27,6 @@ from typing import TYPE_CHECKING, Sequence
 if TYPE_CHECKING:
     from socket import socket
 
-# External imports
-from tornado import netutil
-
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -65,14 +62,8 @@ def bind_sockets(address: str | None, port: int) -> tuple[list[socket], int]:
         (socket, port)
 
     '''
-    ss = netutil.bind_sockets(port=port or 0, address=address)
-    assert len(ss)
-    ports = {s.getsockname()[1] for s in ss}
-    assert len(ports) == 1, "Multiple ports assigned??"
-    actual_port = ports.pop()
-    if port:
-        assert actual_port == port
-    return ss, actual_port
+    from .server import bind_sockets
+    return bind_sockets(address, port)
 
 def check_allowlist(host: str, allowlist: Sequence[str]) -> bool:
     ''' Check a given request host against a allowlist.

--- a/src/bokeh/server/views/session_handler.py
+++ b/src/bokeh/server/views/session_handler.py
@@ -13,7 +13,7 @@
 #-----------------------------------------------------------------------------
 from __future__ import annotations
 
-# pyright: reportArgumentType=false
+# pyright: reportArgumentType=false, reportMissingImports=false
 
 import logging # isort:skip
 log = logging.getLogger(__name__)
@@ -23,22 +23,14 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 # External imports
 from tornado.httputil import HTTPServerRequest
 from tornado.web import HTTPError, authenticated
 
 # Bokeh imports
-from bokeh.core.types import ID
-from bokeh.util.token import (
-    check_token_signature,
-    generate_jwt_token,
-    generate_session_id,
-    get_session_id,
-)
-
-# Bokeh imports
+from ..core import SessionError, create_session
 from .auth_request_handler import AuthRequestHandler
 
 if TYPE_CHECKING:
@@ -84,69 +76,10 @@ class SessionHandler(AuthRequestHandler):
 
     @authenticated # type: ignore[arg-type]
     async def get_session(self) -> ServerSession | None:
-        app = self.application
-        token = self.get_argument("bokeh-token", default=None)
-        session_id = cast(ID | None, self.get_argument("bokeh-session-id", default=None))
-        if 'Bokeh-Session-Id' in self.request.headers:
-            if session_id is not None:
-                log.debug("Server received session ID in request argument and header, expected only one")
-                raise HTTPError(status_code=403, reason="session ID was provided as an argument and header")
-            session_id = cast(ID | None, self.request.headers.get('Bokeh-Session-Id'))
-
-        if token is not None:
-            if session_id is not None:
-                log.debug("Server received both token and session ID, expected only one")
-                raise HTTPError(status_code=403, reason="Both token and session ID were provided")
-            session_id = get_session_id(token)
-        elif session_id is None:
-            if app.generate_session_ids:
-                session_id = generate_session_id(secret_key=app.secret_key,
-                                                 signed=app.sign_sessions)
-            else:
-                log.debug("Server configured not to generate session IDs and none was provided")
-                raise HTTPError(status_code=403, reason="No bokeh-session-id provided")
-
-        if token is None:
-            if app.include_headers is None:
-                excluded_headers = (app.exclude_headers or [])
-                allowed_headers = [header for header in self.request.headers
-                                   if header not in excluded_headers]
-            else:
-                allowed_headers = app.include_headers
-            headers = {k: v for k, v in self.request.headers.items()
-                       if k in allowed_headers}
-
-            if app.include_cookies is None:
-                excluded_cookies = (app.exclude_cookies or [])
-                allowed_cookies = [cookie for cookie in self.request.cookies
-                                   if cookie not in excluded_cookies]
-            else:
-                allowed_cookies = app.include_cookies
-            cookies = {k: v.value for k, v in self.request.cookies.items()
-                       if k in allowed_cookies}
-
-            if cookies and 'Cookie' in headers and 'Cookie' not in (app.include_headers or []):
-                # Do not include Cookie header since cookies can be restored from cookies dict
-                del headers['Cookie']
-
-            arguments = {} if self.request.arguments is None else self.request.arguments
-            payload = {'headers': headers, 'cookies': cookies, 'arguments': arguments}
-            payload.update(self.application_context.application.process_request(self.request))
-            token = generate_jwt_token(session_id,
-                                       secret_key=app.secret_key,
-                                       signed=app.sign_sessions,
-                                       expiration=app.session_token_expiration,
-                                       extra_payload=payload)
-
-        if not check_token_signature(token,
-                                     secret_key=app.secret_key,
-                                     signed=app.sign_sessions):
-            log.error("Session id had invalid signature: %r", session_id)
-            raise HTTPError(status_code=403, reason="Invalid token or session ID")
-
-        session = await self.application_context.create_session_if_needed(session_id, self.request, token)
-
-        return session
+        try:
+            return await create_session(self.application, self.application_context, self.request)
+        except SessionError as error:
+            raise HTTPError(status_code=error.status, reason=error.reason)
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/src/bokeh/server/views/session_handler.py
+++ b/src/bokeh/server/views/session_handler.py
@@ -23,18 +23,19 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 # External imports
 from tornado.httputil import HTTPServerRequest
 from tornado.web import HTTPError, authenticated
 
 # Bokeh imports
-from ..core import SessionError, create_session
+from ..core import SessionError
 from .auth_request_handler import AuthRequestHandler
 
 if TYPE_CHECKING:
     from ..contexts import ApplicationContext
+    from ..request import RequestLike
     from ..session import ServerSession
     from ..tornado import BokehTornado
 
@@ -77,7 +78,8 @@ class SessionHandler(AuthRequestHandler):
     @authenticated # type: ignore[arg-type]
     async def get_session(self) -> ServerSession | None:
         try:
-            return await create_session(self.application, self.application_context, self.request)
+            request = cast("RequestLike", self.request)
+            return await self.application.create_session(self.application_context, request)
         except SessionError as error:
             raise HTTPError(status_code=error.status, reason=error.reason)
 

--- a/src/bokeh/server/views/ws.py
+++ b/src/bokeh/server/views/ws.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 import calendar
 import datetime as dt
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
 
 # External imports
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
     from ..connection import ServerConnection
     from ..contexts import ApplicationContext
+    from ..request import RequestLike
     from ..tornado import BokehTornado
 
 #-----------------------------------------------------------------------------
@@ -210,7 +211,8 @@ class WSHandler(AuthRequestHandler, WebSocketHandler):
         '''
         try:
             session_id = get_session_id(token)
-            await self.application_context.create_session_if_needed(session_id, self.request, token)
+            request = cast("RequestLike", self.request)
+            await self.application.create_session_if_needed(self.application_context, session_id, request, token)
             session = self.application_context.get_session(session_id)
 
             protocol = Protocol()

--- a/src/bokeh/util/asyncio.py
+++ b/src/bokeh/util/asyncio.py
@@ -1,0 +1,213 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Internal utilities for scheduling callbacks on asyncio event loops. '''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations
+
+import logging # isort:skip
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import asyncio
+import inspect
+import threading
+from collections import defaultdict
+from traceback import format_exception
+from typing import Any, Awaitable, Callable, Protocol
+
+# Bokeh imports
+from ..core.types import ID
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = ()
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+type CallbackSync = Callable[[], None]
+type CallbackAsync = Callable[[], Awaitable[None]]
+type Callback = CallbackSync | CallbackAsync
+
+type Remover = Callable[[], None]
+type Removers = dict[ID, Remover]
+type RemoversByCallable = dict[Callback, set[ID]]
+
+class _HasAsyncioLoop(Protocol):
+    asyncio_loop: asyncio.AbstractEventLoop
+
+type Loop = asyncio.AbstractEventLoop | _HasAsyncioLoop
+
+def _asyncio_loop(loop: Loop) -> asyncio.AbstractEventLoop:
+    if isinstance(loop, asyncio.AbstractEventLoop):
+        return loop
+    return loop.asyncio_loop
+
+def _log_task_exception(task: asyncio.Future[Any]) -> None:
+    if task.cancelled():
+        return
+    if (exception := task.exception()) is not None:
+        log.error("Error thrown from callback:")
+        lines = format_exception(exception.__class__, exception, exception.__traceback__)
+        log.error("".join(lines))
+
+class _AsyncPeriodic:
+    ''' Invoke a callback periodically without overlapping invocations. '''
+
+    def __init__(self, func: Callback, period: int, io_loop: Loop) -> None:
+        self._func = func
+        self._loop = _asyncio_loop(io_loop)
+        self._period = period / 1000.0
+        self._started = False
+        self._stopped = False
+        self._task: asyncio.Task[None] | None = None
+
+    async def _run(self) -> None:
+        await asyncio.sleep(self._period)
+        while not self._stopped:
+            started = self._loop.time()
+            result = self._func()
+            if inspect.isawaitable(result):
+                await result
+            elapsed = self._loop.time() - started
+            await asyncio.sleep(max(0, self._period - elapsed))
+
+    def start(self) -> None:
+        if self._started:
+            raise RuntimeError("called start() twice on _AsyncPeriodic")
+        self._started = True
+        self._task = self._loop.create_task(self._run())
+        self._task.add_done_callback(_log_task_exception)
+
+    def stop(self) -> None:
+        self._stopped = True
+        if self._task is not None:
+            if not self._loop.is_closed():
+                self._task.cancel()
+            self._task = None
+
+class _CallbackGroup:
+    ''' A removable collection of callbacks scheduled on an asyncio loop. '''
+
+    def __init__(self, io_loop: Loop) -> None:
+        self._loop_source = io_loop
+        self._next_tick_callback_removers: Removers = {}
+        self._timeout_callback_removers: Removers = {}
+        self._periodic_callback_removers: Removers = {}
+        self._removers_lock = threading.Lock()
+
+        self._next_tick_removers_by_callable: RemoversByCallable = defaultdict(set)
+        self._timeout_removers_by_callable: RemoversByCallable = defaultdict(set)
+        self._periodic_removers_by_callable: RemoversByCallable = defaultdict(set)
+
+    @property
+    def _loop(self) -> asyncio.AbstractEventLoop:
+        return _asyncio_loop(self._loop_source)
+
+    def remove_all_callbacks(self) -> None:
+        for cb_id in list(self._next_tick_callback_removers):
+            self.remove_next_tick_callback(cb_id)
+        for cb_id in list(self._timeout_callback_removers):
+            self.remove_timeout_callback(cb_id)
+        for cb_id in list(self._periodic_callback_removers):
+            self.remove_periodic_callback(cb_id)
+
+    def _get_removers_ids_by_callable(self, removers: Removers) -> RemoversByCallable:
+        if removers is self._next_tick_callback_removers:
+            return self._next_tick_removers_by_callable
+        elif removers is self._timeout_callback_removers:
+            return self._timeout_removers_by_callable
+        elif removers is self._periodic_callback_removers:
+            return self._periodic_removers_by_callable
+        else:
+            raise RuntimeError("Unhandled removers", removers)
+
+    def _assign_remover(self, callback: Callback, callback_id: ID, removers: Removers, remover: Remover) -> None:
+        with self._removers_lock:
+            if callback_id in removers:
+                raise ValueError("A callback of the same type has already been added with this ID")
+            removers[callback_id] = remover
+            self._get_removers_ids_by_callable(removers)[callback].add(callback_id)
+
+    def _execute_remover(self, callback_id: ID, removers: Removers) -> None:
+        try:
+            with self._removers_lock:
+                remover = removers.pop(callback_id)
+                removers_by_callable = self._get_removers_ids_by_callable(removers)
+                for callback, callback_ids in list(removers_by_callable.items()):
+                    callback_ids.discard(callback_id)
+                    if not callback_ids:
+                        del removers_by_callable[callback]
+        except KeyError:
+            raise ValueError("Removing a callback twice (or after it's already been run)")
+        remover()
+
+    def _invoke(self, callback: Callback) -> None:
+        result = callback()
+        if inspect.isawaitable(result):
+            future = asyncio.ensure_future(result, loop=self._loop)
+            future.add_done_callback(_log_task_exception)
+
+    def add_next_tick_callback(self, callback: Callback, callback_id: ID) -> ID:
+        removed = False
+
+        def wrapper() -> None:
+            if removed:
+                return
+            self.remove_next_tick_callback(callback_id)
+            self._invoke(callback)
+
+        def remover() -> None:
+            nonlocal removed
+            removed = True
+
+        self._assign_remover(callback, callback_id, self._next_tick_callback_removers, remover)
+        self._loop.call_soon_threadsafe(wrapper)
+        return callback_id
+
+    def remove_next_tick_callback(self, callback_id: ID) -> None:
+        self._execute_remover(callback_id, self._next_tick_callback_removers)
+
+    def add_timeout_callback(self, callback: CallbackSync, timeout_milliseconds: int, callback_id: ID) -> ID:
+        handle: asyncio.TimerHandle | None = None
+
+        def wrapper() -> None:
+            self.remove_timeout_callback(callback_id)
+            self._invoke(callback)
+
+        def remover() -> None:
+            if handle is not None:
+                handle.cancel()
+
+        self._assign_remover(callback, callback_id, self._timeout_callback_removers, remover)
+        handle = self._loop.call_later(timeout_milliseconds / 1000.0, wrapper)
+        return callback_id
+
+    def remove_timeout_callback(self, callback_id: ID) -> None:
+        self._execute_remover(callback_id, self._timeout_callback_removers)
+
+    def add_periodic_callback(self, callback: Callback, period_milliseconds: int, callback_id: ID) -> None:
+        periodic = _AsyncPeriodic(callback, period_milliseconds, io_loop=self._loop)
+        self._assign_remover(callback, callback_id, self._periodic_callback_removers, periodic.stop)
+        periodic.start()
+
+    def remove_periodic_callback(self, callback_id: ID) -> None:
+        self._execute_remover(callback_id, self._periodic_callback_removers)
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/src/bokeh/util/asyncio.py
+++ b/src/bokeh/util/asyncio.py
@@ -97,7 +97,7 @@ class _AsyncPeriodic:
         self._stopped = True
         if self._task is not None:
             if not self._loop.is_closed():
-                self._task.cancel()
+                self._loop.call_soon_threadsafe(self._task.cancel)
             self._task = None
 
 class _CallbackGroup:
@@ -119,12 +119,31 @@ class _CallbackGroup:
         return _asyncio_loop(self._loop_source)
 
     def remove_all_callbacks(self) -> None:
-        for cb_id in list(self._next_tick_callback_removers):
-            self.remove_next_tick_callback(cb_id)
-        for cb_id in list(self._timeout_callback_removers):
-            self.remove_timeout_callback(cb_id)
-        for cb_id in list(self._periodic_callback_removers):
-            self.remove_periodic_callback(cb_id)
+        with self._removers_lock:
+            next_tick_ids = list(self._next_tick_callback_removers)
+            timeout_ids = list(self._timeout_callback_removers)
+            periodic_ids = list(self._periodic_callback_removers)
+        groups = (
+            (next_tick_ids, self.remove_next_tick_callback),
+            (timeout_ids, self.remove_timeout_callback),
+            (periodic_ids, self.remove_periodic_callback),
+        )
+        for callback_ids, remover in groups:
+            for callback_id in callback_ids:
+                try:
+                    remover(callback_id)
+                except ValueError:
+                    pass
+
+    def _call_on_loop(self, callback: CallbackSync) -> None:
+        try:
+            on_loop = asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            on_loop = False
+        if on_loop:
+            callback()
+        else:
+            self._loop.call_soon_threadsafe(callback)
 
     def _get_removers_ids_by_callable(self, removers: Removers) -> RemoversByCallable:
         if removers is self._next_tick_callback_removers:
@@ -184,17 +203,29 @@ class _CallbackGroup:
 
     def add_timeout_callback(self, callback: CallbackSync, timeout_milliseconds: int, callback_id: ID) -> ID:
         handle: asyncio.TimerHandle | None = None
+        removed = False
+        state_lock = threading.Lock()
 
         def wrapper() -> None:
             self.remove_timeout_callback(callback_id)
             self._invoke(callback)
 
         def remover() -> None:
-            if handle is not None:
-                handle.cancel()
+            nonlocal removed
+            with state_lock:
+                removed = True
+                current_handle = handle
+            if current_handle is not None:
+                self._call_on_loop(current_handle.cancel)
+
+        def start() -> None:
+            nonlocal handle
+            with state_lock:
+                if not removed:
+                    handle = self._loop.call_later(timeout_milliseconds / 1000.0, wrapper)
 
         self._assign_remover(callback, callback_id, self._timeout_callback_removers, remover)
-        handle = self._loop.call_later(timeout_milliseconds / 1000.0, wrapper)
+        self._call_on_loop(start)
         return callback_id
 
     def remove_timeout_callback(self, callback_id: ID) -> None:
@@ -203,7 +234,7 @@ class _CallbackGroup:
     def add_periodic_callback(self, callback: Callback, period_milliseconds: int, callback_id: ID) -> None:
         periodic = _AsyncPeriodic(callback, period_milliseconds, io_loop=self._loop)
         self._assign_remover(callback, callback_id, self._periodic_callback_removers, periodic.stop)
-        periodic.start()
+        self._call_on_loop(periodic.start)
 
     def remove_periodic_callback(self, callback_id: ID) -> None:
         self._execute_remover(callback_id, self._periodic_callback_removers)

--- a/src/bokeh/util/asyncio.py
+++ b/src/bokeh/util/asyncio.py
@@ -24,7 +24,12 @@ import inspect
 import threading
 from collections import defaultdict
 from traceback import format_exception
-from typing import Any, Awaitable, Callable, Protocol
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Protocol,
+)
 
 # Bokeh imports
 from ..core.types import ID

--- a/src/bokeh/util/asyncio.py
+++ b/src/bokeh/util/asyncio.py
@@ -80,9 +80,14 @@ class _AsyncPeriodic:
         await asyncio.sleep(self._period)
         while not self._stopped:
             started = self._loop.time()
-            result = self._func()
-            if inspect.isawaitable(result):
-                await result
+            try:
+                result = self._func()
+                if inspect.isawaitable(result):
+                    await result
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.error("Error thrown from periodic callback:", exc_info=True)
             elapsed = self._loop.time() - started
             await asyncio.sleep(max(0, self._period - elapsed))
 
@@ -98,7 +103,18 @@ class _AsyncPeriodic:
         if self._task is not None:
             if not self._loop.is_closed():
                 self._loop.call_soon_threadsafe(self._task.cancel)
-            self._task = None
+
+    async def wait(self) -> None:
+        task = self._task
+        if task is None:
+            return
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            if self._task is task:
+                self._task = None
 
 class _CallbackGroup:
     ''' A removable collection of callbacks scheduled on an asyncio loop. '''

--- a/src/bokeh/util/tornado.py
+++ b/src/bokeh/util/tornado.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
-from .asyncio import _AsyncPeriodic, _CallbackGroup # noqa: F401
+# Bokeh imports
+from .asyncio import _AsyncPeriodic, _CallbackGroup  # noqa: F401
 
 __all__ = ()

--- a/tests/unit/bokeh/application/handlers/test_code_runner.py
+++ b/tests/unit/bokeh/application/handlers/test_code_runner.py
@@ -17,9 +17,11 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from concurrent.futures import ThreadPoolExecutor
 import os
 import sys
 from os.path import abspath, dirname
+from threading import Event
 from types import ModuleType
 
 # Module under test
@@ -173,6 +175,36 @@ class TestCodeRunner:
         m = cr.new_module()
         cr.run(m, lambda: None)
         assert sys.path == old_path
+
+    def test_run_serializes_process_global_mutations(self) -> None:
+        first_entered = Event()
+        first_release = Event()
+        second_entered = Event()
+
+        first = bahc.CodeRunner("entered.set(); release.wait()", "first.py", [])
+        first_module = first.new_module()
+        first_module.__dict__.update(entered=first_entered, release=first_release)
+
+        second = bahc.CodeRunner("entered.set()", "second.py", [])
+        second_module = second.new_module()
+        second_module.__dict__.update(entered=second_entered)
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        try:
+            first_future = executor.submit(first.run, first_module)
+            assert first_entered.wait(timeout=1)
+
+            second_future = executor.submit(second.run, second_module)
+            assert not second_entered.wait(timeout=0.1)
+
+            first_release.set()
+            first_future.result(timeout=1)
+            second_future.result(timeout=1)
+        finally:
+            first_release.set()
+            executor.shutdown(wait=True)
+
+        assert second_entered.is_set()
 
     def test_doc(self) -> None:
         cr = bahc.CodeRunner("'''some docstring\n\nfoo bar'''", "path", [])

--- a/tests/unit/bokeh/application/handlers/test_code_runner.py
+++ b/tests/unit/bokeh/application/handlers/test_code_runner.py
@@ -17,9 +17,9 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from concurrent.futures import ThreadPoolExecutor
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from os.path import abspath, dirname
 from threading import Event
 from types import ModuleType

--- a/tests/unit/bokeh/document/test_modules.py
+++ b/tests/unit/bokeh/document/test_modules.py
@@ -100,6 +100,25 @@ class TestDocumentModuleManager:
         assert len(dm) == 0
         assert 'FakeMod' not in sys.modules
 
+    def test_destroy_ignores_sys_modules_snapshot(self, caplog: pytest.LogCaptureFixture) -> None:
+        d = Document()
+        dm = bdm.DocumentModuleManager(d)
+
+        mod = FakeMod()
+        dm.add(mod)
+
+        # Runtime introspection may hold a shallow snapshot while the document
+        # is destroyed, especially during ASGI server shutdown.
+        modules_snapshot = sys.modules.copy()
+
+        with caplog.at_level(logging.ERROR):
+            dm.destroy()
+
+        assert modules_snapshot["FakeMod"] is mod
+        assert caplog.records == []
+        assert 'FakeMod' not in sys.modules
+        assert len(dm) == 0
+
     def test_extra_referrer_error(self, caplog: pytest.LogCaptureFixture) -> None:
         d = Document()
         dm = bdm.DocumentModuleManager(d)

--- a/tests/unit/bokeh/embed/test_server__embed.py
+++ b/tests/unit/bokeh/embed/test_server__embed.py
@@ -119,6 +119,14 @@ class TestServerDocument:
         request = f"xhr.open('GET', \"{url}/autoload.js?bokeh-autoload-element={divid}&bokeh-app-path=/foo/bar/sliders\", true);"
         assert request in script.string
 
+    def test_root_relative_url(self) -> None:
+        url = "/bkapp"
+        r = bes.server_document(url=url, relative_urls=True)
+
+        assert f'xhr.open(\'GET\', "{url}/autoload.js?' in r
+        assert "bokeh-app-path=/bkapp" in r
+        assert "bokeh-absolute-url" not in r
+
     @pytest.mark.parametrize("with_credentials", [True, False])
     def test_with_credentials(self, with_credentials):
         script = bes.server_document("http://localhost:8081/foo/bar/sliders", with_credentials=with_credentials)

--- a/tests/unit/bokeh/io/test_doc.py
+++ b/tests/unit/bokeh/io/test_doc.py
@@ -18,6 +18,7 @@ import pytest ; pytest
 
 # Standard library imports
 import gc
+import threading
 import weakref
 
 # Bokeh imports
@@ -52,20 +53,20 @@ def test_patch_curdoc() -> None:
     d2 = Document()
     orig_doc =  bid.curdoc()
 
-    assert bid._PATCHED_CURDOCS == []
+    assert bid._PATCHED_CURDOCS.get() == ()
 
     with bid.patch_curdoc(d1):
-        assert len(bid._PATCHED_CURDOCS) == 1
-        assert isinstance(bid._PATCHED_CURDOCS[0], weakref.ReferenceType)
+        assert len(bid._PATCHED_CURDOCS.get()) == 1
+        assert isinstance(bid._PATCHED_CURDOCS.get()[0], weakref.ReferenceType)
         assert bid.curdoc() is d1
 
         with bid.patch_curdoc(d2):
-            assert len(bid._PATCHED_CURDOCS) == 2
-            assert isinstance(bid._PATCHED_CURDOCS[1], weakref.ReferenceType)
+            assert len(bid._PATCHED_CURDOCS.get()) == 2
+            assert isinstance(bid._PATCHED_CURDOCS.get()[1], weakref.ReferenceType)
             assert bid.curdoc() is d2
 
-        assert len(bid._PATCHED_CURDOCS) == 1
-        assert isinstance(bid._PATCHED_CURDOCS[0], weakref.ReferenceType)
+        assert len(bid._PATCHED_CURDOCS.get()) == 1
+        assert isinstance(bid._PATCHED_CURDOCS.get()[0], weakref.ReferenceType)
         assert bid.curdoc() is d1
 
     assert bid.curdoc() is orig_doc
@@ -73,13 +74,13 @@ def test_patch_curdoc() -> None:
 def test_patch_curdoc_pops_after_exception() -> None:
     doc = Document()
 
-    assert bid._PATCHED_CURDOCS == []
+    assert bid._PATCHED_CURDOCS.get() == ()
 
     with pytest.raises(RuntimeError):
         with bid.patch_curdoc(doc):
             raise RuntimeError("boom")
 
-    assert bid._PATCHED_CURDOCS == []
+    assert bid._PATCHED_CURDOCS.get() == ()
 
 def _doc():
     return Document()
@@ -90,6 +91,24 @@ def test_patch_curdoc_weakref_raises() -> None:
         with pytest.raises(RuntimeError) as e:
             bid.curdoc()
         assert str(e.value) == "Patched curdoc has been previously destroyed"
+
+def test_patch_curdoc_is_context_local() -> None:
+    docs = [Document(), Document()]
+    barrier = threading.Barrier(2)
+    seen: list[Document] = []
+
+    def check(doc: Document) -> None:
+        with bid.patch_curdoc(doc):
+            barrier.wait()
+            seen.append(bid.curdoc())
+
+    threads = [threading.Thread(target=check, args=(doc,)) for doc in docs]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert set(seen) == set(docs)
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/tests/unit/bokeh/server/_util_server.py
+++ b/tests/unit/bokeh/server/_util_server.py
@@ -63,12 +63,13 @@ async def http_get(io_loop: IOLoop, url: str, headers: dict[str, str] | None = N
     return await http_client.fetch(url, headers=headers)
 
 async def websocket_open(io_loop: IOLoop, url: str, origin: str | None = None,
-        subprotocols: list[str] = []) -> WebSocketClientConnection:
+        subprotocols: list[str] | None = None, auto_close: bool = True) -> WebSocketClientConnection:
     request = HTTPRequest(url)
     if origin is not None:
         request.headers["Origin"] = origin
     result = await websocket_connect(request, subprotocols=subprotocols)
-    result.close()
+    if auto_close:
+        result.close()
     return result
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -25,6 +25,7 @@ from bokeh.document import Document
 from bokeh.models import ColumnDataSource, Select
 from bokeh.protocol import Protocol
 from bokeh.server.asgi import BokehASGI
+from bokeh.server.auth import AuthPolicy
 from bokeh.util.token import generate_jwt_token
 
 
@@ -35,6 +36,9 @@ async def http_request(
     query: dict[str, str] | None = None,
     method: str = "GET",
     root_path: str = "",
+    headers: list[tuple[bytes, bytes]] | None = None,
+    user: Any = None,
+    state: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     sent: list[dict[str, Any]] = []
 
@@ -55,8 +59,10 @@ async def http_request(
             "path": path,
             "root_path": root_path,
             "query_string": query_string,
-            "headers": [(b"host", b"localhost")],
+            "headers": [(b"host", b"localhost"), *(headers or [])],
             "client": ("127.0.0.1", 1234),
+            "user": user,
+            "state": state or {},
         },
         receive,
         send,
@@ -70,6 +76,11 @@ def response_status(events: list[dict[str, Any]]) -> int:
 
 def response_body(events: list[dict[str, Any]]) -> bytes:
     return b"".join(event.get("body", b"") for event in events if event["type"] == "http.response.body")
+
+
+def response_header(events: list[dict[str, Any]], name: bytes) -> bytes | None:
+    headers = events[0].get("headers", [])
+    return next((value for key, value in headers if key.lower() == name.lower()), None)
 
 
 def test_example_application_initializes() -> None:
@@ -202,6 +213,75 @@ async def test_autoload_and_static_routes() -> None:
         await app.core.stop()
 
 
+async def test_auth_policy_redirects_and_propagates_user() -> None:
+    authentication_state: list[dict[str, Any]] = []
+
+    def authenticate(request) -> str | None:
+        authentication_state.append(dict(request.state))
+        if request.headers.get("authorization") == "Bearer secret":
+            return "alice"
+        return None
+
+    def modify_document(doc) -> None:
+        doc.title = doc.session_context.request.user
+
+    policy = AuthPolicy(authenticate, login_url=lambda request: f"/login?next={request.path}", logout_url="/logout")
+    app = BokehASGI(Application(FunctionHandler(modify_document)), auth_policy=policy, keep_alive_milliseconds=0)
+    try:
+        anonymous = await http_request(app, "/", state={"request_id": "anonymous"})
+        authenticated = await http_request(
+            app,
+            "/",
+            headers=[(b"authorization", b"Bearer secret")],
+            state={"request_id": "authenticated"},
+        )
+
+        assert response_status(anonymous) == 302
+        assert response_header(anonymous, b"location") == b"/login?next=/"
+        assert response_status(authenticated) == 200
+        session = app.core.get_sessions("/")[0]
+        assert session.document.title == "alice"
+        assert session.document.session_context.request.user == "alice"
+        assert session.document.session_context.logout_url == "/logout"
+        assert authentication_state == [
+            {"request_id": "anonymous"},
+            {"request_id": "authenticated"},
+        ]
+    finally:
+        await app.core.stop()
+
+
+async def test_auth_policy_returns_401_without_login_url() -> None:
+    app = BokehASGI(Application(), auth_policy=AuthPolicy(lambda request: None), keep_alive_milliseconds=0)
+    try:
+        response = await http_request(app, "/metadata")
+
+        assert response_status(response) == 401
+        assert response_body(response) == b"Authentication required"
+        assert not app.core.get_sessions("/")
+    finally:
+        await app.core.stop()
+
+
+async def test_auth_policy_leaves_static_assets_and_preflight_public() -> None:
+    authenticated: list[str] = []
+
+    def authenticate(request) -> None:
+        authenticated.append(request.path)
+        return None
+
+    app = BokehASGI(Application(), auth_policy=AuthPolicy(authenticate), keep_alive_milliseconds=0)
+    try:
+        static = await http_request(app, "/static/js/bokeh.min.js")
+        preflight = await http_request(app, "/autoload.js", method="OPTIONS")
+
+        assert response_status(static) == 200
+        assert response_status(preflight) == 204
+        assert authenticated == []
+    finally:
+        await app.core.stop()
+
+
 async def test_slow_document_does_not_block_other_http_requests() -> None:
     started = threading.Event()
     release = threading.Event()
@@ -297,6 +377,83 @@ async def test_websocket_accepts_bokeh_protocol_and_sends_ack() -> None:
         assert len(fragments) == 3
         assert json.loads(fragments[0])["msgtype"] == "ACK"
         assert app.core.get_sessions("/")[0].connection_count == 0
+    finally:
+        await app.core.stop()
+
+
+async def test_websocket_auth_policy_rejects_anonymous_user() -> None:
+    app = BokehASGI(Application(), auth_policy=AuthPolicy(lambda request: None), keep_alive_milliseconds=0)
+    token = generate_jwt_token(cast(ID, "session"), expiration=300)
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "websocket.connect"}
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "asgi": {"version": "3.0"},
+                "scheme": "ws",
+                "path": "/ws",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [(b"host", b"localhost")],
+                "subprotocols": ["bokeh", token],
+            },
+            receive,
+            send,
+        )
+
+        assert sent == [{
+            "type": "websocket.close",
+            "code": 1008,
+            "reason": "Authentication required",
+        }]
+        assert not app.core.get_sessions("/")
+    finally:
+        await app.core.stop()
+
+
+async def test_websocket_auth_policy_uses_asgi_scope_user() -> None:
+    policy = AuthPolicy(lambda request: request.user if request.user == "alice" else None)
+    app = BokehASGI(Application(), auth_policy=policy, keep_alive_milliseconds=0)
+    token = generate_jwt_token(cast(ID, "session"), expiration=300)
+    incoming = deque([
+        {"type": "websocket.connect"},
+        {"type": "websocket.disconnect", "code": 1000},
+    ])
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return incoming.popleft()
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "asgi": {"version": "3.0"},
+                "scheme": "ws",
+                "path": "/ws",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [(b"host", b"localhost")],
+                "subprotocols": ["bokeh", token],
+                "user": "alice",
+            },
+            receive,
+            send,
+        )
+
+        assert sent[0] == {"type": "websocket.accept", "subprotocol": "bokeh"}
+        session = app.core.get_sessions("/")[0]
+        assert session.document.session_context.request.user == "alice"
     finally:
         await app.core.stop()
 

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -9,14 +9,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+import runpy
 import threading
 from collections import deque
+from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlencode
 
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.core.types import ID
+from bokeh.document import Document
+from bokeh.models import ColumnDataSource, Select
 from bokeh.protocol import Protocol
 from bokeh.server.asgi import BokehASGI
 from bokeh.util.token import generate_jwt_token
@@ -64,6 +68,72 @@ def response_status(events: list[dict[str, Any]]) -> int:
 
 def response_body(events: list[dict[str, Any]]) -> bytes:
     return b"".join(event.get("body", b"") for event in events if event["type"] == "http.response.body")
+
+
+def test_example_application_initializes() -> None:
+    path = Path(__file__).parents[4] / "examples/server/api/asgi/bkapp.py"
+    application = BokehASGI({"/": path}).core.applications["/"].application
+    document = application.create_document()
+    second_document = application.create_document()
+
+    assert document.title == "Bokeh ASGI signal studio"
+    assert len(document.roots) == 1
+    assert document.roots[0] is not second_document.roots[0]
+    waveform = document.select_one({"name": "waveform"})
+    source = document.select_one({"name": "signal-source"})
+    assert isinstance(waveform, Select)
+    assert isinstance(source, ColumnDataSource)
+
+    waveform.value = "Square"
+
+    assert set(source.data["y"]) == {-1.5, 1.5}
+    string_application = BokehASGI(str(path)).core.applications["/"].application
+    assert string_application.create_document().title == "Bokeh ASGI signal studio"
+
+
+def test_explicit_application_specs_remain_supported() -> None:
+    explicit = Application()
+
+    def modify_document(doc: Document) -> None:
+        doc.title = "Callable application"
+
+    app = BokehASGI({"/explicit": explicit, "/callable": modify_document})
+
+    assert app.core.applications["/explicit"].application is explicit
+    assert app.core.applications["/callable"].application.create_document().title == "Callable application"
+
+
+async def test_framework_free_example_routes_site_and_bokeh() -> None:
+    path = Path(__file__).parents[4] / "examples/server/api/asgi/framework_free.py"
+    namespace = runpy.run_path(str(path))
+    application = namespace["application"]
+    bokeh_application = cast(BokehASGI, namespace["bokeh_application"])
+
+    try:
+        index = await http_request(application, "/")
+        document = await http_request(application, "/bkapp/")
+        missing = await http_request(application, "/missing")
+
+        assert response_status(index) == 200
+        assert b"Bokeh meets <span>framework-free ASGI</span>" in response_body(index)
+        assert b'xhr.open(\'GET\', "/bkapp/autoload.js?' in response_body(index)
+        assert b"bokeh-app-path=/bkapp" in response_body(index)
+        assert b"bokeh-absolute-url" not in response_body(index)
+        assert b"<iframe" not in response_body(index)
+        assert response_status(document) == 200
+        assert b"Bokeh ASGI signal studio" in response_body(document)
+        assert b'/bkapp/static/js/bokeh' in response_body(document)
+        assert response_status(missing) == 404
+
+        autoload = await http_request(application, "/bkapp/autoload.js", query={
+            "bokeh-autoload-element": "target",
+            "bokeh-app-path": "/bkapp",
+        })
+        assert response_status(autoload) == 200
+        assert b"target" in response_body(autoload)
+        assert b'/bkapp/static/js/bokeh' in response_body(autoload)
+    finally:
+        await bokeh_application.core.stop()
 
 
 async def test_lifespan_starts_and_stops_application() -> None:

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlencode
 
+import pytest
+
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.core.types import ID
@@ -224,6 +226,38 @@ async def test_slow_document_does_not_block_other_http_requests() -> None:
         release.set()
         await slow
         await app.core.stop()
+
+
+async def test_stop_waits_for_pending_initialization_before_unload() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    unloaded = threading.Event()
+
+    def slow_document(doc) -> None:
+        started.set()
+        assert release.wait(timeout=2)
+
+    handler = FunctionHandler(slow_document)
+    handler.on_server_unloaded = lambda server_context: unloaded.set()
+    app = BokehASGI(Application(handler), keep_alive_milliseconds=0)
+    await app.core.start()
+    context = app.core.applications["/"]
+    pending = asyncio.create_task(context.create_session_if_needed(ID("session")))
+
+    try:
+        await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
+        stopping = asyncio.create_task(app.core.stop())
+        await asyncio.sleep(0)
+        assert not stopping.done()
+        assert not unloaded.is_set()
+    finally:
+        release.set()
+
+    await stopping
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    assert unloaded.is_set()
+    assert not list(context.sessions)
 
 
 async def test_websocket_accepts_bokeh_protocol_and_sends_ack() -> None:

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import asyncio
 import json
 import runpy
+import sys
 import threading
 from collections import deque
 from pathlib import Path
+from types import ModuleType
 from typing import Any, cast
 from urllib.parse import urlencode
 
@@ -149,6 +151,64 @@ async def test_framework_free_example_routes_site_and_bokeh() -> None:
         await bokeh_application.core.stop()
 
 
+@pytest.mark.parametrize("framework", ["fastapi", "starlette"])
+async def test_framework_example_composes_bokeh_lifespan(monkeypatch: pytest.MonkeyPatch, framework: str) -> None:
+    class HostApplication:
+        def __init__(self, *args: Any, lifespan=None, **kwargs: Any) -> None:
+            self.lifespan = lifespan
+
+        def get(self, *args: Any, **kwargs: Any):
+            return lambda func: func
+
+        def mount(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class Route:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    fastapi = ModuleType("fastapi")
+    setattr(fastapi, "FastAPI", HostApplication)
+    setattr(fastapi, "Request", object)
+    fastapi_responses = ModuleType("fastapi.responses")
+    setattr(fastapi_responses, "HTMLResponse", object)
+    starlette_applications = ModuleType("starlette.applications")
+    setattr(starlette_applications, "Starlette", HostApplication)
+    starlette_requests = ModuleType("starlette.requests")
+    setattr(starlette_requests, "Request", object)
+    starlette_responses = ModuleType("starlette.responses")
+    setattr(starlette_responses, "HTMLResponse", object)
+    starlette_routing = ModuleType("starlette.routing")
+    setattr(starlette_routing, "Mount", Route)
+    setattr(starlette_routing, "Route", Route)
+
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi)
+    monkeypatch.setitem(sys.modules, "fastapi.responses", fastapi_responses)
+    monkeypatch.setitem(sys.modules, "starlette.applications", starlette_applications)
+    monkeypatch.setitem(sys.modules, "starlette.requests", starlette_requests)
+    monkeypatch.setitem(sys.modules, "starlette.responses", starlette_responses)
+    monkeypatch.setitem(sys.modules, "starlette.routing", starlette_routing)
+
+    path = Path(__file__).parents[4] / f"examples/server/api/asgi/{framework}_embed.py"
+    namespace = runpy.run_path(str(path))
+    application = cast(BokehASGI, namespace["bokeh_application"])
+    lifespan = namespace["lifespan"]
+    page = namespace["render_page"]("")
+    proxied_page = namespace["render_page"]("/proxy/")
+
+    assert namespace["app"].lifespan is lifespan
+    assert "/bkapp/autoload.js" in page
+    assert "bokeh-app-path=/bkapp" in page
+    assert "bokeh-absolute-url" not in page
+    assert "<iframe" not in page
+    assert "/proxy/bkapp/autoload.js" in proxied_page
+    assert "bokeh-app-path=/proxy/bkapp" in proxied_page
+    assert not application.core._started
+    async with lifespan(namespace["app"]):
+        assert application.core._started
+    assert not application.core._started
+
+
 async def test_lifespan_starts_and_stops_application() -> None:
     app = BokehASGI(Application(), keep_alive_milliseconds=0)
     incoming = deque([{"type": "lifespan.startup"}, {"type": "lifespan.shutdown"}])
@@ -166,6 +226,7 @@ async def test_lifespan_starts_and_stops_application() -> None:
         "lifespan.startup.complete",
         "lifespan.shutdown.complete",
     ]
+    assert app._start_lock is None
 
 
 async def test_document_and_metadata_routes() -> None:
@@ -194,6 +255,26 @@ async def test_mount_root_path_is_removed_before_routing() -> None:
         await app.core.stop()
 
 
+async def test_mount_root_path_is_included_in_root_navigation() -> None:
+    redirecting = BokehASGI({"/plot": Application()}, prefix="pre", keep_alive_milliseconds=0)
+    listing = BokehASGI(
+        {"/one": Application(), "/two": Application()},
+        prefix="pre",
+        redirect_root=False,
+        keep_alive_milliseconds=0,
+    )
+    try:
+        redirect = await http_request(redirecting, "/dashboard/pre/", root_path="/dashboard/")
+        index = await http_request(listing, "/dashboard/pre/", root_path="/dashboard")
+
+        assert response_header(redirect, b"location") == b"/dashboard/pre/plot"
+        assert b'href="/dashboard/pre/one"' in response_body(index)
+        assert b'href="/dashboard/pre/two"' in response_body(index)
+    finally:
+        await redirecting.core.stop()
+        await listing.core.stop()
+
+
 async def test_autoload_and_static_routes() -> None:
     app = BokehASGI(Application(), keep_alive_milliseconds=0)
     try:
@@ -211,6 +292,103 @@ async def test_autoload_and_static_routes() -> None:
         assert response_status(traversal) == 404
     finally:
         await app.core.stop()
+
+
+async def test_root_application_static_files_stream_and_head_only_stats(tmp_path: Path) -> None:
+    content = b"a" * (64*1024 + 1)
+    (tmp_path / "artifact.bin").write_bytes(content)
+    application = Application()
+    app = BokehASGI(application, keep_alive_milliseconds=0)
+    application._static_path = str(tmp_path)
+    try:
+        get = await http_request(app, "/static/artifact.bin")
+        head = await http_request(app, "/static/artifact.bin", method="HEAD")
+
+        assert response_status(get) == 200
+        assert response_header(get, b"content-length") == str(len(content)).encode()
+        assert response_body(get) == content
+        get_bodies = [event for event in get if event["type"] == "http.response.body"]
+        assert len(get_bodies) == 3
+        assert get_bodies[-1] == {"type": "http.response.body", "body": b""}
+
+        assert response_status(head) == 200
+        assert response_header(head, b"content-length") == str(len(content)).encode()
+        assert response_body(head) == b""
+        assert [event for event in head if event["type"] == "http.response.body"] == [
+            {"type": "http.response.body", "body": b""},
+        ]
+    finally:
+        await app.core.stop()
+
+
+async def test_options_only_dispatches_autoload_preflight() -> None:
+    initialized = 0
+
+    def modify_document(doc: Document) -> None:
+        nonlocal initialized
+        initialized += 1
+
+    app = BokehASGI(Application(FunctionHandler(modify_document)), keep_alive_milliseconds=0)
+    try:
+        document = await http_request(app, "/", method="OPTIONS")
+        metadata = await http_request(app, "/metadata", method="OPTIONS")
+        static = await http_request(app, "/static/js/bokeh.min.js", method="OPTIONS")
+        preflight = await http_request(app, "/autoload.js", method="OPTIONS")
+
+        assert [response_status(response) for response in (document, metadata, static)] == [405, 405, 405]
+        assert response_header(document, b"allow") == b"GET, HEAD"
+        assert response_status(preflight) == 204
+        assert response_header(preflight, b"content-length") is None
+        assert response_header(preflight, b"content-type") is None
+        assert response_header(preflight, b"access-control-allow-methods") == b"GET, HEAD, OPTIONS"
+        assert initialized == 0
+        assert not app.core.get_sessions("/")
+    finally:
+        await app.core.stop()
+
+
+def test_request_preserves_non_utf8_query_bytes() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": b"value=%FF&%FF=name&utf8=%C3%A9",
+        "headers": [],
+    }
+
+    request = app._request(scope)
+
+    assert request.arguments == {
+        "value": [b"\xff"],
+        "\xff": [b"name"],
+        "utf8": [b"\xc3\xa9"],
+    }
+
+
+def test_request_combines_repeated_headers_case_insensitively() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": b"",
+        "headers": [
+            (b"Cookie", b"first=one"),
+            (b"cookie", b"second=two"),
+            (b"X-Value", b"one"),
+            (b"x-value", b"two"),
+        ],
+    }
+
+    request = app._request(scope)
+
+    assert request.headers["cookie"] == "first=one; second=two"
+    assert request.headers["x-value"] == "one, two"
+    assert {name: cookie.value for name, cookie in request.cookies.items()} == {
+        "first": "one",
+        "second": "two",
+    }
 
 
 async def test_auth_policy_redirects_and_propagates_user() -> None:
@@ -240,9 +418,10 @@ async def test_auth_policy_redirects_and_propagates_user() -> None:
         assert response_header(anonymous, b"location") == b"/login?next=/"
         assert response_status(authenticated) == 200
         session = app.core.get_sessions("/")[0]
+        session_context = cast(Any, session.document.session_context)
         assert session.document.title == "alice"
-        assert session.document.session_context.request.user == "alice"
-        assert session.document.session_context.logout_url == "/logout"
+        assert session_context.request.user == "alice"
+        assert session_context.logout_url == "/logout"
         assert authentication_state == [
             {"request_id": "anonymous"},
             {"request_id": "authenticated"},
@@ -334,8 +513,15 @@ async def test_stop_waits_for_pending_initialization_before_unload() -> None:
         release.set()
 
     await stopping
-    with pytest.raises(asyncio.CancelledError):
-        await pending
+    try:
+        initialized_session = await pending
+    except asyncio.CancelledError:
+        pass
+    else:
+        # Shutdown may reach the pending-session cancellation before or after
+        # the worker returns. A session that wins that race must still be
+        # destroyed before the unload hook runs.
+        assert initialized_session.destroyed
     assert unloaded.is_set()
     assert not list(context.sessions)
 
@@ -359,7 +545,7 @@ async def test_websocket_accepts_bokeh_protocol_and_sends_ack() -> None:
         await app(
             {
                 "type": "websocket",
-                "asgi": {"version": "3.0"},
+                "asgi": {"version": "3.0", "spec_version": "2.3"},
                 "scheme": "ws",
                 "path": "/ws",
                 "root_path": "",
@@ -396,7 +582,7 @@ async def test_websocket_auth_policy_rejects_anonymous_user() -> None:
         await app(
             {
                 "type": "websocket",
-                "asgi": {"version": "3.0"},
+                "asgi": {"version": "3.0", "spec_version": "2.3"},
                 "scheme": "ws",
                 "path": "/ws",
                 "root_path": "",
@@ -453,7 +639,8 @@ async def test_websocket_auth_policy_uses_asgi_scope_user() -> None:
 
         assert sent[0] == {"type": "websocket.accept", "subprotocol": "bokeh"}
         session = app.core.get_sessions("/")[0]
-        assert session.document.session_context.request.user == "alice"
+        session_context = cast(Any, session.document.session_context)
+        assert session_context.request.user == "alice"
     finally:
         await app.core.stop()
 
@@ -518,6 +705,7 @@ async def test_websocket_rejects_missing_token() -> None:
         await app(
             {
                 "type": "websocket",
+                "asgi": {"version": "3.0", "spec_version": "2.3"},
                 "path": "/ws",
                 "root_path": "",
                 "query_string": b"",
@@ -534,3 +722,155 @@ async def test_websocket_rejects_missing_token() -> None:
         }]
     finally:
         await app.core.stop()
+
+
+@pytest.mark.parametrize("token", [
+    "garbage",
+    "e30=",
+    "W10=",
+    generate_jwt_token(cast(ID, ""), expiration=300),
+    generate_jwt_token(cast(ID, 1), expiration=300),
+])
+async def test_websocket_rejects_malformed_token(token: str) -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "websocket.connect"}
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "asgi": {"version": "3.0", "spec_version": "2.3"},
+                "path": "/ws",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [(b"host", b"localhost")],
+                "subprotocols": ["bokeh", token],
+            },
+            receive,
+            send,
+        )
+
+        assert sent == [{
+            "type": "websocket.close",
+            "code": 1008,
+            "reason": "Invalid or expired token",
+        }]
+    finally:
+        await app.core.stop()
+
+
+async def test_websocket_waits_for_connect_and_gates_close_reason() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    connect_received = False
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        nonlocal connect_received
+        connect_received = True
+        return {"type": "websocket.connect"}
+
+    async def send(event: dict[str, Any]) -> None:
+        assert connect_received
+        sent.append(event)
+
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "asgi": {"version": "3.0", "spec_version": "2.0"},
+                "path": "/ws",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [(b"host", b"localhost")],
+                "subprotocols": ["bokeh"],
+            },
+            receive,
+            send,
+        )
+
+        assert sent == [{"type": "websocket.close", "code": 1002}]
+    finally:
+        await app.core.stop()
+
+
+async def test_websocket_send_oserror_is_treated_as_disconnect() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    token = generate_jwt_token(cast(ID, "session"), expiration=300)
+    incoming = deque([
+        {"type": "websocket.connect"},
+        {"type": "websocket.disconnect", "code": 1001},
+    ])
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return incoming.popleft()
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+        if event["type"] == "websocket.send":
+            raise OSError("peer disconnected")
+
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "asgi": {"version": "3.0", "spec_version": "2.4"},
+                "path": "/ws",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [(b"host", b"localhost")],
+                "subprotocols": ["bokeh", token],
+            },
+            receive,
+            send,
+        )
+
+        assert [event["type"] for event in sent] == ["websocket.accept", "websocket.send"]
+        assert not app.core._clients
+        assert app.core.get_sessions("/")[0].connection_count == 0
+    finally:
+        await app.core.stop()
+
+
+async def test_websocket_disconnect_after_core_stop_does_not_reuse_detached_session() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    token = generate_jwt_token(cast(ID, "session"), expiration=300)
+    incoming: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    await incoming.put({"type": "websocket.connect"})
+    connected = asyncio.Event()
+
+    async def receive() -> dict[str, Any]:
+        return await incoming.get()
+
+    async def send(event: dict[str, Any]) -> None:
+        if event["type"] == "websocket.send":
+            connected.set()
+
+    task = asyncio.create_task(app(
+        {
+            "type": "websocket",
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "path": "/ws",
+            "root_path": "",
+            "query_string": b"",
+            "headers": [(b"host", b"localhost")],
+            "subprotocols": ["bokeh", token],
+        },
+        receive,
+        send,
+    ))
+
+    await asyncio.wait_for(connected.wait(), 1)
+    connection = next(iter(app.core._clients))
+    assert getattr(connection, "_session") is not None
+    await app.core.stop()
+    assert getattr(connection, "_session") is None
+    assert not app.core._clients
+    await incoming.put({"type": "websocket.disconnect", "code": 1001})
+    await asyncio.wait_for(task, 1)

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.core.types import ID
+from bokeh.protocol import Protocol
 from bokeh.server.asgi import BokehASGI
 from bokeh.util.token import generate_jwt_token
 
@@ -110,6 +111,25 @@ async def test_mount_root_path_is_removed_before_routing() -> None:
         await app.core.stop()
 
 
+async def test_autoload_and_static_routes() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    try:
+        autoload = await http_request(app, "/autoload.js", query={
+            "bokeh-autoload-element": "target",
+            "bokeh-app-path": "/",
+        })
+        static = await http_request(app, "/static/js/bokeh.min.js")
+        traversal = await http_request(app, "/static/../asgi.py")
+
+        assert response_status(autoload) == 200
+        assert b"target" in response_body(autoload)
+        assert response_status(static) == 200
+        assert b"Bokeh Contributors" in response_body(static)
+        assert response_status(traversal) == 404
+    finally:
+        await app.core.stop()
+
+
 async def test_slow_document_does_not_block_other_http_requests() -> None:
     started = threading.Event()
     release = threading.Event()
@@ -173,6 +193,52 @@ async def test_websocket_accepts_bokeh_protocol_and_sends_ack() -> None:
         assert len(fragments) == 3
         assert json.loads(fragments[0])["msgtype"] == "ACK"
         assert app.core.get_sessions("/")[0].connection_count == 0
+    finally:
+        await app.core.stop()
+
+
+async def test_websocket_handles_pull_document_round_trip() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    token = generate_jwt_token(cast(ID, "session"), expiration=300)
+    request = Protocol().create("PULL-DOC-REQ")
+    incoming = deque([
+        {"type": "websocket.connect"},
+        {"type": "websocket.receive", "text": request.header_json},
+        {"type": "websocket.receive", "text": request.metadata_json},
+        {"type": "websocket.receive", "text": request.content_json},
+        {"type": "websocket.disconnect", "code": 1000},
+    ])
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return incoming.popleft()
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "asgi": {"version": "3.0"},
+                "scheme": "ws",
+                "path": "/ws",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [(b"host", b"localhost")],
+                "subprotocols": ["bokeh", token],
+            },
+            receive,
+            send,
+        )
+
+        message_types = [
+            value["msgtype"]
+            for event in sent
+            if event["type"] == "websocket.send"
+            if (value := json.loads(event["text"])) and "msgtype" in value
+        ]
+        assert message_types == ["ACK", "PULL-DOC-REPLY"]
     finally:
         await app.core.stop()
 

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -1,0 +1,209 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc. and contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from collections import deque
+from typing import Any, cast
+from urllib.parse import urlencode
+
+from bokeh.application import Application
+from bokeh.application.handlers.function import FunctionHandler
+from bokeh.core.types import ID
+from bokeh.server.asgi import BokehASGI
+from bokeh.util.token import generate_jwt_token
+
+
+async def http_request(
+    app: BokehASGI,
+    path: str,
+    *,
+    query: dict[str, str] | None = None,
+    method: str = "GET",
+    root_path: str = "",
+) -> list[dict[str, Any]]:
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+
+    query_string = urlencode(query or {}).encode()
+    await app(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": method,
+            "scheme": "http",
+            "path": path,
+            "root_path": root_path,
+            "query_string": query_string,
+            "headers": [(b"host", b"localhost")],
+            "client": ("127.0.0.1", 1234),
+        },
+        receive,
+        send,
+    )
+    return sent
+
+
+def response_status(events: list[dict[str, Any]]) -> int:
+    return events[0]["status"]
+
+
+def response_body(events: list[dict[str, Any]]) -> bytes:
+    return b"".join(event.get("body", b"") for event in events if event["type"] == "http.response.body")
+
+
+async def test_lifespan_starts_and_stops_application() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    incoming = deque([{"type": "lifespan.startup"}, {"type": "lifespan.shutdown"}])
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return incoming.popleft()
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+
+    await app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+
+    assert [event["type"] for event in sent] == [
+        "lifespan.startup.complete",
+        "lifespan.shutdown.complete",
+    ]
+
+
+async def test_document_and_metadata_routes() -> None:
+    application = Application()
+    application._metadata = {"meaning": 42}
+    app = BokehASGI({"/plot": application}, keep_alive_milliseconds=0)
+    try:
+        document = await http_request(app, "/plot/")
+        metadata = await http_request(app, "/plot/metadata")
+
+        assert response_status(document) == 200
+        assert b"Bokeh" in response_body(document)
+        assert response_status(metadata) == 200
+        assert b'"meaning": 42' in response_body(metadata)
+    finally:
+        await app.core.stop()
+
+
+async def test_mount_root_path_is_removed_before_routing() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    try:
+        response = await http_request(app, "/dashboard/", root_path="/dashboard")
+        assert response_status(response) == 200
+        assert b'/dashboard/static/js/bokeh' in response_body(response)
+    finally:
+        await app.core.stop()
+
+
+async def test_slow_document_does_not_block_other_http_requests() -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_document(doc) -> None:
+        started.set()
+        release.wait()
+
+    app = BokehASGI(
+        {
+            "/slow": Application(FunctionHandler(slow_document)),
+            "/fast": Application(),
+        },
+        keep_alive_milliseconds=0,
+    )
+    slow = asyncio.create_task(http_request(app, "/slow/"))
+    try:
+        await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
+        fast = await asyncio.wait_for(http_request(app, "/fast/metadata"), 0.2)
+        assert response_status(fast) == 200
+    finally:
+        release.set()
+        await slow
+        await app.core.stop()
+
+
+async def test_websocket_accepts_bokeh_protocol_and_sends_ack() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    token = generate_jwt_token(cast(ID, "session"), expiration=300)
+    incoming = deque([
+        {"type": "websocket.connect"},
+        {"type": "websocket.disconnect", "code": 1000},
+    ])
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return incoming.popleft()
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "asgi": {"version": "3.0"},
+                "scheme": "ws",
+                "path": "/ws",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [(b"host", b"localhost"), (b"origin", b"http://localhost")],
+                "client": ("127.0.0.1", 1234),
+                "subprotocols": ["bokeh", token],
+            },
+            receive,
+            send,
+        )
+
+        assert sent[0] == {"type": "websocket.accept", "subprotocol": "bokeh"}
+        fragments = [event["text"] for event in sent if event["type"] == "websocket.send"]
+        assert len(fragments) == 3
+        assert json.loads(fragments[0])["msgtype"] == "ACK"
+        assert app.core.get_sessions("/")[0].connection_count == 0
+    finally:
+        await app.core.stop()
+
+
+async def test_websocket_rejects_missing_token() -> None:
+    app = BokehASGI(Application(), keep_alive_milliseconds=0)
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "websocket.connect"}
+
+    async def send(event: dict[str, Any]) -> None:
+        sent.append(event)
+
+    try:
+        await app(
+            {
+                "type": "websocket",
+                "path": "/ws",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [(b"host", b"localhost")],
+                "subprotocols": ["bokeh"],
+            },
+            receive,
+            send,
+        )
+        assert sent == [{
+            "type": "websocket.close",
+            "code": 1002,
+            "reason": "Bokeh subprotocol and token required",
+        }]
+    finally:
+        await app.core.stop()

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -24,14 +24,15 @@ import pytest
 
 # Bokeh imports
 from bokeh.application import Application
+from bokeh.application.handlers.directory import DirectoryHandler
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.core.types import ID
 from bokeh.document import Document
-from bokeh.models import ColumnDataSource, Select
+from bokeh.models import ColumnDataSource, Div, Select
 from bokeh.protocol import Protocol
 from bokeh.server.asgi import BokehASGI
 from bokeh.server.auth import AuthPolicy
-from bokeh.util.token import generate_jwt_token
+from bokeh.util.token import generate_jwt_token, get_token_payload
 
 
 async def http_request(
@@ -107,6 +108,63 @@ def test_example_application_initializes() -> None:
     assert set(source.data["y"]) == {-1.5, 1.5}
     string_application = BokehASGI(str(path)).core.applications["/"].application
     assert string_application.create_document().title == "Bokeh ASGI signal studio"
+
+
+async def test_directory_application_path_supports_directory_features(tmp_path: Path) -> None:
+    directory = tmp_path / "directory-app"
+    static = directory / "static"
+    templates = directory / "templates"
+    static.mkdir(parents=True)
+    templates.mkdir()
+    (directory / "main.py").write_text("""
+from bokeh.io import curdoc
+from bokeh.models import Div
+
+curdoc().title = "Directory application"
+curdoc().template_variables["message"] = "custom template"
+curdoc().add_root(Div(name="directory-root"))
+""", encoding="utf-8")
+    (directory / "app_hooks.py").write_text("""
+def on_server_loaded(server_context):
+    server_context.application_context._directory_app_loaded = True
+
+def process_request(request):
+    return {"directory_request_path": request.path}
+""", encoding="utf-8")
+    (directory / "theme.yaml").write_text("""
+attrs:
+    Div:
+        visible: false
+""", encoding="utf-8")
+    (templates / "index.html").write_text(
+        '<div id="directory-template">{{ message }}</div>', encoding="utf-8",
+    )
+    (static / "artifact.txt").write_text("directory static", encoding="utf-8")
+
+    app = BokehASGI({"/directory": directory}, keep_alive_milliseconds=0)
+    context = app.core.applications["/directory"]
+    application = context.application
+
+    assert isinstance(application.handlers[0], DirectoryHandler)
+    assert isinstance(BokehASGI(str(directory)).core.applications["/"].application.handlers[0], DirectoryHandler)
+
+    try:
+        document = await http_request(app, "/directory/")
+        artifact = await http_request(app, "/directory/static/artifact.txt")
+
+        assert response_status(document) == 200
+        assert b'<div id="directory-template">custom template</div>' in response_body(document)
+        assert response_status(artifact) == 200
+        assert response_body(artifact) == b"directory static"
+        assert getattr(context, "_directory_app_loaded")
+
+        session = next(iter(context.sessions))
+        root = session.document.select_one({"name": "directory-root"})
+        assert isinstance(root, Div)
+        assert not root.visible
+        assert get_token_payload(session.token)["directory_request_path"] == "/directory/"
+    finally:
+        await app.core.stop()
 
 
 def test_explicit_application_specs_remain_supported() -> None:

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+# Standard library imports
 import asyncio
 import json
 import runpy
@@ -18,8 +19,10 @@ from types import ModuleType
 from typing import Any, cast
 from urllib.parse import urlencode
 
+# External imports
 import pytest
 
+# Bokeh imports
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.core.types import ID
@@ -724,14 +727,18 @@ async def test_websocket_rejects_missing_token() -> None:
         await app.core.stop()
 
 
-@pytest.mark.parametrize("token", [
-    "garbage",
-    "e30=",
-    "W10=",
-    generate_jwt_token(cast(ID, ""), expiration=300),
-    generate_jwt_token(cast(ID, 1), expiration=300),
+@pytest.mark.parametrize(("token", "session_id"), [
+    pytest.param("garbage", None, id="garbage"),
+    pytest.param("e30=", None, id="empty-object"),
+    pytest.param("W10=", None, id="empty-array"),
+    pytest.param(None, "", id="empty-session-id"),
+    pytest.param(None, 1, id="non-string-session-id"),
 ])
-async def test_websocket_rejects_malformed_token(token: str) -> None:
+async def test_websocket_rejects_malformed_token(token: str | None, session_id: str | int | None) -> None:
+    if token is None:
+        assert session_id is not None
+        token = generate_jwt_token(cast(ID, session_id), expiration=300)
+
     app = BokehASGI(Application(), keep_alive_milliseconds=0)
     sent: list[dict[str, Any]] = []
 

--- a/tests/unit/bokeh/server/test_auth.py
+++ b/tests/unit/bokeh/server/test_auth.py
@@ -7,8 +7,10 @@
 
 from __future__ import annotations
 
+# Standard library imports
 import asyncio
 
+# Bokeh imports
 from bokeh.server.auth import AuthPolicy
 from bokeh.server.request import ServerRequest
 

--- a/tests/unit/bokeh/server/test_auth.py
+++ b/tests/unit/bokeh/server/test_auth.py
@@ -1,0 +1,42 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import asyncio
+
+from bokeh.server.auth import AuthPolicy
+from bokeh.server.request import ServerRequest
+
+
+async def test_sync_authenticator() -> None:
+    request = ServerRequest(method="GET", uri="/", path="/")
+    policy = AuthPolicy(lambda request: "alice")
+
+    assert await policy.authenticate(request) == "alice"
+
+
+async def test_async_authenticator() -> None:
+    async def authenticate(request: ServerRequest) -> str:
+        await asyncio.sleep(0)
+        return "alice"
+
+    request = ServerRequest(method="GET", uri="/", path="/")
+    policy = AuthPolicy(authenticate)
+
+    assert await policy.authenticate(request) == "alice"
+
+
+def test_login_and_logout_urls() -> None:
+    request = ServerRequest(method="GET", uri="/plot", path="/plot")
+
+    fixed = AuthPolicy(lambda request: None, login_url="/login", logout_url="/logout")
+    dynamic = AuthPolicy(lambda request: None, login_url=lambda request: f"/login?next={request.path}")
+
+    assert fixed.get_login_url(request) == "/login"
+    assert fixed.logout_url == "/logout"
+    assert dynamic.get_login_url(request) == "/login?next=/plot"

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -224,6 +224,130 @@ class TestApplicationContext:
         result = await asyncio.wait_for(result_f, 1)
         assert result == message
 
+    async def test_sync_session_callback_does_not_block_event_loop(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        session = await c.create_session_if_needed("foo")
+        loop_thread = threading.get_ident()
+        callback_thread = None
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def callback() -> None:
+            nonlocal callback_thread
+            callback_thread = threading.get_ident()
+            started.set()
+            release.wait()
+            finished.set()
+
+        session.document.add_next_tick_callback(callback)
+        await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
+        await asyncio.wait_for(asyncio.sleep(0), 0.1)
+        release.set()
+        assert await asyncio.wait_for(asyncio.to_thread(finished.wait), 1)
+        await asyncio.sleep(0)
+
+        assert callback_thread != loop_thread
+
+    async def test_session_callbacks_are_serialized(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        session = await c.create_session_if_needed("foo")
+        lock = threading.Lock()
+        active = 0
+        maximum_active = 0
+
+        def callback() -> None:
+            nonlocal active, maximum_active
+            with lock:
+                active += 1
+                maximum_active = max(maximum_active, active)
+            threading.Event().wait(0.02)
+            with lock:
+                active -= 1
+
+        await asyncio.gather(
+            session.with_document_locked(callback),
+            session.with_document_locked(callback),
+        )
+
+        assert maximum_active == 1
+
+    async def test_different_session_callbacks_can_run_concurrently(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        first = await c.create_session_if_needed("first")
+        second = await c.create_session_if_needed("second")
+        barrier = threading.Barrier(2)
+
+        def callback() -> None:
+            barrier.wait(timeout=1)
+
+        await asyncio.gather(
+            first.with_document_locked(callback),
+            second.with_document_locked(callback),
+        )
+
+    async def test_async_session_callback_runs_on_event_loop(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        session = await c.create_session_if_needed("foo")
+        loop_thread = threading.get_ident()
+        callback_thread = None
+
+        async def callback() -> None:
+            nonlocal callback_thread
+            callback_thread = threading.get_ident()
+            await asyncio.sleep(0)
+
+        await session.with_document_locked(callback)
+
+        assert callback_thread == loop_thread
+
+    async def test_session_callback_can_schedule_timeout_from_worker(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        session = await c.create_session_if_needed("foo")
+        fired = threading.Event()
+
+        def callback() -> None:
+            session.document.add_timeout_callback(fired.set, 1)
+
+        await session.with_document_locked(callback)
+
+        assert await asyncio.wait_for(asyncio.to_thread(fired.wait), 1)
+
+    async def test_cancelling_locked_callback_waits_for_worker(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        session = await c.create_session_if_needed("foo")
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def callback() -> None:
+            started.set()
+            release.wait()
+            session.document.title = "finished"
+            finished.set()
+
+        task = asyncio.create_task(session.with_document_locked(callback))
+        await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
+        task.cancel()
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        assert session.expiration_blocked
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert finished.is_set()
+        assert session.document.title == "finished"
+        assert not session.expiration_blocked
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -169,6 +169,25 @@ class TestApplicationContext:
 
         assert maximum_active == 1
 
+    async def test_failed_document_initialization_can_be_retried(self) -> None:
+        attempts = 0
+
+        def modify_document(doc) -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("initialization failed")
+
+        app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+
+        with pytest.raises(RuntimeError, match="initialization failed"):
+            await c.create_session_if_needed("foo")
+        session = await c.create_session_if_needed("foo")
+
+        assert session.id == "foo"
+        assert attempts == 2
+
     async def test_create_session_if_needed_bad_sessionid(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop")

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -20,9 +20,7 @@ import pytest ; pytest
 import asyncio
 import gc
 import logging
-import sys
 import threading
-from types import ModuleType
 
 # External imports
 from tornado.ioloop import IOLoop
@@ -339,37 +337,86 @@ class TestApplicationContext:
         assert not c._pending_sessions
         assert not list(c.sessions)
 
-    async def test_code_handler_uses_context_local_curdoc(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        started = threading.Event()
-        release = threading.Event()
-        support = ModuleType("test_session_initialization_support")
-        support.started = started
-        support.release = release
-        monkeypatch.setitem(sys.modules, support.__name__, support)
-
+    async def test_code_handler_uses_context_local_curdoc_on_event_loop(self) -> None:
         handler = CodeHandler(filename="app.py", source="""
 from threading import get_ident
-from test_session_initialization_support import release, started
 from bokeh.io import curdoc
 
-started.set()
-assert release.wait(timeout=2)
 assert curdoc().session_context.id == "foo"
 curdoc().template_variables["thread_id"] = get_ident()
 """)
         c = bsc.ApplicationContext(Application(handler), io_loop=asyncio.get_running_loop())
         loop_doc = curdoc()
 
-        pending = asyncio.create_task(c.create_session_if_needed("foo"))
-        try:
-            await _wait_for_event(started)
-            assert curdoc() is loop_doc
-        finally:
-            release.set()
-
-        session = await pending
+        session = await c.create_session_if_needed("foo")
         assert not handler.failed
-        assert session.document.template_variables["thread_id"] != threading.get_ident()
+        assert curdoc() is loop_doc
+        assert session.document.template_variables["thread_id"] == threading.get_ident()
+
+    async def test_discard_bookkeeping_runs_on_event_loop(self) -> None:
+        c = bsc.ApplicationContext(Application(), io_loop=asyncio.get_running_loop())
+        session = await c.create_session_if_needed("foo")
+        session.request_expiration()
+        destroy_threads: list[int] = []
+        original_destroy = session.destroy
+
+        def destroy() -> None:
+            destroy_threads.append(threading.get_ident())
+            original_destroy()
+
+        session.destroy = destroy
+        await c._cleanup_sessions(1)
+
+        assert destroy_threads == [threading.get_ident()]
+        assert not list(c.sessions)
+
+    async def test_concurrent_discard_runs_destroy_hook_once(self) -> None:
+        app = Application()
+        destroyed = 0
+
+        async def on_session_destroyed(session_context) -> None:
+            nonlocal destroyed
+            destroyed += 1
+
+        app.on_session_destroyed = on_session_destroyed
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        session = await c.create_session_if_needed("foo")
+        both_started = asyncio.Event()
+        first_checked = asyncio.Event()
+        second_finished = asyncio.Event()
+        arrivals = 0
+
+        async def with_document_locked(func, *args, **kwargs):
+            nonlocal arrivals
+            position = arrivals
+            arrivals += 1
+            session.block_expiration()
+            if arrivals == 2:
+                both_started.set()
+            await both_started.wait()
+
+            if position == 0:
+                result = await func(*args, **kwargs)
+                session.unblock_expiration()
+                first_checked.set()
+                await second_finished.wait()
+                return result
+
+            await first_checked.wait()
+            result = await func(*args, **kwargs)
+            session.unblock_expiration()
+            second_finished.set()
+            return result
+
+        session.with_document_locked = with_document_locked
+        await asyncio.gather(
+            c._discard_session(session, lambda session: True),
+            c._discard_session(session, lambda session: True),
+        )
+
+        assert destroyed == 1
+        assert session.destroyed
+        assert not list(c.sessions)
 
     async def test_create_session_if_needed_bad_sessionid(self) -> None:
         app = Application()
@@ -529,6 +576,20 @@ curdoc().template_variables["thread_id"] = get_ident()
 
         assert finished.is_set()
         assert session.document.title == "finished"
+        assert not session.expiration_blocked
+
+    async def test_locked_callback_can_raise_cancelled_error(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        session = await c.create_session_if_needed("foo")
+
+        def callback() -> None:
+            raise asyncio.CancelledError
+
+        async with asyncio.timeout(1):
+            with pytest.raises(asyncio.CancelledError):
+                await session.with_document_locked(callback)
+
         assert not session.expiration_blocked
 
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -19,14 +19,18 @@ import pytest ; pytest
 # Standard library imports
 import asyncio
 import gc
+import logging
+import sys
 import threading
+from types import ModuleType
 
 # External imports
 from tornado.ioloop import IOLoop
 
 # Bokeh imports
 from bokeh.application import Application
-from bokeh.application.handlers.function import FunctionHandler
+from bokeh.application.handlers import CodeHandler, FunctionHandler
+from bokeh.io import curdoc
 
 # Module under test
 import bokeh.server.contexts as bsc # isort:skip
@@ -38,6 +42,11 @@ import bokeh.server.contexts as bsc # isort:skip
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+async def _wait_for_event(event: threading.Event) -> None:
+    async with asyncio.timeout(1):
+        while not event.is_set():
+            await asyncio.sleep(0)
 
 
 class TestBokehServerContext:
@@ -121,6 +130,12 @@ class TestApplicationContext:
         s = await c.create_session_if_needed("foo")
         assert c.get_session("foo") == s
 
+    async def test_create_session_uses_running_loop_by_default(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app)
+        session = await c.create_session_if_needed("foo")
+        assert session._loop is asyncio.get_running_loop()
+
     async def test_create_session_if_needed_exists(self) -> None:
         app = Application()
         c = bsc.ApplicationContext(app, io_loop="ioloop")
@@ -140,34 +155,35 @@ class TestApplicationContext:
         c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
         task = asyncio.create_task(c.create_session_if_needed("foo"))
 
-        await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
-        # This timeout would fire if modify_document still occupied the loop.
-        await asyncio.wait_for(asyncio.sleep(0), 0.1)
-        release.set()
+        try:
+            await _wait_for_event(started)
+            # This timeout would fire if modify_document still occupied the loop.
+            await asyncio.wait_for(asyncio.sleep(0), 0.1)
+        finally:
+            release.set()
         await task
 
-    async def test_document_initialization_is_serialized_per_application(self) -> None:
-        lock = threading.Lock()
-        active = 0
-        maximum_active = 0
+    async def test_document_initialization_is_concurrent_per_application(self) -> None:
+        slow_started = threading.Event()
+        slow_release = threading.Event()
 
         def modify_document(doc) -> None:
-            nonlocal active, maximum_active
-            with lock:
-                active += 1
-                maximum_active = max(maximum_active, active)
-            threading.Event().wait(0.02)
-            with lock:
-                active -= 1
+            if doc.session_context.id == "slow":
+                slow_started.set()
+                assert slow_release.wait(timeout=2)
 
         app = Application(FunctionHandler(modify_document))
         c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
-        await asyncio.gather(
-            c.create_session_if_needed("one"),
-            c.create_session_if_needed("two"),
-        )
 
-        assert maximum_active == 1
+        slow = asyncio.create_task(c.create_session_if_needed("slow"))
+        try:
+            await _wait_for_event(slow_started)
+            fast = await asyncio.wait_for(c.create_session_if_needed("fast"), timeout=1)
+            assert fast.id == "fast"
+        finally:
+            slow_release.set()
+
+        assert (await slow).id == "slow"
 
     async def test_failed_document_initialization_can_be_retried(self) -> None:
         attempts = 0
@@ -187,6 +203,173 @@ class TestApplicationContext:
 
         assert session.id == "foo"
         assert attempts == 2
+
+    async def test_concurrent_waiters_share_session_creation(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+        attempts = 0
+
+        def modify_document(doc) -> None:
+            nonlocal attempts
+            attempts += 1
+            started.set()
+            assert release.wait(timeout=2)
+
+        app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+
+        first = asyncio.create_task(c.create_session_if_needed("foo"))
+        try:
+            await _wait_for_event(started)
+            second = asyncio.create_task(c.create_session_if_needed("foo"))
+            await asyncio.sleep(0)
+            assert not second.done()
+        finally:
+            release.set()
+
+        first_session, second_session = await asyncio.gather(first, second)
+        assert first_session is second_session
+        assert attempts == 1
+
+    async def test_cancelling_waiter_does_not_cancel_session_creation(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def modify_document(doc) -> None:
+            started.set()
+            assert release.wait(timeout=2)
+
+        app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+
+        first = asyncio.create_task(c.create_session_if_needed("foo"))
+        try:
+            await _wait_for_event(started)
+
+            first.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first
+
+            second = asyncio.create_task(c.create_session_if_needed("foo"))
+        finally:
+            release.set()
+
+        assert (await second).id == "foo"
+
+    async def test_concurrent_waiters_share_session_creation_failure(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+        attempts = 0
+
+        def modify_document(doc) -> None:
+            nonlocal attempts
+            attempts += 1
+            started.set()
+            assert release.wait(timeout=2)
+            raise RuntimeError("shared failure")
+
+        app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+
+        first = asyncio.create_task(c.create_session_if_needed("foo"))
+        try:
+            await _wait_for_event(started)
+            second = asyncio.create_task(c.create_session_if_needed("foo"))
+            await asyncio.sleep(0)
+        finally:
+            release.set()
+
+        results = await asyncio.gather(first, second, return_exceptions=True)
+        assert all(isinstance(result, RuntimeError) for result in results)
+        assert all(str(result) == "shared failure" for result in results)
+        assert attempts == 1
+
+    async def test_abandoned_session_creation_failure_is_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def modify_document(doc) -> None:
+            started.set()
+            assert release.wait(timeout=2)
+            raise RuntimeError("failed after disconnect")
+
+        app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+
+        waiter = asyncio.create_task(c.create_session_if_needed("foo"))
+        try:
+            await _wait_for_event(started)
+
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+        finally:
+            release.set()
+
+        with caplog.at_level(logging.ERROR):
+            async with asyncio.timeout(1):
+                while c._pending_sessions:
+                    await asyncio.sleep(0)
+
+        assert "Failed to create session 'foo': failed after disconnect" in caplog.text
+
+    async def test_shutdown_pending_sessions_prevents_session_registration(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def modify_document(doc) -> None:
+            started.set()
+            assert release.wait(timeout=2)
+
+        app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+
+        pending = asyncio.create_task(c.create_session_if_needed("foo"))
+        try:
+            await _wait_for_event(started)
+            shutdown = asyncio.create_task(c._shutdown_pending_sessions())
+            await asyncio.sleep(0)
+            assert not shutdown.done()
+        finally:
+            release.set()
+
+        await shutdown
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        assert not c._pending_sessions
+        assert not list(c.sessions)
+
+    async def test_code_handler_uses_context_local_curdoc(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        started = threading.Event()
+        release = threading.Event()
+        support = ModuleType("test_session_initialization_support")
+        support.started = started
+        support.release = release
+        monkeypatch.setitem(sys.modules, support.__name__, support)
+
+        handler = CodeHandler(filename="app.py", source="""
+from threading import get_ident
+from test_session_initialization_support import release, started
+from bokeh.io import curdoc
+
+started.set()
+assert release.wait(timeout=2)
+assert curdoc().session_context.id == "foo"
+curdoc().template_variables["thread_id"] = get_ident()
+""")
+        c = bsc.ApplicationContext(Application(handler), io_loop=asyncio.get_running_loop())
+        loop_doc = curdoc()
+
+        pending = asyncio.create_task(c.create_session_if_needed("foo"))
+        try:
+            await _wait_for_event(started)
+            assert curdoc() is loop_doc
+        finally:
+            release.set()
+
+        session = await pending
+        assert not handler.failed
+        assert session.document.template_variables["thread_id"] != threading.get_ident()
 
     async def test_create_session_if_needed_bad_sessionid(self) -> None:
         app = Application()

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -19,12 +19,14 @@ import pytest ; pytest
 # Standard library imports
 import asyncio
 import gc
+import threading
 
 # External imports
 from tornado.ioloop import IOLoop
 
 # Bokeh imports
 from bokeh.application import Application
+from bokeh.application.handlers.function import FunctionHandler
 
 # Module under test
 import bokeh.server.contexts as bsc # isort:skip
@@ -125,6 +127,47 @@ class TestApplicationContext:
         s1 = await c.create_session_if_needed("foo")
         s2 = await c.create_session_if_needed("foo")
         assert s1 == s2
+
+    async def test_document_initialization_does_not_block_event_loop(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def modify_document(doc) -> None:
+            started.set()
+            release.wait()
+
+        app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        task = asyncio.create_task(c.create_session_if_needed("foo"))
+
+        await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
+        # This timeout would fire if modify_document still occupied the loop.
+        await asyncio.wait_for(asyncio.sleep(0), 0.1)
+        release.set()
+        await task
+
+    async def test_document_initialization_is_serialized_per_application(self) -> None:
+        lock = threading.Lock()
+        active = 0
+        maximum_active = 0
+
+        def modify_document(doc) -> None:
+            nonlocal active, maximum_active
+            with lock:
+                active += 1
+                maximum_active = max(maximum_active, active)
+            threading.Event().wait(0.02)
+            with lock:
+                active -= 1
+
+        app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        await asyncio.gather(
+            c.create_session_if_needed("one"),
+            c.create_session_if_needed("two"),
+        )
+
+        assert maximum_active == 1
 
     async def test_create_session_if_needed_bad_sessionid(self) -> None:
         app = Application()

--- a/tests/unit/bokeh/server/test_core.py
+++ b/tests/unit/bokeh/server/test_core.py
@@ -1,0 +1,274 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc. and contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from bokeh.application import Application
+from bokeh.application.handlers.function import FunctionHandler
+from bokeh.protocol import Protocol
+from bokeh.server.core import BokehServerCore
+from bokeh.server.request import Cookie, Headers, ServerRequest
+from bokeh.util.asyncio import _AsyncPeriodic
+from bokeh.util.token import get_token_payload
+
+
+async def test_periodic_callback_continues_after_exception() -> None:
+    calls = 0
+    called_again = asyncio.Event()
+
+    def callback() -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("transient failure")
+        called_again.set()
+
+    periodic = _AsyncPeriodic(callback, 1, asyncio.get_running_loop())
+    periodic.start()
+    try:
+        await asyncio.wait_for(called_again.wait(), 1)
+    finally:
+        periodic.stop()
+        await periodic.wait()
+
+    assert calls >= 2
+
+
+async def test_stop_waits_for_periodic_jobs_before_unload() -> None:
+    application = Application()
+    unloaded = asyncio.Event()
+    application.on_server_unloaded = lambda context: unloaded.set()
+    core = BokehServerCore(
+        application,
+        keep_alive_milliseconds=0,
+        check_unused_sessions_milliseconds=1,
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def cleanup() -> None:
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+            raise
+
+    core._cleanup_sessions = cleanup
+    await core.start()
+    await asyncio.wait_for(started.wait(), 1)
+
+    stopping = asyncio.create_task(core.stop())
+    await asyncio.sleep(0)
+    assert not stopping.done()
+    assert not unloaded.is_set()
+
+    release.set()
+    await stopping
+    assert unloaded.is_set()
+
+
+async def test_stop_cancels_pending_sessions_before_waiting_for_jobs() -> None:
+    initialization_started = threading.Event()
+    initialization_release = threading.Event()
+    job_started = asyncio.Event()
+    job_release = asyncio.Event()
+
+    def modify_document(doc) -> None:
+        initialization_started.set()
+        assert initialization_release.wait(timeout=2)
+
+    core = BokehServerCore(
+        Application(FunctionHandler(modify_document)),
+        keep_alive_milliseconds=0,
+        check_unused_sessions_milliseconds=1,
+    )
+
+    async def cleanup() -> None:
+        job_started.set()
+        try:
+            await job_release.wait()
+        except asyncio.CancelledError:
+            await job_release.wait()
+            raise
+
+    core._cleanup_sessions = cleanup
+    await core.start()
+    context = core.applications["/"]
+    pending_waiter = asyncio.create_task(context.create_session_if_needed("session"))
+    await asyncio.wait_for(asyncio.to_thread(initialization_started.wait), 1)
+    await asyncio.wait_for(job_started.wait(), 1)
+    pending_initializer = context._pending_sessions["session"]
+
+    stopping = asyncio.create_task(core.stop())
+    async with asyncio.timeout(1):
+        while not pending_initializer.cancelling():
+            await asyncio.sleep(0)
+
+    assert pending_initializer.cancelling()
+    assert not stopping.done()
+
+    initialization_release.set()
+    job_release.set()
+    await stopping
+    with pytest.raises(asyncio.CancelledError):
+        await pending_waiter
+
+
+async def test_concurrent_stop_is_shared_and_rejects_new_work() -> None:
+    application = Application()
+    unload_count = 0
+
+    def on_server_unloaded(server_context) -> None:
+        nonlocal unload_count
+        unload_count += 1
+
+    application.on_server_unloaded = on_server_unloaded
+    core = BokehServerCore(
+        application,
+        keep_alive_milliseconds=0,
+        check_unused_sessions_milliseconds=1,
+    )
+    job_started = asyncio.Event()
+    job_release = asyncio.Event()
+
+    async def cleanup() -> None:
+        job_started.set()
+        try:
+            await job_release.wait()
+        except asyncio.CancelledError:
+            await job_release.wait()
+            raise
+
+    core._cleanup_sessions = cleanup
+    await core.start()
+    context = core.applications["/"]
+    session = await context.create_session_if_needed("session")
+    await asyncio.wait_for(job_started.wait(), 1)
+
+    first_stop = asyncio.create_task(core.stop())
+    await asyncio.sleep(0)
+    second_stop = asyncio.create_task(core.stop())
+    await asyncio.sleep(0)
+
+    assert core._stopping
+    assert not first_stop.done()
+    assert not second_stop.done()
+    with pytest.raises(RuntimeError, match="stopping"):
+        await core.start()
+    with pytest.raises(RuntimeError, match="stopping"):
+        await core.create_session(context, ServerRequest(method="GET", uri="/", path="/"))
+    with pytest.raises(RuntimeError, match="stopping"):
+        await core.create_session_if_needed(context, "new-session")
+    with pytest.raises(RuntimeError, match="stopping"):
+        core.new_connection(Protocol(), object(), context, session)
+    assert not context._pending_sessions
+
+    job_release.set()
+    await asyncio.gather(first_stop, second_stop)
+
+    assert unload_count == 1
+    assert not core._started
+    assert not core._stopping
+    assert core._stop_task is None
+
+
+async def test_stop_destroys_sessions_and_document_callbacks() -> None:
+    application = Application()
+    destroyed = asyncio.Event()
+
+    async def on_session_destroyed(session_context) -> None:
+        destroyed.set()
+
+    application.on_session_destroyed = on_session_destroyed
+    core = BokehServerCore(application, keep_alive_milliseconds=0)
+    await core.start()
+    context = core.applications["/"]
+    session = await context.create_session_if_needed("session")
+    calls = 0
+    called = asyncio.Event()
+
+    def callback() -> None:
+        nonlocal calls
+        calls += 1
+        called.set()
+
+    session.document.add_periodic_callback(callback, 1)
+    await asyncio.wait_for(called.wait(), 1)
+    await core.stop()
+    calls_at_stop = calls
+    await asyncio.sleep(0.02)
+
+    assert destroyed.is_set()
+    assert session.destroyed
+    assert not list(context.sessions)
+    assert calls == calls_at_stop
+
+
+async def test_stop_detaches_connections_before_destroying_sessions() -> None:
+    core = BokehServerCore(Application(), keep_alive_milliseconds=0)
+    await core.start()
+    context = core.applications["/"]
+    session = await context.create_session_if_needed("session")
+    connection = core.new_connection(Protocol(), object(), context, session)
+
+    await core.stop()
+
+    assert connection._session is None
+    assert session.connection_count == 0
+    assert session.destroyed
+    assert not core._clients
+    assert not list(context.sessions)
+
+
+async def test_lifecycle_hooks_run_on_event_loop() -> None:
+    application = Application()
+    observed: list[asyncio.AbstractEventLoop] = []
+    application.on_server_loaded = lambda context: observed.append(asyncio.get_running_loop())
+    application.on_server_unloaded = lambda context: observed.append(asyncio.get_running_loop())
+    core = BokehServerCore(application, keep_alive_milliseconds=0)
+
+    await core.start()
+    await core.stop()
+
+    assert observed == [asyncio.get_running_loop(), asyncio.get_running_loop()]
+
+
+def test_core_can_restart_on_a_new_event_loop() -> None:
+    core = BokehServerCore(Application(), keep_alive_milliseconds=0)
+
+    async def cycle() -> None:
+        await core.start()
+        await core.stop()
+
+    asyncio.run(cycle())
+    asyncio.run(cycle())
+
+
+async def test_cookie_header_is_removed_case_insensitively_from_token() -> None:
+    core = BokehServerCore(Application(), keep_alive_milliseconds=0, exclude_cookies=["secret"])
+    request = ServerRequest(
+        method="GET",
+        uri="/",
+        path="/",
+        headers=Headers({"cookie": "secret=hidden; public=visible", "x-test": "visible"}),
+        cookies={"secret": Cookie("hidden"), "public": Cookie("visible")},
+    )
+    await core.start()
+    try:
+        session = await core.create_session(core.applications["/"], request)
+        payload = get_token_payload(session.token)
+
+        assert payload["cookies"] == {"public": "visible"}
+        assert payload["headers"] == {"x-test": "visible"}
+    finally:
+        await core.stop()

--- a/tests/unit/bokeh/server/test_core.py
+++ b/tests/unit/bokeh/server/test_core.py
@@ -7,11 +7,14 @@
 
 from __future__ import annotations
 
+# Standard library imports
 import asyncio
 import threading
 
+# External imports
 import pytest
 
+# Bokeh imports
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.protocol import Protocol

--- a/tests/unit/bokeh/server/test_request.py
+++ b/tests/unit/bokeh/server/test_request.py
@@ -1,0 +1,38 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from bokeh.server.request import Cookie, Headers, ServerRequest
+
+
+def test_headers_are_case_insensitive() -> None:
+    headers = Headers({"Content-Type": "text/plain", "X-Test": "value"})
+
+    assert headers["content-type"] == "text/plain"
+    assert headers["X-TEST"] == "value"
+    assert list(headers) == ["Content-Type", "X-Test"]
+
+
+def test_server_request_defaults() -> None:
+    request = ServerRequest(method="GET", uri="/app", path="/app")
+
+    assert request.arguments == {}
+    assert request.headers == {}
+    assert request.cookies == {}
+    assert request.protocol == "http"
+
+
+def test_server_request_cookie_values_match_tornado_shape() -> None:
+    request = ServerRequest(
+        method="GET",
+        uri="/app",
+        path="/app",
+        cookies={"session": Cookie("abc")},
+    )
+
+    assert request.cookies["session"].value == "abc"

--- a/tests/unit/bokeh/server/test_request.py
+++ b/tests/unit/bokeh/server/test_request.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+# Bokeh imports
 from bokeh.server.request import Cookie, Headers, ServerRequest
 
 

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -24,7 +24,6 @@ import re
 import ssl
 import sys
 import tempfile
-import time
 from datetime import timedelta
 from unittest import mock
 
@@ -778,13 +777,16 @@ async def test__reject_expired_session_websocket(ManagedServerLoop: MSL) -> None
         sessions = server.get_sessions('/')
         assert 0 == len(sessions)
 
-        response = await http_get(server.io_loop, url(server))
+        issued_at = 1_000
+        with mock.patch("bokeh.util.token.calendar.timegm", return_value=issued_at):
+            response = await http_get(server.io_loop, url(server))
         html = response.body
         token = extract_token_from_json(html)
+        expiry = get_token_payload(token)["session_expiry"]
+        assert expiry == issued_at + 1
 
-        time.sleep(1.1)
-
-        ws = await websocket_open(server.io_loop, ws_url(server), subprotocols=["bokeh", token])
+        with mock.patch("bokeh.server.views.ws.calendar.timegm", return_value=expiry):
+            ws = await websocket_open(server.io_loop, ws_url(server), subprotocols=["bokeh", token])
         assert await ws.read_queue.get() is None
 
 async def test__reject_wrong_subprotocol_websocket(ManagedServerLoop: MSL) -> None:

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -967,6 +967,29 @@ def test__ioloop_not_forcibly_stopped() -> None:
     loop.start()
     assert result == [None]
 
+
+async def test__stop_on_running_ioloop_has_completion_barrier() -> None:
+    loop = IOLoop.current()
+    tornado_app = mock.Mock()
+    release = asyncio.Event()
+
+    async def stop_async() -> None:
+        await release.wait()
+
+    tornado_app.stop_async = mock.AsyncMock(side_effect=stop_async)
+    http_server = mock.Mock()
+    base_server = BaseServer(loop, tornado_app, http_server)
+
+    base_server.stop()
+
+    http_server.stop.assert_called_once_with()
+    assert base_server._stop_task is not None
+    assert not base_server._stop_task.done()
+
+    release.set()
+    await base_server.wait_until_stopped()
+    tornado_app.stop_async.assert_awaited_once_with()
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_server__server.py
+++ b/tests/unit/bokeh/server/test_server__server.py
@@ -713,7 +713,11 @@ async def test__use_provided_session_websocket(ManagedServerLoop: MSL) -> None:
 
         expected = 'foo'
         token = generate_jwt_token(expected)
-        await websocket_open(server.io_loop, ws_url(server), subprotocols=["bokeh", token])
+        ws = await websocket_open(server.io_loop, ws_url(server), subprotocols=["bokeh", token], auto_close=False)
+        msg = await ws.read_queue.get()
+        assert isinstance(msg, str)
+        assert 'ACK' in msg
+        ws.close()
 
         sessions = server.get_sessions('/')
         assert 1 == len(sessions)

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -17,8 +17,10 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
 import json
 import logging
+import threading
 from unittest.mock import Mock, patch
 
 # External imports
@@ -28,6 +30,7 @@ from tornado.websocket import WebSocketClosedError
 
 # Bokeh imports
 from bokeh.application import Application
+from bokeh.application.handlers.function import FunctionHandler
 from bokeh.client import pull_session
 from bokeh.core.types import ID
 from bokeh.server.auth_provider import NullAuth
@@ -253,7 +256,7 @@ def test_stop_cancels_pending_sessions_before_unload() -> None:
     t = bst.BokehTornado({"/": Application()})
     context = t._applications["/"]
     calls = []
-    context._cancel_pending_sessions = Mock(side_effect=lambda: calls.append("cancel"))
+    context._cancel_pending_sessions = Mock(side_effect=lambda: calls.append("cancel") or ())
     context.run_unload_hook = Mock(side_effect=lambda: calls.append("unload"))
     t._stats_job = Mock()
     t._mem_job = None
@@ -264,6 +267,96 @@ def test_stop_cancels_pending_sessions_before_unload() -> None:
     t.stop()
 
     assert calls == ["cancel", "unload"]
+
+
+async def test_stop_defers_unload_until_pending_worker_finishes() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    unloaded = threading.Event()
+
+    def modify_document(doc) -> None:
+        started.set()
+        assert release.wait(timeout=2)
+        finished.set()
+
+    handler = FunctionHandler(modify_document)
+    handler.on_server_unloaded = lambda context: unloaded.set()
+    t = bst.BokehTornado({"/": Application(handler)})
+    t._stats_job = Mock()
+    t._mem_job = None
+    t._cleanup_job = Mock()
+    t._ping_job = None
+    t._clients = set()
+    context = t._applications["/"]
+    pending = asyncio.create_task(context.create_session_if_needed("session"))
+    await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
+
+    stopping = asyncio.create_task(t.stop_async())
+    await asyncio.sleep(0)
+    assert not stopping.done()
+    assert not unloaded.is_set()
+    with pytest.raises(RuntimeError, match="stopping"):
+        await t.create_session_if_needed(context, "late-session")
+    assert "late-session" not in context._pending_sessions
+
+    release.set()
+    await stopping
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    assert finished.is_set()
+    assert unloaded.is_set()
+
+
+async def test_stop_waits_for_running_cleanup_before_unload() -> None:
+    t = bst.BokehTornado({"/": Application()})
+    t._stats_job = Mock()
+    t._mem_job = None
+    t._cleanup_job = Mock()
+    t._ping_job = None
+    t._clients = set()
+    context = t._applications["/"]
+    started = asyncio.Event()
+    release = asyncio.Event()
+    unloaded = asyncio.Event()
+
+    async def cleanup(unused_session_linger_milliseconds: int) -> None:
+        started.set()
+        await release.wait()
+
+    context._cleanup_sessions = cleanup
+    context.run_unload_hook = lambda: unloaded.set()
+    cleaning = asyncio.create_task(t._cleanup_sessions())
+    await asyncio.wait_for(started.wait(), 1)
+
+    stopping = asyncio.create_task(t.stop_async())
+    await asyncio.sleep(0)
+    assert not stopping.done()
+    assert not unloaded.is_set()
+
+    release.set()
+    await asyncio.gather(cleaning, stopping)
+    assert unloaded.is_set()
+
+
+async def test_concurrent_stop_async_runs_unload_once() -> None:
+    t = bst.BokehTornado({"/": Application()})
+    t._stats_job = Mock()
+    t._mem_job = None
+    t._cleanup_job = Mock()
+    t._ping_job = None
+    t._clients = set()
+    context = t._applications["/"]
+    unload_count = 0
+
+    def unload() -> None:
+        nonlocal unload_count
+        unload_count += 1
+
+    context.run_unload_hook = unload
+    await asyncio.gather(t.stop_async(), t.stop_async())
+
+    assert unload_count == 1
 
 # tried to use capsys to test what's actually logged and it wasn't
 # working, in the meantime at least this tests that log_stats

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -249,6 +249,22 @@ def test_default_app_paths() -> None:
     t = bst.BokehTornado({"/": app, "/foo": app}, prefix="", extra_websocket_origins=[])
     assert t.app_paths == { "/", "/foo"}
 
+def test_stop_cancels_pending_sessions_before_unload() -> None:
+    t = bst.BokehTornado({"/": Application()})
+    context = t._applications["/"]
+    calls = []
+    context._cancel_pending_sessions = Mock(side_effect=lambda: calls.append("cancel"))
+    context.run_unload_hook = Mock(side_effect=lambda: calls.append("unload"))
+    t._stats_job = Mock()
+    t._mem_job = None
+    t._cleanup_job = Mock()
+    t._ping_job = None
+    t._clients = set()
+
+    t.stop()
+
+    assert calls == ["cancel", "unload"]
+
 # tried to use capsys to test what's actually logged and it wasn't
 # working, in the meantime at least this tests that log_stats
 # doesn't crash in various scenarios

--- a/tests/unit/bokeh/test_typing.py
+++ b/tests/unit/bokeh/test_typing.py
@@ -33,6 +33,8 @@ import pytest ; pytest
 from typing import Literal, assert_type
 
 # Bokeh imports
+from bokeh.document import Document
+from bokeh.io import curdoc
 from bokeh.models.annotations import LegendItem
 from bokeh.models.ranges import Range1d
 from bokeh.models.tools import HoverTool, PanTool
@@ -45,6 +47,9 @@ from bokeh.plotting import figure
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+def mypy_test_curdoc() -> None:
+    assert_type(curdoc(), Document)
 
 def mypy_test_figure_list_attr_splat() -> None:
     p = figure()


### PR DESCRIPTION
Closes https://github.com/bokeh/bokeh/issues/15293

As requested by @philippjfr a single bigger PR to check out and experiment with all at once.  I'd really appreciate any and all feedback to help move this forward. If (hopefully when) we decide to move forward, I will back-fill an issue for this PR. 

---

#### What is in this PR

This preview adds a framework-neutral `BokehASGI` frontend that can be used without Tornado. It supports direct or mounted ASGI deployment, full document/autoload/static/WebSocket routing, auth, and FastAPI/Starlette/Django examples. Shared server internals also gain cancellation-safe session creation and more robust lifecycle/shutdown handling.

Some specific highlights:

- The main architectural change is the framework-neutral runtime in [`core.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/core.py), with the existing Tornado frontend adapted in [`tornado.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/tornado.py).
- ASGI routing and protocol handling—including mounted paths, static assets, autoload, documents, and WebSockets—lives in [`asgi.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/asgi.py).
- Concurrent and cancellation-safe session creation is concentrated in [`contexts.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/contexts.py).
- Shutdown and lifecycle coordination spans [`core.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/core.py), [`server.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/server.py), and [`session.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/session.py).
- Framework-neutral authentication is defined in [`auth.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/auth.py), with runnable configurations in the [ASGI examples](https://github.com/bokeh/bokeh/blob/feature/asgi-server/examples/server/api/asgi/README.md).
- Synchronous session callbacks now run in a bounded worker executor instead of blocking the shared event loop, while preserving per-session document locking and keeping async callbacks on the event loop ([`session.py`](https://github.com/bokeh/bokeh/blob/feature/asgi-server/src/bokeh/server/session.py#L94-L131)).

#### What is NOT in this PR

* `bokeh serve` still relies on Tornado (and probably always will do due to how much Tornado hooks and machinery it uses) but IMO we would start to regard it as a legacy tool
* The pip and conda packages themselves still depend on tornado *for now*. I'd suggest punting any changes there to 3.11 after discussing what is most helpful for Holoviews and other users (e.g. a separate bokeh-base package that omits tornado or literally just making tornado be pip-optional, or something else).

## Example

As a quick example, Bokeh server can now be used in a single process without a separate `bokeh serve` deployment or needing Tornado to be installed:
```python
from pathlib import Path

from fastapi import FastAPI
from fastapi.responses import HTMLResponse
from jinja2 import Environment, FileSystemLoader

from bokeh.server.asgi import BokehASGI

app = FastAPI()

templates = Environment(loader=FileSystemLoader(Path(__file__).parent))
page = templates.get_template("embed.html.jinja").render(framework="FastAPI")

@app.get("/", response_class=HTMLResponse)
async def index():
    return page

app.mount("/bkapp", BokehASGI({"/": Path(__file__).with_name("bkapp.py")}))
```
Run as
```
dev313 ❯ python -m uvicorn fastapi_embed:app --port 8000
INFO:     Started server process [54130]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:54224 - "WebSocket /bkapp/ws" 403
INFO:     127.0.0.1:54227 - "GET / HTTP/1.1" 200 OK
INFO:     127.0.0.1:54227 - "GET /bkapp/autoload.js?bokeh-autoload-element=b5ed3017-3cc0-4036-bb71-8441d42755f0&bokeh-app-path=/bkapp HTTP/1.1" 200 OK
INFO:     127.0.0.1:54227 - "GET /bkapp/static/js/bokeh.min.js HTTP/1.1" 200 OK
INFO:     127.0.0.1:54228 - "GET /bkapp/static/js/bokeh-gl.min.js HTTP/1.1" 200 OK
INFO:     127.0.0.1:54232 - "GET /bkapp/static/js/bokeh-widgets.min.js HTTP/1.1" 200 OK
INFO:     127.0.0.1:54233 - "GET /bkapp/static/js/bokeh-tables.min.js HTTP/1.1" 200 OK
INFO:     127.0.0.1:54234 - "GET /bkapp/static/js/bokeh-mathjax.min.js HTTP/1.1" 200 OK
INFO:     127.0.0.1:54236 - "WebSocket /bkapp/ws" [accepted]
```

<img width="1514" height="1158" alt="image" src="https://github.com/user-attachments/assets/22fbc8e3-459d-413b-9a73-703f853334ea" />

