### PR TITLE
Detach release build Pixi environment in CI

### DIFF
--- a/.github/workflows/bokeh-release-build.yml
+++ b/.github/workflows/bokeh-release-build.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure detached Pixi environment
+        run: |
+          printf 'detached-environments = "%s/pixi-environments"\n' "$RUNNER_TEMP" > "$RUNNER_TEMP/pixi-config.toml"
+          echo "PIXI_CONFIG_FILE=$RUNNER_TEMP/pixi-config.toml" >> "$GITHUB_ENV"
+
       - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           environments: release-build


### PR DESCRIPTION
Our release machinery does a `git clean -fdx` as part of the process, but this blows away the `.pixi` env that is part of the new dev workflow, causing things to fail. We could maybe swap order of operations but that seems fragile. For CI, use a detached pixi env outside the repo. 

@bokeh/core iteration times can be onerous when fixing CI issues, so I will just merge small CI-only issue PRs until this is fixed.  

Edit: just circling back to note this fixed the vuild job issue