### PR TITLE
Throttle rather than debounce the model graph recomputation

### DIFF
--- a/bokehjs/src/lib/document/document.ts
+++ b/bokehjs/src/lib/document/document.ts
@@ -305,8 +305,12 @@ export class Document implements Equatable {
     const timeout = this._recompute_timeout
     if (isNaN(timeout) || timeout <= 0) {
       this._recompute_all_models()
-    } else if (isFinite(timeout)) {
-      this._cancel_recompute_all_models()
+    } else if (isFinite(timeout) && this._recompute_timer == null) {
+      // Throttle, don't debounce: an already pending recomputation is left
+      // alone, so that `timeout` bounds how long unreachable models can linger
+      // in `_all_models`. Restarting the timer on every update would defer the
+      // recomputation indefinitely in a document that is updated more often
+      // than `timeout`, e.g. any server application with a periodic callback.
       this._recompute_timer = setTimeout(() => {
         this._recompute_all_models()
       }, timeout)

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -246,6 +246,27 @@ describe("Document", () => {
     expect(d.all_models.size).to.be.equal(2)
   })
 
+  it("prunes all_models within recompute_timeout when updated continuously", () => {
+    const clock = sinon.useFakeTimers({toFake: ["setTimeout", "clearTimeout"]})
+    try {
+      const d = new Document({recompute_timeout: 1000})
+      const m = new SomeModelWithChildren()
+      d.add_root(m)
+      expect(d.all_models.size).to.be.equal(3)
+
+      // Each update makes the previous child unreachable. Updating more often
+      // than recompute_timeout must not defer pruning indefinitely.
+      for (let i = 0; i < 10; i++) {
+        m.children = [new AnotherModel()]
+        clock.tick(500)
+      }
+
+      expect(d.all_models.size).to.be.equal(4)
+    } finally {
+      clock.restore()
+    }
+  })
+
   it("tracks all_models with list property where list elements have a child", () => {
     const d = new Document({recompute_timeout: NaN})
     expect(d.roots().length).to.be.equal(0)

--- a/bokehjs/test/unit/document/document.ts
+++ b/bokehjs/test/unit/document/document.ts
@@ -256,12 +256,16 @@ describe("Document", () => {
 
       // Each update makes the previous child unreachable. Updating more often
       // than recompute_timeout must not defer pruning indefinitely.
-      for (let i = 0; i < 10; i++) {
+      const first_child = new AnotherModel()
+      m.children = [first_child]
+      clock.tick(500)
+      for (let i = 0; i < 9; i++) {
         m.children = [new AnotherModel()]
         clock.tick(500)
       }
 
       expect(d.all_models.size).to.be.equal(4)
+      expect(first_child.document).to.be.null
     } finally {
       clock.restore()
     }


### PR DESCRIPTION
> The investigation and write-up below were done by an AI (Claude). I have proofread and reviewed the code, but as I do not know much about Bokeh I cannot vouch for every detail.

Fixes #15289.

`_schedule_recompute_all_models` cancelled the pending recomputation before scheduling a new one, so `recompute_timeout` acted as a trailing-edge debounce. In a document that is updated more often than the timeout — a server application with any periodic callback — the recomputation was restarted on every update and never ran, so `_all_models` was append-only for the lifetime of the session and `_doc_detached()` never ran for a removed model.

Leaving an already pending recomputation alone turns the timeout into an upper bound on how long unreachable models can linger, which is what the deferral in #14430 was after. `_recompute_all_models()` already clears the timer, so each recomputation opens a fresh window.

This is the minimal change rather than necessarily the one you want: if you would prefer to resolve the *remove* half incrementally in `partially_update_all_models` instead of by periodic full recomputation, I am happy to drop this PR in favour of that.

The existing `all_models` tests pass `recompute_timeout: NaN` and so only cover the synchronous path; the added test drives the timed path with a fake clock. It fails on the unpatched build with `computed: 13, expected: 4`.

- [x] issues: fixes #15289
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

