### PR TITLE
Treat explicit DataRange1d start/end changes as overrides

### DIFF
--- a/bokehjs/src/lib/models/ranges/data_range1d.ts
+++ b/bokehjs/src/lib/models/ranges/data_range1d.ts
@@ -106,6 +106,15 @@ export class DataRange1d extends DataRange {
       default_span,
       only_visible,
     ], () => this._invalidate_dataranges())
+
+    // once auto-ranged, explicitly setting start or end (e.g. from a callback) overrides
+    // auto-ranging, the same as interactive updates do, until the range is reset
+    const {start, end} = this.properties
+    this.on_change([start, end], () => {
+      if (this._plot_bounds.size != 0) {
+        this.have_updated_interactively = true
+      }
+    })
   }
 
   protected _invalidate_dataranges(): void {
@@ -339,6 +348,8 @@ export class DataRange1d extends DataRange {
         new_range.end = end
       }
       this.setv(new_range)
+      // auto-ranging's own update isn't an explicit one (see connect_signals())
+      this.have_updated_interactively = false
       needs_emit = false
     }
 

--- a/bokehjs/test/unit/regressions.ts
+++ b/bokehjs/test/unit/regressions.ts
@@ -2217,4 +2217,79 @@ ${view.host_selector} {
       expect(rendered()).to.not.be.equal(before)
     })
   })
+
+  describe("in issue #15345", () => {
+    const x = range(0, 100)
+    const y1 = x.map((xi) => Math.sin(xi/5)*10)
+    const y2 = y1.map((yi) => yi + 5)
+
+    function plot(y_range?: DataRange1d) {
+      const source = new ColumnDataSource({data: {x, y1, y2}})
+      const p = fig([600, 400], {tools: "xpan,xwheel_zoom,reset", active_scroll: "xwheel_zoom", y_range})
+      p.line({field: "x"}, {field: "y1"}, {source, legend_label: "Line 1"})
+      const r2 = p.line({field: "x"}, {field: "y2"}, {source, legend_label: "Line 2"})
+      p.legend.click_policy = "hide"
+      return {p, r2, source}
+    }
+
+    async function toggle_line2(view: PlotView, legend: Legend): Promise<void> {
+      const legend_view = view.views.get_one(legend)
+      await tap(legend_view.shadow_el.querySelectorAll(".bk-item")[1])
+      await view.ready
+    }
+
+    it("doesn't preserve a manually updated y_range when toggling a legend item after x-only zoom", async () => {
+      const {p, r2, source} = plot()
+      const {x_range, y_range, legend} = p
+      const autoscale = new CustomJS({args: {y_range, source}, code: `
+        const i = Math.max(Math.floor(cb_obj.start), 0)
+        const j = Math.min(Math.ceil(cb_obj.end), source.data.y1.length)
+        if (j > i) {
+          const vis_y1 = source.data.y1.slice(i, j)
+          const vis_y2 = source.data.y2.slice(i, j)
+          y_range.start = Math.min(...vis_y1, ...vis_y2) - 1
+          y_range.end = Math.max(...vis_y1, ...vis_y2) + 1
+        }
+      `})
+      x_range.js_property_callbacks = {"change:end": [autoscale]}
+
+      const {view} = await display(p)
+      await actions(view).scroll_up(xy(50, 0), 2)
+      await view.ready
+
+      const i = Math.floor(x_range.start)
+      const j = Math.ceil(x_range.end)
+      const visible = [...y1.slice(i, j), ...y2.slice(i, j)]
+      const expected: [number, number] = [Math.min(...visible) - 1, Math.max(...visible) + 1]
+      expect(y_range.interval).to.be.equal(expected)
+
+      await toggle_line2(view, legend)
+      expect(r2.visible).to.be.false
+      expect(y_range.interval).to.be.equal(expected)
+
+      await toggle_line2(view, legend)
+      expect(r2.visible).to.be.true
+      expect(y_range.interval).to.be.equal(expected)
+    })
+
+    it("doesn't auto-range y_range with only_visible=true when toggling a legend item after x-only zoom", async () => {
+      const {p, r2} = plot(new DataRange1d({only_visible: true, range_padding: 0}))
+      const {y_range, legend} = p
+
+      const {view} = await display(p)
+      await actions(view).scroll_up(xy(50, 0), 2)
+      await view.ready
+
+      const both: [number, number] = [Math.min(...y1), Math.max(...y2)]
+      expect(y_range.interval).to.be.similar(both)
+
+      await toggle_line2(view, legend)
+      expect(r2.visible).to.be.false
+      expect(y_range.interval).to.be.similar([Math.min(...y1), Math.max(...y1)])
+
+      await toggle_line2(view, legend)
+      expect(r2.visible).to.be.true
+      expect(y_range.interval).to.be.similar(both)
+    })
+  })
 })


