### PR TITLE
ASGI server followups

### DIFF
--- a/docs/bokeh/source/docs/reference/document/locking.rst
+++ b/docs/bokeh/source/docs/reference/document/locking.rst
@@ -5,3 +5,4 @@ bokeh.document.locking
 
 .. automodule:: bokeh.document.locking
     :members:
+    :exclude-members: LockedCallback, LockedCallbackPolicy

--- a/docs/bokeh/source/docs/user_guide/server/app.rst
+++ b/docs/bokeh/source/docs/user_guide/server/app.rst
@@ -593,6 +593,12 @@ include any or all of the following conventionally named functions:
         # If present, this function executes when the server closes a session.
         pass
 
+The synchronous ``on_session_created`` function defined in ``app_hooks.py``
+runs on a worker thread so that expensive session startup work does not block
+the server's event loop. Hooks for different sessions may run concurrently.
+Use ``session_context.document`` to access the new session's document, and do
+not rely on event-loop or main-thread state in this hook.
+
 You can also define ``on_session_destroyed`` lifecycle hooks directly on the
 ``Document`` being served. This makes it easy to clean up after a user closes
 a session by performing such actions as database connection shutdown without

--- a/docs/bokeh/source/docs/user_guide/server/app.rst
+++ b/docs/bokeh/source/docs/user_guide/server/app.rst
@@ -346,7 +346,7 @@ available, you can define a custom handler hook.
 
 To do so, create an app in :ref:`directory format<ug_server_apps_directory>` and
 include a file called ``request_handler.py`` in the directory. This file must
-include a ``process_request`` function.
+include a synchronous or asynchronous ``process_request`` function.
 
 .. code-block:: python
 
@@ -355,8 +355,11 @@ include a ``process_request`` function.
         return {}
 
 The process then passes Tornado HTTP requests to the handler, which returns a
-dictionary for ``curdoc().session_context.token_payload``. This lets you work
-around some of the ``--num-procs`` issues and provide additional information.
+dictionary for ``curdoc().session_context.token_payload``. Synchronous request
+hooks run in a worker thread so that they do not block unrelated requests.
+Hooks defined with ``async def`` run on the event loop and are awaited. This
+lets you work around some of the ``--num-procs`` issues and provide additional
+information.
 
 .. _ug_server_apps_callbacks:
 
@@ -399,18 +402,25 @@ plots. For more information, see
 Python callbacks in server sessions
 ''''''''''''''''''''''''''''''''''''
 
-Bokeh executes synchronous session callbacks in a bounded worker executor, so
-expensive callback code does not occupy the server's event-loop thread. The
-document remains locked for the duration of the callback: callbacks belonging
-to one session execute serially, while callbacks for different sessions can
-execute concurrently. A synchronous callback may safely update its own
-document, but it should not assume that it is running on the event-loop thread.
+Bokeh executes synchronous periodic, timeout, and next-tick callbacks in a
+bounded worker executor. Model and document callbacks that they trigger, as
+well as callbacks triggered while applying client protocol updates, execute in
+the same worker. The document remains locked for the duration of each callback,
+so callbacks for one session execute serially while callbacks for different
+sessions can execute concurrently. Synchronous callbacks can update their
+session document normally and :func:`~bokeh.io.curdoc` continues to return that
+document, but callback code should not assume it is running on the event-loop
+thread.
 
-Asynchronous periodic, timeout, and next-tick callbacks execute on the event
-loop and retain the document lock across ``await`` expressions. They are useful
-for asynchronous I/O and APIs that require a running event loop. CPU-intensive
-work in an async callback should still be delegated to a thread or process
-executor.
+Callbacks defined with ``async def`` execute on the event loop and retain the
+document lock across ``await`` expressions. They are appropriate for
+asynchronous I/O and event-loop APIs. CPU-intensive or blocking work in an
+async callback must still be delegated to a thread or process executor. Model
+and document callbacks invoked directly by an async callback execute inline as
+part of that callback and must also remain non-blocking.
+
+Updates triggered by a callback are sent over WebSockets on the event-loop
+thread after the synchronous callback finishes.
 
 Unlocked callbacks are available when a long-running operation should not hold
 the session's document lock. See `Updating from unlocked callbacks`_ below.
@@ -432,9 +442,11 @@ bounds queued work when a data producer is faster than the application can
 update.
 
 .. warning::
-    The ONLY safe operations to perform on a document from a different thread
-    are :func:`~bokeh.document.Document.add_next_tick_callback` and
-    :func:`~bokeh.document.Document.remove_next_tick_callback`
+    The only safe ways to update a document from another thread are to invoke
+    a callable created by :meth:`~bokeh.document.Document.locked_callback`, or
+    to schedule and remove callbacks with
+    :func:`~bokeh.document.Document.add_next_tick_callback` and
+    :func:`~bokeh.document.Document.remove_next_tick_callback`.
 
 Remember, direct updates to the document state issuing from another thread,
 whether through other document methods or setting of Bokeh model properties,
@@ -505,11 +517,15 @@ Updating from unlocked callbacks
 ''''''''''''''''''''''''''''''''
 
 Normally Bokeh session callbacks recursively lock the document until all
-future work they initiate is completed. However, you may want to drive
-blocking computations from callbacks using Tornado's ``ThreadPoolExecutor``
-in an asynchronous callback. This requires that you use the
+future work they initiate is completed. However, you may want a long-running
+callback not to prevent other callbacks in the same session from executing.
+This requires that you use the
 :func:`~bokeh.document.without_document_lock` decorator to suppress the normal
 locking behavior.
+
+Synchronous unlocked callbacks run in a worker thread. Asynchronous unlocked
+callbacks run on the event loop; delegate any blocking work they perform to an
+executor as in the following example.
 
 As with the thread example above, **all actions that update document state
 must go through a next tick callback**.

--- a/docs/bokeh/source/docs/user_guide/server/app.rst
+++ b/docs/bokeh/source/docs/user_guide/server/app.rst
@@ -419,9 +419,17 @@ Updating from threads
 '''''''''''''''''''''
 
 You can make blocking computations in separate threads. However, you **must**
-schedule document updates via a next tick callback. This callback executes
-as soon as possible with the next iteration of the Tornado event loop and
-automatically acquires necessary locks to safely update the document state.
+schedule document updates so that they run with the document lock held. The
+:meth:`~bokeh.document.Document.locked_callback` decorator creates a callable
+that can be safely invoked from any thread and schedules the decorated function
+on the document's server session.
+
+The default ``policy="every"`` runs the callback once for every invocation, in
+order. Use ``policy="latest"`` for frequent updates where intermediate values
+may be discarded. At most one invocation waits to run: its arguments may be
+replaced before it starts, or while the current invocation is running. This
+bounds queued work when a data producer is faster than the application can
+update.
 
 .. warning::
     The ONLY safe operations to perform on a document from a different thread
@@ -437,39 +445,38 @@ To allow all threads access to the same document, save a local copy of
 
 .. code-block:: python
 
-    import time
-    from functools import partial
     from random import random
-    from threading import Thread
+    from threading import Event, Thread
 
     from bokeh.models import ColumnDataSource
     from bokeh.plotting import curdoc, figure
 
-    # only modify from a Bokeh session callback
     source = ColumnDataSource(data=dict(x=[0], y=[0]))
-
-    # This is important! Save curdoc() to make sure all threads
-    # see the same document.
     doc = curdoc()
+    stop = Event()
 
-    async def update(x, y):
+    @doc.locked_callback(policy="latest")
+    def update(x, y):
         source.stream(dict(x=[x], y=[y]))
 
     def blocking_task():
-        while True:
+        while not stop.wait(0.1):
             # do some blocking computation
-            time.sleep(0.1)
             x, y = random(), random()
 
-            # but update the document from a callback
-            doc.add_next_tick_callback(partial(update, x=x, y=y))
+            # safe from this thread; the function runs later with the lock
+            update(x, y)
+
+    def session_destroyed(session_context):
+        stop.set()
 
     p = figure(x_range=[0, 1], y_range=[0,1])
     l = p.scatter(marker='circle', x='x', y='y', source=source)
 
     doc.add_root(p)
+    doc.on_session_destroyed(session_destroyed)
 
-    thread = Thread(target=blocking_task)
+    thread = Thread(target=blocking_task, daemon=True)
     thread.start()
 
 To see this example in action, save the above code to a Python file, for
@@ -479,11 +486,13 @@ example, ``testapp.py``, and then execute the following command:
 
     bokeh serve --show testapp.py
 
-.. warning::
-    There is currently no locking around adding next tick callbacks to
-    documents. Bokeh should have a more fine-grained locking for callback
-    methods in the future, but for now it is best to have each thread add no
-    more than one callback to the document.
+The decorated callable returns immediately; its return value is always
+``None``. It may wrap either a synchronous or asynchronous function. You can
+inspect its ``pending`` and ``closed`` properties, and call ``close()`` to
+discard pending work. It closes automatically when the session is destroyed.
+
+For lower-level scheduling, you can still use
+:meth:`~bokeh.document.Document.add_next_tick_callback` directly.
 
 Updating from unlocked callbacks
 ''''''''''''''''''''''''''''''''

--- a/docs/bokeh/source/docs/user_guide/server/app.rst
+++ b/docs/bokeh/source/docs/user_guide/server/app.rst
@@ -440,6 +440,13 @@ Remember, direct updates to the document state issuing from another thread,
 whether through other document methods or setting of Bokeh model properties,
 risk data and protocol corruption.
 
+.. note::
+    The Bokeh server uses a bounded internal worker pool for autoload resources
+    and outbound document and patch serialization. It holds the session's
+    document lock while a worker produces a consistent snapshot, then performs
+    transport writes on the Tornado event loop. This internal use of threads
+    does not make direct document updates from application threads safe.
+
 To allow all threads access to the same document, save a local copy of
 ``curdoc()``. The example below illustrates this process.
 

--- a/docs/bokeh/source/docs/user_guide/server/deploy.rst
+++ b/docs/bokeh/source/docs/user_guide/server/deploy.rst
@@ -549,6 +549,9 @@ current user (or ``None``):
 The module passes the function to the Tornado ``RequestHandler`` that can
 inspect cookies or request headers to determine the authenticated user. If
 there is no authenticated user, these functions should return ``None``.
+Synchronous ``get_user`` functions run in a worker thread so that slow
+authentication does not block unrelated requests. Asynchronous
+``get_user_async`` functions run on the event loop and are awaited.
 
 Additionally, the module must specify where to redirect unauthenticated users
 by including either:
@@ -572,7 +575,8 @@ automatically.
 
 The ``get_login_url`` function is useful in cases where the login URL must
 vary based on the request, cookies, or other factors. You can also specify a
-``LoginHandler`` when defining the ``get_url_function``.
+``LoginHandler`` when defining the ``get_url_function``. Bokeh computes a
+request-specific login URL in a worker thread and caches it for the redirect.
 
 To define an endpoint for logging users out, you can also use optional
 ``logout_url`` and ``LogoutHandler`` parameters, similar to the login options.

--- a/docs/bokeh/source/docs/user_guide/server/library.rst
+++ b/docs/bokeh/source/docs/user_guide/server/library.rst
@@ -64,6 +64,7 @@ The mount's ASGI ``root_path`` is included automatically in Bokeh resource and
 websocket URLs. Equivalent complete examples are available for:
 
 * :bokeh-tree:`examples/server/api/asgi/fastapi_embed.py`
+* :bokeh-tree:`examples/server/api/asgi/fastapi_shared_data.py`
 * :bokeh-tree:`examples/server/api/asgi/starlette_embed.py`
 * :bokeh-tree:`examples/server/api/asgi/django_embed.py`
 * :bokeh-tree:`examples/server/api/asgi/framework_free.py`
@@ -74,6 +75,34 @@ lifespan events. ASGI does not expose websocket ping frames, so transport
 keepalive should be configured on the ASGI server (for example, Uvicorn's
 websocket ping interval) rather than with Bokeh's
 ``keep_alive_milliseconds`` option.
+
+Updating active sessions from the host
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An enclosing ASGI application's lifespan can own a single background producer
+and publish its output to every currently active Bokeh session. Pass
+:meth:`~bokeh.server.asgi.BokehASGI.update_sessions` a callable that accepts a
+single :class:`~bokeh.document.document.Document`:
+
+.. code-block:: python
+
+   def update_document(doc):
+       source = doc.get_model_by_name("shared-source")
+       source.data = latest_snapshot
+
+   await bokeh_app.update_sessions("/", update_document)
+
+Bokeh invokes ``update_document`` once per local session with that document's
+lock held. The callable may be synchronous or asynchronous, and updates to
+different sessions run concurrently. Sessions created after the call starts
+are not included, so application construction should also initialize a new
+document from the latest snapshot. Shared data read by synchronous application
+code must be immutable or protected for access from worker threads.
+
+This operation is process-local. Deployments with multiple ASGI workers need
+an external broker or data service to deliver each snapshot to every worker.
+See :bokeh-tree:`examples/server/api/asgi/fastapi_shared_data.py` for a complete
+lifespan-managed example.
 
 ASGI servers send lifespan events to the top-level application. When Bokeh is
 mounted under a framework that does not propagate those events to mounts, such

--- a/examples/server/api/asgi/README.md
+++ b/examples/server/api/asgi/README.md
@@ -8,6 +8,11 @@ the same interactive signal-studio application directly into the host page.
 The Bokeh application in `bkapp.py` is an ordinary script application loaded
 by passing its `Path` directly to `BokehASGI`.
 
+`fastapi_shared_data.py` is a separate, compact example with one background
+producer owned by the FastAPI lifespan. New Bokeh sessions start from its
+latest immutable snapshot, and `BokehASGI.update_sessions()` safely applies
+each subsequent snapshot to every local session document.
+
 FastAPI and Starlette do not forward lifespan events to mounted applications.
 Those examples therefore start and stop Bokeh explicitly from the host
 application's lifespan context so that server load and unload hooks run.
@@ -18,6 +23,7 @@ chosen example, then run one of:
 ```sh
 python -m uvicorn framework_free:application --port 8000
 python -m uvicorn fastapi_embed:app --port 8000
+python -m uvicorn fastapi_shared_data:app --port 8000
 python -m uvicorn starlette_embed:app --port 8000
 python -m uvicorn django_embed:application --port 8000
 ```

--- a/examples/server/api/asgi/fastapi_shared_data.py
+++ b/examples/server/api/asgi/fastapi_shared_data.py
@@ -1,0 +1,132 @@
+"""Share one background data producer with every local Bokeh session.
+
+Run with::
+
+    python -m uvicorn fastapi_shared_data:app --port 8000
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
+from math import pi, sin
+from threading import Lock
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+
+from bokeh.document import Document
+from bokeh.embed import server_document
+from bokeh.layouts import column
+from bokeh.models import ColumnDataSource, Div
+from bokeh.plotting import figure
+from bokeh.server.asgi import BokehASGI
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    phase: float
+    x: tuple[float, ...]
+    y: tuple[float, ...]
+
+
+class Latest:
+    """A thread-safe reference read while session documents are constructed."""
+
+    def __init__(self, snapshot: Snapshot) -> None:
+        self._lock = Lock()
+        self._snapshot = snapshot
+
+    def read(self) -> Snapshot:
+        with self._lock:
+            return self._snapshot
+
+    def replace(self, snapshot: Snapshot) -> None:
+        with self._lock:
+            self._snapshot = snapshot
+
+
+def make_snapshot(phase: float) -> Snapshot:
+    x = tuple(index / 25 for index in range(151))
+    y = tuple(sin(2 * pi * value + phase) for value in x)
+    return Snapshot(phase, x, y)
+
+
+latest = Latest(make_snapshot(0))
+
+
+def apply_snapshot(doc: Document, snapshot: Snapshot) -> None:
+    source = doc.select_one({"name": "shared-source"})
+    phase = doc.select_one({"name": "shared-phase"})
+    if not isinstance(source, ColumnDataSource) or not isinstance(phase, Div):
+        raise RuntimeError("Shared-data document is missing its named models")
+    source.data = {"x": list(snapshot.x), "y": list(snapshot.y)}
+    phase.text = f"Server phase: {snapshot.phase:.2f} radians"
+
+
+def modify_document(doc: Document) -> None:
+    """Build one independent document from the producer's latest snapshot."""
+    snapshot = latest.read()
+    source = ColumnDataSource(
+        data={"x": list(snapshot.x), "y": list(snapshot.y)},
+        name="shared-source",
+    )
+    phase = Div(text="", name="shared-phase")
+    plot = figure(height=320, sizing_mode="stretch_width", title="One producer, many sessions")
+    plot.line("x", "y", source=source, line_width=3)
+    doc.add_root(column(phase, plot, sizing_mode="stretch_width"))
+    doc.title = "Shared ASGI data"
+    apply_snapshot(doc, snapshot)
+
+
+bokeh_application = BokehASGI({"/": modify_document})
+
+
+async def produce() -> None:
+    phase = 0.0
+    while True:
+        snapshot = make_snapshot(phase)
+        latest.replace(snapshot)
+
+        def update_document(doc: Document) -> None:
+            apply_snapshot(doc, snapshot)
+
+        await bokeh_application.update_sessions("/", update_document)
+        phase = (phase + 0.12) % (2 * pi)
+        await asyncio.sleep(0.1)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # The parent owns both lifecycles because mounted applications don't
+    # receive lifespan events from FastAPI/Starlette.
+    await bokeh_application.core.start()
+    producer = asyncio.create_task(produce())
+    try:
+        yield
+    finally:
+        producer.cancel()
+        with suppress(asyncio.CancelledError):
+            await producer
+        await bokeh_application.core.stop()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    root_path = request.scope.get("root_path", "").rstrip("/")
+    script = server_document(f"{root_path}/bkapp", relative_urls=True)
+    return HTMLResponse(f"""<!doctype html>
+<title>Shared Bokeh data</title>
+<main style="max-width: 900px; margin: 2rem auto; font-family: sans-serif">
+  <h1>One ASGI producer, every Bokeh session</h1>
+  <p>Open this page in another tab: both independent sessions receive the same snapshots.</p>
+  {script}
+</main>
+""")
+
+
+app.mount("/bkapp", bokeh_application)

--- a/examples/server/app/locked_callback.py
+++ b/examples/server/app/locked_callback.py
@@ -9,16 +9,18 @@ doc = curdoc()
 stop = Event()
 
 
-@doc.locked_callback(policy="latest")
-def update(x: float, y: float) -> None:
-    source.stream(dict(x=[x], y=[y]), rollover=100)
+def start_producer() -> None:
+    @doc.locked_callback(policy="latest")
+    def update(x: float, y: float) -> None:
+        source.stream(dict(x=[x], y=[y]), rollover=100)
 
+    def produce_data() -> None:
+        while not stop.wait(0.05):
+            # This function may block or be called by an external library. The
+            # decorated callback schedules the model update with the document lock.
+            update(random(), random())
 
-def produce_data() -> None:
-    while not stop.wait(0.05):
-        # This function may block or be called by an external library. The
-        # decorated callback schedules the model update with the document lock.
-        update(random(), random())
+    Thread(target=produce_data, daemon=True).start()
 
 
 def session_destroyed(session_context) -> None:
@@ -30,5 +32,4 @@ plot.scatter(x="x", y="y", source=source, size=10)
 
 doc.add_root(plot)
 doc.on_session_destroyed(session_destroyed)
-
-Thread(target=produce_data, daemon=True).start()
+doc.add_next_tick_callback(start_producer)

--- a/examples/server/app/locked_callback.py
+++ b/examples/server/app/locked_callback.py
@@ -1,0 +1,34 @@
+from random import random
+from threading import Event, Thread
+
+from bokeh.models import ColumnDataSource
+from bokeh.plotting import curdoc, figure
+
+source = ColumnDataSource(data=dict(x=[0.0], y=[0.0]))
+doc = curdoc()
+stop = Event()
+
+
+@doc.locked_callback(policy="latest")
+def update(x: float, y: float) -> None:
+    source.stream(dict(x=[x], y=[y]), rollover=100)
+
+
+def produce_data() -> None:
+    while not stop.wait(0.05):
+        # This function may block or be called by an external library. The
+        # decorated callback schedules the model update with the document lock.
+        update(random(), random())
+
+
+def session_destroyed(session_context) -> None:
+    stop.set()
+
+
+plot = figure(x_range=(0, 1), y_range=(0, 1), height=350)
+plot.scatter(x="x", y="y", source=source, size=10)
+
+doc.add_root(plot)
+doc.on_session_destroyed(session_destroyed)
+
+Thread(target=produce_data, daemon=True).start()

--- a/src/bokeh/application/application.py
+++ b/src/bokeh/application/application.py
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import inspect
 from abc import ABCMeta, abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -41,6 +42,7 @@ from typing import (
 # Bokeh imports
 from ..document import Document
 from ..settings import settings
+from ..util.asyncio import _run_in_executor
 
 if TYPE_CHECKING:
     from ..core.types import ID
@@ -256,6 +258,21 @@ class Application:
         request_data: dict[str, Any] = {}
         for h in self._handlers:
             request_data.update(h.process_request(request))
+        return request_data
+
+    async def process_request_async(self, request: RequestLike) -> dict[str, Any]:
+        ''' Asynchronously process an incoming HTTP request.
+
+        Synchronous handlers run in a worker, while handlers that return an
+        awaitable continue on the event loop. Handler ordering and dictionary
+        update semantics match :meth:`process_request`.
+        '''
+        request_data: dict[str, Any] = {}
+        for h in self._handlers:
+            result: Any = await _run_in_executor(h.process_request, request)
+            if inspect.isawaitable(result):
+                result = await result
+            request_data.update(result)
         return request_data
 
 

--- a/src/bokeh/application/handlers/lifecycle.py
+++ b/src/bokeh/application/handlers/lifecycle.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
 from typing import TYPE_CHECKING, Any, Callable
 
 # Bokeh imports
@@ -115,7 +116,8 @@ class LifecycleHandler(Handler):
             session_context (SessionContext) :
 
         '''
