### PR TITLE
Fix bokeh init generating incompatible npm version format

### DIFF
--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -120,11 +120,13 @@ export type InitOptions = {
 export async function init(base_dir: Path, _bokehjs_dir: Path, base_setup: InitOptions): Promise<boolean> {
   preamble(base_dir)
 
-  const format_npm_version = (v: string) => v.replace(/\+.*$/, "").replace(/\.?(dev|rc|a|b)(\d+)$/, "-$1.$2")
+  const to_npm_version = (v: string) => {
+    return v.replace(/\+.*$/, "").replace(/\.?(dev|rc|a|b)(\d*)$/, (_, p1, p2) => `-${p1}${p2 ? `.${p2}` : ""}`)
+  }
 
   const setup: Required<InitOptions> = {
     interactive: base_setup.interactive ?? false,
-    bokehjs_version: base_setup.bokehjs_version ?? format_npm_version(base_setup.bokeh_version),
+    bokehjs_version: base_setup.bokehjs_version ?? to_npm_version(base_setup.bokeh_version),
     bokeh_version: base_setup.bokeh_version,
   }
 

--- a/bokehjs/src/compiler/build.ts
+++ b/bokehjs/src/compiler/build.ts
@@ -120,9 +120,11 @@ export type InitOptions = {
 export async function init(base_dir: Path, _bokehjs_dir: Path, base_setup: InitOptions): Promise<boolean> {
   preamble(base_dir)
 
+  const format_npm_version = (v: string) => v.replace(/\+.*$/, "").replace(/\.?(dev|rc|a|b)(\d+)$/, "-$1.$2")
+
   const setup: Required<InitOptions> = {
     interactive: base_setup.interactive ?? false,
-    bokehjs_version: base_setup.bokehjs_version ?? base_setup.bokeh_version.split("-")[0],
+    bokehjs_version: base_setup.bokehjs_version ?? format_npm_version(base_setup.bokeh_version),
     bokeh_version: base_setup.bokeh_version,
   }
 


### PR DESCRIPTION

Fixes #15251

**Problem:**
When running `bokeh init .`, the generated `package.json` includes the `@bokeh/bokehjs` dependency with the raw Python PEP440 version string (e.g., `^3.10.0.dev6+24.ga8a8c4a0.dirty`). NPM rejects this format because it uses a dot for pre-releases instead of a hyphen, and it contains the `+` symbol, resulting in an `EINVALIDTAGNAME` error during `npm install`.

**Solution:**
Updated the `init()` function in `bokehjs/src/compiler/build.ts` to format the python version string into a valid NPM semver format before inserting it into `package.json`. 
- Stripped the local commit hash identifier (`+...`)
- Converted Python's pre-release identifier format (e.g., `.devX`, `.rcX`) to NPM's hyphen-based format (`-dev.X`, `-rc.X`).

Tested locally by compiling the compiler and verifying that `bokeh init` generates a valid `package.json` allowing `npm install` to succeed without errors.