### PR TITLE
Scope CI jobs by changed paths

### DIFF
--- a/.github/ci-path-filters.yml
+++ b/.github/ci-path-filters.yml
@@ -1,0 +1,26 @@
+docs:
+  - 'docs/**'
+
+tools:
+  - 'tools/**'
+  - '!tools/ci/**'
+
+bokehjs:
+  - 'bokehjs/**'
+
+python:
+  - 'src/**'
+
+examples:
+  - 'examples/**'
+
+full:
+  - '**'
+  - '!docs/**'
+  - '!tools/**'
+  - '!bokehjs/**'
+  - '!src/**'
+  - '!examples/**'
+
+ci:
+  - 'tools/ci/**'

--- a/.github/ci-path-filters.yml
+++ b/.github/ci-path-filters.yml
@@ -1,18 +1,41 @@
-docs:
+build:
   - 'docs/**'
+  - 'bokehjs/**'
+  - 'src/**'
+  - 'examples/**'
+
+codebase:
+  - 'src/**'
+  - 'examples/**'
+
+typing:
+  - 'src/**'
 
 tools:
   - 'tools/**'
   - '!tools/ci/**'
-
-bokehjs:
-  - 'bokehjs/**'
-
-python:
   - 'src/**'
 
 examples:
+  - 'src/**'
   - 'examples/**'
+
+unit_test:
+  - 'src/**'
+
+minimal_deps:
+  - 'src/**'
+
+core_deps:
+  - 'src/**'
+
+documentation:
+  - 'docs/**'
+  - 'src/**'
+  - 'examples/**'
+
+bokehjs:
+  - 'bokehjs/**'
 
 full:
   - '**'

--- a/.github/codeql-path-filters.yml
+++ b/.github/codeql-path-filters.yml
@@ -1,0 +1,15 @@
+javascript:
+  - 'bokehjs/**'
+  - 'examples/**'
+  - 'tools/**'
+  - '.github/codeql/**'
+  - '.github/workflows/codeql-analysis.yml'
+  - '.github/codeql-path-filters.yml'
+
+python:
+  - 'src/bokeh/**'
+  - 'examples/**'
+  - 'tools/**'
+  - '.github/codeql/**'
+  - '.github/workflows/codeql-analysis.yml'
+  - '.github/codeql-path-filters.yml'

--- a/.github/workflows/bokeh-ci-full.yml
+++ b/.github/workflows/bokeh-ci-full.yml
@@ -72,8 +72,54 @@ jobs:
       - name: Run codebase checks
         run: pytest --color=yes --durations=20 --durations-min=1 tests/codebase
 
+  tools:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest, windows-latest]
+
+    env:
+      PYTHONPATH: ${{ github.workspace }}/src
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          environments: test-py312
+          activate-environment: test-py312
+          locked: true
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'branch-')) }}
+
+      - name: Install Bokeh from source
+        run: python -m pip install --no-deps --editable .
+
+      - name: List installed software
+        uses: ./.github/workflows/composite/list-software
+        with:
+          environment: test-py312
+
       - name: Run tools tests
         run: pytest --color=yes --durations=20 --durations-min=1 tests/tools
+
+      - name: Check tools code quality
+        if: runner.os == 'Linux'
+        run: |
+          ruff check tools tests/tools
+          isort --gitignore --diff -c tools
+          isort --gitignore --diff -c tests/tools
+
+      - name: Check tools types
+        if: runner.os == 'Linux'
+        run: |
+          mypy --no-sqlite-cache --show-traceback tools tests/tools
+          pyright tools
 
   typing:
     needs: build
@@ -456,7 +502,7 @@ jobs:
           if-no-files-found: ignore
 
   notify-nightly-failure:
-    needs: [build, codebase, typing, examples, unit-test, unit-test-free-threaded, minimal-deps, core-deps, documentation, deployment-proxy, server-e2e]
+    needs: [build, codebase, tools, typing, examples, unit-test, unit-test-free-threaded, minimal-deps, core-deps, documentation, deployment-proxy, server-e2e]
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
 
