### PR TITLE
Remove child views that are replaced or outlive their parent

### DIFF
--- a/bokehjs/src/lib/models/widgets/dropdown.ts
+++ b/bokehjs/src/lib/models/widgets/dropdown.ts
@@ -11,6 +11,7 @@ import dropdown_css from "styles/dropdown.css"
 import carets_css, * as carets from "styles/caret.css"
 import {DividerItem, Menu, MenuItem} from "../ui/menus"
 import type {MenuView} from "../ui/menus/menu"
+import type {ChildView} from "core/build_views"
 import {build_view} from "core/build_views"
 
 export class DropdownView extends AbstractButtonView {
@@ -18,6 +19,10 @@ export class DropdownView extends AbstractButtonView {
 
   protected _open: boolean = false
   protected menu: MenuView
+
+  override _children_views(): ChildView[] {
+    return [...super._children_views(), this.menu]
+  }
 
   override stylesheets(): StyleSheetLike[] {
     return [...super.stylesheets(), dropdown_css, carets_css]
@@ -35,6 +40,7 @@ export class DropdownView extends AbstractButtonView {
     const {menu} = this.model.properties
     this.on_change(menu, async () => {
       const menu_open = this.menu.is_open
+      this.menu.remove()
       await this._build_menu()
       this.rerender()
       if (menu_open) {

--- a/bokehjs/src/lib/models/widgets/input_widget.ts
+++ b/bokehjs/src/lib/models/widgets/input_widget.ts
@@ -150,6 +150,9 @@ export abstract class InputWidgetView extends ControlView {
   }
 
   protected async _build_title(): Promise<void> {
+    if (this.title instanceof View) {
+      this.title.remove()
+    }
     const {title} = this.model
     if (title instanceof HTML) {
       this.title = await build_view(title, {parent: this})
@@ -159,6 +162,9 @@ export abstract class InputWidgetView extends ControlView {
   }
 
   protected async _build_description(): Promise<void> {
+    if (this.description instanceof View) {
+      this.description.remove()
+    }
     const {description} = this.model
     if (description instanceof Tooltip) {
       this.description = await build_view(description, {parent: this})

--- a/bokehjs/test/baselines/linux/Bug__in_issue_#13766__doesn't_allow_to_rebuild_Dropdown.menu_on_change.blf
+++ b/bokehjs/test/baselines/linux/Bug__in_issue_#13766__doesn't_allow_to_rebuild_Dropdown.menu_on_change.blf
@@ -1,1 +1,2 @@
 Dropdown bbox=[0, 0, 106, 28]
+  Menu bbox=[0, 28, 106, 89]

--- a/bokehjs/test/baselines/linux/Widgets__should_allow_Dropdown_with_menu_open.blf
+++ b/bokehjs/test/baselines/linux/Widgets__should_allow_Dropdown_with_menu_open.blf
@@ -1,1 +1,2 @@
 Dropdown bbox=[0, 0, 108, 28]
+  Menu bbox=[0, 28, 108, 92]

--- a/bokehjs/test/baselines/linux/Widgets__should_allow_split_Dropdown_with_menu_open.blf
+++ b/bokehjs/test/baselines/linux/Widgets__should_allow_split_Dropdown_with_menu_open.blf
@@ -1,1 +1,2 @@
 Dropdown bbox=[0, 0, 121, 28]
+  Menu bbox=[0, 28, 121, 92]

--- a/bokehjs/test/unit/models/widgets/dropdown.ts
+++ b/bokehjs/test/unit/models/widgets/dropdown.ts
@@ -1,0 +1,32 @@
+import {expect, expect_instanceof} from "#framework/assertions"
+import {display} from "#framework/layouts"
+
+import {Dropdown} from "@bokehjs/models/widgets"
+import {MenuView} from "@bokehjs/models/ui/menus/menu"
+import {build_view} from "@bokehjs/core/build_views"
+
+describe("DropdownView", () => {
+  it("should remove the previous menu view when 'menu' changes", async () => {
+    const dropdown = new Dropdown({label: "Dropdown", menu: ["A", "B"]})
+    const {view} = await display(dropdown, [200, 100])
+
+    const menu_view = view.children_views().find((child) => child instanceof MenuView)
+    expect_instanceof(menu_view, MenuView)
+
+    dropdown.menu = ["C", "D"]
+    await view.ready
+
+    expect(menu_view.is_destroyed).to.be.true
+  })
+
+  it("should remove its menu view when removed", async () => {
+    const dropdown = new Dropdown({label: "Dropdown", menu: ["A", "B"]})
+    const view = await build_view(dropdown)
+
+    const menu_view = view.children_views().find((child) => child instanceof MenuView)
+    expect_instanceof(menu_view, MenuView)
+
+    view.remove()
+    expect(menu_view.is_destroyed).to.be.true
+  })
+})

--- a/bokehjs/test/unit/models/widgets/input_widget.ts
+++ b/bokehjs/test/unit/models/widgets/input_widget.ts
@@ -1,0 +1,42 @@
+import {expect, expect_not_null} from "#framework/assertions"
+import {display} from "#framework/layouts"
+
+import {TextInput} from "@bokehjs/models/widgets"
+import {HTML} from "@bokehjs/models/dom/html"
+import {Tooltip} from "@bokehjs/models/ui/tooltip"
+import type {HasProps} from "@bokehjs/core/has_props"
+import type {View} from "@bokehjs/core/view"
+
+describe("InputWidgetView", () => {
+  function child_view_of(view: View, model: HasProps): View | null {
+    return view.children_views().find((child) => child.model == model) ?? null
+  }
+
+  it("should remove the previous title view when 'title' changes", async () => {
+    const title = new HTML({html: "title"})
+    const input = new TextInput({title})
+    const {view} = await display(input, [200, 50])
+
+    const title_view = child_view_of(view, title)
+    expect_not_null(title_view)
+
+    input.title = new HTML({html: "other title"})
+    await view.ready
+
+    expect(title_view.is_destroyed).to.be.true
+  })
+
+  it("should remove the previous description view when 'description' changes", async () => {
+    const description = new Tooltip({content: "description", position: "bottom_center"})
+    const input = new TextInput({description})
+    const {view} = await display(input, [200, 50])
+
+    const description_view = child_view_of(view, description)
+    expect_not_null(description_view)
+
+    input.description = new Tooltip({content: "other description", position: "bottom_center"})
+    await view.ready
+
+    expect(description_view.is_destroyed).to.be.true
+  })
+})


### PR DESCRIPTION
**Note** *The investigation and write-up below were performed by an AI agent (Claude). I have proofread the descriptions and reviewed the code, but as I do not know much about Bokeh I cannot vouch for every detail.*

Closes #15319.

`InputWidgetView` rebuilds its `title` and `description` child views whenever the corresponding property changes, and `DropdownView` rebuilds its menu view whenever `menu` changes. Neither removes the view it replaces. Since only the current view is reported as a child, the replaced one is never removed: its signal connections, its event listeners and its DOM subtree survive for the lifetime of the page, and it keeps reacting to changes of its model. Any Python callback that assigns a new `title`, `description` or `menu` therefore adds a permanently retained view subtree per assignment.

`DropdownView` did not report its menu view as a child at all, so even a dropdown whose `menu` is never reassigned retains the menu view — and the item views below it — after the widget itself has been removed.

This is the shape `AbstractButtonView` already uses for its label and icon views.

Found while auditing view lifetimes for #15290, but independent of it.

## Test plan

Unit tests cover the observable effect: after the triggering property change the replaced view reports itself as destroyed, and a dropdown's menu view is destroyed together with the widget. Both fail without the change.

Manual checks against a bokeh server app, all passing (verified locally with a dedicated app made by Claude):

- [x] An input widget's description tooltip still opens on hover, pins on click and unpins on an outside click, after `title` and `description` have been reassigned from the server.
- [x] `Dropdown` still lists and reports the updated items after `menu` has been reassigned from the server, including when the reassignment happens while the menu is open.