### PR DESCRIPTION
- [x] issues: fixes #15345
- [x] tests added / passed
- [ ] release document entry (if new feature or API change)

### Problem

Using the reproducer from https://github.com/bokeh/bokeh/issues/15345#issuecomment-5297785726 (default `DataRange1d` y-range, CustomJS on `x_range.end` that sets `y_range.start`/`end`), hiding a renderer from the legend after an x-only wheel zoom replaces the callback's y-range with the full-data auto range. Reproduced in the browser with a real wheel scroll and legend click:

| Version | y after x-only zoom | y after hiding "Line 2" |
|---|---|---|
| 3.6.3 | `[-10.9999, 15.9854]` | `[-10.9999, 15.9854]` |
| 3.7.0 | `[-10.9999, 15.9854]` | `[-11.2497, 16.2455]` |
| branch-4.0 | `[-10.9999, 15.9854]` | `[-11.2497, 16.2455]` |

### Cause

`DataRange1d.update()` only skips re-fitting when `have_updated_interactively` is set, and only `RangeManager` (tools) and `TileRenderer` set it. A write from a callback isn't recorded, so the next data range invalidation re-fits the range. Here the invalidation comes from `GlyphRendererView` on `visible` change.

The plot doesn't set `window_axis`, so windowed auto-ranging isn't involved. The 3.6/3.7 difference comes from #14353 no longer sending a no-op update for the non-zoomed dimension. In 3.6 that no-op flagged y as updated and happened to protect the manual values. That change was intentional (#6766, #10775), and 3.6.3 also resets y on a legend toggle when there was no zoom first.

### Fix

In `DataRange1d`, explicit `start`/`end` changes set `have_updated_interactively` once the range has been auto-ranged (checked via the existing `_plot_bounds`). `update()` clears it after its own write, so auto-ranging's updates don't count. Changes made before the first auto-range, like `p.y_range.start = 0` before display in the BokehJS API, behave as before.

Alternatives considered:
- Restoring the no-op update for the other dimension would undo #14353 and break windowed auto-ranging.
- Skipping invalidation on visibility changes would still lose manual values on data updates.

### Behavior change to review

After a plot is rendered, explicitly setting a `DataRange1d`'s `start` or `end` now stops auto-ranging for that range until reset, or until a range-defining property such as `range_padding` changes. This applies to writes from CustomJS, `js_link` and server-side Python. It's the same rule pan and zoom already follow. Setting only `start` also freezes `end`. If this should get a release note, I'm happy to add one.

### Tests

New tests in `bokehjs/test/unit/regressions.ts` under `in issue #15345`:
- **Regression:** real `xwheel_zoom`, the issue's CustomJS, then hide and show via the legend. Asserts y is unchanged. Fails on `branch-4.0`, passes with this change.
- **Control:** `only_visible=True` and no callback. After an x-only zoom, the legend toggle still re-fits y.

Run locally (macOS, Chrome 153):
- `node make test:unit`: 2314 passed, 5 skipped
- `node make test:integration`: 1354 passed, 4 skipped. Image baselines are only compared on Linux, so they weren't checked locally.
- `node make lint`, `node make test:codebase`, `node make test:defaults`: all pass