@@ -498,7 +544,7 @@ jobs:
           *Automated notification from [Bokeh-CI-Full](${{ github.server_url }}/${{ github.repository }}/actions/workflows/bokeh-ci-full.yml)*"
 
   notify-pr:
-    needs: [build, codebase, typing, examples, unit-test, unit-test-free-threaded, minimal-deps, core-deps, documentation, deployment-proxy, server-e2e]
+    needs: [build, codebase, tools, typing, examples, unit-test, unit-test-free-threaded, minimal-deps, core-deps, documentation, deployment-proxy, server-e2e]
     if: always() && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -30,13 +30,17 @@ jobs:
       contents: read
 
     outputs:
-      docs: ${{ steps.filter.outputs.docs }}
-      tools: ${{ steps.filter.outputs.tools }}
-      bokehjs: ${{ steps.filter.outputs.bokehjs }}
-      python: ${{ steps.filter.outputs.python }}
-      examples: ${{ steps.filter.outputs.examples }}
-      full: ${{ steps.filter.outputs.full }}
-      ci: ${{ steps.filter.outputs.ci }}
+      build: ${{ steps.full.outputs.selected }}
+      codebase: ${{ steps.full.outputs.selected }}
+      typing: ${{ steps.full.outputs.selected }}
+      tools: ${{ steps.full.outputs.selected }}
+      examples: ${{ steps.full.outputs.selected }}
+      unit_test: ${{ steps.full.outputs.selected }}
+      minimal_deps: ${{ steps.full.outputs.selected }}
+      core_deps: ${{ steps.full.outputs.selected }}
+      documentation: ${{ steps.full.outputs.selected }}
+      bokehjs: ${{ steps.full.outputs.selected }}
+      full: ${{ steps.full.outputs.selected }}
       groups: ${{ steps.filter.outputs.changes }}
 
     steps:
@@ -54,7 +58,13 @@ jobs:
           predicate-quantifier: some-with-excludes
           filters: .github/ci-path-filters.yml
 
+      - name: Select full CI
+        id: full
+        run: echo "selected=true" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
     runs-on: ubuntu-24.04
 
     steps:
@@ -66,7 +76,8 @@ jobs:
         uses: ./.github/workflows/composite/build
 
   codebase:
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.codebase == 'true' && needs.build.result == 'success'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -98,6 +109,8 @@ jobs:
         run: pytest --color=yes --durations=20 --durations-min=1 tests/codebase
 
   tools:
+    needs: changes
+    if: needs.changes.outputs.tools == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -147,7 +160,8 @@ jobs:
           pyright tools
 
   typing:
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.typing == 'true' && needs.build.result == 'success'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -192,7 +206,8 @@ jobs:
             pyright --version && pyright
 
   examples:
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.examples == 'true' && needs.build.result == 'success'
     runs-on: ubuntu-24.04
 
     strategy:
@@ -248,7 +263,8 @@ jobs:
           path: examples-report
 
   unit-test:
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.unit_test == 'true' && needs.build.result == 'success'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -287,7 +303,8 @@ jobs:
           collect-coverage: ${{ runner.os != 'Windows' }}
 
   minimal-deps:
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.minimal_deps == 'true' && needs.build.result == 'success'
     runs-on: ubuntu-24.04
 
     env:
@@ -313,7 +330,8 @@ jobs:
           dep-type: 'minimal'
 
   core-deps:
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.core_deps == 'true' && needs.build.result == 'success'
     runs-on: ubuntu-24.04
 
     env:
@@ -339,7 +357,8 @@ jobs:
           dep-type: 'core'
 
   documentation:
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.documentation == 'true' && needs.build.result == 'success'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -376,3 +395,34 @@ jobs:
         with:
           name: docs-html
           path: docs/bokeh/docs-html.tgz
