### PR TITLE
Refactor/hasprops property metadata

### DIFF
--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -46,11 +46,6 @@ from typing import (
 )
 from weakref import WeakSet
 
-if TYPE_CHECKING:
-    def lru_cache[F: Callable[..., Any]](arg: int | None) -> Callable[[F], F]: ...
-else:
-    from functools import lru_cache
-
 # Bokeh imports
 from ..settings import settings
 from ..util.strings import append_docstring
@@ -114,22 +109,105 @@ def is_DataModel(cls: type[HasProps]) -> bool:
     from ..model import DataModel
     return issubclass(cls, HasProps) and getattr(cls, "__data_model__", False) and cls != DataModel
 
-def _overridden_defaults(class_dict: dict[str, Any]) -> dict[str, Any]:
-    overridden_defaults: dict[str, Any] = {}
-    for name, prop in tuple(class_dict.items()):
-        if isinstance(prop, Override):
-            del class_dict[name]
-            if prop.default_overridden:
-                overridden_defaults[name] = prop.default
-    return overridden_defaults
+class _PropertyInfo:
+    """Property metadata compiled once for each ``HasProps`` subclass."""
 
-def _generators(class_dict: dict[str, Any]):
+    own_properties: dict[str, Property[Any]]
+    own_overridden_defaults: dict[str, Any]
+
+    _properties: dict[str, Property[Any]] | None
+    _property_names: set[str] | None
+    _descriptors: list[PropertyDescriptor[Any]] | None
+    _properties_with_refs: dict[str, Property[Any]] | None
+    _dataspecs: dict[str, DataSpec] | None
+    _overridden_defaults: dict[str, Any] | None
+
+    def __init__(self, own_properties: dict[str, Property[Any]], own_overridden_defaults: dict[str, Any]) -> None:
+        self.own_properties = own_properties
+        self.own_overridden_defaults = own_overridden_defaults
+
+        self._properties = None
+        self._property_names = None
+        self._descriptors = None
+        self._properties_with_refs = None
+        self._dataspecs = None
+        self._overridden_defaults = None
+
+    def _initialize(self, cls: type[HasProps]) -> None:
+        if self._properties is not None:
+            return
+
+        properties: dict[str, Property[Any]] = {}
+        overridden_defaults: dict[str, Any] = {}
+
+        for base in reversed(cls.__mro__):
+            properties.update(getattr(base, "__properties__", {}))
+            overridden_defaults.update(getattr(base, "__overridden_defaults__", {}))
+
+        self._properties = properties
+        self._property_names = set(properties)
+        self._descriptors = [getattr(cls, name) for name in properties]
+        self._properties_with_refs = {name: prop for name, prop in properties.items() if prop.has_ref}
+        self._overridden_defaults = overridden_defaults
+
+    def properties(self, cls: type[HasProps]) -> dict[str, Property[Any]]:
+        self._initialize(cls)
+        assert self._properties is not None
+        return self._properties
+
+    def property_names(self, cls: type[HasProps]) -> set[str]:
+        self._initialize(cls)
+        assert self._property_names is not None
+        return self._property_names
+
+    def descriptors(self, cls: type[HasProps]) -> list[PropertyDescriptor[Any]]:
+        self._initialize(cls)
+        assert self._descriptors is not None
+        return self._descriptors
+
+    def properties_with_refs(self, cls: type[HasProps]) -> dict[str, Property[Any]]:
+        self._initialize(cls)
+        assert self._properties_with_refs is not None
+        return self._properties_with_refs
+
+    def dataspecs(self, cls: type[HasProps]) -> dict[str, DataSpec]:
+        self._initialize(cls)
+        if self._dataspecs is None:
+            from .property.dataspec import DataSpec  # avoid circular import
+
+            assert self._properties is not None
+            self._dataspecs = {name: prop for name, prop in self._properties.items() if isinstance(prop, DataSpec)}
+        return self._dataspecs
+
+    def overridden_defaults(self, cls: type[HasProps]) -> dict[str, Any]:
+        self._initialize(cls)
+        assert self._overridden_defaults is not None
+        return self._overridden_defaults
+
+
+def _compile_property_info(class_name: str, class_dict: dict[str, Any]) -> _PropertyInfo:
+    own_properties: dict[str, Property[Any]] = {}
+    own_overridden_defaults: dict[str, Any] = {}
     generators: dict[str, PropertyDescriptorFactory[Any]] = {}