-        self._on_session_created(session_context)
+        if self._on_session_created is not _do_nothing:
+            await asyncio.to_thread(self._on_session_created, session_context)
 
     async def on_session_destroyed(self, session_context: SessionContext) -> None:
         ''' Execute ``on_session_destroyed`` from the configured module (if

--- a/src/bokeh/document/__init__.py
+++ b/src/bokeh/document/__init__.py
@@ -43,6 +43,8 @@ __all__ = (
     'DEFAULT_TITLE',
     'Document',
     'DocumentLike',
+    'LockedCallback',
+    'LockedCallbackPolicy',
     'without_document_lock',
 )
 
@@ -52,7 +54,7 @@ __all__ = (
 
 from .document import DEFAULT_TITLE
 from .document import Document
-from .locking import UnlockedDocumentProxy, without_document_lock
+from .locking import LockedCallback, LockedCallbackPolicy, UnlockedDocumentProxy, without_document_lock
 
 type DocumentLike = Document | UnlockedDocumentProxy
 

--- a/src/bokeh/document/callbacks.py
+++ b/src/bokeh/document/callbacks.py
@@ -25,7 +25,12 @@ log = logging.getLogger(__name__)
 import weakref
 from collections import defaultdict
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+)
 
 # Bokeh imports
 from ..core.enums import HoldPolicy
@@ -80,7 +85,7 @@ __all__ = (
 )
 
 
-Callback = Callable[[], None]
+Callback = Callable[[], None | Awaitable[None]]
 Originator = Callable[..., Any]
 
 MessageCallback = Callable[[Any], None]
@@ -188,7 +193,7 @@ class DocumentCallbackManager:
         actual_callback: Callback
         if one_shot:
             @wraps(callback)
-            def remove_then_invoke() -> None:
+            def remove_then_invoke() -> None | Awaitable[None]:
                 if callback_obj in self._session_callbacks:
                     self.remove_session_callback(callback_obj)
                 return callback()
@@ -454,7 +459,7 @@ class DocumentCallbackManager:
 # Dev API
 #-----------------------------------------------------------------------------
 
-def invoke_with_curdoc(doc: Document, f: Callable[[], None]) -> None:
+def invoke_with_curdoc[T](doc: Document, f: Callable[[], T]) -> T:
     from ..io.doc import patch_curdoc
 
     curdoc: DocumentLike = UnlockedDocumentProxy(doc) if getattr(f, "nolock", False) else doc
@@ -498,7 +503,7 @@ def _combine_document_events(new_event: DocumentChangedEvent, old_events: list[D
 
 def _wrap_with_curdoc(doc: Document, f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
-    def wrapper(*args: Any, **kwargs: Any) -> None:
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         @wraps(f)
         def invoke() -> Any:
             return f(*args, **kwargs)

--- a/src/bokeh/document/document.py
+++ b/src/bokeh/document/document.py
@@ -40,6 +40,7 @@ from json import loads
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Iterable,
     Literal,
     overload,
@@ -100,6 +101,7 @@ if TYPE_CHECKING:
     )
     from .events import DocumentChangeCallback
     from .json import DocJson, PatchJson
+    from .locking import LockedCallback, LockedCallbackPolicy
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -306,6 +308,68 @@ class Document:
         from ..server.callbacks import NextTickCallback
         cb = NextTickCallback(callback=_no_op_callback, callback_id=make_id())
         return self.callbacks.add_session_callback(cb, callback, one_shot=True)
+
+    @overload
+    def locked_callback[**P](self, callback: Callable[P, Any], *, policy: LockedCallbackPolicy = "every") -> LockedCallback[P]: ...
+
+    @overload
+    def locked_callback[**P](self, callback: None = None, *, policy: LockedCallbackPolicy = "every") -> Callable[[Callable[P, Any]], LockedCallback[P]]: ...
+
+    def locked_callback[**P](
+        self, callback: Callable[P, Any] | None = None, *, policy: LockedCallbackPolicy = "every",
+    ) -> LockedCallback[P] | Callable[[Callable[P, Any]], LockedCallback[P]]:
+        ''' Decorate a callback to safely update this document from any thread.
+
+        The decorated function schedules its work on this document's server
+        session and executes with the document lock held. Calls return
+        immediately instead of returning the wrapped function's result.
+
+        Parentheses are optional when using the default policy. That is,
+        ``@doc.locked_callback`` and ``@doc.locked_callback()`` are equivalent.
+
+        Args:
+            callback (callable, optional):
+                The function to decorate when this method is used without
+                parentheses.
+
+            policy (``"every"`` or ``"latest"``, optional):
+                With ``"every"``, invoke the callback once for every call, in
+                order. With ``"latest"``, keep at most one waiting invocation,
+                replacing its arguments with those from the most recent call.
+
+        Returns:
+            A decorator that produces a
+            :class:`~bokeh.document.locking.LockedCallback`.
+
+        Example:
+
+            .. code-block:: python
+
+                @curdoc().locked_callback(policy="latest")
+                def update(value):
+                    source.data = value
+
+                @curdoc().locked_callback
+                def notify(value):
+                    status.text = value
+
+                # Safe to call from another thread:
+                update(new_data)
+
+        .. note::
+            Locked callbacks require a Bokeh server session and are closed
+            automatically when that session is destroyed.
+
+        '''
+        from .locking import LockedCallback
+
+        if callback is not None:
+            return LockedCallback(self, callback, policy=policy)
+
+        def decorator(callback: Callable[P, Any]) -> LockedCallback[P]:
+            return LockedCallback(self, callback, policy=policy)
+
+        return decorator
 
     def add_periodic_callback(self, callback: Callback, period_milliseconds: int) -> PeriodicCallback:
         ''' Add a callback to be invoked on a session periodically.

--- a/src/bokeh/document/locking.py
+++ b/src/bokeh/document/locking.py
@@ -112,7 +112,7 @@ class LockedCallback[**P]:
 
         # Keep the lifecycle callback alive without making the Document keep
         # this wrapper (and its user callback) alive after an explicit close.
-        self._session_destroyed_callback = session_destroyed
+        self._session_destroyed_callback: Callable[[SessionContext], None] | None = session_destroyed
         document.on_session_destroyed(session_destroyed)
 
     @property
@@ -209,7 +209,7 @@ class LockedCallback[**P]:
             raise
 
         if inspect.isawaitable(result):
-            return self._wait_for_result(cast(Awaitable[Any], result), document)
+            return self._wait_for_result(result, document)
 
         self._finish()
         return result

--- a/src/bokeh/document/locking.py
+++ b/src/bokeh/document/locking.py
@@ -22,10 +22,14 @@ log = logging.getLogger(__name__)
 
 # Standard library imports
 import inspect
-from functools import wraps
+import threading
+import weakref
+from collections import deque
+from functools import update_wrapper, wraps
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Literal,
     Protocol,