+
+  result:
+    name: Bokeh-CI / result
+    if: ${{ always() }}
+    needs: [changes, build, codebase, tools, typing, examples, unit-test, minimal-deps, core-deps, documentation]
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Require every selected job to pass
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          jq -e '
+            . as $results
+            | $results.changes.result == "success" and
+              ([
+                ["build", "build"],
+                ["codebase", "codebase"],
+                ["tools", "tools"],
+                ["typing", "typing"],
+                ["examples", "examples"],
+                ["unit-test", "unit_test"],
+                ["minimal-deps", "minimal_deps"],
+                ["core-deps", "core_deps"],
+                ["documentation", "documentation"]
+              ] | all(.[]; . as [$job, $output]
+                | if $results.changes.outputs[$output] == "true"
+                  then $results[$job].result == "success"
+                  else $results[$job].result == "skipped"
+                  end))
+          ' <<<"$RESULTS"

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -97,8 +97,54 @@ jobs:
       - name: Run codebase checks
         run: pytest --color=yes --durations=20 --durations-min=1 tests/codebase
 
+  tools:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest, windows-latest]
+
+    env:
+      PYTHONPATH: ${{ github.workspace }}/src
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          environments: test-py312
+          activate-environment: test-py312
+          locked: true
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'branch-')) }}
+
+      - name: Install Bokeh from source
+        run: python -m pip install --no-deps --editable .
+
+      - name: List installed software
+        uses: ./.github/workflows/composite/list-software
+        with:
+          environment: test-py312
+
       - name: Run tools tests
         run: pytest --color=yes --durations=20 --durations-min=1 tests/tools
+
+      - name: Check tools code quality
+        if: runner.os == 'Linux'
+        run: |
+          ruff check tools tests/tools
+          isort --gitignore --diff -c tools
+          isort --gitignore --diff -c tests/tools
+
+      - name: Check tools types
+        if: runner.os == 'Linux'
+        run: |
+          mypy --no-sqlite-cache --show-traceback tools tests/tools
+          pyright tools
 
   typing:
     needs: build

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -9,9 +9,11 @@ on:
       - main
       - branch-*
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Unrelated label events still start the workflow, but must not cancel active CI.
+  group: ${{ github.workflow }}-${{ github.event.action == 'labeled' && github.event.label.name != 'ci:full' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
@@ -30,36 +32,48 @@ jobs:
       contents: read
 
     outputs:
-      build: ${{ steps.full.outputs.selected }}
-      codebase: ${{ steps.full.outputs.selected }}
-      typing: ${{ steps.full.outputs.selected }}
-      tools: ${{ steps.full.outputs.selected }}
-      examples: ${{ steps.full.outputs.selected }}
-      unit_test: ${{ steps.full.outputs.selected }}
-      minimal_deps: ${{ steps.full.outputs.selected }}
-      core_deps: ${{ steps.full.outputs.selected }}
-      documentation: ${{ steps.full.outputs.selected }}
-      bokehjs: ${{ steps.full.outputs.selected }}
-      full: ${{ steps.full.outputs.selected }}
+      build: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.build == 'true' }}
+      codebase: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.codebase == 'true' }}
+      typing: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.typing == 'true' }}
+      tools: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.tools == 'true' }}
+      examples: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.examples == 'true' }}
+      unit_test: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.unit_test == 'true' }}
+      minimal_deps: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.minimal_deps == 'true' }}
+      core_deps: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.core_deps == 'true' }}
+      documentation: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.documentation == 'true' }}
+      full: ${{ steps.full.outputs.selected == 'true' }}
       groups: ${{ steps.filter.outputs.changes }}
 
     steps:
       - uses: actions/checkout@v6
+        if: >-
+          github.event_name == 'pull_request' &&
+          (github.event.action != 'labeled' || github.event.label.name == 'ci:full')
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Classify changed paths
+        if: >-
+          github.event_name == 'pull_request' &&
+          (github.event.action != 'labeled' || github.event.label.name == 'ci:full')
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
         with:
-          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base: ${{ github.event.pull_request.base.sha }}
           token: ''
           predicate-quantifier: some-with-excludes
           filters: .github/ci-path-filters.yml
 
       - name: Select full CI
         id: full
