### PR TITLE
Make the downstream workflow able to report failure

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -25,6 +25,9 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
 
+    outputs:
+      failed-suites: ${{ steps.tests.outputs.failed-suites }}
+
     steps:
       - uses: actions/checkout@v6
 
@@ -45,4 +48,57 @@ jobs:
           echo "npm $(npm --version)"
 
       - name: Run tests
+        id: tests
         run: bash tools/ci/run_downstream_tests.sh
+
+  notify-failure:
+    needs: [build, downstream]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post failure notification to GitHub Discussions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get list of failed jobs
+          FAILED_JOBS=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.conclusion == "failure") | "- `\(.name)`"')
+
+          # Which suites broke, if the test step got far enough to report (empty when the
+          # build job is what failed).
+          SUITES="${{ needs.downstream.outputs.failed-suites }}"
+          BROKEN=${SUITES:+$'\n\n'"**Suites that could not run:** ${SUITES}"}
+
+          # Create discussion post
+          gh api graphql -f query='
+            mutation($repositoryId: ID!, $categoryId: ID!, $body: String!, $title: String!) {
+              createDiscussion(input: {
+                repositoryId: $repositoryId,
+                categoryId: $categoryId,
+                body: $body,
+                title: $title
+              }) {
+                discussion {
+                  url
+                }
+              }
+            }
+          ' \
+          -f repositoryId='MDEwOlJlcG9zaXRvcnkzODM0MzMy' \
+          -f categoryId='DIC_kwDOADqB3M4C5RF1' \
+          -f title="❌ Downstream Failed - $(date +%Y-%m-%d)" \
+          -f body="The weekly Downstream workflow has failed.
+
+          This means at least one downstream suite could not run at all: an import or
+          collection error, no tests collected, or a suite that crashed without writing
+          results. Ordinary test failures do not trigger this notification; see the
+          job summary for the full per-suite table.${BROKEN}
+
+          **Failed jobs:**
+          ${FAILED_JOBS}
+
+          [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          ---
+          *Automated notification from [Downstream](${{ github.server_url }}/${{ github.repository }}/actions/workflows/downstream.yml)*"

--- a/conda/environment-test-downstream.yml
+++ b/conda/environment-test-downstream.yml
@@ -18,6 +18,7 @@ dependencies:
 
   # tests
   - pytest >=7.0
+  - pytest-asyncio  # Panel and HoloViews both set asyncio_mode = "auto"
   - pytest-timeout
   - scipy
   - nodejs 24.*

--- a/tools/ci/install_downstream_packages.sh
+++ b/tools/ci/install_downstream_packages.sh
@@ -20,7 +20,7 @@ banner_and_restore() {
 alias banner='{ save_flags="$-"; set +x;} 2> /dev/null; banner_and_restore'
 
 banner "holoviews" 2> /dev/null
-conda install --yes --quiet -c pyviz/label/dev holoviews nose scipy
+conda install --yes --quiet -c pyviz/label/dev holoviews scipy
 
 banner "dask/distributed" 2> /dev/null
 git clone https://github.com/dask/distributed.git

--- a/tools/ci/run_downstream_tests.sh
+++ b/tools/ci/run_downstream_tests.sh
@@ -101,14 +101,18 @@ run_suite "Dask -- dask/diagnostics"      dask        dask               15 dask
 run_suite "Dask -- distributed/dashboard" distributed distributed        35 distributed/dashboard
 
 # Panel and HoloViews are tested as installed, so their own pyproject.toml pytest
-# configuration does not apply. Only `asyncio_mode`, which changes what actually runs, is
-# restored here; their `filterwarnings = ["error", ...]` is deliberately not replicated,
-# since warnings-as-errors against a Bokeh dev build would fail for unrelated reasons.
+# configuration does not apply. Only the settings that change what actually runs are
+# restored here: `asyncio_mode` for both, plus `python_classes` for HoloViews, whose
+# suite has classes such as BokehRendererTest that pytest's default `Test*` pattern
+# does not match (37 tests). Their `filterwarnings = ["error", ...]` is deliberately not
+# replicated, since warnings-as-errors against a Bokeh dev build would fail for
+# unrelated reasons.
 run_suite "Panel"                         panel       "$SITE_PACKAGES" 1500 panel/tests \
     -o asyncio_mode=auto -o asyncio_default_fixture_loop_scope=function
 
 run_suite "HoloViews"                     holoviews   "$SITE_PACKAGES"  400 holoviews/tests/plotting/bokeh \
-    -o asyncio_mode=auto -o asyncio_default_fixture_loop_scope=function
+    -o asyncio_mode=auto -o asyncio_default_fixture_loop_scope=function \
+    -o 'python_classes=*Test*'
 
 set +x
 {

--- a/tools/ci/run_downstream_tests.sh
+++ b/tools/ci/run_downstream_tests.sh
@@ -8,37 +8,122 @@ banner() {
   echo
 }
 
-banner_and_restore() {
-        banner "$*"
-        case "$save_flags" in
-         (*x*)  set -x
-        esac
-}
-
-alias banner='{ save_flags="$-"; set +x;} 2> /dev/null; banner_and_restore'
-
 set -x #echo on
 
-set +e
+# There is deliberately no `set -e` here: every downstream suite must run even when an
+# earlier one fails. Instead each suite's exit status is captured and classified, and
+# this script exits non-zero only on unambiguous "this suite could not run" signals.
+# See classify() for the mapping.
 
-banner "Dask -- dask/diagnostics" 2> /dev/null
-cd dask
-pytest dask/diagnostics
-cd ..
+# Panel and HoloViews both set `asyncio_mode = "auto"`, which is restored below with -o.
+# pytest accepts that option even when the plugin is absent and then silently ignores it,
+# turning every async test into "async def functions are not natively supported", 200+
+# ordinary-looking failures instead of an obvious error. Fail loudly instead.
+if ! python -c 'import pytest_asyncio' 2> /dev/null; then
+  banner "pytest-asyncio is not installed, see conda/environment-test-downstream.yml"
+  exit 1
+fi
 
-banner "Dask -- distributed/dashboard" 2> /dev/null
-cd distributed
-pytest distributed/dashboard
-cd ..
+RESULTS_DIR="${RUNNER_TEMP:-/tmp}/downstream-results"
+mkdir -p "$RESULTS_DIR"
 
-pushd "$(python -c 'import site; print(site.getsitepackages()[0])')" || exit
+SUMMARY_ROWS=()
+FAILED_SUITES=()
+HARD_FAIL=0
 
-banner "Panel" 2> /dev/null
-pytest panel/tests
+# Classify one suite's outcome and record a summary row.
+#
+# pytest exit codes: 0 ok, 1 tests failed, 2 interrupted (this is what a collection or
+# import error produces), 3 internal error, 4 usage error, 5 no tests collected.
+#
+# A missing JUnit XML means the suite never reached the end of its session, e.g. it was
+# hard-killed by pytest-timeout (which calls os._exit(1)) or the working directory did
+# not exist. That is indistinguishable from an ordinary test failure by exit code alone,
+# so the results file is what separates the two.
+classify() {
+  local name=$1 rc=$2 xml=$3 min=$4
+  local status counts="-" tests="" failures="" errors="" skipped=""
 
-banner "Holoviews" 2> /dev/null
-nosetests holoviews/tests/plotting/bokeh
+  if [[ -f $xml ]]; then
+    read -r tests failures errors skipped <<<"$(python -c '
+import sys, xml.etree.ElementTree as ET
+s = ET.parse(sys.argv[1]).getroot().find("testsuite")
+print(s.get("tests"), s.get("failures"), s.get("errors"), s.get("skipped"))
+' "$xml" 2> /dev/null)"
+    [[ -n $tests ]] && counts="$tests tests, $failures failed, $errors errors, $skipped skipped"
+  fi
 
-popd
+  case $rc in
+    0)   status="pass" ;;
+    1)   if [[ -f $xml ]]; then
+           status="tests failed"
+         else
+           status="CRASHED (no results written)"; HARD_FAIL=1
+         fi ;;
+    2)   status="ERROR: collection/import failure"; HARD_FAIL=1 ;;
+    5)   status="ERROR: no tests collected";        HARD_FAIL=1 ;;
+    127) status="ERROR: command not found";         HARD_FAIL=1 ;;
+    *)   status="ERROR: exit $rc";                  HARD_FAIL=1 ;;
+  esac
 