@@ -34,6 +38,7 @@ from typing import (
 
 ## Bokeh imports
 if TYPE_CHECKING:
+    from ..application.application import SessionContext
     from ..server.callbacks import NextTickCallback
     from .document import Callback, Document
 
@@ -42,6 +47,8 @@ if TYPE_CHECKING:
 #-----------------------------------------------------------------------------
 
 __all__ = (
+    'LockedCallback',
+    'LockedCallbackPolicy',
     'UnlockedDocumentProxy',
     'without_document_lock',
 )
@@ -49,6 +56,215 @@ __all__ = (
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+type LockedCallbackPolicy = Literal["every", "latest"]
+
+type _Invocation = tuple[tuple[Any, ...], dict[str, Any]]
+
+
+class LockedCallback[**P]:
+    ''' A thread-safe callable that schedules work with a document lock held.
+
+    Instances are normally created with :meth:`~bokeh.document.Document.locked_callback`
+    instead of constructing them directly.
+
+    Calls return immediately after scheduling the wrapped callback. With the
+    ``"every"`` policy, all calls run in order. With the ``"latest"`` policy,
+    at most one invocation waits to run: its arguments may be replaced before
+    it starts, or while the current invocation is running.
+
+    A locked callback is closed automatically when its server session is
+    destroyed. It can also be closed explicitly with :meth:`close`.
+
+    '''
+
+    __annotations__: dict[str, Any]
+    __name__: str
+    __qualname__: str
+    __wrapped__: Callable[P, Any]
+
+    def __init__(self, document: Document, callback: Callable[P, Any], *, policy: LockedCallbackPolicy = "every") -> None:
+        if policy not in ("every", "latest"):
+            raise ValueError(f"unknown locked callback policy {policy!r}")
+
+        session_context = document.session_context
+        if session_context is None:
+            raise RuntimeError("locked callbacks require a Bokeh server session")
+
+        update_wrapper(self, callback)
+
+        self._document_ref = weakref.ref(document)
+        self._session_context_ref = weakref.ref(session_context)
+        self._callback: Callable[P, Any] | None = callback
+        self._policy: LockedCallbackPolicy = policy
+
+        self._lock = threading.Lock()
+        self._queue: deque[_Invocation] = deque()
+        self._latest: _Invocation | None = None
+        self._scheduled = False
+        self._closed = False
+
+        callback_ref = weakref.ref(self)
+
+        def session_destroyed(session_context: SessionContext) -> None:
+            if locked_callback := callback_ref():
+                locked_callback.close()
+
+        # Keep the lifecycle callback alive without making the Document keep
+        # this wrapper (and its user callback) alive after an explicit close.
+        self._session_destroyed_callback = session_destroyed
+        document.on_session_destroyed(session_destroyed)
+
+    @property
+    def closed(self) -> bool:
+        ''' Whether this callback will reject future invocations. '''
+        with self._lock:
+            return self._closed
+
+    @property
+    def pending(self) -> bool:
+        ''' Whether an invocation is scheduled, running, or waiting to run. '''
+        with self._lock:
+            return self._scheduled
+
+    @property
+    def policy(self) -> LockedCallbackPolicy:
+        ''' The policy used to handle calls that arrive while work is pending. '''
+        return self._policy
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        ''' Schedule the wrapped callback and return immediately. '''
+        if not self._is_active():
+            self.close()
+            return
+
+        invocation: _Invocation = (args, kwargs)
+        schedule = False
+        with self._lock:
+            if self._closed:
+                return
+
+            if self._policy == "every":
+                self._queue.append(invocation)
+            else:
+                self._latest = invocation
+
+            if not self._scheduled:
+                self._scheduled = True
+                schedule = True
+
+        if schedule:
+            self._schedule()
+
+    def close(self) -> None:
+        ''' Discard pending invocations and prevent future calls.
+
+        An invocation that is already running is allowed to finish.
+
+        '''
+        with self._lock:
+            if self._closed:
+                return
+
+            self._closed = True
+            self._scheduled = False
+            self._queue.clear()
+            self._latest = None
+            self._callback = None
+            self._session_destroyed_callback = None
+            self.__dict__.pop("__wrapped__", None)
+
+    def _finish(self) -> None:
+        schedule = False
+        with self._lock:
+            if self._closed:
+                self._scheduled = False
+            elif self._queue or self._latest is not None:
+                schedule = True
+            else:
+                self._scheduled = False
+
+        if schedule:
+            self._schedule()
+
+    def _invoke(self) -> Any:
+        invocation = self._take_invocation()
+        if invocation is None:
+            self._finish()
+            return None
+
+        document = self._document_ref()
+        if document is None:
+            self.close()
+            return None
+
+        from ..io.doc import patch_curdoc
+
+        callback, args, kwargs = invocation
+        try:
+            with patch_curdoc(document):
+                result = callback(*args, **kwargs)
+        except BaseException:
+            self._finish()
+            raise
+
+        if inspect.isawaitable(result):
+            return self._wait_for_result(cast(Awaitable[Any], result), document)
+
+        self._finish()
+        return result
+
+    def _is_active(self) -> bool:
+        document = self._document_ref()
+        session_context = self._session_context_ref()
+        return document is not None and session_context is not None and \
+            document.session_context is session_context and not session_context.destroyed
+
+    def _schedule(self) -> None:
+        document = self._document_ref()
+        if document is None or not self._is_active():
+            self.close()
+            return
+
+        with self._lock:
+            if self._closed or not self._scheduled:
+                return
+
+        try:
+            document.add_next_tick_callback(self._invoke)
+        except Exception:
+            inactive = not self._is_active()
+            self.close()
+            if not inactive:
+                raise
+
+    def _take_invocation(self) -> tuple[Callable[P, Any], tuple[Any, ...], dict[str, Any]] | None:
+        with self._lock:
+            callback = self._callback
+            if self._closed or callback is None:
+                return None
+
+            if self._policy == "every":
+                if not self._queue:
+                    return None
+                args, kwargs = self._queue.popleft()
+            else:
+                if self._latest is None:
+                    return None
+                args, kwargs = self._latest
+                self._latest = None
+
+            return callback, args, kwargs
+
+    async def _wait_for_result(self, result: Awaitable[Any], document: Document) -> Any:
+        from ..io.doc import patch_curdoc
+
+        try:
+            with patch_curdoc(document):
+                return await result
+        finally:
+            self._finish()
+
 
 class NoLockCallback[F: Callable[..., Any]](Protocol):
     __call__: F

--- a/src/bokeh/embed/bundle.py
+++ b/src/bokeh/embed/bundle.py
@@ -143,6 +143,9 @@ class Bundle:
         elif isinstance(artifact, Style):
             self.css_raw.append(artifact.content)
 
+    def clone(self) -> Bundle:
+        return Bundle(self.js_files, self.js_raw, self.css_files, self.css_raw, self.hashes)
+
 def bundle_for_objs_and_resources(objs: Sequence[HasProps | Document] | None, resources: Resources | None) -> Bundle:
     ''' Generate rendered CSS and JS resources suitable for the given
     collection of Bokeh objects

--- a/src/bokeh/protocol/message.py
+++ b/src/bokeh/protocol/message.py
@@ -326,6 +326,13 @@ class Message[Content]:
 
             return sent
 
+    def prepare(self) -> None:
+        ''' Eagerly serialize all message fragments and freeze binary buffers. '''
+        self._buffers = [Buffer(buffer.id, buffer.to_bytes()) for buffer in self._buffers]
+        self._header_json = json.dumps(self.header)
+        self._metadata_json = json.dumps(self.metadata)
+        self._content_json = serialize_json(self.payload)
+
     @property
     def complete(self) -> bool:
         ''' Returns whether all required parts of a message are present.

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from ..application import Application
     from ..application.handlers.function import ModifyDoc
     from ..core.types import ID, PathLike
+    from ..document import Document
     from .connection import ServerConnection
     from .contexts import ApplicationContext
 
@@ -157,6 +158,28 @@ class BokehASGI:
     @property
     def core(self) -> BokehServerCore:
         return self._core
+
+    async def update_sessions(
+        self,
+        app_path: str,
+        update_document: Callable[[Document], None | Awaitable[None]],
+    ) -> None:
+        ''' Update every active session document for an application.
+
+        This is a convenience wrapper for
+        :meth:`~bokeh.server.core.BokehServerCore.update_sessions`.
+
+        Args:
+            app_path:
+                The configured application path whose sessions are updated.
+
+            update_document:
+                A synchronous or asynchronous callable that receives one
+                session :class:`~bokeh.document.document.Document` with its
+                document lock held.
+
+        '''
+        await self._core.update_sessions(app_path, update_document)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope_type = scope["type"]

--- a/src/bokeh/server/asgi.py
+++ b/src/bokeh/server/asgi.py
@@ -548,7 +548,7 @@ class BokehASGI:
         if await self._authenticate(request):
             return True
         assert self._auth_policy is not None
-        if (login_url := self._auth_policy.get_login_url(request)) is not None:
+        if (login_url := await self._auth_policy.get_login_url_async(request)) is not None:
             await self._response(
                 send,
                 302,

--- a/src/bokeh/server/auth.py
+++ b/src/bokeh/server/auth.py
@@ -14,6 +14,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 # Bokeh imports
+from ..util.asyncio import _run_in_executor
 from .request import ServerRequest
 
 __all__ = (
@@ -52,7 +53,7 @@ class AuthPolicy:
 
     async def authenticate(self, request: ServerRequest) -> Any | None:
         ''' Return the authenticated user for a request, or ``None``. '''
-        user = self._authenticator(request)
+        user = await _run_in_executor(self._authenticator, request)
         if inspect.isawaitable(user):
             user = await user
         return user
@@ -61,6 +62,12 @@ class AuthPolicy:
         ''' Return the login URL for an unauthenticated HTTP request. '''
         if callable(self._login_url):
             return self._login_url(request)
+        return self._login_url
+
+    async def get_login_url_async(self, request: ServerRequest) -> str | None:
+        ''' Return a request-specific login URL without blocking the event loop. '''
+        if callable(self._login_url):
+            return await _run_in_executor(self._login_url, request)
         return self._login_url
 
     @property

--- a/src/bokeh/server/callbacks.py
+++ b/src/bokeh/server/callbacks.py
@@ -22,7 +22,12 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import TYPE_CHECKING, Callable, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    Sequence,
+)
 
 # Bokeh imports
 from ..util.asyncio import Loop, _CallbackGroup
@@ -45,7 +50,7 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-Callback = Callable[[], None]
+Callback = Callable[[], None | Awaitable[None]]
 
 class SessionCallback:
     ''' A base class for callback objects associated with Bokeh Documents

--- a/src/bokeh/server/connection.py
+++ b/src/bokeh/server/connection.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING, Any, Awaitable
 
 ## Bokeh imports
 if TYPE_CHECKING:
-    from ..document.events import DocumentPatchedEvent
     from ..protocol import Protocol, messages as msg
     from ..protocol.message import Message
     from .contexts import ApplicationContext
@@ -81,11 +80,8 @@ class ServerConnection:
     def error(self, message: Message[Any], text: str) -> msg.error:
         return self.protocol.create('ERROR', message.header['msgid'], text)
 
-    def send_patch_document(self, event: DocumentPatchedEvent) -> Awaitable[None]:
-        """ Sends a PATCH-DOC message, returning a Future that's completed when it's written out. """
-        msg = self.protocol.create('PATCH-DOC', [event])
-        # yes, *return* the awaitable, it will be awaited when pending writes are processed
-        return self._socket.send_message(msg)
+    def send_message(self, message: Message[Any]) -> Awaitable[None]:
+        return self._socket.send_message(message)
 
     def send_ping(self) -> None:
         self._socket.ping(str(self._ping_count).encode("utf-8"))

--- a/src/bokeh/server/contexts.py
+++ b/src/bokeh/server/contexts.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from ..application.application import Application
     from ..core.types import ID
     from ..util.token import TokenPayload
+    from .executor import _ServerExecutor
     from .request import RequestLike
 
 #-----------------------------------------------------------------------------
@@ -155,9 +156,10 @@ class ApplicationContext:
     _server_context: BokehServerContext
 
     def __init__(self, application: Application, io_loop: Loop | None = None,
-            url: str | None = None, logout_url: str | None = None):
+            url: str | None = None, logout_url: str | None = None, executor: _ServerExecutor | None = None):
         self._application = application
         self._loop = io_loop
+        self._executor = executor
         self._sessions = {}
         self._pending_sessions = {}
         self._session_contexts = {}
@@ -306,7 +308,7 @@ class ApplicationContext:
         await self._initialize_document_async(doc)
 
         io_loop = self._loop or asyncio.get_running_loop()
-        session = ServerSession(session_id, doc, io_loop=io_loop, token=token)
+        session = ServerSession(session_id, doc, io_loop=io_loop, token=token, executor=self._executor)
         self._sessions[session_id] = session
         session_context._set_session(session)
         self._session_contexts[session_id] = session_context

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 # Standard library imports
 import asyncio
 import logging
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from os import PathLike as OSPathLike
 from os.path import isdir
 from typing import (
@@ -39,6 +39,7 @@ from .contexts import ApplicationContext
 if TYPE_CHECKING:
     from ..application.handlers.function import ModifyDoc
     from ..core.types import ID, PathLike
+    from ..document import Document
     from ..protocol import Protocol
     from .request import RequestLike
     from .session import ServerSession
@@ -443,6 +444,38 @@ class BokehServerCore(SessionConfig):
         if app_path not in self._applications:
             raise ValueError(f"Application {app_path} does not exist on this server")
         return list(self._applications[app_path].sessions)
+
+    async def update_sessions(
+        self,
+        app_path: str,
+        update_document: Callable[[Document], None | Awaitable[None]],
+    ) -> None:
+        ''' Update every active document for an application.
+
+        ``update_document`` is called once for each session that exists when
+        this method starts. Each call receives that session's
+        :class:`~bokeh.document.document.Document` with its document lock held.
+        Synchronous and asynchronous callbacks are both supported, and
+        different sessions are updated concurrently.
+
+        Sessions created after this method takes its snapshot are not updated.
+        Only sessions in this server process are included.
+
+        Args:
+            app_path:
+                The configured application path whose sessions are updated.
+
+            update_document:
+                A callable that mutates one session document.
+
+        '''
+        self._require_running()
+        sessions = self.get_sessions(app_path)
+        updates = (
+            cast(Awaitable[None], session.with_document_locked(update_document, session.document))
+            for session in sessions
+        )
+        await asyncio.gather(*updates)
 
     async def _cleanup_sessions(self) -> None:
         for context in self._applications.values():

--- a/src/bokeh/server/core.py
+++ b/src/bokeh/server/core.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 # Standard library imports
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
+from collections.abc import (
+    Awaitable,
+    Callable,
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from os import PathLike as OSPathLike
 from os.path import isdir
 from typing import (
@@ -121,7 +127,7 @@ async def create_session(config: SessionConfig, context: ApplicationContext, req
             "cookies": cookies,
             "arguments": dict(request.arguments),
         }
-        payload.update(context.application.process_request(request))
+        payload.update(await context.application.process_request_async(request))
         token = generate_jwt_token(
             session_id,
             secret_key=config.secret_key,

--- a/src/bokeh/server/executor.py
+++ b/src/bokeh/server/executor.py
@@ -1,0 +1,74 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+''' Utilities for running server response generation away from the IOLoop. '''
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import asyncio
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from typing import Any
+
+#-----------------------------------------------------------------------------
+# Globals and constants
+#-----------------------------------------------------------------------------
+
+__all__ = ()
+
+_DEFAULT_WORKERS = 4
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+class _ServerExecutor:
+
+    def __init__(self, max_workers: int = _DEFAULT_WORKERS) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="bokeh-response")
+
+    async def run[T](self, func: Callable[..., T], *args: Any, cancel_safe: bool = False) -> T:
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(self._executor, partial(func, *args))
+
+        if not cancel_safe:
+            return await future
+
+        cancellation: asyncio.CancelledError | None = None
+        while not future.done():
+            try:
+                await asyncio.shield(future)
+            except asyncio.CancelledError as error:
+                cancellation = error
+                if future.cancelled():
+                    raise
+
+        if cancellation is not None:
+            # Retrieve any worker exception before preserving cancellation of
+            # the coroutine that owns protected state.
+            try:
+                future.result()
+            except BaseException:
+                pass
+            raise cancellation
+
+        return future.result()
+
+    def shutdown(self, wait: bool = True) -> None:
+        self._executor.shutdown(wait=wait, cancel_futures=not wait)
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/src/bokeh/server/executor.py
+++ b/src/bokeh/server/executor.py
@@ -11,16 +11,17 @@
 #-----------------------------------------------------------------------------
 from __future__ import annotations
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
-
 # Standard library imports
 import asyncio
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Any
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
 
 #-----------------------------------------------------------------------------
 # Globals and constants

--- a/src/bokeh/server/executor.py
+++ b/src/bokeh/server/executor.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 # Standard library imports
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Any
@@ -43,31 +43,33 @@ class _ServerExecutor:
         loop = asyncio.get_running_loop()
         future = loop.run_in_executor(self._executor, partial(func, *args))
 
-        if not cancel_safe:
-            return await future
-
-        cancellation: asyncio.CancelledError | None = None
-        while not future.done():
-            try:
-                await asyncio.shield(future)
-            except asyncio.CancelledError as error:
-                cancellation = error
-                if future.cancelled():
-                    raise
-
-        if cancellation is not None:
-            # Retrieve any worker exception before preserving cancellation of
-            # the coroutine that owns protected state.
-            try:
-                future.result()
-            except BaseException:
-                pass
-            raise cancellation
-
-        return future.result()
+        return await _await_cancellation_safe(future) if cancel_safe else await future
 
     def shutdown(self, wait: bool = True) -> None:
         self._executor.shutdown(wait=wait, cancel_futures=not wait)
+
+async def _await_cancellation_safe[T](awaitable: Awaitable[T]) -> T:
+    future = asyncio.ensure_future(awaitable)
+    cancellation: asyncio.CancelledError | None = None
+
+    while not future.done():
+        try:
+            await asyncio.shield(future)
+        except asyncio.CancelledError as error:
+            cancellation = error
+            if future.cancelled():
+                raise
+
+    if cancellation is not None:
+        # Retrieve any exception before preserving cancellation of the
+        # coroutine that owns protected state.
+        try:
+            future.result()
+        except BaseException:
+            pass
+        raise cancellation
+
+    return future.result()
 
 #-----------------------------------------------------------------------------
 # Code

--- a/src/bokeh/server/session.py
+++ b/src/bokeh/server/session.py
@@ -26,7 +26,8 @@ import inspect
 import threading
 import time
 from copy import copy
-from functools import wraps
+from dataclasses import dataclass
+from functools import partial, wraps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -37,9 +38,11 @@ from typing import (
 
 # Bokeh imports
 from ..events import ConnectionLost
+from ..io.doc import patch_curdoc
 from ..util.asyncio import Loop
 from ..util.token import generate_jwt_token
 from .callbacks import DocumentCallbackGroup
+from .executor import _await_cancellation_safe
 
 if TYPE_CHECKING:
     from ..core.types import ID
@@ -49,9 +52,11 @@ if TYPE_CHECKING:
         SessionCallbackAdded,
         SessionCallbackRemoved,
     )
-    from ..protocol import messages as msg
+    from ..protocol import Protocol, messages as msg
+    from ..protocol.message import Message
     from .callbacks import Callback, SessionCallback
     from .connection import ServerConnection
+    from .executor import _ServerExecutor
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -65,6 +70,27 @@ __all__ = (
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _PendingPatch:
+    event: DocumentPatchedEvent
+    protocol: Protocol
+    connections: tuple[ServerConnection, ...]
+
+def _serialize_patches(pending: list[_PendingPatch]) -> list[tuple[Message[Any], tuple[ServerConnection, ...]]]:
+    messages: list[tuple[Message[Any], tuple[ServerConnection, ...]]] = []
+    for patch in pending:
+        with patch_curdoc(patch.event.document):
+            message = patch.protocol.create("PATCH-DOC", [patch.event])
+            message.prepare()
+        messages.append((message, patch.connections))
+    return messages
+
+def _serialize_pull_reply(protocol: Protocol, request_id: ID, document: Document) -> Message[Any]:
+    with patch_curdoc(document):
+        message = protocol.create("PULL-DOC-REPLY", request_id, document)
+        message.prepare()
+    return message
 
 def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
     '''Decorator that adds the necessary locking and post-processing
@@ -132,13 +158,16 @@ def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
                 except BaseException as callback_error:
                     error = callback_error
                 finally:
-                    # we want to be very sure we reset this or we'll
-                    # keep hitting the RuntimeError above as soon as
-                    # any callback goes wrong
                     pending_writes = self._pending_writes
                     self._pending_writes = None
-                for p in pending_writes:
-                    await p
+                try:
+                    # Finish response generation and writes before releasing
+                    # the document lock, even if the callback was cancelled.
+                    if pending_writes:
+                        await _await_cancellation_safe(self._send_pending_patches(pending_writes))
+                except BaseException as write_error:
+                    if error is None:
+                        error = write_error
                 if error is not None:
                     raise error
             return result
@@ -163,9 +192,10 @@ class ServerSession:
 
     _subscribed_connections: set[ServerConnection]
     _current_patch_connection: ServerConnection | None
-    _pending_writes: list[Awaitable[None]] | None
+    _pending_writes: list[_PendingPatch] | None
 
-    def __init__(self, session_id: ID, document: Document, io_loop: Loop | None = None, token: str | None = None) -> None:
+    def __init__(self, session_id: ID, document: Document, io_loop: Loop | None = None,
+            token: str | None = None, executor: _ServerExecutor | None = None) -> None:
         if session_id is None:
             raise ValueError("Sessions must have an id")
         if document is None:
@@ -174,6 +204,7 @@ class ServerSession:
         self._token = token
         self._document = document
         self._loop = io_loop
+        self._executor = executor
         self._subscribed_connections = set()
         self._connections_lock = threading.Lock()
         self._last_unsubscribe_time = current_time()
@@ -293,16 +324,39 @@ class ServerSession:
         # sides change the same attribute at the same time, they will each end
         # up with the state of the other and their final states will differ.
         with self._connections_lock:
-            connections = list(self._subscribed_connections)
-        for connection in connections:
-            if may_suppress and connection is self._current_patch_connection:
-                continue
-            self._pending_writes.append(connection.send_patch_document(event))
+            connections = tuple(
+                connection for connection in self._subscribed_connections
+                if not may_suppress or connection is not self._current_patch_connection
+            )
+        if connections:
+            self._pending_writes.append(_PendingPatch(event, connections[0].protocol, connections))
+
+    async def _run_in_executor[T](self, func: Callable[..., T], *args: Any) -> T:
+        if self._executor is not None:
+            return await self._executor.run(func, *args)
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, partial(func, *args))
+
+    async def _send_pending_patches(self, pending: list[_PendingPatch]) -> None:
+        messages = await self._run_in_executor(_serialize_patches, pending)
+        for message, connections in messages:
+            for connection in connections:
+                await connection.send_message(message)
 
     @_needs_document_lock
-    def _handle_pull(self, message: msg.pull_doc_req, connection: ServerConnection) -> msg.pull_doc_reply:
+    async def _handle_pull(self, message: msg.pull_doc_req, connection: ServerConnection) -> None:
         log.debug(f"Sending pull-doc-reply from session {self.id!r}")
-        return connection.protocol.create('PULL-DOC-REPLY', message.header['msgid'], self.document)
+        async def send_reply() -> None:
+            reply = await self._run_in_executor(
+                _serialize_pull_reply,
+                connection.protocol,
+                message.header["msgid"],
+                self.document,
+            )
+            await connection.send_message(reply)
+
+        await _await_cancellation_safe(send_reply())
 
     def _session_callback_added(self, event: SessionCallbackAdded) -> None:
         wrapped = self._wrap_session_callback(event.callback)
@@ -312,7 +366,7 @@ class ServerSession:
         self._callbacks.remove_session_callback(event.callback)
 
     @classmethod
-    def pull(cls, message: msg.pull_doc_req, connection: ServerConnection) -> msg.pull_doc_reply:
+    def pull(cls, message: msg.pull_doc_req, connection: ServerConnection) -> Awaitable[None]:
         ''' Handle a PULL-DOC, return a Future with work to be scheduled. '''
         return connection.session._handle_pull(message, connection)
 

--- a/src/bokeh/server/session.py
+++ b/src/bokeh/server/session.py
@@ -37,10 +37,12 @@ from typing import (
 )
 
 # Bokeh imports
+from ..document.callbacks import invoke_with_curdoc
 from ..events import ConnectionLost
 from ..io.doc import patch_curdoc
-from ..util.asyncio import Loop
+from ..util.asyncio import Loop, _asyncio_loop
 from ..util.token import generate_jwt_token
+from ..util.tornado import _run_in_executor
 from .callbacks import DocumentCallbackGroup
 from .executor import _await_cancellation_safe
 
@@ -92,7 +94,15 @@ def _serialize_pull_reply(protocol: Protocol, request_id: ID, document: Document
         message.prepare()
     return message
 
-def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
+def _log_connection_lost_error(task: asyncio.Task[Any]) -> None:
+    if not task.cancelled() and (error := task.exception()) is not None:
+        log.error("Failed to notify connection loss: %s", error, exc_info=error)
+
+def _needs_document_lock[**P](
+    func: Callable[P, Any],
+    *,
+    offload: bool = True,
+) -> Callable[P, Awaitable[Any]]:
     '''Decorator that adds the necessary locking and post-processing
        to manipulate the session's document. Expects to decorate a
        method on ServerSession and transforms it into a coroutine
@@ -117,41 +127,12 @@ def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
                 error: BaseException | None = None
                 result: Any = None
                 try:
-                    # Document operations are serialized by the per-session
-                    # lock, but arbitrary synchronous user callbacks must not
-                    # occupy the shared event-loop thread. ``to_thread`` uses
-                    # the loop's bounded executor and propagates context vars,
-                    # including the active ``curdoc()`` context.
-                    worker = asyncio.create_task(asyncio.to_thread(func, self, *args, **kwargs))
-                    cancelled: asyncio.CancelledError | None = None
-                    while True:
-                        try:
-                            result = await asyncio.shield(worker)
-                            break
-                        except asyncio.CancelledError as cancellation:
-                            if worker.done():
-                                if worker.cancelled():
-                                    error = cancelled or cancellation
-                                else:
-                                    try:
-                                        result = worker.result()
-                                    except BaseException as worker_error:
-                                        error = cancelled or worker_error
-                                    else:
-                                        cancelled = cancelled or cancellation
-                                break
-                            # A running thread cannot be cancelled. Keep the
-                            # document lock and pending-write state alive until
-                            # it finishes, then propagate cancellation.
-                            cancelled = cancelled or cancellation
-                        except BaseException as worker_error:
-                            error = cancelled or worker_error
-                            break
-                    if error is None and cancelled is not None:
-                        if inspect.iscoroutine(result):
-                            result.close()
-                        error = cancelled
-                    elif error is None and inspect.isawaitable(result):
+                    callback = cast(Callable[..., Any], func)
+                    if offload:
+                        result = await _run_in_executor(callback, self, *args, **kwargs)
+                    else:
+                        result = callback(self, *args, **kwargs)
+                    if inspect.isawaitable(result):
                         # Async callbacks continue on the event loop while
                         # retaining the document lock across awaits.
                         result = await result
@@ -173,7 +154,12 @@ def _needs_document_lock[F: Callable[..., Any]](func: F) -> F:
             return result
         finally:
             self.unblock_expiration()
-    return cast(F, _needs_document_lock_wrapper)
+    return cast(Callable[P, Awaitable[Any]], _needs_document_lock_wrapper)
+
+def _needs_document_lock_on_loop[**P](
+    func: Callable[P, Any],
+) -> Callable[P, Awaitable[Any]]:
+    return _needs_document_lock(func, offload=False)
 
 #-----------------------------------------------------------------------------
 # General API
@@ -304,10 +290,16 @@ class ServerSession:
 
     def _wrap_document_callback(self, callback: Callback) -> Callback:
         if getattr(callback, "nolock", False):
-            return callback
-        def wrapped_callback(*args: Any, **kwargs: Any) -> Any:
+            @wraps(callback)
+            async def unlocked_callback(*args: Any, **kwargs: Any) -> Any:
+                result = await _run_in_executor(callback, *args, **kwargs)
+                if inspect.isawaitable(result):
+                    await result
+                return None
+            return unlocked_callback
+        def locked_callback(*args: Any, **kwargs: Any) -> Any:
             return self.with_document_locked(callback, *args, **kwargs)
-        return wrapped_callback
+        return locked_callback
 
     def _wrap_session_callback(self, callback: SessionCallback) -> SessionCallback:
         wrapped = copy(callback)
@@ -344,7 +336,7 @@ class ServerSession:
             for connection in connections:
                 await connection.send_message(message)
 
-    @_needs_document_lock
+    @_needs_document_lock_on_loop
     async def _handle_pull(self, message: msg.pull_doc_req, connection: ServerConnection) -> None:
         log.debug(f"Sending pull-doc-reply from session {self.id!r}")
         async def send_reply() -> None:
@@ -370,35 +362,51 @@ class ServerSession:
         ''' Handle a PULL-DOC, return a Future with work to be scheduled. '''
         return connection.session._handle_pull(message, connection)
 
-    @_needs_document_lock
-    def _handle_push(self, message: msg.push_doc, connection: ServerConnection) -> msg.ok:
+    @_needs_document_lock_on_loop
+    async def _handle_push(self, message: msg.push_doc, connection: ServerConnection) -> msg.ok:
         log.debug(f"pushing doc to session {self.id!r}")
-        message.push_to_document(self.document)
+        await _run_in_executor(message.push_to_document, self.document)
         return connection.ok(message)
 
     @classmethod
-    def push(cls, message: msg.push_doc, connection: ServerConnection) -> msg.ok:
+    def push(cls, message: msg.push_doc, connection: ServerConnection) -> Awaitable[msg.ok]:
         ''' Handle a PUSH-DOC, return a Future with work to be scheduled. '''
         return connection.session._handle_push(message, connection)
 
-    @_needs_document_lock
-    def _handle_patch(self, message: msg.patch_doc, connection: ServerConnection) -> msg.ok:
+    @_needs_document_lock_on_loop
+    async def _handle_patch(self, message: msg.patch_doc, connection: ServerConnection) -> msg.ok:
         self._current_patch_connection = connection
         try:
-            message.apply_to_document(self.document, self)
+            await _run_in_executor(message.apply_to_document, self.document, self)
         finally:
             self._current_patch_connection = None
 
         return connection.ok(message)
 
     @classmethod
-    def patch(cls, message: msg.patch_doc, connection: ServerConnection) -> msg.ok:
+    def patch(cls, message: msg.patch_doc, connection: ServerConnection) -> Awaitable[msg.ok]:
         ''' Handle a PATCH-DOC, return a Future with work to be scheduled. '''
         return connection.session._handle_patch(message, connection)
 
     def notify_connection_lost(self) -> None:
         ''' Notify the document that the connection was lost. '''
-        self.document.callbacks.trigger_event(ConnectionLost())
+        event = ConnectionLost()
+
+        def notify() -> None:
+            invoke_with_curdoc(self.document,
+                               lambda: self.document.callbacks.trigger_event(event))
+
+        assert self._loop is not None
+        loop = _asyncio_loop(self._loop)
+
+        async def notify_locked() -> None:
+            await self.with_document_locked(notify)
+
+        def schedule() -> None:
+            task = loop.create_task(notify_locked())
+            task.add_done_callback(_log_connection_lost_error)
+
+        loop.call_soon_threadsafe(schedule)
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -412,7 +412,7 @@ class BokehTornado(TornadoApplication):
                 # second arg must be lstrip'd to avoid dropping the prefix
                 # (urljoin treats a leading-slash second arg as an absolute path and discards the base)
                 logout_url = urljoin(self._prefix + "/", logout_url.lstrip("/"))
-            self._applications[url] = ApplicationContext(app, url=url, logout_url=logout_url)
+            self._applications[url] = ApplicationContext(app, url=url, logout_url=logout_url, executor=self._executor)
         self._stopping = False
         self._shutdown_pending_sessions: tuple[asyncio.Task[ServerSession], ...] = ()
         self._stop_task: asyncio.Task[None] | None = None

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -772,9 +772,11 @@ class BokehTornado(TornadoApplication):
         key = self._autoload_key(resources)
         cache = not settings.dev and (resources is None or not resources.dev)
 
-        if cache and (bundle := self._autoload_cache.get(key)) is not None:
-            self._autoload_cache.move_to_end(key)
-            return bundle.clone()
+        if cache:
+            cached_bundle = self._autoload_cache.get(key)
+            if cached_bundle is not None:
+                self._autoload_cache.move_to_end(key)
+                return cached_bundle.clone()
 
         pending = self._pending_autoload.get(key)
         if pending is None:
@@ -811,11 +813,11 @@ class BokehTornado(TornadoApplication):
         if resources is None:
             return (None, models)
 
-        path_versioner = resources.path_versioner
-        if path_versioner is not None:
-            path_versioner = (
-                getattr(path_versioner, "__self__", None),
-                getattr(path_versioner, "__func__", path_versioner),
+        path_versioner_key: Any = resources.path_versioner
+        if path_versioner_key is not None:
+            path_versioner_key = (
+                getattr(path_versioner_key, "__self__", None),
+                getattr(path_versioner_key, "__func__", path_versioner_key),
             )
 
         return (
@@ -826,7 +828,7 @@ class BokehTornado(TornadoApplication):
             resources.minified,
             resources.log_level,
             resources.root_url,
-            path_versioner,
+            path_versioner_key,
             tuple(resources.components),
             resources.base_dir,
             models,

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -39,7 +39,7 @@ from urllib.parse import urljoin
 
 # External imports
 from tornado.ioloop import PeriodicCallback
-from tornado.web import Application as TornadoApplication, StaticFileHandler
+from tornado.web import Application as TornadoApplication
 from tornado.websocket import WebSocketClosedError
 
 if TYPE_CHECKING:
@@ -67,7 +67,7 @@ from .core import (
 from .urls import per_app_patterns, toplevel_patterns
 from .views.ico_handler import IcoHandler
 from .views.root_handler import RootHandler
-from .views.static_handler import StaticHandler
+from .views.static_handler import AsyncStaticFileHandler, StaticHandler
 from .views.ws import WSHandler
 
 if TYPE_CHECKING:
@@ -898,11 +898,11 @@ class BokehTornado(TornadoApplication):
 # Dev API
 #-----------------------------------------------------------------------------
 
-def create_static_handler(prefix: str, key: str, app: Application) -> tuple[str, type[StaticFileHandler | StaticHandler], dict[str, Any]]:
+def create_static_handler(prefix: str, key: str, app: Application) -> tuple[str, type[AsyncStaticFileHandler | StaticHandler], dict[str, Any]]:
     route = prefix
     route += "/static/(.*)" if key == "/" else key + "/static/(.*)"
     if app.static_path is not None:
-        return (route, StaticFileHandler, {"path" : app.static_path})
+        return (route, AsyncStaticFileHandler, {"path" : app.static_path})
     return (route, StaticHandler, {})
 
 #-----------------------------------------------------------------------------

--- a/src/bokeh/server/tornado.py
+++ b/src/bokeh/server/tornado.py
@@ -27,6 +27,7 @@ import asyncio
 import gc
 import os
 import sys
+from collections import OrderedDict
 from pprint import pformat
 from typing import (
     TYPE_CHECKING,
@@ -64,6 +65,7 @@ from .core import (
     DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
     create_session as _create_session,
 )
+from .executor import _ServerExecutor
 from .urls import per_app_patterns, toplevel_patterns
 from .views.ico_handler import IcoHandler
 from .views.root_handler import RootHandler
@@ -85,6 +87,7 @@ if TYPE_CHECKING:
 #-----------------------------------------------------------------------------
 
 DEFAULT_MEM_LOG_FREQ_MS                  = 0
+_AUTOLOAD_CACHE_SIZE                     = 32
 
 __all__ = (
     'BokehTornado',
@@ -306,6 +309,9 @@ class BokehTornado(TornadoApplication):
                 app.add(DocumentLifecycleHandler())
 
         self._absolute_url = absolute_url
+        self._executor = _ServerExecutor()
+        self._autoload_cache: OrderedDict[tuple[Any, ...], Any] = OrderedDict()
+        self._pending_autoload: dict[tuple[Any, ...], asyncio.Task[Any]] = {}
 
         if prefix is None:
             prefix = ""
@@ -698,6 +704,7 @@ class BokehTornado(TornadoApplication):
         for context in self._applications.values():
             context.run_unload_hook()
         self._clients.clear()
+        self._executor.shutdown(wait=False)
 
     async def stop_async(self) -> None:
         '''Stop the Bokeh Server application and await orderly cleanup.'''
@@ -720,6 +727,7 @@ class BokehTornado(TornadoApplication):
         for context in self._applications.values():
             context.run_unload_hook()
         self._clients.clear()
+        self._executor.shutdown()
 
     def stop(self, wait: bool = True) -> None:
         ''' Stop the Bokeh Server application.
@@ -756,6 +764,73 @@ class BokehTornado(TornadoApplication):
             return None
         asyncio_loop.run_until_complete(self.stop_async())
         return None
+
+    async def _bundle_for_autoload(self, resources: Resources | None) -> Any:
+        from ..embed.bundle import bundle_for_objs_and_resources
+
+        resources = resources.clone() if resources is not None else None
+        key = self._autoload_key(resources)
+        cache = not settings.dev and (resources is None or not resources.dev)
+
+        if cache and (bundle := self._autoload_cache.get(key)) is not None:
+            self._autoload_cache.move_to_end(key)
+            return bundle.clone()
+
+        pending = self._pending_autoload.get(key)
+        if pending is None:
+            pending = asyncio.create_task(
+                self._executor.run(bundle_for_objs_and_resources, None, resources),
+            )
+            self._pending_autoload[key] = pending
+            pending.add_done_callback(lambda task: self._autoload_done(key, cache, task))
+
+        bundle = await asyncio.shield(pending)
+        return bundle.clone()
+
+    def _autoload_done(self, key: tuple[Any, ...], cache: bool, task: asyncio.Task[Any]) -> None:
+        if self._pending_autoload.get(key) is task:
+            del self._pending_autoload[key]
+
+        if task.cancelled():
+            return
+
+        error = task.exception()
+        if error is None and cache:
+            self._autoload_cache[key] = task.result()
+            self._autoload_cache.move_to_end(key)
+            while len(self._autoload_cache) > _AUTOLOAD_CACHE_SIZE:
+                self._autoload_cache.popitem(last=False)
+
+    @staticmethod
+    def _autoload_key(resources: Resources | None) -> tuple[Any, ...]:
+        models = tuple(sorted(
+            (name, id(model))
+            for name, model in Model.model_class_reverse_map.items()
+        ))
+
+        if resources is None:
+            return (None, models)
+
+        path_versioner = resources.path_versioner
+        if path_versioner is not None:
+            path_versioner = (
+                getattr(path_versioner, "__self__", None),
+                getattr(path_versioner, "__func__", path_versioner),
+            )
+
+        return (
+            resources.mode,
+            resources.version,
+            resources.root_dir,
+            resources.dev,
+            resources.minified,
+            resources.log_level,
+            resources.root_url,
+            path_versioner,
+            tuple(resources.components),
+            resources.base_dir,
+            models,
+        )
 
     def new_connection(self, protocol: Protocol, socket: WSHandler,
             application_context: ApplicationContext, session: ServerSession) -> ServerConnection:

--- a/src/bokeh/server/views/auth_request_handler.py
+++ b/src/bokeh/server/views/auth_request_handler.py
@@ -27,6 +27,9 @@ from urllib.parse import urljoin
 # External imports
 from tornado.web import RequestHandler
 
+# Bokeh imports
+from ...util.asyncio import _run_in_executor
+
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------
@@ -65,6 +68,8 @@ class AuthRequestHandler(RequestHandler):
 
         '''
         auth_provider = self.bokeh_app.auth_provider
+        if hasattr(self, "_bokeh_login_url"):
+            return self._bokeh_login_url
         if auth_provider.get_login_url is not None:
             return auth_provider.get_login_url(self)
         if auth_provider.login_url is not None:
@@ -90,6 +95,17 @@ class AuthRequestHandler(RequestHandler):
         auth_provider = self.bokeh_app.auth_provider
         if auth_provider.get_user_async is not None:
             self.current_user = await auth_provider.get_user_async(self)
+        elif auth_provider.get_user is not None and self.request.method != "OPTIONS":
+            self.current_user = await _run_in_executor(auth_provider.get_user, self)
+        else:
+            return
+
+        if (
+            not self.current_user
+            and self.request.method in ("GET", "HEAD")
+            and auth_provider.get_login_url is not None
+        ):
+            self._bokeh_login_url = await _run_in_executor(auth_provider.get_login_url, self)
 
 #-----------------------------------------------------------------------------
 # Private API

--- a/src/bokeh/server/views/autoload_js_handler.py
+++ b/src/bokeh/server/views/autoload_js_handler.py
@@ -33,7 +33,7 @@ from tornado.web import HTTPError
 # Bokeh imports
 from bokeh.core.templates import AUTOLOAD_JS
 from bokeh.core.types import ID
-from bokeh.embed.bundle import Script, bundle_for_objs_and_resources
+from bokeh.embed.bundle import Script
 from bokeh.embed.elements import script_for_render_items
 from bokeh.embed.util import RenderItem
 from bokeh.settings import settings
@@ -110,7 +110,7 @@ class AutoloadJsHandler(SessionHandler):
 
         resources_param = self.get_argument("resources", "default")
         resources = self.application.resources(server_url) if resources_param != "none" else None
-        bundle = bundle_for_objs_and_resources(None, resources)
+        bundle = await self.application._bundle_for_autoload(resources)
 
         render_items = [RenderItem(token=session.token, elementid=element_id, use_for_title=False)]
         bundle.add(Script(script_for_render_items({}, render_items, app_path=app_path, absolute_url=absolute_url)))

--- a/src/bokeh/server/views/multi_root_static_handler.py
+++ b/src/bokeh/server/views/multi_root_static_handler.py
@@ -28,7 +28,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 # External imports
-from tornado.web import HTTPError, StaticFileHandler
+from tornado.web import HTTPError
+
+# Bokeh imports
+from .static_handler import AsyncStaticFileHandler
 
 if TYPE_CHECKING:
     from ...core.types import PathLike
@@ -51,7 +54,7 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-class MultiRootStaticHandler(StaticFileHandler):
+class MultiRootStaticHandler(AsyncStaticFileHandler):
 
     def initialize(self, root: RootPathLike, default_filename: str | None = None) -> None:
         self.root = root  # type: ignore[assignment]
@@ -80,6 +83,16 @@ class MultiRootStaticHandler(StaticFileHandler):
         for artifacts_dir in root.values():
             if Path(absolute_path).is_relative_to(artifacts_dir):
                 return super().validate_absolute_path(str(artifacts_dir), absolute_path)
+
+        return None
+
+    async def _validate_absolute_path(self, root: RootPathLike, absolute_path: str) -> str | None:
+        if isinstance(root, str):
+            return await super()._validate_absolute_path(root, absolute_path)
+
+        for artifacts_dir in root.values():
+            if Path(absolute_path).is_relative_to(artifacts_dir):
+                return await super()._validate_absolute_path(str(artifacts_dir), absolute_path)
 
         return None
 

--- a/src/bokeh/server/views/static_handler.py
+++ b/src/bokeh/server/views/static_handler.py
@@ -29,7 +29,7 @@ from datetime import UTC, datetime
 from typing import Any, TypeVar
 
 # External imports
-from tornado import httputil, iostream
+from tornado import httputil, iostream, version_info as tornado_version_info
 from tornado.ioloop import IOLoop
 from tornado.web import HTTPError, StaticFileHandler as TornadoStaticFileHandler
 
@@ -125,7 +125,10 @@ class AsyncStaticFileHandler(TornadoStaticFileHandler):
 
     def get_modified_time(self) -> datetime:
         stat_result = self._stat()
-        return datetime.fromtimestamp(int(stat_result.st_mtime), UTC)
+        modified = datetime.fromtimestamp(int(stat_result.st_mtime), UTC)
+        if tornado_version_info < (6, 4):
+            return modified.replace(tzinfo=None)
+        return modified
 
     async def _run_in_executor(self, func: Callable[..., T], *args: Any) -> T:
         future = IOLoop.current().run_in_executor(None, func, *args)

--- a/src/bokeh/server/views/static_handler.py
+++ b/src/bokeh/server/views/static_handler.py
@@ -21,10 +21,16 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from typing import Any
+import asyncio
+import os
+import stat
+from collections.abc import Callable, Iterator
+from typing import Any, TypeVar
 
 # External imports
-from tornado.web import StaticFileHandler
+from tornado import httputil, iostream
+from tornado.ioloop import IOLoop
+from tornado.web import HTTPError, StaticFileHandler as TornadoStaticFileHandler
 
 # Bokeh imports
 from bokeh.settings import settings
@@ -34,8 +40,11 @@ from bokeh.settings import settings
 #-----------------------------------------------------------------------------
 
 __all__ = (
+    'AsyncStaticFileHandler',
     'StaticHandler',
 )
+
+T = TypeVar("T")
 
 #-----------------------------------------------------------------------------
 # General API
@@ -45,7 +54,146 @@ __all__ = (
 # Dev API
 #-----------------------------------------------------------------------------
 
-class StaticHandler(StaticFileHandler):
+class AsyncStaticFileHandler(TornadoStaticFileHandler):
+    ''' Serve static files without performing filesystem I/O on the event loop. '''
+
+    async def get(self, path: str, include_body: bool = True) -> None:
+        self.path = self.parse_url_path(path)
+        absolute_path = self.get_absolute_path(self.root, self.path)
+        self.absolute_path = await self._validate_absolute_path(self.root, absolute_path)
+        if self.absolute_path is None:
+            return
+
+        self.modified = await self._run_in_executor(self.get_modified_time)
+        self._computed_etag = await self._run_in_executor(self.compute_etag)
+        self.set_headers()
+
+        if self.should_return_304():
+            self.set_status(304)
+            return
+
+        request_range = None
+        range_header = self.request.headers.get("Range")
+        if range_header:
+            request_range = httputil._parse_request_range(range_header)
+
+        size = await self._run_in_executor(self.get_content_size)
+        if request_range:
+            start, end = request_range
+            if start is not None and start < 0:
+                start += size
+                if start < 0:
+                    start = 0
+            if (
+                start is not None
+                and (start >= size or (end is not None and start >= end))
+            ) or end == 0:
+                self.set_status(416)
+                self.set_header("Content-Type", "text/plain")
+                self.set_header("Content-Range", f"bytes */{size}")
+                return
+            if end is not None and end > size:
+                end = size
+            if size != (end or size) - (start or 0):
+                self.set_status(206)
+                self.set_header(
+                    "Content-Range", httputil._get_content_range(start, end, size),
+                )
+        else:
+            start = end = None
+
+        if start is not None and end is not None:
+            content_length = end - start
+        elif end is not None:
+            content_length = end
+        elif start is not None:
+            content_length = size - start
+        else:
+            content_length = size
+        self.set_header("Content-Length", content_length)
+
+        if include_body:
+            await self._stream_content(start, end)
+        else:
+            assert self.request.method == "HEAD"
+
+    def compute_etag(self) -> str | None:
+        if hasattr(self, "_computed_etag"):
+            return self._computed_etag
+        return super().compute_etag()
+
+    async def _run_in_executor(self, func: Callable[..., T], *args: Any) -> T:
+        future = IOLoop.current().run_in_executor(None, func, *args)
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            try:
+                await future
+            except Exception:
+                pass
+            raise
+
+    async def _validate_absolute_path(self, root: str, absolute_path: str) -> str | None:
+        root = os.path.abspath(root)
+        if not root.endswith(os.path.sep):
+            root += os.path.sep
+        if not (absolute_path + os.path.sep).startswith(root):
+            raise HTTPError(403, "%s is not in root static directory", self.path)
+
+        stat_result = await self._stat_path(absolute_path)
+        if stat.S_ISDIR(stat_result.st_mode) and self.default_filename is not None:
+            if not self.request.path.endswith("/"):
+                if self.request.path.startswith("//"):
+                    raise HTTPError(
+                        403, "cannot redirect path with two initial slashes",
+                    )
+                self.redirect(self.request.path + "/", permanent=True)
+                return None
+            absolute_path = os.path.join(absolute_path, self.default_filename)
+            stat_result = await self._stat_path(absolute_path)
+
+        if not stat.S_ISREG(stat_result.st_mode):
+            raise HTTPError(403, "%s is not a file", self.path)
+
+        self._stat_result = stat_result
+        return absolute_path
+
+    async def _stat_path(self, absolute_path: str) -> os.stat_result:
+        try:
+            return await self._run_in_executor(self._get_stat_result, absolute_path)
+        except OSError as error:
+            raise HTTPError(404) from error
+
+    @classmethod
+    def _get_stat_result(cls, absolute_path: str) -> os.stat_result:
+        return os.stat(absolute_path)
+
+    async def _stream_content(self, start: int | None, end: int | None) -> None:
+        content = await self._run_in_executor(
+            self.get_content, self.absolute_path, start, end,
+        )
+        if isinstance(content, bytes):
+            content = iter([content])
+        else:
+            content = iter(content)
+
+        try:
+            while True:
+                chunk, done = await self._run_in_executor(_next_chunk, content)
+                if done:
+                    return
+                try:
+                    self.write(chunk)
+                    await self.flush()
+                except iostream.StreamClosedError:
+                    return
+        finally:
+            close = getattr(content, "close", None)
+            if close is not None:
+                await self._run_in_executor(close)
+
+
+class StaticHandler(AsyncStaticFileHandler):
     ''' Implements a custom Tornado static file handler for BokehJS
     JavaScript and CSS resources.
 
@@ -72,12 +220,18 @@ class StaticHandler(StaticFileHandler):
         if settings.dev:
             return path
         else:
-            version = StaticFileHandler.get_version(dict(static_path=settings.bokehjs_path()), path)
+            version = TornadoStaticFileHandler.get_version(dict(static_path=settings.bokehjs_path()), path)
             return f"{path}?v={version}"
 
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+def _next_chunk(content: Iterator[bytes]) -> tuple[bytes, bool]:
+    try:
+        return next(content), False
+    except StopIteration:
+        return b"", True
 
 #-----------------------------------------------------------------------------
 # Code

--- a/src/bokeh/server/views/static_handler.py
+++ b/src/bokeh/server/views/static_handler.py
@@ -25,6 +25,7 @@ import asyncio
 import os
 import stat
 from collections.abc import Callable, Iterator
+from datetime import UTC, datetime
 from typing import Any, TypeVar
 
 # External imports
@@ -122,6 +123,10 @@ class AsyncStaticFileHandler(TornadoStaticFileHandler):
             return self._computed_etag
         return super().compute_etag()
 
+    def get_modified_time(self) -> datetime:
+        stat_result = self._stat()
+        return datetime.fromtimestamp(int(stat_result.st_mtime), UTC)
+
     async def _run_in_executor(self, func: Callable[..., T], *args: Any) -> T:
         future = IOLoop.current().run_in_executor(None, func, *args)
         try:
@@ -169,13 +174,10 @@ class AsyncStaticFileHandler(TornadoStaticFileHandler):
         return os.stat(absolute_path)
 
     async def _stream_content(self, start: int | None, end: int | None) -> None:
-        content = await self._run_in_executor(
+        raw_content: bytes | Iterator[bytes] = await self._run_in_executor(
             self.get_content, self.absolute_path, start, end,
         )
-        if isinstance(content, bytes):
-            content = iter([content])
-        else:
-            content = iter(content)
+        content = iter([raw_content]) if isinstance(raw_content, bytes) else iter(raw_content)
 
         try:
             while True:

--- a/src/bokeh/util/asyncio.py
+++ b/src/bokeh/util/asyncio.py
@@ -45,8 +45,7 @@ __all__ = ()
 #-----------------------------------------------------------------------------
 
 type CallbackSync = Callable[[], None]
-type CallbackAsync = Callable[[], Awaitable[None]]
-type Callback = CallbackSync | CallbackAsync
+type Callback = Callable[[], None | Awaitable[None]]
 
 type Remover = Callable[[], None]
 type Removers = dict[ID, Remover]
@@ -69,6 +68,50 @@ def _log_task_exception(task: asyncio.Future[Any]) -> None:
         log.error("Error thrown from callback:")
         lines = format_exception(exception.__class__, exception, exception.__traceback__)
         log.error("".join(lines))
+
+async def _wait_for_task[T](task: asyncio.Future[T]) -> T:
+    ''' Wait for a task to finish before propagating cancellation. '''
+    cancelled: asyncio.CancelledError | None = None
+
+    while True:
+        try:
+            result = await asyncio.shield(task)
+            break
+        except asyncio.CancelledError as cancellation:
+            cancelled = cancelled or cancellation
+            if task.done():
+                if task.cancelled():
+                    raise cancelled
+                try:
+                    result = task.result()
+                except BaseException:
+                    raise cancelled
+                break
+        except BaseException:
+            if cancelled is not None:
+                raise cancelled
+            raise
+
+    if cancelled is not None:
+        raise cancelled
+
+    return result
+
+async def _run_in_executor[T](func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    ''' Run a synchronous callable in a worker without abandoning it on cancellation. '''
+    worker = asyncio.create_task(asyncio.to_thread(func, *args, **kwargs))
+    try:
+        return await _wait_for_task(worker)
+    except asyncio.CancelledError:
+        if not worker.cancelled():
+            try:
+                result = worker.result()
+            except BaseException:
+                pass
+            else:
+                if inspect.iscoroutine(result):
+                    result.close()
+        raise
 
 class _AsyncPeriodic:
     ''' Invoke a callback periodically without overlapping invocations. '''
@@ -222,7 +265,7 @@ class _CallbackGroup:
     def remove_next_tick_callback(self, callback_id: ID) -> None:
         self._execute_remover(callback_id, self._next_tick_callback_removers)
 
-    def add_timeout_callback(self, callback: CallbackSync, timeout_milliseconds: int, callback_id: ID) -> ID:
+    def add_timeout_callback(self, callback: Callback, timeout_milliseconds: int, callback_id: ID) -> ID:
         handle: asyncio.TimerHandle | None = None
         removed = False
         state_lock = threading.Lock()

--- a/src/bokeh/util/compiler.py
+++ b/src/bokeh/util/compiler.py
@@ -21,12 +21,12 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from concurrent.futures import Future
 import hashlib
 import json
 import os
 import re
 import sys
+from concurrent.futures import Future
 from os.path import (
     abspath,
     dirname,

--- a/src/bokeh/util/compiler.py
+++ b/src/bokeh/util/compiler.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+from concurrent.futures import Future
 import hashlib
 import json
 import os
@@ -35,6 +36,7 @@ from os.path import (
 )
 from pathlib import Path
 from subprocess import PIPE, Popen
+from threading import Lock
 from typing import Any, Callable, Sequence
 
 # Bokeh imports
@@ -296,6 +298,9 @@ def calc_cache_key(custom_models: dict[str, CustomModel]) -> str:
     return hashlib.sha256(encoded_names).hexdigest()
 
 _bundle_cache: dict[str, str] = {}
+_bundle_futures: dict[str, Future[str]] = {}
+_bundle_cache_lock = Lock()
+_bundle_compile_lock = Lock()
 
 def bundle_models(models: Sequence[type[HasProps]] | None) -> str | None:
     """Create a bundle of selected `models`. """
@@ -304,15 +309,41 @@ def bundle_models(models: Sequence[type[HasProps]] | None) -> str | None:
         return None
 
     key = calc_cache_key(custom_models)
-    bundle = _bundle_cache.get(key, None)
-    if bundle is None:
+    with _bundle_cache_lock:
+        if (bundle := _bundle_cache.get(key)) is not None:
+            return bundle
+
+        future = _bundle_futures.get(key)
+        if future is None:
+            future = _bundle_futures[key] = Future()
+            compile = True
+        else:
+            compile = False
+
+    if not compile:
+        return future.result()
+
+    try:
         try:
-            _bundle_cache[key] = bundle = _bundle_models(custom_models)
+            # npm installation and module resolution use shared process state,
+            # so distinct bundles are compiled serially.
+            with _bundle_compile_lock:
+                bundle = _bundle_models(custom_models)
         except CompilationError as error:
             print("Compilation failed:", file=sys.stderr)
             print(str(error), file=sys.stderr)
             sys.exit(1)
-    return bundle
+    except BaseException as error:
+        with _bundle_cache_lock:
+            del _bundle_futures[key]
+            future.set_exception(error)
+        raise
+    else:
+        with _bundle_cache_lock:
+            _bundle_cache[key] = bundle
+            del _bundle_futures[key]
+            future.set_result(bundle)
+        return bundle
 
 def bundle_all_models() -> str | None:
     """Create a bundle of all models. """

--- a/src/bokeh/util/tornado.py
+++ b/src/bokeh/util/tornado.py
@@ -9,6 +9,11 @@
 from __future__ import annotations
 
 # Bokeh imports
-from .asyncio import _AsyncPeriodic, _CallbackGroup  # noqa: F401
+from .asyncio import (  # noqa: F401
+    _AsyncPeriodic,
+    _CallbackGroup,
+    _run_in_executor,
+    _wait_for_task,
+)
 
 __all__ = ()

--- a/tests/unit/bokeh/application/handlers/test_server_lifecycle.py
+++ b/tests/unit/bokeh/application/handlers/test_server_lifecycle.py
@@ -16,6 +16,10 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+from threading import get_ident
+from types import SimpleNamespace
+
 # Bokeh imports
 from bokeh.application.handlers.handler import Handler
 from bokeh.document import Document
@@ -167,6 +171,27 @@ def on_session_destroyed(a,b):
         assert "on_server_unloaded" == handler.on_server_unloaded(None)
         assert await handler.on_session_created(None) is None
         assert await handler.on_session_destroyed(None) is None
+
+    async def test_session_created_runs_off_event_loop(self) -> None:
+        result: dict[str, Handler] = {}
+        def load(filename: str):
+            handler = result['handler'] = bahs.ServerLifecycleHandler(filename=filename)
+            if handler.failed:
+                raise RuntimeError(handler.error)
+        with_file_contents("""
+from threading import get_ident
+
+def on_session_created(session_context):
+    session_context.thread_id = get_ident()
+""", load)
+
+        handler = result['handler']
+        session_context = SimpleNamespace(thread_id=None)
+        loop_thread_id = get_ident()
+
+        await handler.on_session_created(session_context)
+
+        assert session_context.thread_id != loop_thread_id
 
     def test_url_path(self) -> None:
         result: dict[str, Handler] = {}

--- a/tests/unit/bokeh/application/test_application.py
+++ b/tests/unit/bokeh/application/test_application.py
@@ -17,7 +17,9 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
 import logging
+from threading import Event, get_ident
 from unittest.mock import MagicMock, patch
 
 # Bokeh imports
@@ -77,6 +79,57 @@ class Test_Application:
         a.add(RequestHandler(dict(b=20)))
         a.add(RequestHandler(dict(a=30)))
         assert a.process_request("request") == dict(a=30, b=20)
+
+    async def test_process_request_async_runs_sync_handlers_in_worker(self) -> None:
+        started = Event()
+        release = Event()
+        loop_thread = get_ident()
+        handler_thread = None
+
+        class BlockingRequestHandler(Handler):
+            def process_request(self, request):
+                nonlocal handler_thread
+                handler_thread = get_ident()
+                started.set()
+                assert release.wait(timeout=2)
+                return dict(a=10)
+
+        a = baa.Application(BlockingRequestHandler())
+        pending = asyncio.create_task(a.process_request_async("request"))
+        try:
+            async with asyncio.timeout(1):
+                while not started.is_set():
+                    await asyncio.sleep(0)
+            heartbeat = asyncio.Event()
+            asyncio.get_running_loop().call_soon(heartbeat.set)
+            await asyncio.wait_for(heartbeat.wait(), 1)
+        finally:
+            release.set()
+
+        assert await pending == dict(a=10)
+        assert handler_thread != loop_thread
+
+    async def test_process_request_async_awaits_async_handlers_in_order(self) -> None:
+        loop_thread = get_ident()
+        calls = []
+
+        class AsyncRequestHandler(Handler):
+            async def process_request(self, request):
+                calls.append(("async", get_ident()))
+                await asyncio.sleep(0)
+                return dict(a=10)
+
+        class SyncRequestHandler(Handler):
+            def process_request(self, request):
+                calls.append(("sync", get_ident()))
+                return dict(a=20, b=30)
+
+        a = baa.Application(AsyncRequestHandler(), SyncRequestHandler())
+
+        assert await a.process_request_async("request") == dict(a=20, b=30)
+        assert calls[0] == ("async", loop_thread)
+        assert calls[1][0] == "sync"
+        assert calls[1][1] != loop_thread
 
     def test_one_handler(self) -> None:
         a = baa.Application()

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -138,6 +138,101 @@ class TestDocument:
         d._session_context = weakref.ref(sc)
         assert d.session_context is sc
 
+    def test_locked_callback_requires_server_session(self) -> None:
+        d = document.Document()
+
+        with pytest.raises(RuntimeError, match="require a Bokeh server session"):
+            @d.locked_callback
+            def update() -> None:
+                pass
+
+    def test_locked_callback_rejects_unknown_policy(self) -> None:
+        d = document.Document()
+
+        with pytest.raises(ValueError, match="unknown locked callback policy"):
+            @d.locked_callback(policy="unknown") # type: ignore[arg-type]
+            def update() -> None:
+                pass
+
+    def test_locked_callback_latest_coalesces_and_preserves_metadata(self) -> None:
+        d = document.Document()
+        sc = BokehSessionContext(None, None, d)
+        d._session_context = weakref.ref(sc)
+        scheduled: list[Any] = []
+        calls: list[int] = []
+
+        with patch.object(d, "add_next_tick_callback", side_effect=lambda callback: scheduled.append(callback)):
+            @d.locked_callback(policy="latest")
+            def update(value: int) -> None:
+                ''' Update the value. '''
+                calls.append(value)
+
+            assert update.__name__ == "update"
+            assert update.__doc__ == "Update the value. "
+            assert update.policy == "latest"
+            assert not update.pending
+            assert not update.closed
+
+            update(1)
+            update(2)
+            update(3)
+
+            assert update.pending
+            assert len(scheduled) == 1
+            scheduled.pop(0)()
+
+            assert calls == [3]
+            assert not update.pending
+
+    def test_locked_callback_every_continues_after_exception(self) -> None:
+        d = document.Document()
+        sc = BokehSessionContext(None, None, d)
+        d._session_context = weakref.ref(sc)
+        scheduled: list[Any] = []
+        calls: list[int] = []
+
+        with patch.object(d, "add_next_tick_callback", side_effect=lambda callback: scheduled.append(callback)):
+            @d.locked_callback
+            def update(value: int) -> None:
+                calls.append(value)
+                if value == 1:
+                    raise RuntimeError("transient failure")
+
+            update(1)
+            update(2)
+
+            assert len(scheduled) == 1
+            with pytest.raises(RuntimeError, match="transient failure"):
+                scheduled.pop(0)()
+
+            assert len(scheduled) == 1
+            scheduled.pop(0)()
+            assert calls == [1, 2]
+            assert not update.pending
+
+    def test_locked_callback_closes_on_session_destroyed(self) -> None:
+        d = document.Document()
+        sc = BokehSessionContext(None, None, d)
+        d._session_context = weakref.ref(sc)
+        scheduled: list[Any] = []
+        calls: list[int] = []
+
+        with patch.object(d, "add_next_tick_callback", side_effect=lambda callback: scheduled.append(callback)):
+            @d.locked_callback()
+            def update(value: int) -> None:
+                calls.append(value)
+
+            update(1)
+            for callback in d.session_destroyed_callbacks:
+                callback(sc)
+
+            assert update.closed
+            assert not update.pending
+
+            update(2)
+            scheduled.pop(0)()
+            assert calls == []
+
     def test_add_roots(self) -> None:
         d = document.Document()
         assert not d.roots

--- a/tests/unit/bokeh/document/test_document.py
+++ b/tests/unit/bokeh/document/test_document.py
@@ -168,7 +168,7 @@ class TestDocument:
                 calls.append(value)
 
             assert update.__name__ == "update"
-            assert update.__doc__ == "Update the value. "
+            assert update.__doc__ == update.__wrapped__.__doc__
             assert update.policy == "latest"
             assert not update.pending
             assert not update.closed

--- a/tests/unit/bokeh/protocol/messages/test_pull_doc.py
+++ b/tests/unit/bokeh/protocol/messages/test_pull_doc.py
@@ -85,6 +85,23 @@ class TestPullDocument:
         assert isinstance(cds, ColumnDataSource)
         assert isinstance(cds.data["a"], np.ndarray)
 
+    def test_prepare_freezes_buffers(self) -> None:
+        sample = self._sample_doc()
+        _, _, cds = sample.roots
+        assert isinstance(cds, ColumnDataSource)
+        array = cds.data["a"]
+        assert isinstance(array, np.ndarray)
+
+        msg = proto.create("PULL-DOC-REPLY", ID("fakereqid"), sample)
+        msg.prepare()
+        [buffer] = msg.buffers
+        expected = buffer.data
+
+        assert isinstance(expected, bytes)
+        array[0] = 10.0
+        assert buffer.data == expected
+        assert msg.content_json == msg._content_json
+
 #-----------------------------------------------------------------------------
 # Dev API
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_asgi.py
+++ b/tests/unit/bokeh/server/test_asgi.py
@@ -179,6 +179,54 @@ def test_explicit_application_specs_remain_supported() -> None:
     assert app.core.applications["/callable"].application.create_document().title == "Callable application"
 
 
+async def test_update_sessions_updates_each_document_with_its_lock() -> None:
+    def modify_document(doc: Document) -> None:
+        doc.add_root(Div(text="initial", name="status"))
+
+    app = BokehASGI(modify_document, keep_alive_milliseconds=0)
+
+    with pytest.raises(RuntimeError, match="not running"):
+        await app.update_sessions("/", lambda doc: None)
+
+    await app.core.start()
+    try:
+        context = app.core.applications["/"]
+        sessions = [
+            await context.create_session_if_needed(cast(ID, "first")),
+            await context.create_session_if_needed(cast(ID, "second")),
+        ]
+        sync_documents: list[Document] = []
+
+        def sync_update(doc: Document) -> None:
+            sync_documents.append(doc)
+            status = doc.select_one({"name": "status"})
+            assert isinstance(status, Div)
+            status.text = "sync"
+
+        await app.update_sessions("/", sync_update)
+
+        assert set(sync_documents) == {session.document for session in sessions}
+
+        def status_text(doc: Document) -> str:
+            status = doc.select_one({"name": "status"})
+            assert isinstance(status, Div)
+            return status.text
+
+        assert [status_text(session.document) for session in sessions] == ["sync", "sync"]
+
+        async def async_update(doc: Document) -> None:
+            await asyncio.sleep(0)
+            status = doc.select_one({"name": "status"})
+            assert isinstance(status, Div)
+            status.text = "async"
+
+        await app.update_sessions("/", async_update)
+
+        assert [status_text(session.document) for session in sessions] == ["async", "async"]
+    finally:
+        await app.core.stop()
+
+
 async def test_framework_free_example_routes_site_and_bokeh() -> None:
     path = Path(__file__).parents[4] / "examples/server/api/asgi/framework_free.py"
     namespace = runpy.run_path(str(path))

--- a/tests/unit/bokeh/server/test_auth.py
+++ b/tests/unit/bokeh/server/test_auth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 # Standard library imports
 import asyncio
+from threading import get_ident
 
 # Bokeh imports
 from bokeh.server.auth import AuthPolicy
@@ -17,13 +18,27 @@ from bokeh.server.request import ServerRequest
 
 async def test_sync_authenticator() -> None:
     request = ServerRequest(method="GET", uri="/", path="/")
-    policy = AuthPolicy(lambda request: "alice")
+    loop_thread = get_ident()
+    auth_thread = None
+
+    def authenticate(request: ServerRequest) -> str:
+        nonlocal auth_thread
+        auth_thread = get_ident()
+        return "alice"
+
+    policy = AuthPolicy(authenticate)
 
     assert await policy.authenticate(request) == "alice"
+    assert auth_thread != loop_thread
 
 
 async def test_async_authenticator() -> None:
+    loop_thread = get_ident()
+    auth_thread = None
+
     async def authenticate(request: ServerRequest) -> str:
+        nonlocal auth_thread
+        auth_thread = get_ident()
         await asyncio.sleep(0)
         return "alice"
 
@@ -31,6 +46,7 @@ async def test_async_authenticator() -> None:
     policy = AuthPolicy(authenticate)
 
     assert await policy.authenticate(request) == "alice"
+    assert auth_thread == loop_thread
 
 
 def test_login_and_logout_urls() -> None:
@@ -42,3 +58,19 @@ def test_login_and_logout_urls() -> None:
     assert fixed.get_login_url(request) == "/login"
     assert fixed.logout_url == "/logout"
     assert dynamic.get_login_url(request) == "/login?next=/plot"
+
+
+async def test_dynamic_login_url_runs_in_worker() -> None:
+    request = ServerRequest(method="GET", uri="/plot", path="/plot")
+    loop_thread = get_ident()
+    login_thread = None
+
+    def get_login_url(request: ServerRequest) -> str:
+        nonlocal login_thread
+        login_thread = get_ident()
+        return f"/login?next={request.path}"
+
+    policy = AuthPolicy(lambda request: None, login_url=get_login_url)
+
+    assert await policy.get_login_url_async(request) == "/login?next=/plot"
+    assert login_thread != loop_thread

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -21,6 +21,7 @@ import asyncio
 import gc
 import logging
 import threading
+from threading import Event, get_ident
 
 # External imports
 from tornado.ioloop import IOLoop
@@ -29,7 +30,10 @@ from tornado.ioloop import IOLoop
 from bokeh.application import Application
 from bokeh.application.handlers import CodeHandler, FunctionHandler
 from bokeh.application.handlers.lifecycle import LifecycleHandler
+from bokeh.document import without_document_lock
+from bokeh.events import ConnectionLost
 from bokeh.io import curdoc
+from bokeh.models import Slider
 
 # Module under test
 import bokeh.server.contexts as bsc # isort:skip
@@ -479,47 +483,86 @@ curdoc().template_variables["thread_id"] = get_ident()
         result = await asyncio.wait_for(result_f, 1)
         assert result == message
 
-    async def test_sync_session_callback_does_not_block_event_loop(self) -> None:
+    @pytest.mark.parametrize("callback_type", ["next_tick", "timeout", "periodic"])
+    async def test_sync_session_callbacks_run_in_worker(
+            self, callback_type: str) -> None:
         app = Application()
-        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
         session = await c.create_session_if_needed("foo")
-        loop_thread = threading.get_ident()
+        loop_thread = get_ident()
         callback_thread = None
-        started = threading.Event()
-        release = threading.Event()
-        finished = threading.Event()
+        started = Event()
+        release = Event()
+        finished = Event()
+        periodic = None
 
         def callback() -> None:
             nonlocal callback_thread
-            callback_thread = threading.get_ident()
+            callback_thread = get_ident()
+            assert curdoc() is session.document
+            if periodic is not None:
+                session.document.remove_periodic_callback(periodic)
             started.set()
-            release.wait()
+            assert release.wait(timeout=2)
             finished.set()
 
-        session.document.add_next_tick_callback(callback)
-        await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
-        await asyncio.wait_for(asyncio.sleep(0), 0.1)
-        release.set()
-        assert await asyncio.wait_for(asyncio.to_thread(finished.wait), 1)
-        await asyncio.sleep(0)
+        if callback_type == "next_tick":
+            session.document.add_next_tick_callback(callback)
+        elif callback_type == "timeout":
+            session.document.add_timeout_callback(callback, 1)
+        else:
+            periodic = session.document.add_periodic_callback(callback, 1)
+
+        try:
+            await _wait_for_event(started)
+            heartbeat = asyncio.Event()
+            asyncio.get_running_loop().call_soon(heartbeat.set)
+            await asyncio.wait_for(heartbeat.wait(), 1)
+        finally:
+            release.set()
+        await _wait_for_event(finished)
 
         assert callback_thread != loop_thread
 
+    async def test_sync_unlocked_callback_runs_in_worker(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
+        session = await c.create_session_if_needed("foo")
+        loop_thread = get_ident()
+        callback_thread = None
+        callback_doc = None
+        finished = Event()
+
+        @without_document_lock
+        def callback() -> None:
+            nonlocal callback_doc, callback_thread
+            callback_thread = get_ident()
+            callback_doc = curdoc()
+            finished.set()
+
+        session.document.add_next_tick_callback(callback)
+        await _wait_for_event(finished)
+
+        assert callback_thread != loop_thread
+        assert callback_doc is not None
+        with pytest.raises(AttributeError, match="Only 'add_next_tick_callback'"):
+            callback_doc.title
+
     async def test_session_callbacks_are_serialized(self) -> None:
         app = Application()
-        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
         session = await c.create_session_if_needed("foo")
-        lock = threading.Lock()
+        state_lock = threading.Lock()
         active = 0
         maximum_active = 0
 
         def callback() -> None:
             nonlocal active, maximum_active
-            with lock:
+            with state_lock:
                 active += 1
                 maximum_active = max(maximum_active, active)
-            threading.Event().wait(0.02)
-            with lock:
+            Event().wait(0.02)
+            with state_lock:
                 active -= 1
 
         await asyncio.gather(
@@ -531,7 +574,7 @@ curdoc().template_variables["thread_id"] = get_ident()
 
     async def test_different_session_callbacks_can_run_concurrently(self) -> None:
         app = Application()
-        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
         first = await c.create_session_if_needed("first")
         second = await c.create_session_if_needed("second")
         barrier = threading.Barrier(2)
@@ -546,49 +589,58 @@ curdoc().template_variables["thread_id"] = get_ident()
 
     async def test_async_session_callback_runs_on_event_loop(self) -> None:
         app = Application()
-        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
         session = await c.create_session_if_needed("foo")
-        loop_thread = threading.get_ident()
+        loop_thread = get_ident()
         callback_thread = None
 
         async def callback() -> None:
             nonlocal callback_thread
-            callback_thread = threading.get_ident()
+            callback_thread = get_ident()
             await asyncio.sleep(0)
 
         await session.with_document_locked(callback)
 
         assert callback_thread == loop_thread
 
-    async def test_session_callback_can_schedule_timeout_from_worker(self) -> None:
+    async def test_callback_can_schedule_timers_from_worker(self) -> None:
         app = Application()
-        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
         session = await c.create_session_if_needed("foo")
-        fired = threading.Event()
+        timeout_finished = Event()
+        periodic_finished = Event()
+        periodic = None
+
+        def periodic_callback() -> None:
+            assert periodic is not None
+            session.document.remove_periodic_callback(periodic)
+            periodic_finished.set()
 
         def callback() -> None:
-            session.document.add_timeout_callback(fired.set, 1)
+            nonlocal periodic
+            session.document.add_timeout_callback(timeout_finished.set, 1)
+            periodic = session.document.add_periodic_callback(periodic_callback, 1)
 
         await session.with_document_locked(callback)
-
-        assert await asyncio.wait_for(asyncio.to_thread(fired.wait), 1)
+        await _wait_for_event(timeout_finished)
+        await _wait_for_event(periodic_finished)
 
     async def test_cancelling_locked_callback_waits_for_worker(self) -> None:
         app = Application()
-        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
         session = await c.create_session_if_needed("foo")
-        started = threading.Event()
-        release = threading.Event()
-        finished = threading.Event()
+        started = Event()
+        release = Event()
+        finished = Event()
 
         def callback() -> None:
             started.set()
-            release.wait()
+            assert release.wait(timeout=2)
             session.document.title = "finished"
             finished.set()
 
         task = asyncio.create_task(session.with_document_locked(callback))
-        await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
+        await _wait_for_event(started)
         task.cancel()
         await asyncio.sleep(0)
 
@@ -616,6 +668,69 @@ curdoc().template_variables["thread_id"] = get_ident()
                 await session.with_document_locked(callback)
 
         assert not session.expiration_blocked
+
+    async def test_protocol_callback_runs_in_worker(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
+        session = await c.create_session_if_needed("foo")
+        slider = Slider()
+        await session.with_document_locked(session.document.add_root, slider)
+        loop_thread = get_ident()
+        apply_thread = None
+        model_callback_thread = None
+        document_callback_thread = None
+
+        def model_callback(attr, old, new):
+            nonlocal model_callback_thread
+            model_callback_thread = get_ident()
+            assert curdoc() is session.document
+
+        def document_callback(event):
+            nonlocal document_callback_thread
+            if getattr(event, "attr", None) == "value":
+                document_callback_thread = get_ident()
+                assert curdoc() is session.document
+
+        slider.on_change("value", model_callback)
+        session.document.on_change(document_callback)
+
+        class Message:
+            def apply_to_document(self, doc, setter):
+                nonlocal apply_thread
+                apply_thread = get_ident()
+                slider.value = 1
+
+        class Connection:
+            def ok(self, message):
+                assert get_ident() == loop_thread
+                return "ok"
+
+        result = await session._handle_patch(Message(), Connection())
+
+        assert result == "ok"
+        assert apply_thread != loop_thread
+        assert model_callback_thread == apply_thread
+        assert document_callback_thread == apply_thread
+
+    async def test_connection_lost_callback_runs_in_worker_with_curdoc(self) -> None:
+        app = Application()
+        c = bsc.ApplicationContext(app, io_loop=IOLoop.current())
+        session = await c.create_session_if_needed("foo")
+        loop_thread = get_ident()
+        callback_thread = None
+        finished = Event()
+
+        def callback(event) -> None:
+            nonlocal callback_thread
+            callback_thread = get_ident()
+            assert curdoc() is session.document
+            finished.set()
+
+        session.document.on_event(ConnectionLost, callback)
+        session.notify_connection_lost()
+        await _wait_for_event(finished)
+
+        assert callback_thread != loop_thread
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/server/test_contexts.py
+++ b/tests/unit/bokeh/server/test_contexts.py
@@ -28,6 +28,7 @@ from tornado.ioloop import IOLoop
 # Bokeh imports
 from bokeh.application import Application
 from bokeh.application.handlers import CodeHandler, FunctionHandler
+from bokeh.application.handlers.lifecycle import LifecycleHandler
 from bokeh.io import curdoc
 
 # Module under test
@@ -171,6 +172,30 @@ class TestApplicationContext:
                 assert slow_release.wait(timeout=2)
 
         app = Application(FunctionHandler(modify_document))
+        c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
+
+        slow = asyncio.create_task(c.create_session_if_needed("slow"))
+        try:
+            await _wait_for_event(slow_started)
+            fast = await asyncio.wait_for(c.create_session_if_needed("fast"), timeout=1)
+            assert fast.id == "fast"
+        finally:
+            slow_release.set()
+
+        assert (await slow).id == "slow"
+
+    async def test_session_created_does_not_block_other_sessions(self) -> None:
+        slow_started = threading.Event()
+        slow_release = threading.Event()
+        handler = LifecycleHandler()
+
+        def on_session_created(session_context) -> None:
+            if session_context.id == "slow":
+                slow_started.set()
+                assert slow_release.wait(timeout=2)
+
+        handler._on_session_created = on_session_created
+        app = Application(handler)
         c = bsc.ApplicationContext(app, io_loop=asyncio.get_running_loop())
 
         slow = asyncio.create_task(c.create_session_if_needed("slow"))

--- a/tests/unit/bokeh/server/test_core.py
+++ b/tests/unit/bokeh/server/test_core.py
@@ -17,6 +17,8 @@ import pytest
 # Bokeh imports
 from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
+from bokeh.io import curdoc
+from bokeh.models import Div
 from bokeh.protocol import Protocol
 from bokeh.server.core import BokehServerCore
 from bokeh.server.request import Cookie, Headers, ServerRequest
@@ -44,6 +46,108 @@ async def test_periodic_callback_continues_after_exception() -> None:
         await periodic.wait()
 
     assert calls >= 2
+
+
+async def test_locked_callback_latest_runs_from_threads_with_document_lock() -> None:
+    callbacks = []
+    models: list[Div] = []
+    calls: list[str] = []
+    callback_threads: list[int] = []
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def modify_document(doc) -> None:
+        model = Div()
+        models.append(model)
+        doc.add_root(model)
+
+        @doc.locked_callback(policy="latest")
+        def update(value: str) -> None:
+            assert curdoc() is doc
+            calls.append(value)
+            callback_threads.append(threading.get_ident())
+            if value == "first":
+                started.set()
+                assert release.wait(timeout=2)
+            model.text = value
+            if value == "latest":
+                finished.set()
+
+        callbacks.append(update)
+
+    core = BokehServerCore(Application(FunctionHandler(modify_document)), keep_alive_milliseconds=0)
+    await core.start()
+    loop_thread = threading.get_ident()
+    try:
+        context = core.applications["/"]
+        session = await context.create_session_if_needed("session")
+        update = callbacks[0]
+
+        await asyncio.to_thread(update, "first")
+        assert await asyncio.wait_for(asyncio.to_thread(started.wait), 1)
+        assert session._lock.locked()
+
+        await asyncio.to_thread(update, "middle")
+        await asyncio.to_thread(update, "latest")
+        release.set()
+        assert await asyncio.wait_for(asyncio.to_thread(finished.wait), 1)
+
+        assert calls == ["first", "latest"]
+        assert models[0].text == "latest"
+        assert all(thread != loop_thread for thread in callback_threads)
+        assert not update.pending
+    finally:
+        release.set()
+        await core.stop()
+
+    assert update.closed
+    update("ignored")
+
+
+async def test_locked_callback_every_awaits_async_callbacks_in_order() -> None:
+    callbacks = []
+    models: list[Div] = []
+    calls: list[int] = []
+    callback_threads: list[int] = []
+    finished = asyncio.Event()
+
+    def modify_document(doc) -> None:
+        model = Div()
+        models.append(model)
+        doc.add_root(model)
+
+        @doc.locked_callback
+        async def update(value: int) -> None:
+            await asyncio.sleep(0)
+            assert curdoc() is doc
+            calls.append(value)
+            callback_threads.append(threading.get_ident())
+            model.text = str(value)
+            if value == 3:
+                finished.set()
+
+        callbacks.append(update)
+
+    core = BokehServerCore(Application(FunctionHandler(modify_document)), keep_alive_milliseconds=0)
+    await core.start()
+    try:
+        context = core.applications["/"]
+        session = await context.create_session_if_needed("session")
+        update = callbacks[0]
+
+        await asyncio.to_thread(update, 1)
+        await asyncio.to_thread(update, 2)
+        await asyncio.to_thread(update, 3)
+        await asyncio.wait_for(finished.wait(), 1)
+
+        assert calls == [1, 2, 3]
+        assert models[0].text == "3"
+        assert callback_threads == [threading.get_ident()] * 3
+        assert not update.pending
+        assert not session._lock.locked()
+    finally:
+        await core.stop()
 
 
 async def test_stop_waits_for_periodic_jobs_before_unload() -> None:

--- a/tests/unit/bokeh/server/test_executor.py
+++ b/tests/unit/bokeh/server/test_executor.py
@@ -60,6 +60,33 @@ async def test_cancel_safe_run_finishes_before_propagating_cancellation() -> Non
 
     executor.shutdown()
 
+async def test_worker_concurrency_is_bounded() -> None:
+    executor = _ServerExecutor(max_workers=1)
+    first_started = Event()
+    first_release = Event()
+    second_started = Event()
+
+    def first_work() -> None:
+        first_started.set()
+        assert first_release.wait(timeout=2)
+
+    first = asyncio.create_task(executor.run(first_work))
+    second = asyncio.create_task(executor.run(second_started.set))
+    try:
+        async with asyncio.timeout(1):
+            while not first_started.is_set():
+                await asyncio.sleep(0)
+
+        await asyncio.sleep(0)
+        assert not second_started.is_set()
+    finally:
+        first_release.set()
+
+    await asyncio.gather(first, second)
+    assert second_started.is_set()
+
+    executor.shutdown()
+
 #-----------------------------------------------------------------------------
 # Code
 #-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_executor.py
+++ b/tests/unit/bokeh/server/test_executor.py
@@ -1,0 +1,65 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import asyncio
+from threading import Event, get_ident
+
+# Module under test
+from bokeh.server.executor import _ServerExecutor # isort:skip
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+async def test_run_uses_worker_thread() -> None:
+    executor = _ServerExecutor(max_workers=1)
+    try:
+        assert await executor.run(get_ident) != get_ident()
+    finally:
+        executor.shutdown()
+
+async def test_cancel_safe_run_finishes_before_propagating_cancellation() -> None:
+    executor = _ServerExecutor(max_workers=1)
+    started = Event()
+    release = Event()
+
+    def work() -> None:
+        started.set()
+        assert release.wait(timeout=2)
+
+    task = asyncio.create_task(executor.run(work, cancel_safe=True))
+    try:
+        async with asyncio.timeout(1):
+            while not started.is_set():
+                await asyncio.sleep(0)
+
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    executor.shutdown()
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/server/test_session__server.py
+++ b/tests/unit/bokeh/server/test_session__server.py
@@ -17,10 +17,22 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import asyncio
+from threading import Event, get_ident
 from unittest import mock
 
+# External imports
+import numpy as np
+
 # Bokeh imports
+from bokeh.core.properties import Int
 from bokeh.document import Document
+from bokeh.io import curdoc
+from bokeh.model import Model
+from bokeh.models import ColumnDataSource
+from bokeh.protocol import Protocol
+from bokeh.server.connection import ServerConnection
+from bokeh.server.executor import _ServerExecutor
 
 # Module under test
 import bokeh.server.session as bss # isort:skip
@@ -32,6 +44,51 @@ import bokeh.server.session as bss # isort:skip
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+class SomeModelInTestServerSession(Model):
+    value = Int(default=0)
+
+class TrackingProtocol(Protocol):
+
+    def __init__(self, tracked: str, started: Event | None = None, release: Event | None = None) -> None:
+        super().__init__()
+        self.tracked = tracked
+        self.started = started
+        self.release = release
+        self.thread_ids: list[int] = []
+        self.current_documents: list[Document] = []
+
+    def create(self, msgtype, *args, **kwargs):
+        if msgtype == self.tracked:
+            self.thread_ids.append(get_ident())
+            self.current_documents.append(curdoc())
+            if self.started is not None:
+                self.started.set()
+            if self.release is not None:
+                assert self.release.wait(timeout=2)
+        return super().create(msgtype, *args, **kwargs)
+
+class RecordingSocket:
+
+    def __init__(self, block_first: bool = False) -> None:
+        self.messages = []
+        self.thread_ids: list[int] = []
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        if not block_first:
+            self.release.set()
+
+    async def send_message(self, message) -> None:
+        self.thread_ids.append(get_ident())
+        self.started.set()
+        await self.release.wait()
+        self.messages.append(message)
+
+def make_connection(document: Document, protocol: Protocol, executor: _ServerExecutor) -> tuple[bss.ServerSession, RecordingSocket, ServerConnection]:
+    session = bss.ServerSession("some-id", document, executor=executor)
+    socket = RecordingSocket()
+    connection = ServerConnection(protocol, socket, mock.Mock(), session)
+    return session, socket, connection
 
 def test_creation() -> None:
     d = Document()
@@ -64,6 +121,119 @@ def test_destroy_calls() -> None:
             assert s.destroyed
             docroc.assert_called_with(s)
         docdm.assert_called_once()
+
+async def test_patch_serialization_runs_off_loop_and_freezes_buffers() -> None:
+    main_thread = get_ident()
+    executor = _ServerExecutor(max_workers=1)
+    document = Document()
+    source = ColumnDataSource(data={"a": np.array([0.0])})
+    document.add_root(source)
+    document.to_json()
+    protocol = TrackingProtocol("PATCH-DOC")
+    session, socket, _ = make_connection(document, protocol, executor)
+    array = np.array([1.0, 2.0])
+
+    try:
+        await session.with_document_locked(lambda: setattr(source, "data", {"a": array}))
+        [message] = socket.messages
+        [buffer] = message.buffers
+        expected = buffer.data
+
+        assert protocol.thread_ids and protocol.thread_ids[0] != main_thread
+        assert protocol.current_documents == [document]
+        assert socket.thread_ids == [main_thread]
+        assert isinstance(expected, bytes)
+        assert message.content_json == message._content_json
+
+        array[0] = 10.0
+        assert buffer.data == expected
+    finally:
+        executor.shutdown()
+
+async def test_patch_cancellation_waits_for_serialization_and_write() -> None:
+    executor = _ServerExecutor(max_workers=1)
+    started = Event()
+    release = Event()
+    document = Document()
+    root = SomeModelInTestServerSession()
+    document.add_root(root)
+    document.to_json()
+    protocol = TrackingProtocol("PATCH-DOC", started, release)
+    session, socket, _ = make_connection(document, protocol, executor)
+
+    task = asyncio.create_task(session.with_document_locked(lambda: setattr(root, "value", 1)))
+    try:
+        async with asyncio.timeout(1):
+            while not started.is_set():
+                await asyncio.sleep(0)
+
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        assert not socket.messages
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert len(socket.messages) == 1
+
+    executor.shutdown()
+
+async def test_patch_messages_preserve_event_order() -> None:
+    executor = _ServerExecutor(max_workers=1)
+    document = Document()
+    root = SomeModelInTestServerSession()
+    document.add_root(root)
+    document.to_json()
+    protocol = TrackingProtocol("PATCH-DOC")
+    session, socket, _ = make_connection(document, protocol, executor)
+
+    def update() -> None:
+        root.value = 1
+        root.value = 2
+
+    try:
+        await session.with_document_locked(update)
+        assert [
+            message.content["events"][0]["new"]
+            for message in socket.messages
+        ] == [1, 2]
+    finally:
+        executor.shutdown()
+
+async def test_pull_reply_precedes_later_patch_and_is_cancellation_safe() -> None:
+    executor = _ServerExecutor(max_workers=1)
+    document = Document()
+    root = SomeModelInTestServerSession()
+    document.add_root(root)
+    protocol = TrackingProtocol("PULL-DOC-REPLY")
+    session = bss.ServerSession("some-id", document, executor=executor)
+    socket = RecordingSocket(block_first=True)
+    connection = ServerConnection(protocol, socket, mock.Mock(), session)
+    request = protocol.create("PULL-DOC-REQ")
+
+    pull = asyncio.create_task(bss.ServerSession.pull(request, connection))
+    try:
+        await asyncio.wait_for(socket.started.wait(), timeout=1)
+        pull.cancel()
+        patch = asyncio.create_task(session.with_document_locked(lambda: setattr(root, "value", 1)))
+        await asyncio.sleep(0)
+
+        assert not pull.done()
+        assert not patch.done()
+
+        socket.release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await pull
+        await patch
+
+        assert [message.msgtype for message in socket.messages] == ["PULL-DOC-REPLY", "PATCH-DOC"]
+        assert all(thread_id == get_ident() for thread_id in socket.thread_ids)
+        assert protocol.thread_ids and protocol.thread_ids[0] != get_ident()
+        assert protocol.current_documents == [document]
+    finally:
+        executor.shutdown()
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -25,7 +25,6 @@ from unittest.mock import Mock, patch
 
 # External imports
 from _util_server import http_get, url
-from tornado.web import StaticFileHandler
 from tornado.websocket import WebSocketClosedError
 
 # Bokeh imports
@@ -34,7 +33,7 @@ from bokeh.application.handlers.function import FunctionHandler
 from bokeh.client import pull_session
 from bokeh.core.types import ID
 from bokeh.server.auth_provider import NullAuth
-from bokeh.server.views.static_handler import StaticHandler
+from bokeh.server.views.static_handler import AsyncStaticFileHandler, StaticHandler
 from bokeh.server.views.ws import WSHandler
 from tests.support.plugins.managed_server_loop import MSL
 from tests.support.util.env import envset
@@ -436,13 +435,13 @@ class Test_create_static_handler:
         result = bst.create_static_handler("/prefix", "/key", app)
         assert len(result) == 3
         assert result[0] == "/prefix/key/static/(.*)"
-        assert result[1] == StaticFileHandler
+        assert result[1] == AsyncStaticFileHandler
         assert result[2] == {"path" : app.static_path}
 
         result = bst.create_static_handler("/prefix", "/", app)
         assert len(result) == 3
         assert result[0] == "/prefix/static/(.*)"
-        assert result[1] == StaticFileHandler
+        assert result[1] == AsyncStaticFileHandler
         assert result[2] == {"path" : app.static_path}
 
     def test_no_app_static_path(self):

--- a/tests/unit/bokeh/server/test_tornado__server.py
+++ b/tests/unit/bokeh/server/test_tornado__server.py
@@ -32,6 +32,7 @@ from bokeh.application import Application
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.client import pull_session
 from bokeh.core.types import ID
+from bokeh.embed.bundle import Bundle, Script
 from bokeh.server.auth_provider import NullAuth
 from bokeh.server.views.static_handler import AsyncStaticFileHandler, StaticHandler
 from bokeh.server.views.ws import WSHandler
@@ -240,6 +241,44 @@ def test_websocket_compression_level() -> None:
     ws_rule = ws_rules[0]
     assert ws_rule.target_kwargs.get('compression_level') == 2
     assert ws_rule.target_kwargs.get('mem_level') == 3
+
+async def test_autoload_bundle_runs_off_loop_and_is_coalesced(monkeypatch: pytest.MonkeyPatch) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    thread_ids: list[int] = []
+
+    def bundle(objs, resources):
+        thread_ids.append(threading.get_ident())
+        started.set()
+        assert release.wait(timeout=2)
+        return Bundle(js_raw=["base"])
+
+    monkeypatch.setattr("bokeh.embed.bundle.bundle_for_objs_and_resources", bundle)
+    app = bst.BokehTornado({})
+
+    first = asyncio.create_task(app._bundle_for_autoload(None))
+    try:
+        async with asyncio.timeout(1):
+            while not started.is_set():
+                await asyncio.sleep(0)
+
+        second = asyncio.create_task(app._bundle_for_autoload(None))
+        await asyncio.sleep(0)
+    finally:
+        release.set()
+
+    first_bundle, second_bundle = await asyncio.gather(first, second)
+    await asyncio.sleep(0)
+
+    assert len(thread_ids) == 1
+    assert thread_ids[0] != threading.get_ident()
+    assert first_bundle is not second_bundle
+
+    first_bundle.add(Script("request-specific"))
+    cached_bundle = await app._bundle_for_autoload(None)
+    assert cached_bundle.js_raw == ["base"]
+
+    app._executor.shutdown()
 
 def test_websocket_origins(ManagedServerLoop, unused_tcp_port) -> None:
     application = Application()

--- a/tests/unit/bokeh/server/views/test_auth_request_handler.py
+++ b/tests/unit/bokeh/server/views/test_auth_request_handler.py
@@ -17,7 +17,10 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from unittest.mock import MagicMock
+import asyncio
+from threading import Event, get_ident
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 # Module under test
 from bokeh.server.views.auth_request_handler import AuthRequestHandler # isort:skip
@@ -34,6 +37,13 @@ def _make_handler(login_url=None, get_login_url=None, prefix=""):
 
     handler = AuthRequestHandler.__new__(AuthRequestHandler)
     handler.application = app
+    return handler
+
+def _make_auth_handler(*, get_user=None, get_user_async=None, get_login_url=None):
+    handler = _make_handler(get_login_url=get_login_url)
+    handler.application.auth_provider.get_user = get_user
+    handler.application.auth_provider.get_user_async = get_user_async
+    handler.request = SimpleNamespace(method="GET")
     return handler
 
 #-----------------------------------------------------------------------------
@@ -69,6 +79,98 @@ class TestGetLoginUrl:
         handler = _make_handler()
         with pytest.raises(RuntimeError):
             handler.get_login_url()
+
+
+class TestPrepare:
+    async def test_sync_get_user_runs_in_worker(self) -> None:
+        started = Event()
+        release = Event()
+        loop_thread = get_ident()
+        auth_thread = None
+
+        def get_user(handler):
+            nonlocal auth_thread
+            auth_thread = get_ident()
+            started.set()
+            assert release.wait(timeout=2)
+            return "alice"
+
+        handler = _make_auth_handler(get_user=get_user)
+        pending = asyncio.create_task(handler.prepare())
+        try:
+            async with asyncio.timeout(1):
+                while not started.is_set():
+                    await asyncio.sleep(0)
+            heartbeat = asyncio.Event()
+            asyncio.get_running_loop().call_soon(heartbeat.set)
+            await asyncio.wait_for(heartbeat.wait(), 1)
+        finally:
+            release.set()
+
+        await pending
+        assert handler.current_user == "alice"
+        assert auth_thread != loop_thread
+
+    async def test_async_get_user_runs_on_event_loop(self) -> None:
+        loop_thread = get_ident()
+        auth_thread = None
+
+        async def get_user_async(handler):
+            nonlocal auth_thread
+            auth_thread = get_ident()
+            await asyncio.sleep(0)
+            return "alice"
+
+        handler = _make_auth_handler(get_user_async=get_user_async)
+        await handler.prepare()
+
+        assert handler.current_user == "alice"
+        assert auth_thread == loop_thread
+
+    async def test_dynamic_login_url_is_computed_in_worker_and_cached(self) -> None:
+        loop_thread = get_ident()
+        login_thread = None
+        calls = 0
+
+        def get_user(handler):
+            return None
+
+        def get_login_url(handler):
+            nonlocal calls, login_thread
+            calls += 1
+            login_thread = get_ident()
+            return "/login"
+
+        handler = _make_auth_handler(get_user=get_user, get_login_url=get_login_url)
+        await handler.prepare()
+
+        assert handler.get_login_url() == "/login"
+        assert handler.get_login_url() == "/login"
+        assert calls == 1
+        assert login_thread != loop_thread
+
+    async def test_sync_get_user_is_not_called_for_options(self) -> None:
+        get_user = MagicMock()
+        handler = _make_auth_handler(get_user=get_user)
+        handler.request.method = "OPTIONS"
+
+        await handler.prepare()
+
+        get_user.assert_not_called()
+
+    async def test_async_options_does_not_compute_login_url(self) -> None:
+        get_user_async = AsyncMock(return_value=None)
+        get_login_url = MagicMock(return_value="/login")
+        handler = _make_auth_handler(
+            get_user_async=get_user_async,
+            get_login_url=get_login_url,
+        )
+        handler.request.method = "OPTIONS"
+
+        await handler.prepare()
+
+        get_user_async.assert_awaited_once_with(handler)
+        get_login_url.assert_not_called()
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/tests/unit/bokeh/server/views/test_static_handler.py
+++ b/tests/unit/bokeh/server/views/test_static_handler.py
@@ -28,6 +28,7 @@ from typing import Any
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPResponse
 
 # Bokeh imports
+import bokeh.server.views.static_handler as static_handler
 from bokeh.application import Application
 from bokeh.server.views.static_handler import AsyncStaticFileHandler
 from tests.support.plugins.managed_server_loop import MSL
@@ -48,6 +49,18 @@ async def _fetch(server: Any, path: str, **kwargs: Any) -> HTTPResponse:
 #-----------------------------------------------------------------------------
 # General API
 #-----------------------------------------------------------------------------
+
+def test_modified_time_matches_tornado_timezone_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "asset.txt"
+    path.write_bytes(_CONTENT)
+    handler = object.__new__(AsyncStaticFileHandler)
+    handler.absolute_path = str(path)
+
+    monkeypatch.setattr(static_handler, "tornado_version_info", (6, 3, 3, 0))
+    assert handler.get_modified_time().tzinfo is None
+
+    monkeypatch.setattr(static_handler, "tornado_version_info", (6, 4, 0, 0))
+    assert handler.get_modified_time().tzinfo is not None
 
 async def test_static_response_compatibility(tmp_path: Path, ManagedServerLoop: MSL) -> None:
     (tmp_path / "asset.txt").write_bytes(_CONTENT)

--- a/tests/unit/bokeh/server/views/test_static_handler.py
+++ b/tests/unit/bokeh/server/views/test_static_handler.py
@@ -1,0 +1,253 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) Anaconda, Inc., and Bokeh Contributors.
+# All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Boilerplate
+#-----------------------------------------------------------------------------
+from __future__ import annotations # isort:skip
+
+import pytest ; pytest
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import asyncio
+import os
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+# External imports
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPResponse
+
+# Bokeh imports
+from bokeh.application import Application
+from bokeh.server.views.static_handler import AsyncStaticFileHandler
+from tests.support.plugins.managed_server_loop import MSL
+
+#-----------------------------------------------------------------------------
+# Setup
+#-----------------------------------------------------------------------------
+
+_CONTENT = b"0123456789abcdef"
+
+def _url(server: Any, path: str) -> str:
+    return f"http://localhost:{server.port}/custom/static/{path}"
+
+async def _fetch(server: Any, path: str, **kwargs: Any) -> HTTPResponse:
+    request = HTTPRequest(_url(server, path), **kwargs)
+    return await AsyncHTTPClient().fetch(request, raise_error=False)
+
+#-----------------------------------------------------------------------------
+# General API
+#-----------------------------------------------------------------------------
+
+async def test_static_response_compatibility(tmp_path: Path, ManagedServerLoop: MSL) -> None:
+    (tmp_path / "asset.txt").write_bytes(_CONTENT)
+    (tmp_path / "directory").mkdir()
+    AsyncStaticFileHandler.reset()
+
+    patterns = [
+        (r"/custom/static/(.*)", AsyncStaticFileHandler, {"path": str(tmp_path)}),
+    ]
+    with ManagedServerLoop(Application(), extra_patterns=patterns) as server:
+        response = await _fetch(server, "asset.txt")
+
+        assert response.code == 200
+        assert response.body == _CONTENT
+        assert response.headers["Accept-Ranges"] == "bytes"
+        assert response.headers["Content-Length"] == str(len(_CONTENT))
+        assert response.headers["Content-Type"].startswith("text/plain")
+        assert "Etag" in response.headers
+        assert "Last-Modified" in response.headers
+
+        etag = response.headers["Etag"]
+        last_modified = response.headers["Last-Modified"]
+
+        head = await _fetch(server, "asset.txt", method="HEAD")
+        assert head.code == 200
+        assert head.body == b""
+        assert head.headers["Content-Length"] == str(len(_CONTENT))
+        assert head.headers["Etag"] == etag
+
+        partial = await _fetch(
+            server, "asset.txt", headers={"Range": "bytes=2-5"},
+        )
+        assert partial.code == 206
+        assert partial.body == _CONTENT[2:6]
+        assert partial.headers["Content-Length"] == "4"
+        assert partial.headers["Content-Range"] == f"bytes 2-5/{len(_CONTENT)}"
+        assert partial.headers["Etag"] == etag
+
+        not_modified = await _fetch(
+            server, "asset.txt", headers={"If-None-Match": etag},
+        )
+        assert not_modified.code == 304
+        assert not_modified.body == b""
+
+        not_modified_since = await _fetch(
+            server, "asset.txt", headers={"If-Modified-Since": last_modified},
+        )
+        assert not_modified_since.code == 304
+        assert not_modified_since.body == b""
+
+        unsatisfiable = await _fetch(
+            server, "asset.txt", headers={"Range": "bytes=100-"},
+        )
+        assert unsatisfiable.code == 416
+        assert unsatisfiable.headers["Content-Range"] == f"bytes */{len(_CONTENT)}"
+
+        missing = await _fetch(server, "missing.txt")
+        assert missing.code == 404
+
+        directory = await _fetch(server, "directory/")
+        assert directory.code == 403
+
+async def test_static_filesystem_operations_run_off_loop(tmp_path: Path, ManagedServerLoop: MSL) -> None:
+    path = tmp_path / "asset.bin"
+    path.write_bytes(_CONTENT)
+    loop_thread = threading.get_ident()
+
+    class TrackingStaticFileHandler(AsyncStaticFileHandler):
+        operations: list[tuple[str, int]] = []
+
+        @classmethod
+        def _get_stat_result(cls, absolute_path: str) -> os.stat_result:
+            cls.operations.append(("stat", threading.get_ident()))
+            return super()._get_stat_result(absolute_path)
+
+        @classmethod
+        def get_content(cls, abspath: str, start: int | None = None,
+                end: int | None = None) -> Iterator[bytes]:
+            cls.operations.append(("open", threading.get_ident()))
+            file = open(abspath, "rb")
+            try:
+                if start is not None:
+                    file.seek(start)
+                remaining = None if end is None else end - (start or 0)
+                while remaining is None or remaining > 0:
+                    cls.operations.append(("read", threading.get_ident()))
+                    chunk = file.read(4 if remaining is None else min(4, remaining))
+                    if not chunk:
+                        return
+                    if remaining is not None:
+                        remaining -= len(chunk)
+                    yield chunk
+            finally:
+                cls.operations.append(("close", threading.get_ident()))
+                file.close()
+
+    TrackingStaticFileHandler.reset()
+    patterns = [
+        (r"/custom/static/(.*)", TrackingStaticFileHandler, {"path": str(tmp_path)}),
+    ]
+    with ManagedServerLoop(Application(), extra_patterns=patterns) as server:
+        response = await _fetch(server, path.name)
+
+    assert response.code == 200
+    assert response.body == _CONTENT
+    assert {"stat", "open", "read", "close"} <= {name for name, _ in TrackingStaticFileHandler.operations}
+    assert all(thread_id != loop_thread for _, thread_id in TrackingStaticFileHandler.operations)
+
+async def test_static_streaming_waits_for_flush(tmp_path: Path, ManagedServerLoop: MSL) -> None:
+    (tmp_path / "asset.bin").write_bytes(b"abc")
+    loop_thread = threading.get_ident()
+
+    class BackpressureStaticFileHandler(AsyncStaticFileHandler):
+        first_flush = asyncio.Event()
+        release_flush = asyncio.Event()
+        closed = threading.Event()
+        chunks_requested = 0
+        close_thread: int | None = None
+
+        def compute_etag(self) -> str:
+            return '"fixed"'
+
+        @classmethod
+        def get_content(cls, abspath: str, start: int | None = None,
+                end: int | None = None) -> Iterator[bytes]:
+            try:
+                for chunk in (b"a", b"b", b"c"):
+                    cls.chunks_requested += 1
+                    yield chunk
+            finally:
+                cls.close_thread = threading.get_ident()
+                cls.closed.set()
+
+        async def flush(self, include_footers: bool = False) -> None:
+            if not self.first_flush.is_set():
+                self.first_flush.set()
+                await self.release_flush.wait()
+            await super().flush(include_footers)
+
+    patterns = [
+        (r"/custom/static/(.*)", BackpressureStaticFileHandler, {"path": str(tmp_path)}),
+    ]
+    with ManagedServerLoop(Application(), extra_patterns=patterns) as server:
+        response_future = asyncio.create_task(_fetch(server, "asset.bin"))
+        await asyncio.wait_for(BackpressureStaticFileHandler.first_flush.wait(), 5)
+        assert BackpressureStaticFileHandler.chunks_requested == 1
+
+        BackpressureStaticFileHandler.release_flush.set()
+        response = await asyncio.wait_for(response_future, 5)
+
+    assert response.code == 200
+    assert response.body == b"abc"
+    assert BackpressureStaticFileHandler.closed.is_set()
+    assert BackpressureStaticFileHandler.close_thread != loop_thread
+
+async def test_static_content_is_closed_on_read_error(tmp_path: Path, ManagedServerLoop: MSL) -> None:
+    (tmp_path / "asset.bin").write_bytes(b"x")
+    loop_thread = threading.get_ident()
+
+    class BrokenContent:
+        def __iter__(self) -> BrokenContent:
+            return self
+
+        def __next__(self) -> bytes:
+            raise OSError("read failed")
+
+        def close(self) -> None:
+            BrokenStaticFileHandler.close_thread = threading.get_ident()
+            BrokenStaticFileHandler.closed.set()
+
+    class BrokenStaticFileHandler(AsyncStaticFileHandler):
+        closed = threading.Event()
+        close_thread: int | None = None
+
+        def compute_etag(self) -> str:
+            return '"fixed"'
+
+        @classmethod
+        def get_content(cls, abspath: str, start: int | None = None,
+                end: int | None = None) -> BrokenContent:
+            return BrokenContent()
+
+    patterns = [
+        (r"/custom/static/(.*)", BrokenStaticFileHandler, {"path": str(tmp_path)}),
+    ]
+    with ManagedServerLoop(Application(), extra_patterns=patterns) as server:
+        response = await _fetch(server, "asset.bin")
+
+    assert response.code == 500
+    assert BrokenStaticFileHandler.closed.is_set()
+    assert BrokenStaticFileHandler.close_thread != loop_thread
+
+#-----------------------------------------------------------------------------
+# Dev API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Private API
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Code
+#-----------------------------------------------------------------------------

--- a/tests/unit/bokeh/util/test_compiler.py
+++ b/tests/unit/bokeh/util/test_compiler.py
@@ -19,6 +19,8 @@ import pytest ; pytest
 # Standard library imports
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
 from unittest.mock import MagicMock, patch
 
 # Module under test
@@ -135,6 +137,37 @@ def test_jsons() -> None:
         if file.endswith('.json'):
             with open(os.path.join(buc.bokehjs_dir, "js", file), encoding="utf-8") as f:
                 assert all('\\' not in mod for mod in json.load(f))
+
+def test_bundle_models_coalesces_concurrent_compilation(monkeypatch: pytest.MonkeyPatch) -> None:
+    started = Event()
+    release = Event()
+    calls = 0
+    calls_lock = Lock()
+    custom_models = {"TestModel": MagicMock(full_name="TestModel")}
+
+    def bundle(models):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        started.set()
+        assert release.wait(timeout=2)
+        return "bundle"
+
+    monkeypatch.setattr(buc, "_bundle_cache", {})
+    monkeypatch.setattr(buc, "_bundle_futures", {})
+    monkeypatch.setattr(buc, "_get_custom_models", lambda models: custom_models)
+    monkeypatch.setattr(buc, "_bundle_models", bundle)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(buc.bundle_models, None)
+        assert started.wait(timeout=1)
+        second = executor.submit(buc.bundle_models, None)
+        release.set()
+
+        assert first.result(timeout=1) == "bundle"
+        assert second.result(timeout=1) == "bundle"
+
+    assert calls == 1
 
 def test_inline_extension() -> None:
     from bokeh.io import save

--- a/tests/unit/bokeh/util/test_tornado__util.py
+++ b/tests/unit/bokeh/util/test_tornado__util.py
@@ -16,7 +16,12 @@ import pytest ; pytest
 # Imports
 #-----------------------------------------------------------------------------
 
+# Standard library imports
+import asyncio
+
+# Bokeh imports
 # Module under test
+from bokeh.util.tornado import _wait_for_task
 
 #-----------------------------------------------------------------------------
 # Setup
@@ -33,6 +38,21 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 # Private API
 #-----------------------------------------------------------------------------
+
+async def test_wait_for_task_prefers_outer_cancellation() -> None:
+    loop = asyncio.get_running_loop()
+    inner: asyncio.Future[None] = loop.create_future()
+    outer = asyncio.create_task(_wait_for_task(inner))
+    await asyncio.sleep(0)
+
+    def complete_and_cancel() -> None:
+        inner.set_exception(RuntimeError("inner failure"))
+        outer.cancel()
+
+    loop.call_soon(complete_and_cancel)
+
+    with pytest.raises(asyncio.CancelledError):
+        await outer
 
 #-----------------------------------------------------------------------------
 # Code


### PR DESCRIPTION
[codex assisted]

- [x] issues: fixes #15294, fixes #5138
- [x] tests added / passed
- [x] release document entry (add to the 4.0 release notes when that document is available)

This PR combines the server follow-up work into one change on top of the framework-neutral ASGI server core. It keeps synchronous and blocking server work off the event loop while preserving per-session document locking, callback ordering, cancellation safety, and event-loop-only transport writes.

## What changed

- Added `BokehServerCore.update_sessions()` and `BokehASGI.update_sessions()` for safely applying sync or async updates to every active session for an application.
- Added `Document.locked_callback()` for cross-thread document updates. The default `"every"` policy preserves every invocation; `"latest"` bounds queued work by coalescing pending calls.
    
    @philippjfr note this basically means the next-tick callback dance is not needed any longer.  Wrapped Bokeh callbacks can be passed directly to external things to invoke safely
   ```python
    @doc.locked_callback(policy="latest")
    def update(x: float, y: float) -> None:
        source.stream({"x": [x], "y": [y]}, rollover=100)
    ```
- Run synchronous session, model, document, session-created lifecycle, request, authentication, protocol, unlocked, and connection-loss callbacks in workers. Async callbacks remain on the event loop.
- Added an async Tornado static-file handler that offloads metadata checks, file opening, seeking, reading, iteration, and closing while retaining compatible range, conditional-request, `HEAD`, cache, and content-type behavior.
- Added a bounded server executor for autoload bundle generation and outbound document/patch serialization. Concurrent identical autoload requests share one build, completed bundles use a bounded cache, and shutdown drains or cancels work as appropriate.
- Freeze protocol messages before event-loop transport writes and keep the session document lock until pending messages have been serialized and sent.
- Added ASGI shared-data and locked-callback examples, plus server and deployment documentation for the new threading behavior.

## Concurrency and cancellation behavior

Callbacks for a single session remain serialized by its document lock, while callbacks for different sessions can run concurrently. Worker execution preserves the active `curdoc()` context. If an awaiting task is cancelled, Bokeh waits for already-running, non-cancellable worker work before releasing the document lock or propagating cancellation.

Protocol mutation and serialization happen against a consistent document state. The resulting prepared messages are written on the event-loop thread.
