### PR TITLE
Use npm publishing environment

### DIFF
--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -19,6 +19,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-24.04
+    environment: publish-npm
 
     steps:
       - name: Check Maintainer


### PR DESCRIPTION
Second, unrelated small issue for the release deploy job. The upcoming trusted publishing PR necessitates multiple OIDC environments, which means they all need to get actual names, unlike the previous one for NPM publishing. This PR updates the GH config to use the OIDC environment that was configured on NPM. 