-    for name, generator in tuple(class_dict.items()):
-        if isinstance(generator, PropertyDescriptorFactory):
+
+    for name, value in tuple(class_dict.items()):
+        if isinstance(value, Override):
             del class_dict[name]
-            generators[name] = generator
-    return generators
+            if value.default_overridden:
+                own_overridden_defaults[name] = value.default
+        elif isinstance(value, PropertyDescriptorFactory):
+            del class_dict[name]
+            generators[name] = value
+
+    for name, generator in generators.items():
+        for descriptor in generator.make_descriptors(name):
+            descriptor_name = descriptor.name
+            if descriptor_name in class_dict:
+                raise RuntimeError(f"Two property generators both created {class_name}.{descriptor_name}")
+            class_dict[descriptor_name] = descriptor
+            own_properties[descriptor_name] = descriptor.property
+
+    return _PropertyInfo(own_properties, own_overridden_defaults)
 
 class _ModelResolver:
     """ A class responsible for tracking of models and how to resolve them. """
@@ -181,55 +259,45 @@ class MetaHasProps(type):
     __properties__: dict[str, Property[Any]]
     __overridden_defaults__: dict[str, Any]
     __themed_values__: dict[str, Any]
+    __property_info__: _PropertyInfo
 
     def __new__(cls, class_name: str, bases: tuple[type, ...], class_dict: dict[str, Any]):
         '''
 
         '''
-        overridden_defaults = _overridden_defaults(class_dict)
-        generators = _generators(class_dict)
+        property_info = _compile_property_info(class_name, class_dict)
+        class_dict["__property_info__"] = property_info
+        class_dict["__properties__"] = property_info.own_properties
+        class_dict["__overridden_defaults__"] = property_info.own_overridden_defaults
 
-        properties = {}
+        new_cls = super().__new__(cls, class_name, bases, class_dict)
 
-        for name, generator in generators.items():
-            descriptors = generator.make_descriptors(name)
-            for descriptor in descriptors:
-                name = descriptor.name
-                if name in class_dict:
-                    raise RuntimeError(f"Two property generators both created {class_name}.{name}")
-                class_dict[name] = descriptor
-                properties[name] = descriptor.property
-
-        class_dict["__properties__"] = properties
-        class_dict["__overridden_defaults__"] = overridden_defaults
-
-        return super().__new__(cls, class_name, bases, class_dict)
-
-    def __init__(cls, class_name: str, bases: tuple[type, ...], _) -> None:
         # HasProps itself may not have any properties defined
         if class_name == "HasProps":
-            return
+            return new_cls
 
         # Check for improperly redeclared a Property attribute.
         base_properties: dict[str, Any] = {}
         for base in (x for x in bases if issubclass(x, HasProps)):
             base_properties.update(base.properties(_with_props=True))
-        own_properties = {k: v for k, v in cls.__dict__.items() if isinstance(v, PropertyDescriptor)}
+        own_properties = {k: v for k, v in new_cls.__dict__.items() if isinstance(v, PropertyDescriptor)}
         redeclared = own_properties.keys() & base_properties.keys()
         if redeclared:
             from ..util.warnings import warn
 
