### PR TITLE
Fix `waterfall.ts` and allow `@bokehjs/` imports in old-style extensions

### DIFF
--- a/bokehjs/src/compiler/compile.ts
+++ b/bokehjs/src/compiler/compile.ts
@@ -24,6 +24,9 @@ export function compile_typescript(base_dir: string, inputs: Inputs, bokehjs_dir
     module: ts.ModuleKind.CommonJS,
     target: ts.ScriptTarget.ES2024,
     paths: {
+      "@bokehjs/*": [
+        join(bokehjs_dir, "js/lib/*"),
+      ],
       "*": [
         join(bokehjs_dir, "js/lib/*"),
       ],

--- a/examples/server/app/spectrogram/waterfall.ts
+++ b/examples/server/app/spectrogram/waterfall.ts
@@ -6,7 +6,7 @@ import {canvas} from "core/dom"
 import * as p from "core/properties"
 
 export class WaterfallRendererView extends RendererView {
-  model: WaterfallRenderer
+  declare model: WaterfallRenderer
 
   private canvases: HTMLCanvasElement[]
   private images: Uint32Array[]
@@ -18,7 +18,7 @@ export class WaterfallRendererView extends RendererView {
   private yscale: Scale
   private max_freq: number
 
-  initialize(): void {
+  override initialize(): void {
     super.initialize()
 
     const N = Math.ceil(this.model.num_grams/this.model.tile_width) + 1
@@ -43,9 +43,9 @@ export class WaterfallRendererView extends RendererView {
     this.max_freq = this.plot_view.frame.y_range.end
   }
 
-  connect_signals(): void {
+  override connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.change, this.request_paint)
+    this.connect(this.model.change, () => this.request_paint())
   }
 
   protected _paint(): void {
@@ -119,8 +119,8 @@ export namespace WaterfallRenderer {
 export interface WaterfallRenderer extends WaterfallRenderer.Attrs {}
 
 export class WaterfallRenderer extends Renderer {
-  properties: WaterfallRenderer.Props
-  __view_type__: WaterfallRendererView
+  declare properties: WaterfallRenderer.Props
+  declare __view_type__: WaterfallRendererView
 
   constructor(attrs?: Partial<WaterfallRenderer.Attrs>) {
     super(attrs)

--- a/examples/server/app/spectrogram/waterfall.ts
+++ b/examples/server/app/spectrogram/waterfall.ts
@@ -1,9 +1,9 @@
-import {Renderer, RendererView} from "models/renderers/renderer"
-import {LinearColorMapper} from "models/mappers/linear_color_mapper"
-import {Scale} from "models/scales/scale"
-import {Color} from "core/types"
-import {canvas} from "core/dom"
-import * as p from "core/properties"
+import {Renderer, RendererView} from "@bokehjs/models/renderers/renderer"
+import {LinearColorMapper} from "@bokehjs/models/mappers/linear_color_mapper"
+import {Scale} from "@bokehjs/models/scales/scale"
+import {Color} from "@bokehjs/core/types"
+import {canvas} from "@bokehjs/core/dom"
+import * as p from "@bokehjs/core/properties"
 
 export class WaterfallRendererView extends RendererView {
   declare model: WaterfallRenderer

--- a/examples/server/app/surface3d/surface3d.ts
+++ b/examples/server/app/surface3d/surface3d.ts
@@ -9,11 +9,11 @@
 // Making it easy to hook up python data analytics tools (NumPy, SciPy,
 // Pandas, etc.) to web presentations using the Bokeh server.
 
-import {LayoutDOM, LayoutDOMView} from "models/layouts/layout_dom"
-import {ColumnDataSource} from "models/sources/column_data_source"
-import {to_object} from "core/util/object"
-import type {Dict, PlainObject} from "core/types"
-import * as p from "core/properties"
+import {LayoutDOM, LayoutDOMView} from "@bokehjs/models/layouts/layout_dom"
+import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
+import {to_object} from "@bokehjs/core/util/object"
+import type {Dict, PlainObject} from "@bokehjs/core/types"
+import * as p from "@bokehjs/core/properties"
 
 declare namespace vis {
   class Graph3d {
@@ -49,7 +49,7 @@ const OPTIONS = {
 // into the DOM, we must create a View subclass for the model. In this case we
 // will subclass from the existing BokehJS ``LayoutDOMView``, corresponding to our.
 export class Surface3dView extends LayoutDOMView {
-  model: Surface3d
+  declare model: Surface3d
 
   private _graph: vis.Graph3d
 
@@ -114,8 +114,8 @@ export namespace Surface3d {
 export interface Surface3d extends Surface3d.Attrs {}
 
 export class Surface3d extends LayoutDOM {
-  properties: Surface3d.Props
-  __view_type__: Surface3dView
+  declare properties: Surface3d.Props
+  declare __view_type__: Surface3dView
 
   constructor(attrs?: Partial<Surface3d.Attrs>) {
     super(attrs)

--- a/src/bokeh/util/compiler.py
+++ b/src/bokeh/util/compiler.py
@@ -560,9 +560,10 @@ def _bundle_models(custom_models: dict[str, CustomModel]) -> str:
 
         return resolved
 
-    def resolve_deps(deps : list[str], root: str) -> dict[str, str]:
+    def resolve_deps(deps: list[str], root: str) -> dict[str, str]:
         custom_modules = {model.module for model in custom_models.values()}
-        missing = set(deps) - known_modules - custom_modules
+        normalized_deps = [dep.removeprefix("@bokehjs/") for dep in deps]
+        missing = set(normalized_deps) - known_modules - custom_modules
         return resolve_modules(missing, root)
 
     for model in custom_models.values():


### PR DESCRIPTION
Addition of `@bokehjs/` isn't necessary, but makes it easier to set up old-style extensions for proper type checking, by normalizing imports with new-style extensions. This way you can copy `tsconfig.json` from another extension and you are set up for development in vscode, etc.

fixes #15238