+        if: >-
+          github.event_name != 'pull_request' ||
+          (github.event.action == 'labeled' && github.event.label.name == 'ci:full') ||
+          (github.event.action != 'labeled' &&
+            (contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+             steps.filter.outputs.full == 'true' ||
+             steps.filter.outputs.ci == 'true'))
         run: echo "selected=true" >> "$GITHUB_OUTPUT"
 
   build:

--- a/.github/workflows/bokeh-ci.yml
+++ b/.github/workflows/bokeh-ci.yml
@@ -23,6 +23,37 @@ env:
   CHROME_REV: "chromium_3265"
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      tools: ${{ steps.filter.outputs.tools }}
+      bokehjs: ${{ steps.filter.outputs.bokehjs }}
+      python: ${{ steps.filter.outputs.python }}
+      examples: ${{ steps.filter.outputs.examples }}
+      full: ${{ steps.filter.outputs.full }}
+      ci: ${{ steps.filter.outputs.ci }}
+      groups: ${{ steps.filter.outputs.changes }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Classify changed paths
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
+        with:
+          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          token: ''
+          predicate-quantifier: some-with-excludes
+          filters: .github/ci-path-filters.yml
+
   build:
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -6,9 +6,11 @@ on:
       - main
       - branch-*
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Unrelated label events still start the workflow, but must not cancel active CI.
+  group: ${{ github.workflow }}-${{ github.event.action == 'labeled' && github.event.label.name != 'ci:full' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -23,36 +25,40 @@ jobs:
       contents: read
 
     outputs:
-      build: ${{ steps.full.outputs.selected }}
-      codebase: ${{ steps.full.outputs.selected }}
-      typing: ${{ steps.full.outputs.selected }}
-      tools: ${{ steps.full.outputs.selected }}
-      examples: ${{ steps.full.outputs.selected }}
-      unit_test: ${{ steps.full.outputs.selected }}
-      minimal_deps: ${{ steps.full.outputs.selected }}
-      core_deps: ${{ steps.full.outputs.selected }}
-      documentation: ${{ steps.full.outputs.selected }}
-      bokehjs: ${{ steps.full.outputs.selected }}
-      full: ${{ steps.full.outputs.selected }}
+      bokehjs: ${{ steps.full.outputs.selected == 'true' || steps.filter.outputs.bokehjs == 'true' }}
+      full: ${{ steps.full.outputs.selected == 'true' }}
       groups: ${{ steps.filter.outputs.changes }}
 
     steps:
       - uses: actions/checkout@v6
+        if: >-
+          github.event_name == 'pull_request' &&
+          (github.event.action != 'labeled' || github.event.label.name == 'ci:full')
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Classify changed paths
+        if: >-
+          github.event_name == 'pull_request' &&
+          (github.event.action != 'labeled' || github.event.label.name == 'ci:full')
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
         with:
-          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base: ${{ github.event.pull_request.base.sha }}
           token: ''
           predicate-quantifier: some-with-excludes
           filters: .github/ci-path-filters.yml
 
       - name: Select full CI
         id: full
+        if: >-
+          github.event_name != 'pull_request' ||
+          (github.event.action == 'labeled' && github.event.label.name == 'ci:full') ||
+          (github.event.action != 'labeled' &&
+            (contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+             steps.filter.outputs.full == 'true' ||
+             steps.filter.outputs.ci == 'true'))
         run: echo "selected=true" >> "$GITHUB_OUTPUT"
 
   test:

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -23,13 +23,17 @@ jobs:
       contents: read
 
     outputs:
-      docs: ${{ steps.filter.outputs.docs }}
-      tools: ${{ steps.filter.outputs.tools }}
-      bokehjs: ${{ steps.filter.outputs.bokehjs }}
-      python: ${{ steps.filter.outputs.python }}
-      examples: ${{ steps.filter.outputs.examples }}
-      full: ${{ steps.filter.outputs.full }}
-      ci: ${{ steps.filter.outputs.ci }}
+      build: ${{ steps.full.outputs.selected }}
+      codebase: ${{ steps.full.outputs.selected }}
+      typing: ${{ steps.full.outputs.selected }}
+      tools: ${{ steps.full.outputs.selected }}
+      examples: ${{ steps.full.outputs.selected }}
+      unit_test: ${{ steps.full.outputs.selected }}
+      minimal_deps: ${{ steps.full.outputs.selected }}
+      core_deps: ${{ steps.full.outputs.selected }}
+      documentation: ${{ steps.full.outputs.selected }}
+      bokehjs: ${{ steps.full.outputs.selected }}
+      full: ${{ steps.full.outputs.selected }}
       groups: ${{ steps.filter.outputs.changes }}
 
     steps:
@@ -47,7 +51,13 @@ jobs:
           predicate-quantifier: some-with-excludes
           filters: .github/ci-path-filters.yml
 
+      - name: Select full CI
+        id: full
+        run: echo "selected=true" >> "$GITHUB_OUTPUT"
+
   test:
+    needs: changes
+    if: needs.changes.outputs.bokehjs == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -169,3 +179,22 @@ jobs:
         with:
           name: bokehjs-report
           path: bokehjs-report
+
+  result:
+    name: BokehJS-CI / result
+    if: ${{ always() }}
+    needs: [changes, test]
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Require every selected job to pass
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          jq -e '
+            .changes.result == "success" and
+            (if .changes.outputs.bokehjs == "true"
+             then .test.result == "success"
+             else .test.result == "skipped"
+             end)
+          ' <<<"$RESULTS"

--- a/.github/workflows/bokehjs-ci.yml
+++ b/.github/workflows/bokehjs-ci.yml
@@ -16,6 +16,37 @@ env:
   CHROME_REV: "chromium_3265"
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      tools: ${{ steps.filter.outputs.tools }}
+      bokehjs: ${{ steps.filter.outputs.bokehjs }}
+      python: ${{ steps.filter.outputs.python }}
+      examples: ${{ steps.filter.outputs.examples }}
+      full: ${{ steps.filter.outputs.full }}
+      ci: ${{ steps.filter.outputs.ci }}
+      groups: ${{ steps.filter.outputs.changes }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Classify changed paths
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
+        with:
+          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          token: ''
+          predicate-quantifier: some-with-excludes
+          filters: .github/ci-path-filters.yml
+
   test:
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,13 +7,42 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ branch-* ]
     paths:
-      - bokehjs
-      - examples
-      - tools
-      - src/bokeh
+      - 'bokehjs/**'
+      - 'examples/**'
+      - 'tools/**'
+      - 'src/bokeh/**'
+      - '.github/codeql/**'
+      - '.github/codeql-path-filters.yml'
+      - '.github/workflows/codeql-analysis.yml'
 
 jobs:
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    outputs:
+      codeql_languages: ${{ github.event_name != 'pull_request' && '["javascript","python"]' || steps.filter.outputs.changes }}
+
+    steps:
+      - uses: actions/checkout@v6
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Classify changed paths
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
+        with:
+          base: ${{ github.event.pull_request.base.sha }}
+          token: ''
+          filters: .github/codeql-path-filters.yml
+
   analyze:
+    needs: changes
     name: Analyze
     runs-on: ubuntu-24.04
     permissions:
@@ -24,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python' ]
+        language: ${{ fromJSON(needs.changes.outputs.codeql_languages) }}
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
[codex-assisted]

This PR makes pull-request CI path-aware using a pinned `dorny/paths-filter` action and simple prefix-based routing:

- `docs/**`: build the package and documentation;
- ordinary `tools/**`: run the standalone maintainer-tool tests, lint, and typing checks;
- `bokehjs/**`: build the package and run the BokehJS test matrix;
- `src/**`: run the standard Python/library coverage without the separate BokehJS matrix;
- `examples/**`: run the build, codebase, examples, and documentation jobs.

Mixed scoped changes run the union of their routes. Changes under `tools/ci/**`, changes anywhere outside these prefixes, pushes to long-lived branches, and PRs labeled `ci:full` continue to run the full standard suites. CodeQL now selects JavaScript, Python, or both from its own small prefix table, while stable result jobs ensure every selected job passes.

The comprehensive scheduled workflow, release workflows, and downstream testing are unchanged. Local validation covered representative routing combinations, tools and codebase tests, static checks, workflow parsing, and `actionlint`.

## PR routing evidence

A disposable stacked PR, #15390, moved a harmless probe file between path prefixes one push at a time. All seven expected routes were observed. CodeQL was intentionally outside the scope of this exercise.

| Probe | Expected and observed workload | Bokeh-CI elapsed vs full | BokehJS-CI elapsed vs full |
|---|---|---|---|
| `docs/**` | build, documentation; BokehJS skipped | [16m40s](https://github.com/bokeh/bokeh/actions/runs/33292244842) (+19s) | [28s](https://github.com/bokeh/bokeh/actions/runs/33292244895) (-8m29s) |
| `tools/**` | tools on Linux, macOS, Windows; all library/docs/BokehJS jobs skipped | [3m46s](https://github.com/bokeh/bokeh/actions/runs/33293183383) (-12m35s) | [24s](https://github.com/bokeh/bokeh/actions/runs/33293183384) (-8m33s) |
| `bokehjs/**` | build and BokehJS tests on Linux, macOS, Windows; Python library/docs jobs skipped | [2m02s](https://github.com/bokeh/bokeh/actions/runs/33293363025) (-14m19s) | [8m33s](https://github.com/bokeh/bokeh/actions/runs/33293363019) (-24s) |
| `examples/**` | build, codebase, examples, documentation; unrelated jobs skipped | [16m55s](https://github.com/bokeh/bokeh/actions/runs/33293693080) (+34s) | [24s](https://github.com/bokeh/bokeh/actions/runs/33293693079) (-8m33s) |
| `src/**` | full Python/library coverage; BokehJS skipped | [16m49s](https://github.com/bokeh/bokeh/actions/runs/33294378671) (+28s) | [29s](https://github.com/bokeh/bokeh/actions/runs/33294378669) (-8m28s) |
| unclassified root path | full standard Bokeh and BokehJS suites | [16m21s](https://github.com/bokeh/bokeh/actions/runs/33295047166) (reference) | [8m57s](https://github.com/bokeh/bokeh/actions/runs/33295047167) (reference) |
| `tools/ci/**` | explicit full standard Bokeh and BokehJS suites | [14m25s](https://github.com/bokeh/bokeh/actions/runs/33295738645) (-1m56s) | [8m57s](https://github.com/bokeh/bokeh/actions/runs/33295738770) (same) |

Elapsed time is workflow wall time from `startedAt` to `updatedAt`, compared with the successful unclassified full-CI runs. These are individual observations rather than a benchmark; wall time also understates the runner-usage reduction when a retained documentation or examples job remains the longest job.

The first `tools/ci/**` [Bokeh-CI](https://github.com/bokeh/bokeh/actions/runs/33295677731) and [BokehJS-CI](https://github.com/bokeh/bokeh/actions/runs/33295677775) runs were superseded by a label-triggered rerun in the same concurrency group. Their zero-second canceled jobs are not test failures; the replacement runs linked in the table completed successfully.

<details>
<summary>Selected workload job links</summary>

### `docs/**`

- Bokeh-CI: [build](https://github.com/bokeh/bokeh/actions/runs/33292244842/job/99205823669), [documentation](https://github.com/bokeh/bokeh/actions/runs/33292244842/job/99206005655)
- BokehJS-CI: no workload jobs selected

### `tools/**`

- Bokeh-CI: [tools (macOS)](https://github.com/bokeh/bokeh/actions/runs/33293183383/job/99208308517), [tools (Linux)](https://github.com/bokeh/bokeh/actions/runs/33293183383/job/99208308527), [tools (Windows)](https://github.com/bokeh/bokeh/actions/runs/33293183383/job/99208308531)
- BokehJS-CI: no workload jobs selected

### `bokehjs/**`

- Bokeh-CI: [build](https://github.com/bokeh/bokeh/actions/runs/33293363025/job/99208777633)
- BokehJS-CI: [test (Linux)](https://github.com/bokeh/bokeh/actions/runs/33293363019/job/99208797585), [test (Windows)](https://github.com/bokeh/bokeh/actions/runs/33293363019/job/99208797593), [test (macOS)](https://github.com/bokeh/bokeh/actions/runs/33293363019/job/99208797608)

### `examples/**`

- Bokeh-CI: [build](https://github.com/bokeh/bokeh/actions/runs/33293693080/job/99209653277), [examples](https://github.com/bokeh/bokeh/actions/runs/33293693080/job/99209842922), [documentation](https://github.com/bokeh/bokeh/actions/runs/33293693080/job/99209842930), [codebase (macOS)](https://github.com/bokeh/bokeh/actions/runs/33293693080/job/99209842944), [codebase (Windows)](https://github.com/bokeh/bokeh/actions/runs/33293693080/job/99209842955), [codebase (Linux)](https://github.com/bokeh/bokeh/actions/runs/33293693080/job/99209842964)
- BokehJS-CI: no workload jobs selected

### `src/**`

- Bokeh-CI: [build](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211451436), [tools (Linux)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211451395), [tools (Windows)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211451406), [tools (macOS)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211451429), [core dependencies](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630363), [examples](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630386), [documentation](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630389), [unit (Linux)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630390), [typing (Python 3.14)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630392), [typing (Python 3.12)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630394), [codebase (macOS)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630410), [unit (macOS)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630419), [codebase (Windows)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630420), [minimal dependencies](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630434), [unit (Windows)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630455), [codebase (Linux)](https://github.com/bokeh/bokeh/actions/runs/33294378671/job/99211630483)
- BokehJS-CI: no workload jobs selected

### Unclassified root path

- Bokeh-CI: [build](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213175897), [tools (Windows)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213175853), [tools (macOS)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213175867), [tools (Linux)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213175868), [documentation](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333195), [minimal dependencies](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333211), [core dependencies](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333213), [codebase (Windows)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333218), [unit (Windows)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333219), [examples](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333220), [unit (Linux)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333232), [typing (Python 3.12)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333235), [typing (Python 3.14)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333243), [unit (macOS)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333303), [codebase (macOS)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333315), [codebase (Linux)](https://github.com/bokeh/bokeh/actions/runs/33295047166/job/99213333316)
- BokehJS-CI: [test (Windows)](https://github.com/bokeh/bokeh/actions/runs/33295047167/job/99213176507), [test (Linux)](https://github.com/bokeh/bokeh/actions/runs/33295047167/job/99213176517), [test (macOS)](https://github.com/bokeh/bokeh/actions/runs/33295047167/job/99213176588)

### `tools/ci/**`

- Bokeh-CI: [build](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215013098), [tools (macOS)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215013097), [tools (Windows)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215013103), [tools (Linux)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215013143), [examples](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215171955), [codebase (macOS)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215171958), [codebase (Windows)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215171965), [typing (Python 3.12)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215171984), [unit (Windows)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215171991), [unit (Linux)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215171993), [documentation](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215171996), [minimal dependencies](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215172001), [typing (Python 3.14)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215172011), [unit (macOS)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215172034), [core dependencies](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215172039), [codebase (Linux)](https://github.com/bokeh/bokeh/actions/runs/33295738645/job/99215172068)
- BokehJS-CI: [test (macOS)](https://github.com/bokeh/bokeh/actions/runs/33295738770/job/99215014485), [test (Linux)](https://github.com/bokeh/bokeh/actions/runs/33295738770/job/99215014495), [test (Windows)](https://github.com/bokeh/bokeh/actions/runs/33295738770/job/99215014500)

</details>

The workflow-run links above also expose the classifier, aggregate result, and every intentionally skipped job for each probe.