-            warn(f"Properties {redeclared!r} in class {cls.__name__} were previously declared on a parent "
+            warn(f"Properties {redeclared!r} in class {new_cls.__name__} were previously declared on a parent "
                  "class. It never makes sense to do this. Redundant properties should be deleted here, or on "
                  "the parent class. Override() can be used to change a default value of a base class property.",
                  RuntimeWarning)
 
         # Check for no-op Overrides
-        unused_overrides = cls.__overridden_defaults__.keys() - cls.properties(_with_props=True).keys()
+        unused_overrides = property_info.own_overridden_defaults.keys() - property_info.properties(new_cls).keys()
         if unused_overrides:
             from ..util.warnings import warn
 
-            warn(f"Overrides of {unused_overrides} in class {cls.__name__} does not override anything.", RuntimeWarning)
+            warn(f"Overrides of {unused_overrides} in class {new_cls.__name__} does not override anything.", RuntimeWarning)
+
+        return new_cls
 
     @property
     def model_class_reverse_map(cls) -> dict[str, type[HasProps]]:
@@ -510,16 +578,13 @@ class HasProps(Serializable, metaclass=MetaHasProps):
 
     @overload
     @classmethod
-    @lru_cache(None)
     def properties(cls, *, _with_props: Literal[False] = False) -> set[str]: ...
 
     @overload
     @classmethod
-    @lru_cache(None)
-    def properties(cls, *, _with_props: Literal[True] = True) -> dict[str, Property[Any]]: ...
+    def properties(cls, *, _with_props: Literal[True]) -> dict[str, Property[Any]]: ...
 
     @classmethod
-    @lru_cache(None)
     def properties(cls, *, _with_props: bool = False) -> set[str] | dict[str, Property[Any]]:
         ''' Collect the names of properties on this class.
 
@@ -532,23 +597,16 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             property names
 
         '''
-        props: dict[str, Property[Any]] = {}
-        for c in reversed(cls.__mro__):
-            props.update(getattr(c, "__properties__", {}))
-
-        if not _with_props:
-            return set(props)
-
-        return props
+        if _with_props:
+            return cls.__property_info__.properties(cls)
+        return cls.__property_info__.property_names(cls)
 
     @classmethod
-    @lru_cache(None)
     def descriptors(cls) -> list[PropertyDescriptor[Any]]:
         """ List of property descriptors in the order of definition. """
-        return [ cls.lookup(name) for name, _ in cls.properties(_with_props=True).items() ]
+        return cls.__property_info__.descriptors(cls)
 
     @classmethod
-    @lru_cache(None)
     def properties_with_refs(cls) -> dict[str, Property[Any]]:
         ''' Collect the names of all properties on this class that also have
         references.
@@ -560,10 +618,9 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             set[str] : names of properties that have references
 
         '''
-        return {k: v for k, v in cls.properties(_with_props=True).items() if v.has_ref}
+        return cls.__property_info__.properties_with_refs(cls)
 
     @classmethod
-    @lru_cache(None)
     def dataspecs(cls) -> dict[str, DataSpec]:
         ''' Collect the names of all ``DataSpec`` properties on this class.
 
@@ -574,8 +631,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             set[str] : names of ``DataSpec`` properties
 
         '''
-        from .property.dataspec import DataSpec  # avoid circular import
-        return {k: v for k, v in cls.properties(_with_props=True).items() if isinstance(v, DataSpec)}
+        return cls.__property_info__.dataspecs(cls)
 
     def properties_with_values(self, *, include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Any]:
         ''' Collect a dict mapping property names to their values.
@@ -609,10 +665,7 @@ class HasProps(Serializable, metaclass=MetaHasProps):
             This is an implementation detail of ``Property``.
 
         '''
-        defaults: dict[str, Any] = {}
-        for c in reversed(cls.__mro__):
-            defaults.update(getattr(c, "__overridden_defaults__", {}))
-        return defaults
+        return cls.__property_info__.overridden_defaults(cls)
 
     def query_properties_with_values(self, query: Callable[[PropertyDescriptor[Any]], bool], *,
             include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Any]:

--- a/src/bokeh/core/has_props.py
+++ b/src/bokeh/core/has_props.py
@@ -115,26 +115,19 @@ class _PropertyInfo:
     own_properties: dict[str, Property[Any]]
     own_overridden_defaults: dict[str, Any]
 
-    _properties: dict[str, Property[Any]] | None
-    _property_names: set[str] | None
-    _descriptors: list[PropertyDescriptor[Any]] | None
-    _properties_with_refs: dict[str, Property[Any]] | None
-    _dataspecs: dict[str, DataSpec] | None
-    _overridden_defaults: dict[str, Any] | None
+    _properties: dict[str, Property[Any]]
+    _property_names: set[str]
+    _descriptors: list[PropertyDescriptor[Any]]
+    _properties_with_refs: dict[str, Property[Any]]
+    _dataspecs: dict[str, DataSpec]
+    _overridden_defaults: dict[str, Any]
 
     def __init__(self, own_properties: dict[str, Property[Any]], own_overridden_defaults: dict[str, Any]) -> None:
         self.own_properties = own_properties
         self.own_overridden_defaults = own_overridden_defaults
 
-        self._properties = None
-        self._property_names = None
-        self._descriptors = None
-        self._properties_with_refs = None
-        self._dataspecs = None
-        self._overridden_defaults = None
-
     def _initialize(self, cls: type[HasProps]) -> None:
-        if self._properties is not None:
+        if hasattr(self, "_properties"):
             return
 
         properties: dict[str, Property[Any]] = {}
@@ -152,36 +145,30 @@ class _PropertyInfo:
 
     def properties(self, cls: type[HasProps]) -> dict[str, Property[Any]]:
         self._initialize(cls)
-        assert self._properties is not None
         return self._properties
 
     def property_names(self, cls: type[HasProps]) -> set[str]:
         self._initialize(cls)
-        assert self._property_names is not None
         return self._property_names
 
     def descriptors(self, cls: type[HasProps]) -> list[PropertyDescriptor[Any]]:
         self._initialize(cls)
-        assert self._descriptors is not None
         return self._descriptors
 
     def properties_with_refs(self, cls: type[HasProps]) -> dict[str, Property[Any]]:
         self._initialize(cls)
-        assert self._properties_with_refs is not None
         return self._properties_with_refs
 
     def dataspecs(self, cls: type[HasProps]) -> dict[str, DataSpec]:
         self._initialize(cls)
-        if self._dataspecs is None:
+        if not hasattr(self, "_dataspecs"):
             from .property.dataspec import DataSpec  # avoid circular import
 
-            assert self._properties is not None
             self._dataspecs = {name: prop for name, prop in self._properties.items() if isinstance(prop, DataSpec)}
         return self._dataspecs
 
     def overridden_defaults(self, cls: type[HasProps]) -> dict[str, Any]:
         self._initialize(cls)
-        assert self._overridden_defaults is not None
         return self._overridden_defaults
 
 
@@ -295,7 +282,7 @@ class MetaHasProps(type):
         if unused_overrides:
             from ..util.warnings import warn
 
-            warn(f"Overrides of {unused_overrides} in class {new_cls.__name__} does not override anything.", RuntimeWarning)
+            warn(f"Overrides of {sorted(unused_overrides)} in class {new_cls.__name__} do not override anything.", RuntimeWarning)
 
         return new_cls
 

--- a/src/bokeh/core/has_props.pyi
+++ b/src/bokeh/core/has_props.pyi
@@ -6,7 +6,6 @@
 #-----------------------------------------------------------------------------
 
 # Standard library imports
-from functools import lru_cache
 from typing import (
     Any,
     Callable,
@@ -53,8 +52,6 @@ class MetaHasProps(type):
     __themed_values__: dict[str, Any]
 
     def __new__(cls, class_name: str, bases: tuple[type, ...], class_dict: dict[str, Any]) -> type[HasProps]: ...
-
-    def __init__(cls, class_name: str, bases: tuple[type, ...], class_dict: dict[str, Any]) -> None: ...
 
     @property
     def model_class_reverse_map(cls) -> dict[str, type[HasProps]]: ...
@@ -119,15 +116,12 @@ class HasProps(Serializable, metaclass=MetaHasProps):
     def properties(cls, *, _with_props: Literal[True]) -> dict[str, Property[Any]]: ...
 
     @classmethod
-    @lru_cache(None)
     def descriptors(cls) -> list[PropertyDescriptor[Any]]: ...
 
     @classmethod
-    @lru_cache(None)
     def properties_with_refs(cls) -> dict[str, Property[Any]]: ...
 
     @classmethod
-    @lru_cache(None)
     def dataspecs(cls) -> dict[str, DataSpec]: ...
 
     def properties_with_values(self, *, include_defaults: bool = True, include_undefined: bool = False) -> dict[str, Any]: ...

--- a/src/bokeh/core/property/descriptors.py
+++ b/src/bokeh/core/property/descriptors.py
@@ -118,7 +118,7 @@ class _HasDocument(Protocol):
     document: Document | None
 
 class _HasOverriddenDefaults(Protocol):
-    __overridden_defaults__: dict[str, Any]
+    def _overridden_defaults(self) -> dict[str, Any]: ...
 
 class _HasTrigger(Protocol):
     def trigger(self, attr: str, old: Any, new: Any,
@@ -502,7 +502,7 @@ class PropertyDescriptor[T]:
     def has_unstable_default(self, obj: HasProps) -> bool:
         # _may_have_unstable_default() doesn't have access to overrides, so check manually
         return self.property._may_have_unstable_default() or \
-            self.is_unstable(cast(_HasOverriddenDefaults, obj).__overridden_defaults__.get(self.name, None))
+            self.is_unstable(cast(_HasOverriddenDefaults, obj)._overridden_defaults().get(self.name, None))
 
     @classmethod
     def is_unstable(cls, value: Any) -> TypeGuard[Callable[[], Any]]:

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -17,8 +17,10 @@ import pytest ; pytest
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import gc
 from types import MethodType
 from unittest.mock import MagicMock, patch
+from weakref import ref
 
 # Bokeh imports
 from bokeh.core.properties import (
@@ -177,6 +179,45 @@ def test_HasProps_override() -> None:
     assert ov.int1 == 20
     assert ov.ds1 == field("x")
     assert ov.lst1 == []
+
+def test_HasProps_inherited_unstable_override() -> None:
+    calls = 0
+
+    def default() -> int:
+        nonlocal calls
+        calls += 1
+        return calls
+
+    class Base(hp.HasProps, hp.Local):
+        value = Int(default=0)
+
+    class Child(Base):
+        value = Override(default=default)
+
+    class Grandchild(Child):
+        pass
+
+    obj = Grandchild()
+
+    assert obj.value == 1
+    assert obj.value == 1
+    assert calls == 1
+
+def test_HasProps_property_metadata_does_not_retain_class() -> None:
+    class Dynamic(hp.HasProps, hp.Local):
+        value = Int(default=0)
+
+    Dynamic.properties()
+    Dynamic.properties(_with_props=True)
+    Dynamic.descriptors()
+    Dynamic.properties_with_refs()
+    Dynamic.dataspecs()
+
+    dynamic_ref = ref(Dynamic)
+    del Dynamic
+    gc.collect()
+
+    assert dynamic_ref() is None
 
 def test_HasProps_intrinsic() -> None:
     obj0 = Parent(int1=Intrinsic, ds1=Intrinsic, lst1=Intrinsic)

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -192,9 +192,10 @@ def test_HasProps_warns_on_unused_override() -> None:
     class Base(hp.HasProps, hp.Local):
         pass
 
-    with pytest.warns(RuntimeWarning, match="does not override anything"):
+    with pytest.warns(RuntimeWarning, match=r"Overrides of \['alpha', 'value'\].*do not override anything"):
         class Child(Base):
             value = Override(default=1)
+            alpha = Override(default=2)
 
 def test_HasProps_local_and_effective_property_metadata() -> None:
     class Base(hp.HasProps, hp.Local):

--- a/tests/unit/bokeh/core/test_has_props.py
+++ b/tests/unit/bokeh/core/test_has_props.py
@@ -180,6 +180,42 @@ def test_HasProps_override() -> None:
     assert ov.ds1 == field("x")
     assert ov.lst1 == []
 
+def test_HasProps_warns_on_redeclared_property() -> None:
+    class Base(hp.HasProps, hp.Local):
+        value = Int()
+
+    with pytest.warns(RuntimeWarning, match="previously declared on a parent class"):
+        class Child(Base):
+            value = Int()
+
+def test_HasProps_warns_on_unused_override() -> None:
+    class Base(hp.HasProps, hp.Local):
+        pass
+
+    with pytest.warns(RuntimeWarning, match="does not override anything"):
+        class Child(Base):
+            value = Override(default=1)
+
+def test_HasProps_local_and_effective_property_metadata() -> None:
+    class Base(hp.HasProps, hp.Local):
+        x = Int()
+
+    class Child(Base):
+        x = Override(default=2)
+        y = String()
+
+    class Grandchild(Child):
+        z = Int()
+
+    assert list(Base.__properties__) == ["x"]
+    assert list(Child.__properties__) == ["y"]
+    assert list(Grandchild.__properties__) == ["z"]
+
+    assert list(Grandchild.properties(_with_props=True)) == ["x", "y", "z"]
+    assert Child.__overridden_defaults__ == {"x": 2}
+    assert Grandchild.__overridden_defaults__ == {}
+    assert Grandchild._overridden_defaults() == {"x": 2}
+
 def test_HasProps_inherited_unstable_override() -> None:
     calls = 0
 


### PR DESCRIPTION
[codex-assisted]

3.10 compatible streamlining and improvement. Removes the need for LRU caching which can muck with garbage collection, and removes some redundant work currently done in HasProps init.

No existing tests are changed or removed.

- [x] issues: fixes #15321
- [x] tests added / passed
