### PR TITLE
Use necessary WebGL numeric precision

### DIFF
--- a/bokehjs/src/lib/models/glyphs/webgl/accumulate.frag
+++ b/bokehjs/src/lib/models/glyphs/webgl/accumulate.frag
@@ -1,4 +1,8 @@
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
 
 uniform sampler2D u_framebuffer_tex;
 varying vec2 v_tex_coords;

--- a/bokehjs/src/lib/models/glyphs/webgl/accumulate.vert
+++ b/bokehjs/src/lib/models/glyphs/webgl/accumulate.vert
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 attribute vec2 a_position;
 varying vec2 v_tex_coords;

--- a/bokehjs/src/lib/models/glyphs/webgl/image.frag
+++ b/bokehjs/src/lib/models/glyphs/webgl/image.frag
@@ -1,4 +1,8 @@
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
 
 uniform sampler2D u_tex;
 uniform float u_global_alpha;

--- a/bokehjs/src/lib/models/glyphs/webgl/image.vert
+++ b/bokehjs/src/lib/models/glyphs/webgl/image.vert
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 attribute vec2 a_position;
 attribute vec4 a_bounds;

--- a/bokehjs/src/lib/models/glyphs/webgl/marker.frag
+++ b/bokehjs/src/lib/models/glyphs/webgl/marker.frag
@@ -1,4 +1,8 @@
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
 
 const float SQRT2 = sqrt(2.0);
 const float SQRT3 = sqrt(3.0);

--- a/bokehjs/src/lib/models/glyphs/webgl/marker.vert
+++ b/bokehjs/src/lib/models/glyphs/webgl/marker.vert
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 attribute vec2 a_position;
 attribute vec2 a_center;

--- a/bokehjs/src/lib/models/glyphs/webgl/polygon.frag
+++ b/bokehjs/src/lib/models/glyphs/webgl/polygon.frag
@@ -1,4 +1,8 @@
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
 
 uniform float u_antialias;
 

--- a/bokehjs/src/lib/models/glyphs/webgl/polygon.vert
+++ b/bokehjs/src/lib/models/glyphs/webgl/polygon.vert
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 attribute vec2 a_position;
 attribute vec4 a_fill_color;

--- a/bokehjs/src/lib/models/glyphs/webgl/regl_line.frag
+++ b/bokehjs/src/lib/models/glyphs/webgl/regl_line.frag
@@ -1,4 +1,8 @@
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
 
 const int butt_cap   = 0;
 const int round_cap  = 1;

--- a/bokehjs/src/lib/models/glyphs/webgl/regl_line.vert
+++ b/bokehjs/src/lib/models/glyphs/webgl/regl_line.vert
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 const int butt_cap   = 0;
 const int round_cap  = 1;

