### PR TITLE
`Column(ar)DataSource` to CSV/JSON methods

### DIFF
--- a/bokehjs/src/lib/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/lib/models/sources/columnar_data_source.ts
@@ -6,13 +6,14 @@ import {Signal, Signal0} from "core/signaling"
 import type {Arrayable, ArrayableNew, Data, Dict} from "core/types"
 import type {PatchSet} from "core/patching"
 import {assert} from "core/util/assert"
-import {uniq} from "core/util/array"
+import {map, uniq} from "core/util/array"
 import {is_NDArray} from "core/util/ndarray"
 import {keys, values, entries, dict, clone} from "core/util/object"
 import {isBoolean, isNumber, isString, isArray} from "core/util/types"
 import type {GlyphRenderer} from "../renderers/glyph_renderer"
 import {SelectionPolicy, UnionRenderers} from "../selections/interaction_policy"
 import {Selection} from "../selections/selection"
+import type {OpaqueIndices} from "../selections/selection"
 import {DataSource} from "./data_source"
 import type {Index} from "core/util/templating"
 
@@ -137,6 +138,15 @@ export abstract class ColumnarDataSource extends DataSource {
     return result
   }
 
+  get_rows(indices: OpaqueIndices): {[key: string]: unknown} {
+    const mapped_indices = map(indices, (index: Index) => isNumber(index) ? index : index.index)
+    const result: {[key: string]: unknown} = {}
+    for (const [column, array] of entries(this.data)) {
+      result[column] = map(mapped_indices, (index: number) => array[index])
+    }
+    return result
+  }
+
   columns(): string[] {
     // return the column names in this data source
     return keys(this.data)
@@ -184,5 +194,40 @@ export abstract class ColumnarDataSource extends DataSource {
 
   patch(patches: PatchSet<unknown>, {sync}: {sync?: boolean} = {}): void {
     this.patch_to(this.properties.data, patches, {sync})
+  }
+
+  _row_to_csv(index: Index): string {
+    const values = []
+    const escape_characters = [",", '"']
+    for (const value of Object.values(this.get_row(index))) {
+      let string_value = is_NDArray(value) || isArray(value) ? JSON.stringify(value) : String(value)
+      if (escape_characters.some(escape_character => string_value.includes(escape_character))) {
+        string_value = `"${string_value.replace(/"/g, '""')}"`
+      }
+      values.push(string_value)
+    }
+    return values.join()
+  }
+
+  to_csv(): string {
+    const headers = this.columns().join()
+    const rows = []
+    if (this.selected.indices.length > 0) {
+      for (const row of this.selected.indices) {
+        rows.push(this._row_to_csv(row))
+      }
+    } else {
+      for (let row = 0; row < this.length; row++) {
+        rows.push(this._row_to_csv(row))
+      }
+    }
+    return [headers, ...rows].join("\n")
+  }
+
+  to_json(): string {
+    if (this.selected.indices.length > 0) {
+      return JSON.stringify(this.get_rows(this.selected.indices))
+    }
+    return JSON.stringify(this.data)
   }
 }

--- a/bokehjs/src/lib/models/sources/columnar_data_source.ts
+++ b/bokehjs/src/lib/models/sources/columnar_data_source.ts
@@ -133,7 +133,7 @@ export abstract class ColumnarDataSource extends DataSource {
     const i = isNumber(index) ? index : index.index
     const result: {[key: string]: unknown} = {}
     for (const [column, array] of entries(this.data)) {
-      result[column] = array[i]
+      result[column] = is_NDArray(array) ? array.get(i) : array[i]
     }
     return result
   }
@@ -142,7 +142,7 @@ export abstract class ColumnarDataSource extends DataSource {
     const mapped_indices = map(indices, (index: Index) => isNumber(index) ? index : index.index)
     const result: {[key: string]: unknown} = {}
     for (const [column, array] of entries(this.data)) {
-      result[column] = map(mapped_indices, (index: number) => array[index])
+      result[column] = map(mapped_indices, (index: number) => is_NDArray(array) ? array.get(index) : array[index])
     }
     return result
   }
@@ -221,6 +221,10 @@ export abstract class ColumnarDataSource extends DataSource {
         rows.push(this._row_to_csv(row))
       }
     }
+    // Push empty string to have last row with newline character
+    // possibliy something worthy to be configurable via an option as well as
+    // separator and characters to escape
+    rows.push("")
     return [headers, ...rows].join("\n")
   }
 

--- a/bokehjs/test/unit/models/sources/column_data_source.ts
+++ b/bokehjs/test/unit/models/sources/column_data_source.ts
@@ -188,4 +188,108 @@ describe("column_data_source module", () => {
       // TODO ["d15", new Map([[0, "a"], [1, "b"], [2, "c"]])],
     ]))
   })
