### PR TITLE
Fix Anaconda preflight output capture

### DIFF
--- a/.github/workflows/bokeh-release-deploy.yml
+++ b/.github/workflows/bokeh-release-deploy.yml
@@ -31,14 +31,17 @@ jobs:
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
-          if ! identity="$("$HOME/.ana/tools/anaconda-cli/bin/anaconda" --token "$ANACONDA_TOKEN" whoami)"; then
+          if ! identity="$("$HOME/.ana/tools/anaconda-cli/bin/anaconda" -t "$ANACONDA_TOKEN" whoami 2>&1)"; then
+            printf '%s\n' "$identity"
             echo "::error::Anaconda token authentication failed"
             exit 1
           fi
           if [[ "$identity" != *"Username: bokeh"* ]]; then
+            printf '%s\n' "$identity"
             echo "::error::Anaconda token is not authenticated as bokeh"
             exit 1
           fi
+          echo "Verified Anaconda credentials"
 
   prepare:
     needs: preflight

--- a/tests/tools/release/test_stages_and_cli.py
+++ b/tests/tools/release/test_stages_and_cli.py
@@ -303,8 +303,10 @@ def test_deploy_workflow_uses_isolated_publishers() -> None:
     assert setup_anaconda["with"] == {"version": "v0.2.1", "tools": "anaconda-cli"}
     validate_anaconda = next(step for step in preflight["steps"] if step.get("name") == "Validate Anaconda token")
     assert validate_anaconda["env"] == {"ANACONDA_TOKEN": "${{ secrets.ANACONDA_TOKEN }}"}
-    assert "--token \"$ANACONDA_TOKEN\" whoami" in validate_anaconda["run"]
+    assert "-t \"$ANACONDA_TOKEN\" whoami 2>&1" in validate_anaconda["run"]
+    assert "printf '%s\\n' \"$identity\"" in validate_anaconda["run"]
     assert "Username: bokeh" in validate_anaconda["run"]
+    assert "Verified Anaconda credentials" in validate_anaconda["run"]
 
     assert prepare["needs"] == "preflight"
 


### PR DESCRIPTION
Previous build machinery with `system.run()` combined stderr and stdout, so the pre-flight anaconda token check succeeded. Need to explicity capture stderr to achieve the same now without `system.run()`
