### PR TITLE
Release models removed from the client-side model graph

### DIFF
--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -36,6 +36,13 @@ export namespace View {
 
 export type IterViews<T extends View = View> = Generator<T, void, undefined>
 
+/**
+ * Shared abort reason. Aborting without one makes the browser construct a
+ * `DOMException` with a stack trace, which is an order of magnitude more
+ * expensive and is paid by every view being removed.
+ */
+const view_removed = new DOMException("view removed", "AbortError")
+
 type TransitiveOpts = {
   recursive?: boolean
   signal?: (obj: HasProps) => Signal<unknown, HasProps>
@@ -43,6 +50,8 @@ type TransitiveOpts = {
 
 export abstract class View implements ISignalable, Equatable {
   readonly removed = new Signal0<this>(this, "removed")
+
+  private readonly _abort_controller = new AbortController()
 
   readonly model: HasProps
 
@@ -120,6 +129,22 @@ export abstract class View implements ISignalable, Equatable {
 
   async lazy_initialize(): Promise<void> {}
 
+  /**
+   * An `AbortSignal` that is aborted when this view is removed.
+   *
+   * Pass it as `{signal: this.abort_signal}` to `addEventListener()` when
+   * subscribing to an event target that outlives this view (e.g. `document`,
+   * `window` or `visualViewport`). Such a target retains the listener, and
+   * through its closure this view and its model, for the lifetime of the page.
+   *
+   * Don't use it for listeners on elements this view owns. Those are released
+   * with the element itself, and registering an abort algorithm for them only
+   * adds a reference from this view to DOM it would otherwise let go of.
+   */
+  protected get abort_signal(): AbortSignal {
+    return this._abort_controller.signal
+  }
+
   protected _destroyed: boolean = false
   remove(): void {
     if (this._destroyed) {
@@ -127,6 +152,7 @@ export abstract class View implements ISignalable, Equatable {
       return
     }
     this.disconnect_signals()
+    this._abort_controller.abort(view_removed)
     for (const view of this.children_views()) {
       view.remove()
     }

--- a/bokehjs/src/lib/models/plots/plot_canvas.ts
+++ b/bokehjs/src/lib/models/plots/plot_canvas.ts
@@ -1061,7 +1061,7 @@ export class PlotView extends LayoutDOMView implements Paintable {
         if (this.canvas.resize()) {
           this.request_repaint()
         }
-      })
+      }, {signal: this.abort_signal})
     }
   }
 

--- a/bokehjs/src/lib/models/tools/actions/fullscreen_tool.ts
+++ b/bokehjs/src/lib/models/tools/actions/fullscreen_tool.ts
@@ -21,8 +21,8 @@ export class FullscreenToolView extends ActionToolView {
       this.model.active = active
     }
 
-    document.addEventListener("fullscreenchange", handler)
-    document.addEventListener("webkitfullscreenchange", handler)
+    document.addEventListener("fullscreenchange", handler, {signal: this.abort_signal})
+    document.addEventListener("webkitfullscreenchange", handler, {signal: this.abort_signal})
   }
 
   async fullscreen(): Promise<void> {

--- a/bokehjs/src/lib/models/ui/dialog.ts
+++ b/bokehjs/src/lib/models/ui/dialog.ts
@@ -262,9 +262,9 @@ export class DialogView extends UIElementView {
         target,
       }
 
-      document.addEventListener("pointermove", pointer_move)
-      document.addEventListener("pointerup", pointer_up)
-      document.addEventListener("keydown", key_press)
+      document.addEventListener("pointermove", pointer_move, {signal: this.abort_signal})
+      document.addEventListener("pointerup", pointer_up, {signal: this.abort_signal})
+      document.addEventListener("keydown", key_press, {signal: this.abort_signal})
 
       const target_el = this._handles[target]
       target_el.setPointerCapture(event.pointerId)

--- a/bokehjs/src/lib/models/widgets/autocomplete_input.ts
+++ b/bokehjs/src/lib/models/widgets/autocomplete_input.ts
@@ -119,7 +119,7 @@ export class AutocompleteInputView extends TextInputView {
           this._hide_menu()
         }
       }
-      document.addEventListener("click", listener)
+      document.addEventListener("click", listener, {signal: this.abort_signal})
     }
   }
 

--- a/bokehjs/src/lib/models/widgets/help_button.ts
+++ b/bokehjs/src/lib/models/widgets/help_button.ts
@@ -60,11 +60,11 @@ export class HelpButtonView extends AbstractButtonView {
         persistent = false
         toggle(false)
       }
-    })
+    }, {signal: this.abort_signal})
     window.addEventListener("blur", () => {
       persistent = false
       toggle(false)
-    })
+    }, {signal: this.abort_signal})
   }
 }
 