+
+  describe("to_csv", () => {
+    it("should return string with only newline for empty data source", () => {
+      const cds = new ColumnDataSource()
+      expect(cds.to_csv()).to.be.equal("\n")
+
+      const cds2 = new ColumnDataSource({data: {}})
+      expect(cds2.to_csv()).to.be.equal("\n")
+    })
+
+    it("should handle empty columns", () => {
+      const cds = new ColumnDataSource({data: {
+        foo: [],
+      }})
+      expect(cds.to_csv()).to.be.equal("foo\n")
+
+      const cds2 = new ColumnDataSource({data: {
+        foo: [],
+        bar: [],
+      }})
+      expect(cds2.to_csv()).to.be.equal("foo,bar\n")
+    })
+
+    it("should handle single column", () => {
+      const cds = new ColumnDataSource({data: {
+        foo: [1],
+      }})
+      expect(cds.to_csv()).to.be.equal("foo\n1\n")
+    })
+
+    it("should treat 1-dimensional ndarray just like a normal array", () => {
+      const cds = new ColumnDataSource({data: {
+        foo: ndarray([1, 0, 1], {dtype: "bool", shape: [3]}),
+        bar: ndarray([10, 9, 8], {dtype: "uint8", shape: [3]}),
+      }})
+      expect(cds.to_csv()).to.be.equal("foo,bar\ntrue,10\nfalse,9\ntrue,8\n")
+    })
+
+    it("should handle values for ndarray with dimension > 1", () => {
+      const cds = new ColumnDataSource({data: {
+        foo: ndarray([255, 0, 0, 0, 255, 0], {dtype: "uint8", shape: [2, 3]}),
+        bar: ndarray([0.5, 3.5, 10.25, -0.125, 3.75, 0.25, 0.5, -0.125], {dtype: "float32", shape: [2, 4]}),
+      }})
+      // NDArrays implementation doesn't handle yet multi-dimensional indices
+      // See src\lib\core\util\ndarray.ts
+      expect(cds.to_csv()).to.be.equal(
+        "foo,bar\n" +
+        "255,0.5\n" +
+        "0,3.5\n",
+      )
+    })
+  })
+
+  describe("to_json", () => {
+    it("should return string with empty object for empty data source", () => {
+      const cds = new ColumnDataSource()
+      expect(cds.to_json()).to.be.equal("{}")
+
+      const cds2 = new ColumnDataSource({data: {}})
+      expect(cds2.to_json()).to.be.equal("{}")
+    })
+
+    it("should handle empty columns", () => {
+      const cds = new ColumnDataSource({data: {
+        foo: [],
+      }})
+      expect(cds.to_json()).to.be.equal('{"foo":[]}')
+
+      const cds2 = new ColumnDataSource({data: {
+        foo: [],
+        bar: [],
+      }})
+      expect(cds2.to_json()).to.be.equal('{"foo":[],"bar":[]}')
+    })
+
+    it("should handle single column", () => {
+      const cds = new ColumnDataSource({data: {
+        foo: [1],
+      }})
+      expect(cds.to_json()).to.be.equal('{"foo":[1]}')
+    })
+
+    it("should handle 1-dimensional ndarray properties", () => {
+      const cds = new ColumnDataSource({data: {
+        foo: ndarray([1, 0, 1], {dtype: "bool", shape: [3]}),
+        bar: ndarray([10, 9, 8], {dtype: "uint8", shape: [3]}),
+      }})
+      expect(cds.to_json()).to.be.equal(
+        '{"foo":{"0":1,"1":0,"2":1,"dtype":"bool","shape":[3],"dimension":1},'+
+        '"bar":{"0":10,"1":9,"2":8,"dtype":"uint8","shape":[3],"dimension":1}}',
+      )
+    })
+
+    it("should handle properties for ndarray with dimension > 1", () => {
+      const cds = new ColumnDataSource({data: {
+        foo: ndarray([255, 0, 0, 0, 255, 0], {dtype: "uint8", shape: [2, 3]}),
+        bar: ndarray([0.5, 3.5, 10.25, -0.125, 3.75, 0.25, 0.5, -0.125], {dtype: "float32", shape: [2, 4]}),
+      }})
+      expect(cds.to_json()).to.be.equal(
+        '{"foo":{"0":255,"1":0,"2":0,"3":0,"4":255,"5":0,"dtype":"uint8","shape":[2,3],"dimension":2},'+
+        '"bar":{"0":0.5,"1":3.5,"2":10.25,"3":-0.125,"4":3.75,"5":0.25,"6":0.5,"7":-0.125,"dtype":"float32","shape":[2,4],"dimension":2}}',
+      )
+    })
+  })
 })

--- a/src/bokeh/models/sources.py
+++ b/src/bokeh/models/sources.py
@@ -422,6 +422,20 @@ class ColumnDataSource(ColumnarDataSource):
         import pandas as pd
         return pd.DataFrame(self.data)
 
+    def to_csv(self) -> str:
+        # TODO: Handle pandas not being available
+        selected_indices = self.selected.indices
+        if len(selected_indices) > 0:
+            return self.to_df().iloc[self.selected.indices].to_csv(index=False)
+        return self.to_df().to_csv(index=False)
+
+    def to_json(self) -> str:
+        # TODO: Handle pandas not being available
+        selected_indices = self.selected.indices
+        if len(selected_indices) > 0:
+            return self.to_df().iloc[self.selected.indices].to_json()
+        return self.to_df().to_json()
+
     def add(self, data: Sequence[Any], name: str | None = None) -> str:
         ''' Appends a new column of data to the data source.
 


### PR DESCRIPTION
- [x] issues: fixes https://github.com/bokeh/bokeh/issues/14506
- [ ] tests added
- [ ] release document entry (if new feature or API change)

An initial simple/naive vanilla implementation for `ColumDataSource` `to_csv` and `to_json` methods for BokehJS and one based on pandas `DataFrames` functionality for the Python side of things. It is scoped to a bare minimum where simply if there is a selection the methods generate a representation of the data selected and otherwise a representation of all the data. Probably the methods should handle some configuration/args (from what I could see in previous attempts to implement the feature) so open to any feedback/ideas

Notes:

* What should be the proper CSV/JSON representation of ndarrays? Are there specific cases that should be handled in a different manner?