### PR TITLE
Fix duplicate/orphaned child views from overlapping build_views() calls

### DIFF
--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -66,17 +66,24 @@ export async function build_views<T extends HasProps>(
   const created_views: ViewOf<T>[] = []
   const new_models = models.filter((model) => !view_storage.has(model) && !building!.has(model))
 
-  const pending: Promise<void>[] = []
+  // Start all new builds concurrently (so overlapping build_views() calls can
+  // dedupe against them via the `new_models` filter above), but resolve them
+  // in `new_models` order rather than completion order, so that insertion
+  // order into view_storage (and thus created_views) doesn't depend on how
+  // long each individual view's lazy_initialize() happens to take.
+  const own_promises = new Map<T, Promise<ViewOf<T>>>()
   for (const model of new_models) {
     const promise = _build_view(cls(model), model, options)
     building.set(model, promise)
-    pending.push(promise.then((view) => {
-      view_storage.set(model, view)
-      created_views.push(view)
-      building!.delete(model)
-    }))
+    own_promises.set(model, promise)
   }
-  await Promise.all(pending)
+
+  for (const model of new_models) {
+    const view = await own_promises.get(model)!
+    view_storage.set(model, view)
+    created_views.push(view)
+    building.delete(model)
+  }
 
   for (const view of created_views) {
     view.connect_signals()

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -29,34 +29,26 @@ export async function build_view<T extends HasProps>(model: T, options: Options<
 
 export type BuildResult<T extends HasProps> = {created: ViewOf<T>[], removed: ViewOf<T>[]}
 
-// Serializes build_views() calls per view_storage, so that overlapping calls
-// (e.g. triggered by two properties changing in the same patch, each
-// independently calling an async update_children()) run one after another
-// instead of racing. Without this, a later call's to_remove/new_models diff
-// can be computed against a view_storage that an earlier, still in-flight
-// call hasn't finished updating yet, which can build duplicate views for the
-// same model, or drop a model that the earlier call is still building,
-// leaking an orphaned view that keeps reacting to model changes forever.
-const _queues = new WeakMap<ViewStorage<any>, Promise<unknown>>()
+// Tracks, per view_storage, which models currently have a build in flight
+// (so an overlapping build_views() call doesn't start a second build for
+// the same model) and the most recently requested set of models (so that if
+// a model stops being wanted while its view is still being built, the call
+// holding that build can tear the view down once it finishes, instead of
+// storing and connecting a view nobody asked for any more). Neither call
+// ever awaits the other's completion, so overlapping calls can't deadlock
+// each other, including when a view's own construction reenters
+// build_views() on the same view_storage.
+const _building = new WeakMap<ViewStorage<any>, Set<HasProps>>()
+const _desired = new WeakMap<ViewStorage<any>, Set<HasProps>>()
 
-export function build_views<T extends HasProps>(
+export async function build_views<T extends HasProps>(
   view_storage: ViewStorage<T>,
   models: T[],
   options: Options<ViewOf<T>> = {parent: null},
   cls: (model: T) => T["default_view"] = (model) => model.default_view,
 ): Promise<BuildResult<T>> {
-  const previous = _queues.get(view_storage) ?? Promise.resolve()
-  const current = previous.catch(() => {}).then(() => _build_views(view_storage, models, options, cls))
-  _queues.set(view_storage, current.catch(() => {}))
-  return current
-}
+  _desired.set(view_storage, new Set(models))
 
-async function _build_views<T extends HasProps>(
-  view_storage: ViewStorage<T>,
-  models: T[],
-  options: Options<ViewOf<T>>,
-  cls: (model: T) => T["default_view"],
-): Promise<BuildResult<T>> {
   const to_remove = difference([...view_storage.keys()], models)
 
   const removed_views: ViewOf<T>[] = []
@@ -69,20 +61,47 @@ async function _build_views<T extends HasProps>(
     }
   }
 
-  const created_views: ViewOf<T>[] = []
-  const new_models = models.filter((model) => !view_storage.has(model))
+  let building = _building.get(view_storage)
+  if (building == null) {
+    building = new Set()
+    _building.set(view_storage, building)
+  }
 
-  // Build views for new models one at a time, in order, fully awaiting each
-  // one (including any views it recursively builds) before starting the
-  // next. Some renderers and annotations read state off their siblings while
-  // building (e.g. ColorBar deriving its range from an associated
-  // GlyphRenderer's already-mapped data) and rely on that ordering guarantee.
-  // A failure here throws immediately, before storing or connecting any view
-  // for a model after the one that failed.
+  // Reserve the whole batch up front, before awaiting anything, so that an
+  // overlapping build_views() call on the same view_storage sees every
+  // model in this batch as already being built, not just the one whose
+  // turn has come up in the loop below.
+  const new_models = models.filter((model) => !view_storage.has(model) && !building.has(model))
   for (const model of new_models) {
-    const view = await _build_view(cls(model), model, options)
-    view_storage.set(model, view)
-    created_views.push(view)
+    building.add(model)
+  }
+
+  const created_views: ViewOf<T>[] = []
+  try {
+    // Build views for new models one at a time, in order, fully awaiting
+    // each one (including any views it recursively builds) before starting
+    // the next. Some renderers and annotations read state off their
+    // siblings while building (e.g. ColorBar deriving its range from an
+    // associated GlyphRenderer's already-mapped data) and rely on that
+    // ordering guarantee. A failure here throws immediately, before
+    // building any model after the one that failed.
+    for (const model of new_models) {
+      const view = await _build_view(cls(model), model, options)
+      if (_desired.get(view_storage)?.has(model) !== true) {
+        // A later call decided this model isn't wanted any more while this
+        // build was in flight. Tear it down instead of storing/connecting a
+        // view that nothing asked for any more.
+        removed_views.push(view)
+        view.remove()
+        continue
+      }
+      view_storage.set(model, view)
+      created_views.push(view)
+    }
+  } finally {
+    for (const model of new_models) {
+      building.delete(model)
+    }
   }
 
   for (const view of created_views) {

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -78,11 +78,25 @@ export async function build_views<T extends HasProps>(
     own_promises.set(model, promise)
   }
 
+  // Always clear `building` for every attempted model, even if its own view
+  // failed to construct, or a sibling's did and would otherwise abort this
+  // loop early. Otherwise a single failed build permanently marks that model
+  // as "in progress" for this view_storage, silently blocking every future
+  // build_views() call for it.
+  let error: unknown
   for (const model of new_models) {
-    const view = await own_promises.get(model)!
-    view_storage.set(model, view)
-    created_views.push(view)
-    building.delete(model)
+    try {
+      const view = await own_promises.get(model)!
+      view_storage.set(model, view)
+      created_views.push(view)
+    } catch (e) {
+      error ??= e
+    } finally {
+      building.delete(model)
+    }
+  }
+  if (error !== undefined) {
+    throw error
   }
 
   for (const view of created_views) {

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -66,27 +66,22 @@ export async function build_views<T extends HasProps>(
   const created_views: ViewOf<T>[] = []
   const new_models = models.filter((model) => !view_storage.has(model) && !building.has(model))
 
-  // Start all new builds concurrently (so overlapping build_views() calls can
-  // dedupe against them via the `new_models` filter above), but resolve them
-  // in `new_models` order rather than completion order, so that insertion
-  // order into view_storage (and thus created_views) doesn't depend on how
-  // long each individual view's lazy_initialize() happens to take.
-  const own_promises = new Map<T, Promise<ViewOf<T>>>()
+  // Build views for new models one at a time, in order, fully awaiting each
+  // one (including any views it recursively builds) before starting the
+  // next. Some renderers and annotations read state off their siblings while
+  // building (e.g. ColorBar deriving its range from an associated
+  // GlyphRenderer's already-mapped data) and rely on that ordering guarantee.
+  //
+  // Each model is registered in `building` before it's awaited, so an
+  // overlapping build_views() call on the same view_storage can still dedupe
+  // against it via the `new_models` filter above, even though builds
+  // themselves run serially.
+  let error: unknown
   for (const model of new_models) {
     const promise = _build_view(cls(model), model, options)
     building.set(model, promise)
-    own_promises.set(model, promise)
-  }
-
-  // Always clear `building` for every attempted model, even if its own view
-  // failed to construct, or a sibling's did and would otherwise abort this
-  // loop early. Otherwise a single failed build permanently marks that model
-  // as "in progress" for this view_storage, silently blocking every future
-  // build_views() call for it.
-  let error: unknown
-  for (const model of new_models) {
     try {
-      const view = await own_promises.get(model)!
+      const view = await promise
       view_storage.set(model, view)
       created_views.push(view)
     } catch (e) {

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -29,17 +29,27 @@ export async function build_view<T extends HasProps>(model: T, options: Options<
 
 export type BuildResult<T extends HasProps> = {created: ViewOf<T>[], removed: ViewOf<T>[]}
 
-// Tracks, per view_storage, which models currently have a build in flight
-// (so an overlapping build_views() call doesn't start a second build for
-// the same model) and the most recently requested set of models (so that if
-// a model stops being wanted while its view is still being built, the call
-// holding that build can tear the view down once it finishes, instead of
-// storing and connecting a view nobody asked for any more). Neither call
-// ever awaits the other's completion, so overlapping calls can't deadlock
-// each other, including when a view's own construction reenters
+// Per view_storage: models with a build currently in flight (so overlapping
+// calls don't build the same model twice) and the most recently requested
+// models (so a build that's no longer wanted, once finished, tears itself
+// down instead of getting stored). Neither call awaits the other, so they
+// can't deadlock each other, even if a view's construction reenters
 // build_views() on the same view_storage.
 const _building = new WeakMap<ViewStorage<any>, Set<HasProps>>()
 const _desired = new WeakMap<ViewStorage<any>, Set<HasProps>>()
+
+// Re-appends (delete + set, which moves a key to the end) every stored model
+// in `order`, in that sequence, so Map iteration order matches it. Needed
+// because a model's build can finish after a later-requested model's.
+function _reorder<T extends HasProps>(view_storage: ViewStorage<T>, order: Iterable<T>): void {
+  for (const model of order) {
+    const view = view_storage.get(model)
+    if (view != null) {
+      view_storage.delete(model)
+      view_storage.set(model, view)
+    }
+  }
+}
 
 export async function build_views<T extends HasProps>(
   view_storage: ViewStorage<T>,
@@ -67,10 +77,8 @@ export async function build_views<T extends HasProps>(
     _building.set(view_storage, building)
   }
 
-  // Reserve the whole batch up front, before awaiting anything, so that an
-  // overlapping build_views() call on the same view_storage sees every
-  // model in this batch as already being built, not just the one whose
-  // turn has come up in the loop below.
+  // Reserve the whole batch up front, before awaiting anything, so an
+  // overlapping call sees every model in this batch as already building.
   const new_models = models.filter((model) => !view_storage.has(model) && !building.has(model))
   for (const model of new_models) {
     building.add(model)
@@ -78,21 +86,15 @@ export async function build_views<T extends HasProps>(
 
   const created_views: ViewOf<T>[] = []
   try {
-    // Build views for new models one at a time, in order, fully awaiting
-    // each one (including any views it recursively builds) before starting
-    // the next. Some renderers and annotations read state off their
-    // siblings while building (e.g. ColorBar deriving its range from an
-    // associated GlyphRenderer's already-mapped data) and rely on that
-    // ordering guarantee. A failure here throws immediately, before
-    // building any model after the one that failed.
+    // Build one at a time, fully awaiting each before starting the next:
+    // some renderers/annotations (e.g. ColorBar) read state off siblings
+    // built earlier in the same batch. A failure throws immediately.
     for (const model of new_models) {
       const view = await _build_view(cls(model), model, options)
       if (_desired.get(view_storage)?.has(model) !== true) {
-        // A later call decided this model isn't wanted any more while this
-        // build was in flight. Tear it down instead of storing it. Still
-        // connect it first: remove() unconditionally calls disconnect_signals(),
-        // and views may assume connect_signals() already ran (e.g. by only
-        // creating an observer or listener there).
+        // No longer wanted: connect then immediately remove, rather than
+        // remove() alone, since some disconnect_signals() implementations
+        // assume connect_signals() already ran.
         removed_views.push(view)
         view.connect_signals()
         view.remove()
@@ -105,6 +107,13 @@ export async function build_views<T extends HasProps>(
     for (const model of new_models) {
       building.delete(model)
     }
+  }
+
+  // Builds can finish out of request order under overlapping calls; re-sort
+  // once to match the latest request.
+  const desired = _desired.get(view_storage)
+  if (desired != null) {
+    _reorder(view_storage, desired)
   }
 
   for (const view of created_views) {

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -141,9 +141,15 @@ export async function build_views<T extends HasProps>(
         built.push([model, view])
       } else {
         // A later call stopped wanting this model but couldn't see the build in
-        // progress, so cleaning up is up to us.
+        // progress, so cleaning up is up to us. Connect first, so that remove()
+        // is never called on a view that was never connected, which
+        // disconnect_signals() overrides are entitled to assume.
         removed_views.push(view)
-        view.remove()
+        try {
+          view.connect_signals()
+        } finally {
+          view.remove()
+        }
       }
       state.pending.delete(model)
       deferred.resolve()

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -29,18 +29,40 @@ export async function build_view<T extends HasProps>(model: T, options: Options<
 
 export type BuildResult<T extends HasProps> = {created: ViewOf<T>[], removed: ViewOf<T>[]}
 
-// Per view_storage: models with a build currently in flight (so overlapping
-// calls don't build the same model twice) and the most recently requested
-// models (so a build that's no longer wanted, once finished, tears itself
-// down instead of getting stored). Neither call awaits the other, so they
-// can't deadlock each other, even if a view's construction reenters
-// build_views() on the same view_storage.
-const _building = new WeakMap<ViewStorage<any>, Set<HasProps>>()
-const _desired = new WeakMap<ViewStorage<any>, Set<HasProps>>()
+type Deferred = {
+  readonly promise: Promise<void>
+  readonly resolve: () => void
+  readonly reject: (error: unknown) => void
+}
 
-// Re-appends (delete + set, which moves a key to the end) every stored model
-// in `order`, in that sequence, so Map iteration order matches it. Needed
-// because a model's build can finish after a later-requested model's.
+function _deferred(): Deferred {
+  let resolve!: () => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  promise.catch(() => {})
+  return {promise, resolve, reject}
+}
+
+type BuildState<T extends HasProps> = {
+  readonly pending: Map<T, Deferred>
+  desired: Set<T>
+  baseline: Set<T>
+}
+
+const _states = new WeakMap<ViewStorage<any>, BuildState<any>>()
+
+function _state<T extends HasProps>(view_storage: ViewStorage<T>): BuildState<T> {
+  let state = _states.get(view_storage)
+  if (state == null) {
+    state = {pending: new Map(), desired: new Set(), baseline: new Set()}
+    _states.set(view_storage, state)
+  }
+  return state
+}
+
 function _reorder<T extends HasProps>(view_storage: ViewStorage<T>, order: Iterable<T>): void {
   for (const model of order) {
     const view = view_storage.get(model)
@@ -51,13 +73,26 @@ function _reorder<T extends HasProps>(view_storage: ViewStorage<T>, order: Itera
   }
 }
 
+/**
+ * Builds views for `models` into `view_storage` and removes views of models
+ * that aren't wanted any more.
+ *
+ * Overlapping calls on the same `view_storage` cooperate: a model is built at
+ * most once, by whichever call reserved it first, and a call wanting a model
+ * somebody else is building waits for that build. So once this resolves, every
+ * requested model that is still wanted has its view in `view_storage`.
+ *
+ * A call only waits on builds it doesn't own, and only after finishing its own,
+ * so waiting can't cycle.
+ */
 export async function build_views<T extends HasProps>(
   view_storage: ViewStorage<T>,
   models: T[],
   options: Options<ViewOf<T>> = {parent: null},
   cls: (model: T) => T["default_view"] = (model) => model.default_view,
 ): Promise<BuildResult<T>> {
-  _desired.set(view_storage, new Set(models))
+  const state = _state(view_storage)
+  state.desired = new Set(models)
 
   const to_remove = difference([...view_storage.keys()], models)
 
@@ -71,53 +106,89 @@ export async function build_views<T extends HasProps>(
     }
   }
 
-  let building = _building.get(view_storage)
-  if (building == null) {
-    building = new Set()
-    _building.set(view_storage, building)
+  if (state.pending.size == 0) {
+    state.baseline = new Set(view_storage.keys())
+  }
+  const {baseline} = state
+
+  // Reserved up front, before awaiting anything, so an overlapping call can't
+  // start a second build for any of the batch, not even models we haven't
+  // gotten to yet.
+  const owned = new Map<T, Deferred>()
+  const awaited: Promise<void>[] = []
+  for (const model of models) {
+    if (view_storage.has(model) || owned.has(model)) {
+      continue
+    }
+    const pending = state.pending.get(model)
+    if (pending != null) {
+      awaited.push(pending.promise)
+    } else {
+      const deferred = _deferred()
+      state.pending.set(model, deferred)
+      owned.set(model, deferred)
+    }
   }
 
-  // Reserve the whole batch up front, before awaiting anything, so an
-  // overlapping call sees every model in this batch as already building.
-  const new_models = models.filter((model) => !view_storage.has(model) && !building.has(model))
-  for (const model of new_models) {
-    building.add(model)
+  const built: [T, ViewOf<T>][] = []
+  let failure: unknown = null
+
+  try {
+    for (const [model, deferred] of owned) {
+      const view = await _build_view(cls(model), model, options)
+      if (state.desired.has(model)) {
+        view_storage.set(model, view)
+        built.push([model, view])
+      } else {
+        // A later call stopped wanting this model but couldn't see the build in
+        // progress, so cleaning up is up to us.
+        removed_views.push(view)
+        view.remove()
+      }
+      state.pending.delete(model)
+      deferred.resolve()
+    }
+  } catch (error) {
+    failure = error
+  }
+
+  // Release reservations we still hold (i.e. after a failure), so waiters can't hang.
+  for (const [model, deferred] of owned) {
+    if (state.pending.get(model) === deferred) {
+      state.pending.delete(model)
+      deferred.reject(failure ?? new Error(`${model} view build was abandoned`))
+    }
+  }
+
+  if (failure == null) {
+    try {
+      await Promise.all(awaited)
+    } catch (error) {
+      failure = error
+    }
+  }
+
+  _reorder(view_storage, [...state.desired].filter((model) => !baseline.has(model)))
+
+  if (state.pending.size == 0) {
+    // Run fully settled: let the next one snapshot afresh, and stop retaining
+    // models that are long gone.
+    state.baseline = new Set()
   }
 
   const created_views: ViewOf<T>[] = []
-  try {
-    // Build one at a time, fully awaiting each before starting the next:
-    // some renderers/annotations (e.g. ColorBar) read state off siblings
-    // built earlier in the same batch. A failure throws immediately.
-    for (const model of new_models) {
-      const view = await _build_view(cls(model), model, options)
-      if (_desired.get(view_storage)?.has(model) !== true) {
-        // No longer wanted: connect then immediately remove, rather than
-        // remove() alone, since some disconnect_signals() implementations
-        // assume connect_signals() already ran.
-        removed_views.push(view)
-        view.connect_signals()
-        view.remove()
-        continue
-      }
-      view_storage.set(model, view)
+  for (const [model, view] of built) {
+    // An overlapping call may have removed this view while we built the rest of
+    // the batch. Connecting a removed view would leave it reacting to its model
+    // forever, with nothing left to disconnect it.
+    if (view_storage.get(model) === view) {
+      view.connect_signals()
       created_views.push(view)
     }
-  } finally {
-    for (const model of new_models) {
-      building.delete(model)
-    }
   }
 
-  // Builds can finish out of request order under overlapping calls; re-sort
-  // once to match the latest request.
-  const desired = _desired.get(view_storage)
-  if (desired != null) {
-    _reorder(view_storage, desired)
-  }
-
-  for (const view of created_views) {
-    view.connect_signals()
+  if (failure != null) {
+    throw failure
   }
 
   return {
@@ -127,6 +198,10 @@ export async function build_views<T extends HasProps>(
 }
 
 export function remove_views(view_storage: ViewStorage<HasProps>): void {
+  // Nothing is wanted any more, so that a build still in flight tears its view
+  // down instead of storing and connecting it into a storage nobody owns.
+  _state(view_storage).desired = new Set()
+
   for (const [model, view] of view_storage) {
     view.remove()
     view_storage.delete(model)

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -29,25 +29,15 @@ export async function build_view<T extends HasProps>(model: T, options: Options<
 
 export type BuildResult<T extends HasProps> = {created: ViewOf<T>[], removed: ViewOf<T>[]}
 
-type Deferred = {
-  readonly promise: Promise<void>
-  readonly resolve: () => void
-  readonly reject: (error: unknown) => void
-}
-
-function _deferred(): Deferred {
-  let resolve!: () => void
-  let reject!: (error: unknown) => void
-  const promise = new Promise<void>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-  promise.catch(() => {})
-  return {promise, resolve, reject}
-}
+/**
+ * A build of a single model's view, shared by all calls that want that model.
+ * Resolves with the view and whether it ended up in `view_storage` (it doesn't
+ * if nothing wants the model any more by the time it's built).
+ */
+type PendingBuild<T extends HasProps> = Promise<{view: ViewOf<T>, stored: boolean}>
 
 type BuildState<T extends HasProps> = {
-  readonly pending: Map<T, Deferred>
+  readonly pending: Map<T, PendingBuild<T>>
   desired: Set<T>
   baseline: Set<T>
 }
@@ -73,17 +63,54 @@ function _reorder<T extends HasProps>(view_storage: ViewStorage<T>, order: Itera
   }
 }
 
+async function _build_into<T extends HasProps>(
+  view_storage: ViewStorage<T>,
+  state: BuildState<T>,
+  model: T,
+  options: Options<ViewOf<T>>,
+  cls: (model: T) => T["default_view"],
+): PendingBuild<T> {
+  try {
+    const view = await _build_view(cls(model), model, options)
+    if (state.desired.has(model)) {
+      view_storage.set(model, view)
+      // Connected before returning, i.e. before anything else gets to run, so
+      // that `view_storage` never holds a view that hasn't been connected yet.
+      // An overlapping call's `to_remove` diff can see anything in there, and
+      // remove() assumes connect_signals() already ran.
+      view.connect_signals()
+      return {view, stored: true}
+    } else {
+      // Nothing wants this model any more, but the call that dropped it couldn't
+      // see this build in progress, so cleaning up is up to us. Never connected,
+      // so that connect_signals() side effects (e.g. an async continuation that
+      // lands on this view later) can't outlive a view nothing asked for.
+      view.remove()
+      return {view, stored: false}
+    }
+  } finally {
+    state.pending.delete(model)
+  }
+}
+
 /**
  * Builds views for `models` into `view_storage` and removes views of models
  * that aren't wanted any more.
  *
  * Overlapping calls on the same `view_storage` cooperate: a model is built at
- * most once, by whichever call reserved it first, and a call wanting a model
- * somebody else is building waits for that build. So once this resolves, every
- * requested model that is still wanted has its view in `view_storage`.
+ * most once, by whichever call got to it first, and a call wanting a model
+ * somebody else is already building waits for that build instead of starting a
+ * second one. So once this resolves, every requested model that is still wanted
+ * has a connected view in `view_storage`.
  *
- * A call only waits on builds it doesn't own, and only after finishing its own,
- * so waiting can't cycle.
+ * Models are processed in request order, waiting included, so a view is never
+ * initialized ahead of a view requested before it.
+ *
+ * A build belongs to the model, not to the call that started it, and never
+ * waits on a call, so waiting can't cycle and a failing model doesn't poison
+ * unrelated models: whatever is still wanted can be built by a later call. The
+ * one thing this can't support is a view whose (lazy) initialization asks the
+ * same `view_storage` for its own model, which would wait for itself.
  */
 export async function build_views<T extends HasProps>(
   view_storage: ViewStorage<T>,
@@ -111,67 +138,39 @@ export async function build_views<T extends HasProps>(
   }
   const {baseline} = state
 
-  // Reserved up front, before awaiting anything, so an overlapping call can't
-  // start a second build for any of the batch, not even models we haven't
-  // gotten to yet.
-  const owned = new Map<T, Deferred>()
-  const awaited: Promise<void>[] = []
-  for (const model of models) {
-    if (view_storage.has(model) || owned.has(model)) {
-      continue
-    }
-    const pending = state.pending.get(model)
-    if (pending != null) {
-      awaited.push(pending.promise)
-    } else {
-      const deferred = _deferred()
-      state.pending.set(model, deferred)
-      owned.set(model, deferred)
-    }
-  }
-
   const built: [T, ViewOf<T>][] = []
   let failure: unknown = null
 
   try {
-    for (const [model, deferred] of owned) {
-      const view = await _build_view(cls(model), model, options)
-      if (state.desired.has(model)) {
-        view_storage.set(model, view)
+    for (const model of models) {
+      if (view_storage.has(model) || !state.desired.has(model)) {
+        // Either already built, or a later call has stopped wanting it, in which
+        // case building it would just be followed by tearing it down again.
+        continue
+      }
+      const pending = state.pending.get(model)
+      if (pending != null) {
+        // Somebody got here first. Wait for their build, both to not build a
+        // second view for this model, and to keep the rest of our batch behind
+        // this model's initialization.
+        await pending
+        continue
+      }
+      // Registered before awaiting anything, so an overlapping call is
+      // guaranteed to find this build instead of starting its own. The build
+      // clears its own entry as it settles, so a failed one is never left
+      // around for a later call to inherit.
+      const build = _build_into(view_storage, state, model, options, cls)
+      state.pending.set(model, build)
+      const {view, stored} = await build
+      if (stored) {
         built.push([model, view])
       } else {
-        // A later call stopped wanting this model but couldn't see the build in
-        // progress, so cleaning up is up to us. Connect first, so that remove()
-        // is never called on a view that was never connected, which
-        // disconnect_signals() overrides are entitled to assume.
         removed_views.push(view)
-        try {
-          view.connect_signals()
-        } finally {
-          view.remove()
-        }
       }
-      state.pending.delete(model)
-      deferred.resolve()
     }
   } catch (error) {
     failure = error
-  }
-
-  // Release reservations we still hold (i.e. after a failure), so waiters can't hang.
-  for (const [model, deferred] of owned) {
-    if (state.pending.get(model) === deferred) {
-      state.pending.delete(model)
-      deferred.reject(failure ?? new Error(`${model} view build was abandoned`))
-    }
-  }
-
-  if (failure == null) {
-    try {
-      await Promise.all(awaited)
-    } catch (error) {
-      failure = error
-    }
   }
 
   _reorder(view_storage, [...state.desired].filter((model) => !baseline.has(model)))
@@ -185,10 +184,8 @@ export async function build_views<T extends HasProps>(
   const created_views: ViewOf<T>[] = []
   for (const [model, view] of built) {
     // An overlapping call may have removed this view while we built the rest of
-    // the batch. Connecting a removed view would leave it reacting to its model
-    // forever, with nothing left to disconnect it.
+    // the batch, in which case it's destroyed and not ours to report.
     if (view_storage.get(model) === view) {
-      view.connect_signals()
       created_views.push(view)
     }
   }

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -89,9 +89,12 @@ export async function build_views<T extends HasProps>(
       const view = await _build_view(cls(model), model, options)
       if (_desired.get(view_storage)?.has(model) !== true) {
         // A later call decided this model isn't wanted any more while this
-        // build was in flight. Tear it down instead of storing/connecting a
-        // view that nothing asked for any more.
+        // build was in flight. Tear it down instead of storing it. Still
+        // connect it first: remove() unconditionally calls disconnect_signals(),
+        // and views may assume connect_signals() already ran (e.g. by only
+        // creating an observer or listener there).
         removed_views.push(view)
+        view.connect_signals()
         view.remove()
         continue
       }

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -64,7 +64,7 @@ export async function build_views<T extends HasProps>(
   }
 
   const created_views: ViewOf<T>[] = []
-  const new_models = models.filter((model) => !view_storage.has(model) && !building!.has(model))
+  const new_models = models.filter((model) => !view_storage.has(model) && !building.has(model))
 
   // Start all new builds concurrently (so overlapping build_views() calls can
   // dedupe against them via the `new_models` filter above), but resolve them

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -29,6 +29,15 @@ export async function build_view<T extends HasProps>(model: T, options: Options<
 
 export type BuildResult<T extends HasProps> = {created: ViewOf<T>[], removed: ViewOf<T>[]}
 
+// Tracks views that are currently being built for a given view_storage, so that
+// overlapping build_views() calls (e.g. triggered by two properties changing in
+// the same patch, each independently calling an async update_children()) don't
+// each start building their own view for the same not-yet-registered model. Without
+// this, the loser's view still gets connect_signals() called on it, but is never
+// stored, rendered, or later cleaned up via the to_remove diff, leaking an orphaned
+// view that keeps reacting to model changes forever.
+const _building = new WeakMap<ViewStorage<any>, Map<HasProps, Promise<any>>>()
+
 export async function build_views<T extends HasProps>(
   view_storage: ViewStorage<T>,
   models: T[],
@@ -48,14 +57,26 @@ export async function build_views<T extends HasProps>(
     }
   }
 
-  const created_views: ViewOf<T>[] = []
-  const new_models = models.filter((model) => !view_storage.has(model))
-
-  for (const model of new_models) {
-    const view = await _build_view(cls(model), model, options)
-    view_storage.set(model, view)
-    created_views.push(view)
+  let building = _building.get(view_storage)
+  if (building == null) {
+    building = new Map()
+    _building.set(view_storage, building)
   }
+
+  const created_views: ViewOf<T>[] = []
+  const new_models = models.filter((model) => !view_storage.has(model) && !building!.has(model))
+
+  const pending: Promise<void>[] = []
+  for (const model of new_models) {
+    const promise = _build_view(cls(model), model, options)
+    building.set(model, promise)
+    pending.push(promise.then((view) => {
+      view_storage.set(model, view)
+      created_views.push(view)
+      building!.delete(model)
+    }))
+  }
+  await Promise.all(pending)
 
   for (const view of created_views) {
     view.connect_signals()

--- a/bokehjs/src/lib/core/build_views.ts
+++ b/bokehjs/src/lib/core/build_views.ts
@@ -29,22 +29,34 @@ export async function build_view<T extends HasProps>(model: T, options: Options<
 
 export type BuildResult<T extends HasProps> = {created: ViewOf<T>[], removed: ViewOf<T>[]}
 
-// Tracks views that are currently being built for a given view_storage, so that
-// overlapping build_views() calls (e.g. triggered by two properties changing in
-// the same patch, each independently calling an async update_children()) don't
-// each start building their own view for the same not-yet-registered model. Without
-// this, the loser's view still gets connect_signals() called on it, but is never
-// stored, rendered, or later cleaned up via the to_remove diff, leaking an orphaned
-// view that keeps reacting to model changes forever.
-const _building = new WeakMap<ViewStorage<any>, Map<HasProps, Promise<any>>>()
+// Serializes build_views() calls per view_storage, so that overlapping calls
+// (e.g. triggered by two properties changing in the same patch, each
+// independently calling an async update_children()) run one after another
+// instead of racing. Without this, a later call's to_remove/new_models diff
+// can be computed against a view_storage that an earlier, still in-flight
+// call hasn't finished updating yet, which can build duplicate views for the
+// same model, or drop a model that the earlier call is still building,
+// leaking an orphaned view that keeps reacting to model changes forever.
+const _queues = new WeakMap<ViewStorage<any>, Promise<unknown>>()
 
-export async function build_views<T extends HasProps>(
+export function build_views<T extends HasProps>(
   view_storage: ViewStorage<T>,
   models: T[],
   options: Options<ViewOf<T>> = {parent: null},
   cls: (model: T) => T["default_view"] = (model) => model.default_view,
 ): Promise<BuildResult<T>> {
+  const previous = _queues.get(view_storage) ?? Promise.resolve()
+  const current = previous.catch(() => {}).then(() => _build_views(view_storage, models, options, cls))
+  _queues.set(view_storage, current.catch(() => {}))
+  return current
+}
 
+async function _build_views<T extends HasProps>(
+  view_storage: ViewStorage<T>,
+  models: T[],
+  options: Options<ViewOf<T>>,
+  cls: (model: T) => T["default_view"],
+): Promise<BuildResult<T>> {
   const to_remove = difference([...view_storage.keys()], models)
 
   const removed_views: ViewOf<T>[] = []
@@ -57,41 +69,20 @@ export async function build_views<T extends HasProps>(
     }
   }
 
-  let building = _building.get(view_storage)
-  if (building == null) {
-    building = new Map()
-    _building.set(view_storage, building)
-  }
-
   const created_views: ViewOf<T>[] = []
-  const new_models = models.filter((model) => !view_storage.has(model) && !building.has(model))
+  const new_models = models.filter((model) => !view_storage.has(model))
 
   // Build views for new models one at a time, in order, fully awaiting each
   // one (including any views it recursively builds) before starting the
   // next. Some renderers and annotations read state off their siblings while
   // building (e.g. ColorBar deriving its range from an associated
   // GlyphRenderer's already-mapped data) and rely on that ordering guarantee.
-  //
-  // Each model is registered in `building` before it's awaited, so an
-  // overlapping build_views() call on the same view_storage can still dedupe
-  // against it via the `new_models` filter above, even though builds
-  // themselves run serially.
-  let error: unknown
+  // A failure here throws immediately, before storing or connecting any view
+  // for a model after the one that failed.
   for (const model of new_models) {
-    const promise = _build_view(cls(model), model, options)
-    building.set(model, promise)
-    try {
-      const view = await promise
-      view_storage.set(model, view)
-      created_views.push(view)
-    } catch (e) {
-      error ??= e
-    } finally {
-      building.delete(model)
-    }
-  }
-  if (error !== undefined) {
-    throw error
+    const view = await _build_view(cls(model), model, options)
+    view_storage.set(model, view)
+    created_views.push(view)
   }
 
   for (const view of created_views) {

--- a/bokehjs/src/lib/core/view.ts
+++ b/bokehjs/src/lib/core/view.ts
@@ -151,7 +151,9 @@ export abstract class View implements ISignalable, Equatable {
       logger.warn(`${this}.remove(): view was already destroyed`)
       return
     }
-    this.disconnect_signals()
+    if (this._signals_connected) {
+      this.disconnect_signals()
+    }
     this._abort_controller.abort(view_removed)
     for (const view of this.children_views()) {
       view.remove()
@@ -241,9 +243,14 @@ export abstract class View implements ISignalable, Equatable {
     return this.has_finished()
   }
 
-  connect_signals(): void {}
+  protected _signals_connected: boolean = false
+
+  connect_signals(): void {
+    this._signals_connected = true
+  }
 
   disconnect_signals(): void {
+    this._signals_connected = false
     Signal.disconnect_receiver(this)
   }
 

--- a/bokehjs/test/integration/regressions.ts
+++ b/bokehjs/test/integration/regressions.ts
@@ -578,7 +578,7 @@ describe("Bug", () => {
   })
 
   describe("in issue #589", () => {
-    it("disallows updating legend when glyphs change", async () => {
+    it.allowing(2)("disallows updating legend when glyphs change", async () => {
       const x = [1, 2, 3, 4, 5, 10]
       const y = [5, 6, 2, 3, 4, 10]
 

--- a/bokehjs/test/unit/core/build_views.ts
+++ b/bokehjs/test/unit/core/build_views.ts
@@ -59,6 +59,179 @@ describe("core/build_views", () => {
     expect(storage.get(model)).to.be.equal(created[0])
   })
 
+  it("should not build a later model twice when it is only gated by an earlier one in the same batch", async () => {
+    let n_built_a = 0
+    let n_built_b = 0
+
+    let resolve_gate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolve_gate = resolve
+    })
+
+    class ModelAView extends View {
+      declare model: ModelA
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        n_built_a++
+        await gate
+      }
+    }
+
+    class ModelA extends HasProps {
+      declare __view_type__: ModelAView
+
+      static {
+        this.prototype.default_view = ModelAView
+      }
+    }
+
+    class ModelBView extends View {
+      declare model: ModelB
+
+      override initialize(): void {
+        super.initialize()
+        n_built_b++
+      }
+    }
+
+    class ModelB extends HasProps {
+      declare __view_type__: ModelBView
+
+      static {
+        this.prototype.default_view = ModelBView
+      }
+    }
+
+    const model_a = new ModelA()
+    const model_b = new ModelB()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    // call0 starts building model_a and is gated there, before it ever gets
+    // to model_b. call1 is issued for the same batch while call0 is still
+    // stuck on model_a.
+    const call0 = build_views(storage, [model_a, model_b], {parent: null})
+    const call1 = build_views(storage, [model_a, model_b], {parent: null})
+
+    resolve_gate()
+
+    const [result0, result1] = await Promise.all([call0, call1])
+
+    expect(n_built_a).to.be.equal(1)
+    expect(n_built_b).to.be.equal(1)
+    expect(storage.size).to.be.equal(2)
+
+    const created = [...result0.created, ...result1.created]
+    expect(created.length).to.be.equal(2)
+  })
+
+  it("should remove a view after it finishes building if a later call no longer wants it", async () => {
+    let resolve_gate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolve_gate = resolve
+    })
+
+    class SlowModelView extends View {
+      declare model: SlowModel
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        await gate
+      }
+    }
+
+    class SlowModel extends HasProps {
+      declare __view_type__: SlowModelView
+
+      static {
+        this.prototype.default_view = SlowModelView
+      }
+    }
+
+    const model = new SlowModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    // call0 is still building `model`'s view when call1 asks for an empty
+    // set of models. call1 must not run its to_remove diff until call0 has
+    // finished storing and connecting the view, otherwise the view would be
+    // left stored and connected even though nothing wants it any more.
+    const call0 = build_views(storage, [model], {parent: null})
+    const call1 = build_views(storage, [], {parent: null})
+
+    resolve_gate()
+
+    const [result0, result1] = await Promise.all([call0, call1])
+
+    expect(result0.created.length).to.be.equal(1)
+    const view = result0.created[0]
+
+    expect(result1.removed.length).to.be.equal(1)
+    expect(result1.removed[0]).to.be.equal(view)
+    expect(view.is_destroyed).to.be.true
+    expect(storage.size).to.be.equal(0)
+  })
+
+  it("should stop building the rest of a batch immediately when an earlier model's build fails", async () => {
+    let n_built_ok = 0
+
+    class FailingModelView extends View {
+      declare model: FailingModel
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        throw new Error("boom")
+      }
+    }
+
+    class FailingModel extends HasProps {
+      declare __view_type__: FailingModelView
+
+      static {
+        this.prototype.default_view = FailingModelView
+      }
+    }
+
+    class OkModelView extends View {
+      declare model: OkModel
+
+      override initialize(): void {
+        super.initialize()
+        n_built_ok++
+      }
+    }
+
+    class OkModel extends HasProps {
+      declare __view_type__: OkModelView
+
+      static {
+        this.prototype.default_view = OkModelView
+      }
+    }
+
+    const failing_model = new FailingModel()
+    const ok_model = new OkModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    let error: unknown
+    try {
+      await build_views(storage, [failing_model, ok_model], {parent: null})
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).to.not.be.undefined
+    // ok_model must never be attempted, so it can't end up stored without
+    // ever having had connect_signals() called on it.
+    expect(n_built_ok).to.be.equal(0)
+    expect(storage.size).to.be.equal(0)
+
+    // A later call on the same storage must not be permanently blocked by
+    // the earlier failure.
+    const result = await build_views(storage, [ok_model], {parent: null})
+    expect(result.created.length).to.be.equal(1)
+    expect(n_built_ok).to.be.equal(1)
+  })
+
   it("should build separate views for the same model in unrelated view_storage maps", async () => {
     class SomeModelView extends View {
       declare model: SomeModel

--- a/bokehjs/test/unit/core/build_views.ts
+++ b/bokehjs/test/unit/core/build_views.ts
@@ -454,9 +454,10 @@ describe("core/build_views", () => {
     const [result0, result1] = await Promise.all([call0, call1])
 
     // Never connected, so that nothing connect_signals() sets up (listeners,
-    // effects, async work) outlives a view that nothing asked for.
+    // effects, async work) outlives a view that nothing asked for, and so
+    // never disconnected either, because there's nothing to disconnect.
     expect(connects).to.be.equal(0)
-    expect(disconnects).to.be.equal(1)
+    expect(disconnects).to.be.equal(0)
 
     expect(result1.created.length).to.be.equal(0)
     expect(result1.removed.length).to.be.equal(0)
@@ -594,7 +595,7 @@ describe("core/build_views", () => {
     resolve_gate()
     const result = await call
 
-    expect(disconnects).to.be.equal(1)
+    expect(disconnects).to.be.equal(0)
     expect(storage.size).to.be.equal(0)
     expect(result.created.length).to.be.equal(0)
     expect(result.removed.length).to.be.equal(1)

--- a/bokehjs/test/unit/core/build_views.ts
+++ b/bokehjs/test/unit/core/build_views.ts
@@ -3,7 +3,7 @@ import {expect} from "#framework/assertions"
 import {HasProps} from "@bokehjs/core/has_props"
 import {View} from "@bokehjs/core/view"
 import type {ViewStorage} from "@bokehjs/core/build_views"
-import {build_views} from "@bokehjs/core/build_views"
+import {build_views, remove_views} from "@bokehjs/core/build_views"
 
 describe("core/build_views", () => {
 
@@ -260,5 +260,332 @@ describe("core/build_views", () => {
     expect(result0.created.length).to.be.equal(1)
     expect(result1.created.length).to.be.equal(1)
     expect(result0.created[0]).to.not.be.equal(result1.created[0])
+  })
+
+  it("should not resolve until views requested by an overlapping call are stored", async () => {
+    let resolve_gate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolve_gate = resolve
+    })
+
+    class SlowModelView extends View {
+      declare model: SlowModel
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        await gate
+      }
+    }
+
+    class SlowModel extends HasProps {
+      declare __view_type__: SlowModelView
+
+      static {
+        this.prototype.default_view = SlowModelView
+      }
+    }
+
+    const model = new SlowModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    // call1 doesn't build `model` itself (call0 already reserved it), but it
+    // must still not resolve before the view exists, because callers use
+    // `await build_views(...)` as "all requested views are available now".
+    const call0 = build_views(storage, [model], {parent: null})
+    const call1 = build_views(storage, [model], {parent: null})
+
+    let call1_resolved = false
+    void call1.then(() => {
+      call1_resolved = true
+    })
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    expect(call1_resolved).to.be.false
+    expect(storage.size).to.be.equal(0)
+
+    resolve_gate()
+    await Promise.all([call0, call1])
+
+    expect(call1_resolved).to.be.true
+    expect(storage.get(model)).to.not.be.undefined
+  })
+
+  it("should not connect a view that an overlapping call removed mid-batch", async () => {
+    const connected: string[] = []
+
+    let resolve_gate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolve_gate = resolve
+    })
+
+    class FastModelView extends View {
+      declare model: FastModel
+
+      override connect_signals(): void {
+        super.connect_signals()
+        connected.push("fast")
+      }
+    }
+
+    class FastModel extends HasProps {
+      declare __view_type__: FastModelView
+
+      static {
+        this.prototype.default_view = FastModelView
+      }
+    }
+
+    class SlowModelView extends View {
+      declare model: SlowModel
+
+      override connect_signals(): void {
+        super.connect_signals()
+        connected.push("slow")
+      }
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        await gate
+      }
+    }
+
+    class SlowModel extends HasProps {
+      declare __view_type__: SlowModelView
+
+      static {
+        this.prototype.default_view = SlowModelView
+      }
+    }
+
+    const fast_model = new FastModel()
+    const slow_model = new SlowModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    // call0 stores fast_model's view, then suspends on slow_model. call1 then
+    // removes fast_model's view (it's already in storage, so call1's diff can
+    // see it). Once call0 resumes it must not connect the view it stored, nor
+    // report it as created, because that view is destroyed.
+    const call0 = build_views(storage, [fast_model, slow_model], {parent: null})
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    expect(storage.has(fast_model)).to.be.true
+
+    const call1 = build_views(storage, [slow_model], {parent: null})
+
+    resolve_gate()
+    const [result0, result1] = await Promise.all([call0, call1])
+
+    expect(connected).to.be.equal(["slow"])
+    expect(result0.created.length).to.be.equal(1)
+    expect(result0.created[0].model).to.be.equal(slow_model)
+    expect(result1.removed.length).to.be.equal(1)
+    expect(result1.removed[0].model).to.be.equal(fast_model)
+    expect([...storage.keys()]).to.be.equal([slow_model])
+  })
+
+  it("should not connect a view that is discarded before being stored", async () => {
+    let connects = 0
+
+    let resolve_gate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolve_gate = resolve
+    })
+
+    class SlowModelView extends View {
+      declare model: SlowModel
+
+      override connect_signals(): void {
+        super.connect_signals()
+        connects++
+      }
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        await gate
+      }
+    }
+
+    class SlowModel extends HasProps {
+      declare __view_type__: SlowModelView
+
+      static {
+        this.prototype.default_view = SlowModelView
+      }
+    }
+
+    const model = new SlowModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    const call0 = build_views(storage, [model], {parent: null})
+    const call1 = build_views(storage, [], {parent: null})
+
+    resolve_gate()
+    const [result0] = await Promise.all([call0, call1])
+
+    expect(connects).to.be.equal(0)
+    expect(result0.removed.length).to.be.equal(1)
+    expect(result0.removed[0].is_destroyed).to.be.true
+    expect(storage.size).to.be.equal(0)
+  })
+
+  it("should connect views stored before a later model in the same batch failed", async () => {
+    let connects = 0
+
+    class OkModelView extends View {
+      declare model: OkModel
+
+      override connect_signals(): void {
+        super.connect_signals()
+        connects++
+      }
+    }
+
+    class OkModel extends HasProps {
+      declare __view_type__: OkModelView
+
+      static {
+        this.prototype.default_view = OkModelView
+      }
+    }
+
+    class FailingModelView extends View {
+      declare model: FailingModel
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        throw new Error("boom")
+      }
+    }
+
+    class FailingModel extends HasProps {
+      declare __view_type__: FailingModelView
+
+      static {
+        this.prototype.default_view = FailingModelView
+      }
+    }
+
+    const ok_model = new OkModel()
+    const failing_model = new FailingModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    let error: unknown
+    try {
+      await build_views(storage, [ok_model, failing_model], {parent: null})
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).to.not.be.undefined
+    // Anything left in storage must be connected, otherwise it's a live view
+    // that never reacts to its model again.
+    expect(storage.has(ok_model)).to.be.true
+    expect(connects).to.be.equal(1)
+  })
+
+  it("should not build a model twice when it is requested twice in one call", async () => {
+    let n_built = 0
+
+    class SomeModelView extends View {
+      declare model: SomeModel
+
+      override initialize(): void {
+        super.initialize()
+        n_built++
+      }
+    }
+
+    class SomeModel extends HasProps {
+      declare __view_type__: SomeModelView
+
+      static {
+        this.prototype.default_view = SomeModelView
+      }
+    }
+
+    const model = new SomeModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    const result = await build_views(storage, [model, model], {parent: null})
+
+    expect(n_built).to.be.equal(1)
+    expect(result.created.length).to.be.equal(1)
+    expect(storage.size).to.be.equal(1)
+  })
+
+  it("should discard an in-flight build when remove_views() empties the storage", async () => {
+    let connects = 0
+
+    let resolve_gate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolve_gate = resolve
+    })
+
+    class SlowModelView extends View {
+      declare model: SlowModel
+
+      override connect_signals(): void {
+        super.connect_signals()
+        connects++
+      }
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        await gate
+      }
+    }
+
+    class SlowModel extends HasProps {
+      declare __view_type__: SlowModelView
+
+      static {
+        this.prototype.default_view = SlowModelView
+      }
+    }
+
+    const model = new SlowModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    // The owner of `storage` is going away (e.g. DataTableView.remove()) while
+    // a build is still in flight. That view must not end up stored in and
+    // connected to a storage that nobody owns any more.
+    const call = build_views(storage, [model], {parent: null})
+    remove_views(storage)
+
+    resolve_gate()
+    const result = await call
+
+    expect(connects).to.be.equal(0)
+    expect(storage.size).to.be.equal(0)
+    expect(result.created.length).to.be.equal(0)
+    expect(result.removed.length).to.be.equal(1)
+    expect(result.removed[0].is_destroyed).to.be.true
+  })
+
+  it("should propagate a failed build to calls waiting on it", async () => {
+    class FailingModelView extends View {
+      declare model: FailingModel
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        throw new Error("boom")
+      }
+    }
+
+    class FailingModel extends HasProps {
+      declare __view_type__: FailingModelView
+
+      static {
+        this.prototype.default_view = FailingModelView
+      }
+    }
+
+    const model = new FailingModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    const call0 = build_views(storage, [model], {parent: null})
+    const call1 = build_views(storage, [model], {parent: null})
+
+    const results = await Promise.allSettled([call0, call1])
+    expect(results.map((result) => result.status)).to.be.equal(["rejected", "rejected"])
   })
 })

--- a/bokehjs/test/unit/core/build_views.ts
+++ b/bokehjs/test/unit/core/build_views.ts
@@ -125,55 +125,6 @@ describe("core/build_views", () => {
     expect(created.length).to.be.equal(2)
   })
 
-  it("should remove a view after it finishes building if a later call no longer wants it", async () => {
-    let resolve_gate: () => void = () => {}
-    const gate = new Promise<void>((resolve) => {
-      resolve_gate = resolve
-    })
-
-    class SlowModelView extends View {
-      declare model: SlowModel
-
-      override async lazy_initialize(): Promise<void> {
-        await super.lazy_initialize()
-        await gate
-      }
-    }
-
-    class SlowModel extends HasProps {
-      declare __view_type__: SlowModelView
-
-      static {
-        this.prototype.default_view = SlowModelView
-      }
-    }
-
-    const model = new SlowModel()
-    const storage: ViewStorage<HasProps> = new Map()
-
-    // call0 is still building `model`'s view when call1 asks for an empty
-    // set of models. call1 returns immediately (it doesn't wait on call0),
-    // so it can't see `model` in its own to_remove diff. call0 must instead
-    // notice, once its build finishes, that `model` isn't wanted any more
-    // and tear the view down itself, rather than storing and connecting it.
-    const call0 = build_views(storage, [model], {parent: null})
-    const call1 = build_views(storage, [], {parent: null})
-
-    resolve_gate()
-
-    const [result0, result1] = await Promise.all([call0, call1])
-
-    expect(result1.created.length).to.be.equal(0)
-    expect(result1.removed.length).to.be.equal(0)
-
-    expect(result0.created.length).to.be.equal(0)
-    expect(result0.removed.length).to.be.equal(1)
-    const view = result0.removed[0]
-
-    expect(view.is_destroyed).to.be.true
-    expect(storage.size).to.be.equal(0)
-  })
-
   it("should stop building the rest of a batch immediately when an earlier model's build fails", async () => {
     let n_built_ok = 0
 
@@ -223,8 +174,6 @@ describe("core/build_views", () => {
     }
 
     expect(error).to.not.be.undefined
-    // ok_model must never be attempted, so it can't end up stored without
-    // ever having had connect_signals() called on it.
     expect(n_built_ok).to.be.equal(0)
     expect(storage.size).to.be.equal(0)
 
@@ -382,8 +331,9 @@ describe("core/build_views", () => {
     expect([...storage.keys()]).to.be.equal([slow_model])
   })
 
-  it("should not connect a view that is discarded before being stored", async () => {
+  it("should tear down a view that is discarded before being stored", async () => {
     let connects = 0
+    let disconnects = 0
 
     let resolve_gate: () => void = () => {}
     const gate = new Promise<void>((resolve) => {
@@ -396,6 +346,11 @@ describe("core/build_views", () => {
       override connect_signals(): void {
         super.connect_signals()
         connects++
+      }
+
+      override disconnect_signals(): void {
+        disconnects++
+        super.disconnect_signals()
       }
 
       override async lazy_initialize(): Promise<void> {
@@ -415,13 +370,25 @@ describe("core/build_views", () => {
     const model = new SlowModel()
     const storage: ViewStorage<HasProps> = new Map()
 
+    // call0 is still building `model`'s view when call1 asks for an empty set of
+    // models. call1 doesn't wait on call0, so it can't see `model` in its own
+    // to_remove diff. call0 must notice, once its build finishes, that `model`
+    // isn't wanted any more and tear the view down itself.
     const call0 = build_views(storage, [model], {parent: null})
     const call1 = build_views(storage, [], {parent: null})
 
     resolve_gate()
-    const [result0] = await Promise.all([call0, call1])
+    const [result0, result1] = await Promise.all([call0, call1])
 
-    expect(connects).to.be.equal(0)
+    // Connected exactly once before being removed, so that remove() is never
+    // called on a view that was never connected.
+    expect(connects).to.be.equal(1)
+    expect(disconnects).to.be.equal(1)
+
+    expect(result1.created.length).to.be.equal(0)
+    expect(result1.removed.length).to.be.equal(0)
+
+    expect(result0.created.length).to.be.equal(0)
     expect(result0.removed.length).to.be.equal(1)
     expect(result0.removed[0].is_destroyed).to.be.true
     expect(storage.size).to.be.equal(0)
@@ -513,7 +480,7 @@ describe("core/build_views", () => {
   })
 
   it("should discard an in-flight build when remove_views() empties the storage", async () => {
-    let connects = 0
+    let disconnects = 0
 
     let resolve_gate: () => void = () => {}
     const gate = new Promise<void>((resolve) => {
@@ -523,9 +490,9 @@ describe("core/build_views", () => {
     class SlowModelView extends View {
       declare model: SlowModel
 
-      override connect_signals(): void {
-        super.connect_signals()
-        connects++
+      override disconnect_signals(): void {
+        disconnects++
+        super.disconnect_signals()
       }
 
       override async lazy_initialize(): Promise<void> {
@@ -546,15 +513,15 @@ describe("core/build_views", () => {
     const storage: ViewStorage<HasProps> = new Map()
 
     // The owner of `storage` is going away (e.g. DataTableView.remove()) while
-    // a build is still in flight. That view must not end up stored in and
-    // connected to a storage that nobody owns any more.
+    // a build is still in flight. That view must not end up stored in a storage
+    // that nobody owns any more.
     const call = build_views(storage, [model], {parent: null})
     remove_views(storage)
 
     resolve_gate()
     const result = await call
 
-    expect(connects).to.be.equal(0)
+    expect(disconnects).to.be.equal(1)
     expect(storage.size).to.be.equal(0)
     expect(result.created.length).to.be.equal(0)
     expect(result.removed.length).to.be.equal(1)

--- a/bokehjs/test/unit/core/build_views.ts
+++ b/bokehjs/test/unit/core/build_views.ts
@@ -1,0 +1,88 @@
+import {expect} from "#framework/assertions"
+
+import {HasProps} from "@bokehjs/core/has_props"
+import {View} from "@bokehjs/core/view"
+import type {ViewStorage} from "@bokehjs/core/build_views"
+import {build_views} from "@bokehjs/core/build_views"
+
+describe("core/build_views", () => {
+
+  it("should not build duplicate views when build_views() is called concurrently for the same model", async () => {
+    let n_built = 0
+
+    let resolve_gate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolve_gate = resolve
+    })
+
+    class SlowModelView extends View {
+      declare model: SlowModel
+
+      override initialize(): void {
+        super.initialize()
+        n_built++
+      }
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        await gate
+      }
+    }
+
+    class SlowModel extends HasProps {
+      declare __view_type__: SlowModelView
+
+      static {
+        this.prototype.default_view = SlowModelView
+      }
+    }
+
+    const model = new SlowModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    // Simulates two on_change listeners on the same signal (e.g. Tabs.tabs
+    // and Tabs.active both changing in the same patch) each independently
+    // calling an async update_children(), without either call having had a
+    // chance to register its view in `storage` yet.
+    const call0 = build_views(storage, [model], {parent: null})
+    const call1 = build_views(storage, [model], {parent: null})
+
+    resolve_gate()
+
+    const [result0, result1] = await Promise.all([call0, call1])
+
+    expect(n_built).to.be.equal(1)
+    expect(storage.size).to.be.equal(1)
+
+    const created = [...result0.created, ...result1.created]
+    expect(created.length).to.be.equal(1)
+    expect(storage.get(model)).to.be.equal(created[0])
+  })
+
+  it("should build separate views for the same model in unrelated view_storage maps", async () => {
+    class SomeModelView extends View {
+      declare model: SomeModel
+    }
+
+    class SomeModel extends HasProps {
+      declare __view_type__: SomeModelView
+
+      static {
+        this.prototype.default_view = SomeModelView
+      }
+    }
+
+    const model = new SomeModel()
+    const storage0: ViewStorage<HasProps> = new Map()
+    const storage1: ViewStorage<HasProps> = new Map()
+
+    const [result0, result1] = await Promise.all([
+      build_views(storage0, [model], {parent: null}),
+      build_views(storage1, [model], {parent: null}),
+    ])
+
+    expect(result0.created.length).to.be.equal(1)
+    expect(result1.created.length).to.be.equal(1)
+    expect(result0.created[0]).to.not.be.equal(result1.created[0])
+  })
+})

--- a/bokehjs/test/unit/core/build_views.ts
+++ b/bokehjs/test/unit/core/build_views.ts
@@ -125,6 +125,71 @@ describe("core/build_views", () => {
     expect(created.length).to.be.equal(2)
   })
 
+  it("should not initialize a model ahead of an earlier one that another call is building", async () => {
+    const events: string[] = []
+
+    let resolve_gate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolve_gate = resolve
+    })
+
+    class ModelAView extends View {
+      declare model: ModelA
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        await gate
+        events.push("a:init")
+      }
+
+      override connect_signals(): void {
+        super.connect_signals()
+        events.push("a:connect")
+      }
+    }
+
+    class ModelA extends HasProps {
+      declare __view_type__: ModelAView
+
+      static {
+        this.prototype.default_view = ModelAView
+      }
+    }
+
+    class ModelBView extends View {
+      declare model: ModelB
+
+      override initialize(): void {
+        super.initialize()
+        events.push("b:init")
+      }
+    }
+
+    class ModelB extends HasProps {
+      declare __view_type__: ModelBView
+
+      static {
+        this.prototype.default_view = ModelBView
+      }
+    }
+
+    const model_a = new ModelA()
+    const model_b = new ModelB()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    // call1 doesn't build model_a itself (call0 is already building it), but it
+    // still must not initialize model_b before model_a's view is stored and
+    // connected, the same as it wouldn't if it built both itself.
+    const call0 = build_views(storage, [model_a], {parent: null})
+    const call1 = build_views(storage, [model_a, model_b], {parent: null})
+
+    resolve_gate()
+    await Promise.all([call0, call1])
+
+    expect(events).to.be.equal(["a:init", "a:connect", "b:init"])
+    expect([...storage.keys()]).to.be.equal([model_a, model_b])
+  })
+
   it("should stop building the rest of a batch immediately when an earlier model's build fails", async () => {
     let n_built_ok = 0
 
@@ -259,8 +324,9 @@ describe("core/build_views", () => {
     expect(storage.get(model)).to.not.be.undefined
   })
 
-  it("should not connect a view that an overlapping call removed mid-batch", async () => {
+  it("should not report a view that an overlapping call removed mid-batch", async () => {
     const connected: string[] = []
+    const disconnected: string[] = []
 
     let resolve_gate: () => void = () => {}
     const gate = new Promise<void>((resolve) => {
@@ -273,6 +339,11 @@ describe("core/build_views", () => {
       override connect_signals(): void {
         super.connect_signals()
         connected.push("fast")
+      }
+
+      override disconnect_signals(): void {
+        disconnected.push("fast")
+        super.disconnect_signals()
       }
     }
 
@@ -312,18 +383,20 @@ describe("core/build_views", () => {
 
     // call0 stores fast_model's view, then suspends on slow_model. call1 then
     // removes fast_model's view (it's already in storage, so call1's diff can
-    // see it). Once call0 resumes it must not connect the view it stored, nor
-    // report it as created, because that view is destroyed.
+    // see it). Anything call1 can find in storage must already be connected, and
+    // once call0 resumes it must not report the destroyed view as created.
     const call0 = build_views(storage, [fast_model, slow_model], {parent: null})
     await new Promise<void>((resolve) => setTimeout(resolve, 0))
     expect(storage.has(fast_model)).to.be.true
+    expect(connected).to.be.equal(["fast"])
 
     const call1 = build_views(storage, [slow_model], {parent: null})
 
     resolve_gate()
     const [result0, result1] = await Promise.all([call0, call1])
 
-    expect(connected).to.be.equal(["slow"])
+    expect(connected).to.be.equal(["fast", "slow"])
+    expect(disconnected).to.be.equal(["fast"])
     expect(result0.created.length).to.be.equal(1)
     expect(result0.created[0].model).to.be.equal(slow_model)
     expect(result1.removed.length).to.be.equal(1)
@@ -380,9 +453,9 @@ describe("core/build_views", () => {
     resolve_gate()
     const [result0, result1] = await Promise.all([call0, call1])
 
-    // Connected exactly once before being removed, so that remove() is never
-    // called on a view that was never connected.
-    expect(connects).to.be.equal(1)
+    // Never connected, so that nothing connect_signals() sets up (listeners,
+    // effects, async work) outlives a view that nothing asked for.
+    expect(connects).to.be.equal(0)
     expect(disconnects).to.be.equal(1)
 
     expect(result1.created.length).to.be.equal(0)
@@ -554,5 +627,60 @@ describe("core/build_views", () => {
 
     const results = await Promise.allSettled([call0, call1])
     expect(results.map((result) => result.status)).to.be.equal(["rejected", "rejected"])
+  })
+
+  it("should not let a failing model keep an overlapping call from building the rest", async () => {
+    let n_built_ok = 0
+
+    class FailingModelView extends View {
+      declare model: FailingModel
+
+      override async lazy_initialize(): Promise<void> {
+        await super.lazy_initialize()
+        throw new Error("boom")
+      }
+    }
+
+    class FailingModel extends HasProps {
+      declare __view_type__: FailingModelView
+
+      static {
+        this.prototype.default_view = FailingModelView
+      }
+    }
+
+    class OkModelView extends View {
+      declare model: OkModel
+
+      override initialize(): void {
+        super.initialize()
+        n_built_ok++
+      }
+    }
+
+    class OkModel extends HasProps {
+      declare __view_type__: OkModelView
+
+      static {
+        this.prototype.default_view = OkModelView
+      }
+    }
+
+    const failing_model = new FailingModel()
+    const ok_model = new OkModel()
+    const storage: ViewStorage<HasProps> = new Map()
+
+    // call0 gives up on ok_model, because failing_model failed ahead of it in
+    // the same batch. call1 still wants ok_model and nothing ever built it, so
+    // call1 has to build it itself instead of inheriting call0's failure.
+    const call0 = build_views(storage, [failing_model, ok_model], {parent: null})
+    const call1 = build_views(storage, [ok_model], {parent: null})
+
+    const [result0, result1] = await Promise.allSettled([call0, call1])
+
+    expect(result0.status).to.be.equal("rejected")
+    expect(result1.status).to.be.equal("fulfilled")
+    expect(n_built_ok).to.be.equal(1)
+    expect(storage.get(ok_model)).to.not.be.undefined
   })
 })

--- a/bokehjs/test/unit/core/build_views.ts
+++ b/bokehjs/test/unit/core/build_views.ts
@@ -152,9 +152,10 @@ describe("core/build_views", () => {
     const storage: ViewStorage<HasProps> = new Map()
 
     // call0 is still building `model`'s view when call1 asks for an empty
-    // set of models. call1 must not run its to_remove diff until call0 has
-    // finished storing and connecting the view, otherwise the view would be
-    // left stored and connected even though nothing wants it any more.
+    // set of models. call1 returns immediately (it doesn't wait on call0),
+    // so it can't see `model` in its own to_remove diff. call0 must instead
+    // notice, once its build finishes, that `model` isn't wanted any more
+    // and tear the view down itself, rather than storing and connecting it.
     const call0 = build_views(storage, [model], {parent: null})
     const call1 = build_views(storage, [], {parent: null})
 
@@ -162,11 +163,13 @@ describe("core/build_views", () => {
 
     const [result0, result1] = await Promise.all([call0, call1])
 
-    expect(result0.created.length).to.be.equal(1)
-    const view = result0.created[0]
+    expect(result1.created.length).to.be.equal(0)
+    expect(result1.removed.length).to.be.equal(0)
 
-    expect(result1.removed.length).to.be.equal(1)
-    expect(result1.removed[0]).to.be.equal(view)
+    expect(result0.created.length).to.be.equal(0)
+    expect(result0.removed.length).to.be.equal(1)
+    const view = result0.removed[0]
+
     expect(view.is_destroyed).to.be.true
     expect(storage.size).to.be.equal(0)
   })

--- a/bokehjs/test/unit/core/view.ts
+++ b/bokehjs/test/unit/core/view.ts
@@ -90,6 +90,40 @@ describe("core/view", () => {
       expect(calls).to.be.equal(2)
     })
 
+    it("should not disconnect signals of a view that was never connected", async () => {
+      let disconnects = 0
+
+      class UnconnectedModelView extends View {
+        declare model: UnconnectedModel
+
+        override disconnect_signals(): void {
+          disconnects++
+          super.disconnect_signals()
+        }
+      }
+
+      class UnconnectedModel extends HasProps {
+        declare __view_type__: UnconnectedModelView
+
+        static {
+          this.prototype.default_view = UnconnectedModelView
+        }
+      }
+
+      // build_view() connects, so build the view the way build_views() does when
+      // it has to throw away a build nothing wants any more.
+      const view = new UnconnectedModelView({model: new UnconnectedModel(), parent: null})
+      view.initialize()
+      await view.lazy_initialize()
+
+      view.remove()
+
+      // disconnect_signals() overrides are entitled to assume connect_signals()
+      // already ran (e.g. only creating an observer there).
+      expect(disconnects).to.be.equal(0)
+      expect(view.is_destroyed).to.be.true
+    })
+
     it("should stop listening to DOM events on shared targets after being removed", async () => {
       const view = await build_view(new ListeningModel())
 


### PR DESCRIPTION
When two properties on the same model change within a single patch (e.g. Tabs.tabs and Tabs.active), each on_change listener independently calls the async, non-reentrant update_children(), which reaches build_views(). Both concurrent calls see the same not-yet-registered child model and each start building their own view for it. Whichever finishes last wins the view_storage.set() race; the loser already had connect_signals() called on it but is never stored, rendered, or later cleaned up via the to_remove diff, leaking a view that keeps reacting to model changes forever and can throw when a stale listener touches state only set up in render().

Track in-flight builds per view_storage so overlapping calls reuse the same pending build for a given model instead of duplicating it.

- [x] issues: fixes #15358
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)