--- a/bokehjs/src/lib/models/widgets/input_widget.ts
+++ b/bokehjs/src/lib/models/widgets/input_widget.ts
@@ -139,11 +139,11 @@ export abstract class InputWidgetView extends ControlView {
             persistent = false
             toggle(false)
           }
-        })
+        }, {signal: this.abort_signal})
         window.addEventListener("blur", () => {
           persistent = false
           toggle(false)
-        })
+        }, {signal: this.abort_signal})
       }
       return desc_el
     }

--- a/bokehjs/test/unit/core/view.ts
+++ b/bokehjs/test/unit/core/view.ts
@@ -48,6 +48,25 @@ export class SomeModel extends HasProps {
   }
 }
 
+class ListeningModelView extends View {
+  declare model: ListeningModel
+
+  received: number = 0
+
+  override connect_signals(): void {
+    super.connect_signals()
+    document.addEventListener("some_event", () => this.received++, {signal: this.abort_signal})
+  }
+}
+
+export class ListeningModel extends HasProps {
+  declare __view_type__: ListeningModelView
+
+  static {
+    this.prototype.default_view = ListeningModelView
+  }
+}
+
 describe("core/view", () => {
 
   describe("View", () => {
@@ -69,6 +88,20 @@ describe("core/view", () => {
       expect(view.connect(model.change, slot)).to.be.true
       model.change.emit()
       expect(calls).to.be.equal(2)
+    })
+
+    it("should stop listening to DOM events on shared targets after being removed", async () => {
+      const view = await build_view(new ListeningModel())
+
+      try {
+        document.dispatchEvent(new Event("some_event"))
+        expect(view.received).to.be.equal(1)
+      } finally {
+        view.remove()
+      }
+
+      document.dispatchEvent(new Event("some_event"))
+      expect(view.received).to.be.equal(1)
     })
 
     it("should disconnect changes from former transitive references", async () => {

--- a/bokehjs/test/unit/models/plots/plot.ts
+++ b/bokehjs/test/unit/models/plots/plot.ts
@@ -1,6 +1,6 @@
 import * as sinon from "sinon"
 
-import {expect} from "#framework/assertions"
+import {expect, expect_not_null} from "#framework/assertions"
 import {display} from "#framework/layouts"
 
 import {Plot} from "@bokehjs/models/plots/plot"
@@ -153,6 +153,22 @@ describe("Plot module", () => {
       expect(element_cache1.map((view) => view.model)).to.be.equal([element1])
       expect(renderer_view0.is_destroyed).to.be.true
       expect(element_view0.is_destroyed).to.be.true
+    })
+
+    it("should stop responding to visual viewport resizes after being removed", async () => {
+      expect_not_null(visualViewport)
+      const view = await new_plot_view()
+      const spy_resize = sinon.spy(view.canvas, "resize")
+
+      try {
+        visualViewport.dispatchEvent(new Event("resize"))
+        expect(spy_resize.callCount).to.be.equal(1)
+      } finally {
+        view.remove()
+      }
+
+      visualViewport.dispatchEvent(new Event("resize"))
+      expect(spy_resize.callCount).to.be.equal(1)
     })
 
     it("should perform standard reset actions by default", async () => {


### PR DESCRIPTION
Fixes #15290.

## Note

*The investigation and write-up below were performed by an AI agent (Claude). I have proofread the descriptions and reviewed the code, but as I do not know much about Bokeh I cannot vouch for every detail. For code review, I therefore used a guide I had Claude make for a "non expert" &mdash; not sure it is useful for you (but it also includes an interesting section about how it traced the problem): https://claude.ai/code/artifact/f2ef6d92-33ef-4ca8-99c6-240f7e02c3c3?org=e9fd120f-6b16-409a-a437-989319261ed9*

## Problem

Replacing a plot in a layout retains the whole figure for the rest of the session. `PlotView.connect_signals()` subscribes to `resize` on `window.visualViewport` and never unsubscribes. That event target lives as long as the page, so its listener list kept the closure — and through the closure the `PlotView`, the view's model, and every model below it — reachable long after the view was removed and the models were dropped from the document's model graph. The models were unlinked correctly; they just could not be collected.

It is not only a memory problem. Every retained view still ran the handler, so a single viewport resize called `canvas.resize()` and `request_repaint()` once per destroyed plot, i.e. work proportional to how often the dashboard has swapped a plot, on views that have been torn down.

Five other views subscribe to `document` or `window` without unsubscribing on removal, and retain their models the same way.

This is independent of #15289 and its fix in #15291. Pruning the model graph is necessary for removed models to become collectable, but not sufficient: with the pruning forced by hand, the models still stayed in the heap. Both are needed before a long-running server application holds steady.

## Change

`View` owns an `AbortController` that is aborted in `remove()`, exposed to subclasses as `abort_signal`. A listener on an event target that outlives the view is then bound to the view's lifetime with `{signal: this.abort_signal}` where it is registered.

The obvious alternative is a matching `removeEventListener()` in a teardown method, which is what the correct sites already do (`Menu`, `Pane`, `Tooltip`). It requires hoisting the listener into a field to keep its identity, and mirroring the capture flag, and staying in sync with the registration. `core/ui_events.ts` shows where that ends up: it registers `keydown`/`keyup` on `this.hit_area` and removes them from `document`, so both calls are no-ops in opposite directions, and never removes `focus`/`blur` at all. With `{signal}` there is no target to get wrong, no capture flag to mismatch and no function identity to preserve.

`abort()` is called with a shared `DOMException` rather than no argument: aborting without a reason makes the browser construct a fresh `DOMException` with a stack trace, measured at 4.0 µs versus 0.37 µs per call in Chromium, and every view being removed pays it whether or not it registered a listener.

Three commits, because the six sites are not all the same bug:

- The first commit fixes #15290. `PlotView` and `FullscreenToolView` register once per view, so binding the listener to the view is a complete fix.
- The second commit covers `InputWidgetView`, `HelpButtonView` and `AutocompleteInputView`, which register from `render()` or from `_show_menu()`. Those run repeatedly, so nothing outlives the view any more, but a live widget still gains one listener set per rerender. Registering them once means hoisting per-render closure state into fields, and belongs with the `on_change()` connections that accumulate beside them for the same reason — a follow-up that is ready and waiting on this PR to merge.
- The third commit covers `DialogView`, which registers its drag listeners per drag and removes them when the drag ends. Only removal mid-drag leaks, so the signal is the missing half of an otherwise correct teardown.

`{signal}` on `addEventListener` is Chrome 90 / Firefox 86 / Safari 15, and `abort(reason)` is Safari 15.4; both are well inside what bokehjs already requires (array assignment to `adoptedStyleSheets` needs Safari 16.4).

## Measurements

Bokeh server application that replaces a plot in a layout every 3 s while a second periodic callback keeps patches flowing, driven for 40 s (13 replacements), then the model graph is pruned by hand and a heap snapshot is taken after two forced collections:

| | `Figure`s live in heap | unreachable from the model graph |
| --- | --- | --- |
| before | 14 | 13 |
| after | 2 | 1 |

Total heap snapshot for the session drops from 65 MB to 38 MB. The one remaining stale `Figure` is a different and bounded effect — a live `GlyphRendererView`'s `visuals` object shares a V8 hidden class whose property accessor closes over the previously removed view — so retention no longer grows with the number of replacements.

## Test plan

- `PlotView` now has a regression test asserting it stops responding to `visualViewport` resizes once removed. Verified to fail without the fix.
- A `core/view` test covers the mechanism itself: a listener registered by a view against a shared target stops firing after the view is removed.
- `node make test:unit` passes: 2262 passed, 5 skipped.

Manual checks, since the remaining paths are user-interaction driven:

- [x] Plot still resizes when the visual viewport changes (pinch-zoom on a touch device, or browser zoom under mobile emulation).
- [x] Input widget description tooltip still opens on hover, pins on click, and closes on an outside click and on window blur.
- [x] `HelpButton` tooltip behaves the same.
- [x] `AutocompleteInput` menu still closes when clicking outside the widget.
- [x] `FullscreenTool` still tracks state when leaving fullscreen with Escape.
- [x] `Dialog` still drags, resizes, and ends the drag on pointer release and on Escape.

## Not addressed here

- `Document` adds a `change` listener to a `matchMedia` query that is never removed, but it retains nothing that is not retained anyway: every `Document` pushes itself into the exported module-global `documents` array in its constructor and is never taken out. Releasing documents is a larger and separate question.
- `core/ui_events.ts` cleanup is wired to the wrong target, as described above. `UIEventBus`, `UIGestures`, `ContextMenu` and `Pane` are not `View`s, so they cannot reach `abort_signal`; `CanvasView` already owns `ui_event_bus.remove()` and could pass its signal down.
- `InputWidgetView._build_title()` and `_build_description()` replace `this.title` / `this.description` with a freshly built view without removing the previous one, which then drops out of `_children_views()` and is never torn down, so its `abort_signal` never fires. Fixed in #15299, along with the same defect in `DropdownView`; that PR stands on its own and does not depend on this one.
- A lint rule against bare `document` / `window` subscriptions in view code would be the durable guard, since nothing stops the next call site from forgetting. `no-restricted-syntax` expresses it without new machinery, but it flags around twenty existing calls, most of them in code that has no view to take a signal from, so it needs its own change and a decision about those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

