### PR TITLE
Fix documentation deployment cache metadata

### DIFF
--- a/tests/tools/release/test_deploy.py
+++ b/tests/tools/release/test_deploy.py
@@ -58,9 +58,14 @@ def test_publish_full_documentation_updates_version_latest_and_switcher(config: 
 
     assert result.kind is ActionResult.PASS
     assert len(system.commands) == 4
+    assert all("--acl" not in command for command in system.commands)
     assert "s3://docs.bokeh.org/en/4.0.0/" in system.commands[0]
     assert "s3://docs.bokeh.org/en/latest/" in system.commands[1]
-    assert "deployment-4.0.0/docs/bokeh/switcher.json" in system.commands[2]
+    assert system.commands[2] == (
+        "aws s3 cp deployment-4.0.0/docs/bokeh/switcher.json s3://docs.bokeh.org/ "
+        "--only-show-errors "
+        "--cache-control no-cache,max-age=0,must-revalidate --region us-east-1"
+    )
     assert '"/en/latest*" "/en/4.0.0*" "/switcher.json"' in system.commands[3]
 
 
@@ -72,8 +77,13 @@ def test_publish_prerelease_documentation_updates_dev_and_switcher(version: str)
 
     assert result.kind is ActionResult.PASS
     assert len(system.commands) == 3
+    assert all("--acl" not in command for command in system.commands)
     assert "s3://docs.bokeh.org/en/dev-4.0/" in system.commands[0]
-    assert "switcher.json" in system.commands[1]
+    assert system.commands[1] == (
+        f"aws s3 cp deployment-{version}/docs/bokeh/switcher.json s3://docs.bokeh.org/ "
+        "--only-show-errors "
+        "--cache-control no-cache,max-age=0,must-revalidate --region us-east-1"
+    )
     assert '"/en/dev-4.0*" "/switcher.json"' in system.commands[2]
 
 

--- a/tools/release/deploy.py
+++ b/tools/release/deploy.py
@@ -51,8 +51,13 @@ def publish_conda_package(config: Config, system: System) -> ActionReturn:
 def publish_documentation(config: Config, system: System) -> ActionReturn:
     version, release_level = config.version, config.release_level
     path = f"deployment-{version}/docs/bokeh/build/html"
-    flags = "--only-show-errors --acl bucket-owner-full-control"
+    flags = "--only-show-errors"
     switcher = f"deployment-{version}/docs/bokeh/switcher.json"
+    # CloudFront invalidations cannot evict copies already stored by browsers, so
+    # the switcher must be revalidated on every use. Its dedicated /switcher.json
+    # behavior uses Managed-CachingDisabled and Managed-CORS-S3Origin to disable
+    # CDN caching and preserve S3's CORS handling.
+    switcher_cache = "--cache-control no-cache,max-age=0,must-revalidate"
     WEEK = 3600 * 24 * 7
     YEAR = 3600 * 24 * 365
     def cache(max_age: int) -> str:
@@ -60,12 +65,12 @@ def publish_documentation(config: Config, system: System) -> ActionReturn:
     try:
         if config.prerelease:
             system.run(f"aws s3 sync {path} s3://docs.bokeh.org/en/dev-{release_level}/ --delete {flags} {cache(YEAR)} {REGION}")
-            system.run(f"aws s3 cp {switcher} s3://docs.bokeh.org/ {flags} {cache(WEEK)} {REGION}")
+            system.run(f"aws s3 cp {switcher} s3://docs.bokeh.org/ {flags} {switcher_cache} {REGION}")
             system.run(f'aws cloudfront create-invalidation --distribution-id {CLOUDFRONT_ID} --paths "/en/dev-{release_level}*" "/switcher.json" {REGION}')
         else:
             system.run(f"aws s3 sync {path} s3://docs.bokeh.org/en/{version}/ {flags} {cache(YEAR)} {REGION}")
             system.run(f"aws s3 sync {path} s3://docs.bokeh.org/en/latest/ --delete {flags} {cache(WEEK)} {REGION}")
-            system.run(f"aws s3 cp {switcher} s3://docs.bokeh.org/ {flags} {cache(WEEK)} {REGION}")
+            system.run(f"aws s3 cp {switcher} s3://docs.bokeh.org/ {flags} {switcher_cache} {REGION}")
             system.run(f'aws cloudfront create-invalidation --distribution-id {CLOUDFRONT_ID} --paths "/en/latest*" "/en/{version}*" "/switcher.json" {REGION}')
         return PASSED("Publish to documentation site succeeded")
     except RuntimeError as e:


### PR DESCRIPTION
Small PR to upload `switcher.json` with revalidation-required cache metadata and remove the obsolete S3 ACL option.

Just noting the reason for the revalidation is so that a force-reload is not needed to see the docs/switcher update immediately.

- [x] issues: fixes #15312
- [x] tests added / passed
