### PR TITLE
Add hover_delay to WheelZoomTool to prevent accidental zoom while page-scrolling

### DIFF
--- a/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts
@@ -23,12 +23,53 @@ type Renderers = typeof Renderers["__type__"]
 export class WheelZoomToolView extends GestureToolView {
   declare model: WheelZoomTool
 
+  private _hover_active: boolean = false
+  private _hover_timer: ReturnType<typeof setTimeout> | null = null
+
+  override remove(): void {
+    if (this._hover_timer != null) {
+      clearTimeout(this._hover_timer)
+    }
+    super.remove()
+  }
+
+  override connect_signals(): void {
+    super.connect_signals()
+
+    this.connect(this.plot_view.mouseenter, () => {
+      const {hover_delay} = this.model
+      if (hover_delay <= 0) {
+        this._hover_active = true
+        return
+      }
+      this._hover_timer = setTimeout(() => {
+        this._hover_active = true
+        this._hover_timer = null
+      }, hover_delay)
+    })
+
+    this.connect(this.plot_view.mouseleave, () => {
+      if (this._hover_timer != null) {
+        clearTimeout(this._hover_timer)
+        this._hover_timer = null
+      }
+      this._hover_active = false
+    })
+  }
+
   override _scroll(ev: ScrollEvent): boolean {
     const {modifiers} = this.model
     if (!satisfies_modifiers(modifiers, ev.modifiers)) {
       this.plot_view.notify_about(`use ${print_modifiers(modifiers)} + scroll to zoom`)
       return false
     }
+
+    const {hover_delay} = this.model
+    if (hover_delay > 0 && !this._hover_active) {
+      this.plot_view.notify_about("hover over the plot to enable zoom")
+      return false
+    }
+
     const {sx, sy, delta} = ev
     this.zoom(sx, sy, delta)
     return true
@@ -257,6 +298,7 @@ export namespace WheelZoomTool {
     zoom_together: p.Property<ZoomTogether>
     speed: p.Property<number>
     modifiers: p.Property<Modifiers>
+    hover_delay: p.Property<number>
   }
 }
 
@@ -285,6 +327,7 @@ export class WheelZoomTool extends GestureTool {
       zoom_together:  [ ZoomTogether, "all" ],
       speed:          [ Float, 1/600 ],
       modifiers:      [ Modifiers, {} ],
+      hover_delay:    [ NonNegative(Int), 0 ],
     }))
 
     this.register_alias("wheel_zoom", () => new WheelZoomTool({dimensions: "both"}))

--- a/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
+++ b/bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts
@@ -256,6 +256,54 @@ describe("WheelZoomTool", () => {
         y: [-0.833333, 0.833333],
       })
     })
+
+    it("should not zoom before hover_delay has elapsed", async () => {
+      const wheel_zoom = new WheelZoomTool({hover_delay: 50})
+      const {view, tool_view} = await make_plot(wheel_zoom)
+
+      view.mouseenter.emit(new MouseEvent("mouseenter"))
+
+      const zoom_event = {type: "wheel" as const, sx: 150, sy: 150, delta: 100, modifiers, native: new WheelEvent("wheel")}
+      tool_view._scroll(zoom_event)
+
+      expect(xy_axis(view)).to.be.similar({
+        x: [-1.0, 1.0],
+        y: [-1.0, 1.0],
+      })
+    })
+
+    it("should zoom once hover_delay has elapsed", async () => {
+      const wheel_zoom = new WheelZoomTool({hover_delay: 10})
+      const {view, tool_view} = await make_plot(wheel_zoom)
+
+      view.mouseenter.emit(new MouseEvent("mouseenter"))
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      const zoom_event = {type: "wheel" as const, sx: 150, sy: 150, delta: 100, modifiers, native: new WheelEvent("wheel")}
+      tool_view._scroll(zoom_event)
+
+      expect(xy_axis(view)).to.be.similar({
+        x: [-0.833333, 0.833333],
+        y: [-0.833333, 0.833333],
+      })
+    })
+
+    it("should reset hover state on mouseleave", async () => {
+      const wheel_zoom = new WheelZoomTool({hover_delay: 10})
+      const {view, tool_view} = await make_plot(wheel_zoom)
+
+      view.mouseenter.emit(new MouseEvent("mouseenter"))
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      view.mouseleave.emit(new MouseEvent("mouseleave"))
+
+      const zoom_event = {type: "wheel" as const, sx: 150, sy: 150, delta: 100, modifiers, native: new WheelEvent("wheel")}
+      tool_view._scroll(zoom_event)
+
+      expect(xy_axis(view)).to.be.similar({
+        x: [-1.0, 1.0],
+        y: [-1.0, 1.0],
+      })
+    })
   })
 
   it("should support auto-activation when active_scroll='auto' and plot has focus", async () => {

--- a/src/bokeh/models/tools.py
+++ b/src/bokeh/models/tools.py
@@ -789,6 +789,19 @@ class WheelZoomTool(Scroll):
 
     """).accepts(String, _parse_modifiers)
 
+    hover_delay = NonNegative(Int, default=0, help="""
+    Delay in milliseconds that the cursor must hover over the plot before
+    scrolling is registered as a zoom.
+
+    This is useful to prevent accidentally zooming a plot while scrolling
+    down a page that contains it. While the cursor is hovering but the
+    delay has not yet elapsed, scroll events are ignored by this tool and
+    passed through to the page.
+
+    If ``0`` (the default), zooming happens immediately on scroll, with no
+    hover delay.
+    """)
+
 class CustomAction(ActionTool):
     ''' Execute a custom action, e.g. ``CustomJS`` callback when a toolbar
     icon is activated.

--- a/tests/baselines/defaults.json5
+++ b/tests/baselines/defaults.json5
@@ -7263,6 +7263,7 @@
     modifiers: {
       type: "map",
     },
+    hover_delay: 0,
   },
   ZoomBaseTool: {
     __extends__: "PlotActionTool",


### PR DESCRIPTION
All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

**Please review our [AI Contribution Guidelines](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management#ai-contribution-guidelines)**
to ensure your contribution follows project expectations.

- [x] issues: fixes #15209
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

## Problem

When scrolling down a page that contains a Bokeh plot, the scroll can
accidentally get captured by the plot's wheel zoom tool instead of
continuing to scroll the page.

## Solution

As suggested in the issue thread, this adds a configuration property
(`hover_delay`) directly to `WheelZoomTool` rather than introducing a
separate tool. When `hover_delay` is set to a positive number of
milliseconds, the cursor must remain hovering over the plot for that
long before a scroll event is treated as a zoom. Scrolls that happen
before the delay elapses are ignored by the tool and pass through to
the page, with a brief "hover over the plot to enable zoom" notice
(mirroring the existing `modifiers` gate/notification pattern already
on this tool).

Default is `0` (no delay), so existing behavior is unchanged unless a
user opts in:

```python
from bokeh.models import WheelZoomTool
plot.add_tools(WheelZoomTool(hover_delay=750))  # 750ms hover before scroll zooms
```

## Changes

- `bokehjs/src/lib/models/tools/gestures/wheel_zoom_tool.ts`: track
  hover state via the plot's existing `mouseenter`/`mouseleave`
  signals, gate `_scroll` on it when `hover_delay > 0`.
- `src/bokeh/models/tools.py`: matching `hover_delay` property.
- `bokehjs/test/unit/models/tools/gestures/wheel_zoom_tool.ts`: unit
  tests covering pre-delay, post-delay, and mouseleave-reset behavior.
- `tests/baselines/defaults.json5`: updated default-value baseline.