### PR TITLE
Improve fit_columns and fit_viewport performance of DataTable

### DIFF
--- a/bokehjs/src/lib/models/widgets/tables/data_table.ts
+++ b/bokehjs/src/lib/models/widgets/tables/data_table.ts
@@ -77,6 +77,10 @@ export class TableDataProvider implements Partial<SlickDataView<Item>> {
     return item as T
   }
 
+  getCellValue(i: number, field: string): unknown {
+    return this.getField(i, field)
+  }
+
   getItemMetadata(_index: number): ItemMetadata | null {
     return null
   }


### PR DESCRIPTION
- [x] issues: fixes #14668
- [x] tests added / passed

Speed up is 10-30x depending on the example.

Before Firefox:

<img width="427" height="255" alt="image" src="https://github.com/user-attachments/assets/2aa03baa-4c4f-47b1-ad53-37bc1a84c696" />


After Firefox:

<img width="575" height="284" alt="image" src="https://github.com/user-attachments/assets/88e8abc3-0ada-4a24-9bc1-40148aea5c87" />

Before Chrome:

<img width="556" height="249" alt="image" src="https://github.com/user-attachments/assets/8ca40729-ec1b-4b1e-88fe-1ccfafc104de" />

After Chrome:

<img width="190" height="279" alt="image" src="https://github.com/user-attachments/assets/ae2f6930-aaf6-425c-87f6-c5d9a71cd3b2" />