--- a/bokehjs/src/lib/models/glyphs/webgl/utils/math.ts
+++ b/bokehjs/src/lib/models/glyphs/webgl/utils/math.ts
@@ -1,31 +1,28 @@
 // Greatest Common Divisor of 2+ integers using Euclid's algorithm.
 function gcd2(a: number, b: number): number {
-  let higher: number
-  let lower: number
+  a = Math.abs(a)
+  b = Math.abs(b)
 
-  if (a > b) {
-    higher = a
-    lower = b
-  } else {
-    higher = b
-    lower = a
+  if (a == 0) {
+    return b
+  }
+  if (b == 0) {
+    return a
   }
 
-  let divisor = higher % lower
-
-  while (divisor != 0) {
-    higher = lower
-    lower = divisor
-    divisor = higher % lower
+  while (b != 0) {
+    const remainder = a % b
+    a = b
+    b = remainder
   }
 
-  return lower
+  return a
 }
 
 export function gcd(values: number[]): number {
-  let ret = values[0]
+  let ret = 0
 
-  for (let i = 1; i < values.length; i++) {
+  for (let i = 0; i < values.length; i++) {
     ret = gcd2(ret, values[i])
   }
 

--- a/bokehjs/test/unit/models/glyphs/webgl/math.ts
+++ b/bokehjs/test/unit/models/glyphs/webgl/math.ts
@@ -9,6 +9,11 @@ describe("WebGL math utilities", () => {
     expect(gcd([0, 0])).to.be.equal(0)
   })
 
+  it("should return the absolute value for a single input", () => {
+    expect(gcd([6])).to.be.equal(6)
+    expect(gcd([-6])).to.be.equal(6)
+  })
+
   it("should ignore zero values and operand signs", () => {
     expect(gcd([0, 6, 9])).to.be.equal(3)
     expect(gcd([-8, 0, 12])).to.be.equal(4)

--- a/bokehjs/test/unit/models/glyphs/webgl/math.ts
+++ b/bokehjs/test/unit/models/glyphs/webgl/math.ts
@@ -1,0 +1,17 @@
+import {expect} from "#framework/assertions"
+
+import {gcd} from "@bokehjs/models/glyphs/webgl/utils/math"
+
+describe("WebGL math utilities", () => {
+  it("should return zero for empty and all-zero inputs", () => {
+    expect(gcd([])).to.be.equal(0)
+    expect(gcd([0])).to.be.equal(0)
+    expect(gcd([0, 0])).to.be.equal(0)
+  })
+
+  it("should ignore zero values and operand signs", () => {
+    expect(gcd([0, 6, 9])).to.be.equal(3)
+    expect(gcd([-8, 0, 12])).to.be.equal(4)
+    expect(gcd([-8, -12])).to.be.equal(4)
+  })
+})

--- a/bokehjs/test/unit/models/glyphs/webgl/shader_precision.ts
+++ b/bokehjs/test/unit/models/glyphs/webgl/shader_precision.ts
@@ -1,4 +1,4 @@
-import {expect} from "#framework/assertions"
+import {expect, expect_condition, expect_not_null} from "#framework/assertions"
 
 import accumulate_vertex_source from "@bokehjs/models/glyphs/webgl/accumulate.vert"
 import accumulate_fragment_source from "@bokehjs/models/glyphs/webgl/accumulate.frag"
@@ -27,6 +27,35 @@ const fragment_sources = new Map([
   ["polygon", polygon_fragment_source],
 ])
 
+function compile_shader(gl: WebGLRenderingContext, type: number, source: string, label: string): WebGLShader {
+  const shader = gl.createShader(type)
+  expect_not_null(shader)
+
+  gl.shaderSource(shader, source)
+  gl.compileShader(shader)
+  expect_condition(gl.getShaderParameter(shader, gl.COMPILE_STATUS) === true,
+    `${label} shader failed to compile: ${gl.getShaderInfoLog(shader) ?? "unknown error"}`)
+
+  return shader
+}
+
+function compile_program(gl: WebGLRenderingContext, vertex_source: string, fragment_source: string, label: string): void {
+  const vertex_shader = compile_shader(gl, gl.VERTEX_SHADER, vertex_source, `${label} vertex`)
+  const fragment_shader = compile_shader(gl, gl.FRAGMENT_SHADER, fragment_source, `${label} fragment`)
+  const program = gl.createProgram()
+  expect_not_null(program)
+
+  gl.attachShader(program, vertex_shader)
+  gl.attachShader(program, fragment_shader)
+  gl.linkProgram(program)
+  expect_condition(gl.getProgramParameter(program, gl.LINK_STATUS) === true,
+    `${label} program failed to link: ${gl.getProgramInfoLog(program) ?? "unknown error"}`)
+
+  gl.deleteProgram(program)
+  gl.deleteShader(fragment_shader)
+  gl.deleteShader(vertex_shader)
+}
+
 describe("WebGL shader precision", () => {
   it("should request high precision in every vertex shader", () => {
     for (const source of vertex_sources.values()) {
@@ -43,6 +72,20 @@ describe("WebGL shader precision", () => {
       expect(source.includes("precision mediump float;")).to.be.true
       expect(source.includes("#endif")).to.be.true
       expect(source.includes("#include")).to.be.false
+    }
+  })
+
+  it("should compile and link every generated shader pair in WebGL", () => {
+    const canvas = document.createElement("canvas")
+    const gl = canvas.getContext("webgl")
+    expect_not_null(gl)
+
+    for (const [name, vertex_source] of vertex_sources) {
+      const fragment_source = fragment_sources.get(name)
+      expect_not_null(fragment_source)
+      // Marker shaders are templates and need a concrete variant, as in regl_marker().
+      const prefix = name == "marker" ? "#define USE_CIRCLE\n" : ""
+      compile_program(gl, `${prefix}${vertex_source}`, `${prefix}${fragment_source}`, name)
     }
   })
 })

--- a/bokehjs/test/unit/models/glyphs/webgl/shader_precision.ts
+++ b/bokehjs/test/unit/models/glyphs/webgl/shader_precision.ts
@@ -1,0 +1,48 @@
+import {expect} from "#framework/assertions"
+
+import accumulate_vertex_source from "@bokehjs/models/glyphs/webgl/accumulate.vert"
+import accumulate_fragment_source from "@bokehjs/models/glyphs/webgl/accumulate.frag"
+import image_vertex_source from "@bokehjs/models/glyphs/webgl/image.vert"
+import image_fragment_source from "@bokehjs/models/glyphs/webgl/image.frag"
+import line_vertex_source from "@bokehjs/models/glyphs/webgl/regl_line.vert"
+import line_fragment_source from "@bokehjs/models/glyphs/webgl/regl_line.frag"
+import marker_vertex_source from "@bokehjs/models/glyphs/webgl/marker.vert"
+import marker_fragment_source from "@bokehjs/models/glyphs/webgl/marker.frag"
+import polygon_vertex_source from "@bokehjs/models/glyphs/webgl/polygon.vert"
+import polygon_fragment_source from "@bokehjs/models/glyphs/webgl/polygon.frag"
+
+const vertex_sources = new Map([
+  ["accumulate", accumulate_vertex_source],
+  ["image", image_vertex_source],
+  ["line", line_vertex_source],
+  ["marker", marker_vertex_source],
+  ["polygon", polygon_vertex_source],
+])
+
+const fragment_sources = new Map([
+  ["accumulate", accumulate_fragment_source],
+  ["image", image_fragment_source],
+  ["line", line_fragment_source],
+  ["marker", marker_fragment_source],
+  ["polygon", polygon_fragment_source],
+])
+
+describe("WebGL shader precision", () => {
+  it("should request high precision in every vertex shader", () => {
+    for (const source of vertex_sources.values()) {
+      expect(source.trimStart().startsWith("precision highp float;")).to.be.true
+      expect(source.includes("#include")).to.be.false
+    }
+  })
+
+  it("should prefer high fragment precision with a portable fallback", () => {
+    for (const source of fragment_sources.values()) {
+      expect(source.includes("#ifdef GL_FRAGMENT_PRECISION_HIGH")).to.be.true
+      expect(source.includes("precision highp float;")).to.be.true
+      expect(source.includes("#else")).to.be.true
+      expect(source.includes("precision mediump float;")).to.be.true
+      expect(source.includes("#endif")).to.be.true
+      expect(source.includes("#include")).to.be.false
+    }
+  })
+})


### PR DESCRIPTION
[codex assisted]

- [x] issues: fixes #15280
- [x] tests added / passed

## Summary

- request high floating-point precision in WebGL vertex shaders
- prefer high precision in fragment shaders while retaining a portable `mediump` fallback
- make the WebGL GCD helper robust for empty, zero-valued, and signed inputs
- add focused unit coverage for shader precision declarations, real WebGL shader compilation/linking, and GCD edge cases