-exit 0
+  # A suite that quietly stops collecting most of its tests is the same failure this
+  # script exists to catch, and pytest reports it as success. The floors are catastrophic
+  # drop tripwires at roughly half the observed count, not exact expectations.
+  if [[ $status == pass || $status == "tests failed" ]] \
+     && [[ $tests =~ ^[0-9]+$ ]] && (( tests < min )); then
+    status="ERROR: only $tests tests collected, expected at least $min"
+    HARD_FAIL=1
+  fi
+
+  [[ $status == ERROR* || $status == CRASHED* ]] && FAILED_SUITES+=("$name")
+  SUMMARY_ROWS+=("| $name | $status | $rc | $counts |")
+}
+
+# run_suite <display name> <results slug> <working directory> <min tests> <pytest args...>
+run_suite() {
+  local name=$1 slug=$2 workdir=$3 min=$4
+  shift 4
+  local xml="$RESULTS_DIR/$slug.xml"
+
+  # A leftover results file would make a crashed suite look like it merely failed.
+  rm -f "$xml"
+
+  banner "$name" 2> /dev/null
+  ( cd "$workdir" && pytest "$@" "--junitxml=$xml" )
+  local rc=$?
+
+  classify "$name" "$rc" "$xml" "$min"
+}
+
+SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
+
+run_suite "Dask -- dask/diagnostics"      dask        dask               15 dask/diagnostics
+run_suite "Dask -- distributed/dashboard" distributed distributed        35 distributed/dashboard
+
+# Panel and HoloViews are tested as installed, so their own pyproject.toml pytest
+# configuration does not apply. Only `asyncio_mode`, which changes what actually runs, is
+# restored here; their `filterwarnings = ["error", ...]` is deliberately not replicated,
+# since warnings-as-errors against a Bokeh dev build would fail for unrelated reasons.
+run_suite "Panel"                         panel       "$SITE_PACKAGES" 1500 panel/tests \
+    -o asyncio_mode=auto -o asyncio_default_fixture_loop_scope=function
+
+run_suite "HoloViews"                     holoviews   "$SITE_PACKAGES"  400 holoviews/tests/plotting/bokeh \
+    -o asyncio_mode=auto -o asyncio_default_fixture_loop_scope=function
+
+set +x
+{
+  echo "## Downstream test results"
+  echo
+  echo "| Suite | Status | Exit | Counts |"
+  echo "| --- | --- | --- | --- |"
+  printf '%s\n' "${SUMMARY_ROWS[@]}"
+  echo
+  echo "_Ordinary test failures are reported but do not fail this job._"
+} | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+# Consumed by the notify-failure job so the notification can name the broken suites.
+if [[ -n ${GITHUB_OUTPUT:-} ]]; then
+  printf 'failed-suites=%s\n' "$(IFS=,; echo "${FAILED_SUITES[*]}")" >> "$GITHUB_OUTPUT"
+fi
+
+exit $HARD_FAIL


### PR DESCRIPTION
- [x] issues: fixes #15356
- [x] tests added / passed (CI shell script, verified locally)
- [ ] release document entry (if new feature or API change)

`run_downstream_tests.sh` uses `set +e` and ends in `exit 0`, so the Downstream job cannot fail. It has reported success for eight weeks while `distributed/dashboard` regressed, `panel/tests` failed 218-219 times a week, and the HoloViews step did not run at all (`nose` cannot import on 3.12).

Per-suite status is now captured into a `$GITHUB_STEP_SUMMARY` table, and the script fails only on signals meaning a suite could not run: pytest exit 2, 5 or 127, no JUnit XML written, or a collected count below a floor. Ordinary test failures are reported but do not gate.

`nosetests` becomes `pytest` for HoloViews, `pytest-asyncio` is added to the environment, and failures post to the existing Automatons discussion category on scheduled runs only, so no PR is ever commented on.
