### PR TITLE
Fix diverging_palette returning the wrong number of colors

### DIFF
--- a/src/bokeh/palettes.py
+++ b/src/bokeh/palettes.py
@@ -1563,9 +1563,10 @@ def diverging_palette(palette1: Palette, palette2: Palette, n: int, midpoint: fl
     # flip palette2 so that perceptually light colors are joined
     palette2 = palette2[::-1]
 
-    # determine number of colors from each palette
+    # determine number of colors from each palette; n2 is a remainder rather than a
+    # second rounding so that the two always add up to n
     n1 = round(midpoint * n)
-    n2 = round((1 - midpoint) * n)
+    n2 = n - n1
 
     # return piecewise linear interpolation of colors
     return linear_palette(palette1, n1) + linear_palette(palette2, n2)

--- a/tests/unit/bokeh/test_palettes.py
+++ b/tests/unit/bokeh/test_palettes.py
@@ -73,6 +73,20 @@ def test_interp_palette() -> None:
     with pytest.raises(ValueError):
         pal.interp_palette(("black", "red"), -1)
 
+def test_diverging_palette() -> None:
+    # n is the size of the returned palette, including when midpoint * n lands on a
+    # half-integer and rounding both halves separately would not add up to n
+    for n in range(19):
+        assert len(pal.diverging_palette(pal.Blues9, pal.Reds9, n)) == n
+
+    for midpoint in (0.1, 0.25, 0.75, 0.9):
+        for n in range(11):
+            assert len(pal.diverging_palette(pal.Blues9, pal.Reds9, n, midpoint)) == n
+
+    assert pal.diverging_palette(pal.Reds9, pal.Greys9, 18) == pal.Reds9 + pal.Greys9[::-1]
+    assert pal.diverging_palette(pal.Reds9, pal.Greys9, 5) == \
+        pal.linear_palette(pal.Reds9, 2) + pal.linear_palette(pal.Greys9[::-1], 3)
+
 def test_varying_alpha_palette() -> None:
     assert pal.varying_alpha_palette("blue", 3) == ("#0000ff00", "#0000ff80", "#0000ff")
     assert pal.varying_alpha_palette("red", 3, start_alpha=255, end_alpha=128) == ("#ff0000", "#ff0000c0", "#ff000080")

--- a/tests/unit/bokeh/test_palettes.py
+++ b/tests/unit/bokeh/test_palettes.py
@@ -73,16 +73,18 @@ def test_interp_palette() -> None:
     with pytest.raises(ValueError):
         pal.interp_palette(("black", "red"), -1)
 
-def test_diverging_palette() -> None:
-    # n is the size of the returned palette, including when midpoint * n lands on a
-    # half-integer and rounding both halves separately would not add up to n
+def test_diverging_palette_returns_n_colors() -> None:
+    # odd n is the case that regressed: midpoint * n lands on a half-integer, and
+    # rounding each half separately does not add back up to n
     for n in range(19):
         assert len(pal.diverging_palette(pal.Blues9, pal.Reds9, n)) == n
 
+def test_diverging_palette_returns_n_colors_for_off_center_midpoint() -> None:
     for midpoint in (0.1, 0.25, 0.75, 0.9):
         for n in range(11):
             assert len(pal.diverging_palette(pal.Blues9, pal.Reds9, n, midpoint)) == n
 
+def test_diverging_palette_splits_across_both_palettes() -> None:
     assert pal.diverging_palette(pal.Reds9, pal.Greys9, 18) == pal.Reds9 + pal.Greys9[::-1]
     assert pal.diverging_palette(pal.Reds9, pal.Greys9, 5) == \
         pal.linear_palette(pal.Reds9, 2) + pal.linear_palette(pal.Greys9[::-1], 3)


### PR DESCRIPTION
fixes #15396

`diverging_palette` rounds each half of the split separately:

```python
n1 = round(midpoint * n)
n2 = round((1 - midpoint) * n)
```

When `midpoint * n` lands exactly on a half-integer, both roundings break the tie the same way and the counts stop adding up to `n`. With the default `midpoint=0.5` that is every odd `n`:

```pycon
>>> [len(diverging_palette(Blues9, Reds9, n)) for n in (1, 3, 5, 7, 9)]
[0, 4, 4, 8, 8]
```

So `n=1` hands back an empty palette and `n=5` a 4-color one. It happens off-center too: `n=5` with `midpoint=0.1` gives 4 colors, `n=10` with `midpoint=0.95` gives 11. Nothing raises, so a color mapper just ends up with the wrong number of bins.

Taking `n2` as the remainder fixes it. `n1` is untouched, so the midpoint semantics do not move. I swept `n` in 0..60 against midpoints 0.0 to 1.0 in steps of 0.05: 50 combinations were wrong before, none after, and those 50 are the only outputs that change.

The new test fails on `branch-4.0` with `assert 0 == 1`.

Developed with AI assistance (Claude Code, claude-opus-5). The reproduction, the sweep and the test were run locally.
